### PR TITLE
feat(frontend): backend-persisted drafts center + composer stability fixes

### DIFF
--- a/src/api/apiGetTenantTheming.ts
+++ b/src/api/apiGetTenantTheming.ts
@@ -1,10 +1,32 @@
 import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
 import { endpoints } from '../resources/scripts/endpoints';
 import { TenantDataInterface } from '../globalState/interfaces';
+import { getValueFromCookie } from '../components/sessionCookie/accessSessionCookie';
+import { parseJwt } from '../utils/parseJWT';
 
 export const apiGetTenantTheming = async (): Promise<TenantDataInterface> => {
+	const accessToken = getValueFromCookie('keycloak');
+	let tenantId: number | null = null;
+
+	if (accessToken) {
+		const jwtPayload = parseJwt(accessToken);
+		if (typeof jwtPayload?.tenantId === 'number') {
+			tenantId = jwtPayload.tenantId;
+		} else if (
+			typeof jwtPayload?.tenantId === 'string' &&
+			jwtPayload.tenantId.trim() !== ''
+		) {
+			tenantId = Number(jwtPayload.tenantId);
+		}
+	}
+
+	const url =
+		tenantId && tenantId > 0
+			? `${endpoints.tenantServiceBase}/public/id/${tenantId}`
+			: `${endpoints.tenantServiceBase}/public/`;
+
 	return fetchData({
-		url: `${endpoints.tenantServiceBase}/public/`,
+		url,
 		method: FETCH_METHODS.GET,
 		skipAuth: true,
 		responseHandling: [FETCH_ERRORS.CATCH_ALL]

--- a/src/api/apiPostRegistration.ts
+++ b/src/api/apiPostRegistration.ts
@@ -17,9 +17,10 @@ export const apiPostRegistration = (
 		method: FETCH_METHODS.POST,
 		bodyData: JSON.stringify(data),
 		skipAuth: true,
-		...(useMultiTenancyWithSingleDomain && {
-			// headersData: { agencyId: data.agencyId }
-		}),
+		...(useMultiTenancyWithSingleDomain &&
+			data.agencyId && {
+				headersData: { agencyId: data.agencyId }
+			}),
 		responseHandling: [FETCH_ERRORS.CATCH_ALL_WITH_RESPONSE]
 	}).then(() =>
 		autoLogin({

--- a/src/api/apiUserDrafts.ts
+++ b/src/api/apiUserDrafts.ts
@@ -1,0 +1,65 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+
+export interface IUserDraftItem {
+	id?: number;
+	scopeKey: string;
+	text: string;
+	actionPath?: string | null;
+	title?: string | null;
+	sourceSessionId?: number | null;
+	roomRef?: string | null;
+	threadRootId?: string | null;
+	updatedAt?: string | null;
+}
+
+export interface IUserDraftFeedResponse {
+	items: IUserDraftItem[];
+	page: number;
+	perPage: number;
+}
+
+export const apiGetUserDrafts = async (
+	page = 0,
+	perPage = 200
+): Promise<IUserDraftFeedResponse> =>
+	fetchData({
+		url: `${endpoints.userDrafts}?page=${page}&perPage=${perPage}`,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
+	});
+
+export const apiGetUserDraft = async (
+	scopeKey: string,
+	signal?: AbortSignal
+): Promise<IUserDraftItem> =>
+	fetchData({
+		url: `${endpoints.userDrafts}/single?scopeKey=${encodeURIComponent(scopeKey)}`,
+		method: FETCH_METHODS.GET,
+		responseHandling: [
+			FETCH_ERRORS.EMPTY,
+			FETCH_ERRORS.CATCH_ALL,
+			FETCH_SUCCESS.CONTENT
+		],
+		...(signal && { signal })
+	});
+
+export const apiUpsertUserDraft = async (
+	scopeKey: string,
+	payload: Omit<IUserDraftItem, 'id' | 'scopeKey' | 'updatedAt'>
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.userDrafts}?scopeKey=${encodeURIComponent(scopeKey)}`,
+		method: FETCH_METHODS.PATCH,
+		bodyData: JSON.stringify(payload),
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
+	});
+
+export const apiDeleteUserDraft = async (scopeKey: string): Promise<void> =>
+	fetchData({
+		url: `${endpoints.userDrafts}?scopeKey=${encodeURIComponent(scopeKey)}`,
+		method: FETCH_METHODS.DELETE,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
+	});
+
+

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,6 +2,7 @@ export * from './apiAgencySelection';
 export * from './apiDeleteAskerAccount';
 export * from './apiDeleteSessionAndUser';
 export * from './apiDraftMessages';
+export * from './apiUserDrafts';
 export * from './apiGetSessionSupervisors';
 export * from './apiAddSessionSupervisor';
 export * from './apiRemoveSessionSupervisor';

--- a/src/components/app/RouterConfig.tsx
+++ b/src/components/app/RouterConfig.tsx
@@ -38,6 +38,7 @@ import { BookingEvents } from '../../containers/bookings/components/BookingEvent
 import { BookingReschedule } from '../../containers/bookings/components/BookingReschedule/bookingReschedule';
 import { hasVideoCallFeature } from '../../utils/videoCallHelpers';
 import { NotificationsCenter } from '../notificationsCenter/NotificationsCenter';
+import { DraftsCenter } from '../draftsCenter/DraftsCenter';
 
 const SessionView = lazy(() =>
 	import('../session/SessionView').then((m) => ({ default: m.SessionView }))
@@ -126,6 +127,14 @@ export const RouterConfigUser = (
 				}
 			},
 			{
+				to: '/drafts',
+				icon: MessagesIconOutline,
+				iconFilled: MessagesIconFilled,
+				titleKeys: {
+					large: 'navigation.drafts'
+				}
+			},
+			{
 				condition: (userData) => !userData.userName?.startsWith('Anonymous-'),
 				to: '/profile',
 				icon: ProfilIconOutline,
@@ -209,6 +218,11 @@ export const RouterConfigUser = (
 				component: NotificationsCenter
 			},
 			{
+				path: '/drafts',
+				exact: true,
+				component: DraftsCenter
+			},
+			{
 				path: '/profile',
 				exact: false,
 				component: Profile
@@ -268,6 +282,14 @@ export const RouterConfigConsultant = (settings: AppConfigInterface): any => {
 				iconFilled: NotificationBellIcon,
 				titleKeys: {
 					large: 'navigation.notifications'
+				}
+			},
+			{
+				to: '/drafts',
+				icon: MessagesIconOutline,
+				iconFilled: MessagesIconFilled,
+				titleKeys: {
+					large: 'navigation.drafts'
 				}
 			},
 			{
@@ -386,6 +408,11 @@ export const RouterConfigConsultant = (settings: AppConfigInterface): any => {
 				path: '/notifications',
 				exact: true,
 				component: NotificationsCenter
+			},
+			{
+				path: '/drafts',
+				exact: true,
+				component: DraftsCenter
 			},
 			{
 				path: '/overview',

--- a/src/components/app/Routing.tsx
+++ b/src/components/app/Routing.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useContext, useMemo, Suspense } from 'react';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import { RouterConfigUser, RouterConfigConsultant } from './RouterConfig';
 import { AbsenceHandler } from './AbsenceHandler';
 import {
@@ -28,6 +28,7 @@ interface RoutingProps {
 }
 
 export const Routing = (props: RoutingProps) => {
+	const location = useLocation();
 	const settings = useAppConfig();
 	const { userData } = useContext(UserDataContext);
 	const { consultingTypes } = useContext(ConsultingTypesContext);
@@ -49,6 +50,10 @@ export const Routing = (props: RoutingProps) => {
 			...(routerConfig.appointmentRoutes || []),
 			...(routerConfig.toolsRoutes || [])
 		].map((route) => route.path, []);
+
+	const isEmbeddedNotificationsView =
+		new URLSearchParams(location.search).get('embeddedNotifications') ===
+		'1';
 
 	return (
 		<Switch>
@@ -73,7 +78,13 @@ export const Routing = (props: RoutingProps) => {
 				<Walkthrough />
 				<E2EEProvider>
 					<NonPlainRoutesWrapper logoutHandler={() => props.logout()}>
-						<div className="app__wrapper">
+						<div
+							className={`app__wrapper ${
+								isEmbeddedNotificationsView
+									? 'app__wrapper--embeddedNotifications'
+									: ''
+							}`}
+						>
 							<NavigationBar
 								routerConfig={routerConfig}
 								onLogout={() => props.logout()}

--- a/src/components/app/authenticatedApp.styles.scss
+++ b/src/components/app/authenticatedApp.styles.scss
@@ -218,3 +218,28 @@ a {
 		}
 	}
 }
+
+.app__wrapper--embeddedNotifications {
+	.navigation__wrapper {
+		display: none !important;
+	}
+
+	.contentWrapper {
+		.header {
+			display: none !important;
+		}
+
+		&__list {
+			display: none !important;
+		}
+
+		&__content {
+			width: 100%;
+		}
+
+		&__detail {
+			width: 100% !important;
+			flex: 1 1 auto;
+		}
+	}
+}

--- a/src/components/draftsCenter/DraftsCenter.tsx
+++ b/src/components/draftsCenter/DraftsCenter.tsx
@@ -1,0 +1,172 @@
+import * as React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { apiDeleteUserDraft, apiGetUserDrafts, IUserDraftItem } from '../../api';
+import { REMOTE_DRAFT_INDEX_SCOPE } from '../../services/draftStore';
+import './draftsCenter.styles';
+
+const formatRelativeTime = (timestamp?: string | null) => {
+	if (!timestamp) {
+		return '';
+	}
+	const diffMs = Date.now() - new Date(timestamp).getTime();
+	const diffMin = Math.max(0, Math.floor(diffMs / (1000 * 60)));
+	if (diffMin < 1) return 'now';
+	if (diffMin < 60) return `${diffMin}m`;
+	const diffHours = Math.floor(diffMin / 60);
+	if (diffHours < 24) return `${diffHours}h`;
+	const diffDays = Math.floor(diffHours / 24);
+	return `${diffDays}d`;
+};
+
+export const DraftsCenter = () => {
+	const { t: translate } = useTranslation();
+	const history = useHistory();
+	const [selectedDraftKey, setSelectedDraftKey] = useState<string | null>(null);
+	const [refreshToken, setRefreshToken] = useState(0);
+	const [drafts, setDrafts] = useState<IUserDraftItem[]>([]);
+
+	useEffect(() => {
+		let isMounted = true;
+		const loadRemoteDrafts = async () => {
+			const response = await apiGetUserDrafts(0, 200).catch(() => null);
+			if (!isMounted) {
+				return;
+			}
+			const visibleDrafts =
+				response?.items?.filter(
+					(entry) => entry.scopeKey !== REMOTE_DRAFT_INDEX_SCOPE
+				) || [];
+			setDrafts(visibleDrafts);
+		};
+
+		void loadRemoteDrafts();
+		return () => {
+			isMounted = false;
+		};
+	}, [refreshToken]);
+
+	useEffect(() => {
+		if (!selectedDraftKey && drafts.length > 0) {
+			setSelectedDraftKey(drafts[0].scopeKey);
+			return;
+		}
+		if (
+			selectedDraftKey &&
+			!drafts.find((entry) => entry.scopeKey === selectedDraftKey)
+		) {
+			setSelectedDraftKey(drafts[0]?.scopeKey || null);
+		}
+	}, [drafts, selectedDraftKey]);
+
+	const selectedDraft = useMemo(
+		() => drafts.find((entry) => entry.scopeKey === selectedDraftKey) || null,
+		[drafts, selectedDraftKey]
+	);
+
+	const handleOpenDraft = useCallback(
+		(entry: IUserDraftItem) => {
+			if (!entry.actionPath) {
+				return;
+			}
+			history.push(entry.actionPath);
+		},
+		[history]
+	);
+
+	const handleDeleteDraft = useCallback((entry: IUserDraftItem) => {
+		apiDeleteUserDraft(entry.scopeKey).then(() =>
+			setRefreshToken((token) => token + 1)
+		);
+	}, []);
+
+	return (
+		<div className="draftsCenter">
+			<div className="draftsCenter__header">
+				<h2 className="draftsCenter__title">
+					{translate('drafts.center.title', 'Drafts')}
+				</h2>
+				<p className="draftsCenter__subtitle">
+					{translate(
+						'drafts.center.subtitle',
+						'Unsent messages are saved per chat and thread.'
+					)}
+				</p>
+			</div>
+			<div className="draftsCenter__content">
+				<div className="draftsCenter__list">
+					{drafts.length === 0 ? (
+						<div className="draftsCenter__empty">
+							{translate('drafts.center.empty', 'No drafts yet.')}
+						</div>
+					) : (
+						drafts.map((entry) => (
+							<button
+								type="button"
+								key={entry.scopeKey}
+								className={`draftsCenter__listItem ${
+									entry.scopeKey === selectedDraftKey
+										? 'draftsCenter__listItem--active'
+										: ''
+								}`}
+								onClick={() => setSelectedDraftKey(entry.scopeKey)}
+							>
+								<div className="draftsCenter__listItemHeader">
+									<span className="draftsCenter__listItemTitle">
+										{entry.title ||
+											translate('drafts.center.untitledChat', 'Chat')}
+									</span>
+									<span className="draftsCenter__listItemTime">
+										{formatRelativeTime(entry.updatedAt)}
+									</span>
+								</div>
+								<p className="draftsCenter__listItemText">{entry.text}</p>
+								{entry.threadRootId && (
+									<span className="draftsCenter__threadTag">
+										{translate('drafts.center.thread', 'Thread')}
+									</span>
+								)}
+							</button>
+						))
+					)}
+				</div>
+				<div className="draftsCenter__detail">
+					{selectedDraft ? (
+						<div className="draftsCenter__detailCard">
+							<h3 className="draftsCenter__detailTitle">
+								{selectedDraft.title ||
+									translate('drafts.center.untitledChat', 'Chat')}
+							</h3>
+							<p className="draftsCenter__detailText">{selectedDraft.text}</p>
+							<div className="draftsCenter__detailActions">
+								<button
+									type="button"
+									className="draftsCenter__openButton"
+									onClick={() => handleOpenDraft(selectedDraft)}
+								>
+									{translate('drafts.center.open', 'Open draft')}
+								</button>
+								<button
+									type="button"
+									className="draftsCenter__deleteButton"
+									onClick={() => handleDeleteDraft(selectedDraft)}
+								>
+									{translate('drafts.center.delete', 'Delete draft')}
+								</button>
+							</div>
+						</div>
+					) : (
+						<div className="draftsCenter__empty">
+							{translate(
+								'drafts.center.emptyDetail',
+								'Select a draft to continue writing.'
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+};
+

--- a/src/components/draftsCenter/draftsCenter.styles.scss
+++ b/src/components/draftsCenter/draftsCenter.styles.scss
@@ -1,0 +1,146 @@
+.draftsCenter {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	padding: 24px;
+	background: #f8f9fb;
+}
+
+.draftsCenter__header {
+	margin-bottom: 16px;
+}
+
+.draftsCenter__title {
+	margin: 0;
+	font-size: 24px;
+	font-weight: 700;
+}
+
+.draftsCenter__subtitle {
+	margin: 6px 0 0;
+	color: #68727d;
+	font-size: 14px;
+}
+
+.draftsCenter__content {
+	display: grid;
+	grid-template-columns: minmax(280px, 360px) 1fr;
+	gap: 16px;
+	min-height: 0;
+	flex: 1;
+}
+
+.draftsCenter__list,
+.draftsCenter__detail {
+	background: #fff;
+	border: 1px solid #e5e8ee;
+	border-radius: 12px;
+	min-height: 0;
+	overflow: auto;
+}
+
+.draftsCenter__listItem {
+	width: 100%;
+	border: 0;
+	background: transparent;
+	text-align: left;
+	padding: 14px 16px;
+	border-bottom: 1px solid #f0f2f6;
+	cursor: pointer;
+}
+
+.draftsCenter__listItem--active {
+	background: #f3f7ff;
+}
+
+.draftsCenter__listItemHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.draftsCenter__listItemTitle {
+	font-weight: 600;
+}
+
+.draftsCenter__listItemTime {
+	color: #77818b;
+	font-size: 12px;
+}
+
+.draftsCenter__listItemText {
+	margin: 8px 0 0;
+	color: #4f5b66;
+	font-size: 14px;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.draftsCenter__threadTag {
+	display: inline-block;
+	margin-top: 8px;
+	font-size: 11px;
+	padding: 2px 8px;
+	border-radius: 999px;
+	background: #eef2ff;
+	color: #3758b7;
+}
+
+.draftsCenter__detailCard {
+	padding: 20px;
+}
+
+.draftsCenter__detailTitle {
+	margin: 0 0 12px;
+	font-size: 20px;
+}
+
+.draftsCenter__detailText {
+	margin: 0;
+	white-space: pre-wrap;
+	line-height: 1.5;
+}
+
+.draftsCenter__detailActions {
+	display: flex;
+	gap: 10px;
+	margin-top: 20px;
+}
+
+.draftsCenter__openButton,
+.draftsCenter__deleteButton {
+	border: 0;
+	border-radius: 8px;
+	padding: 10px 14px;
+	cursor: pointer;
+}
+
+.draftsCenter__openButton {
+	background: #d63447;
+	color: #fff;
+}
+
+.draftsCenter__deleteButton {
+	background: #f1f3f5;
+	color: #29333d;
+}
+
+.draftsCenter__empty {
+	padding: 20px;
+	color: #77818b;
+}
+
+@media (max-width: 900px) {
+	.draftsCenter {
+		padding: 12px;
+	}
+	.draftsCenter__content {
+		grid-template-columns: 1fr;
+	}
+}
+
+

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -7,7 +7,7 @@ import {
 	useRef,
 	useState
 } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { SendMessageButton } from './SendMessageButton';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
@@ -173,6 +173,7 @@ export const MessageSubmitInterfaceComponent = ({
 	}, []);
 	const tenant = useTenant();
 	const history = useHistory();
+	const location = useLocation();
 	const { getDevToolbarOption } = useDevToolbar();
 
 	const textareaInputRef = useRef<HTMLDivElement>(null);
@@ -304,8 +305,43 @@ export const MessageSubmitInterfaceComponent = ({
 		setIsTypingActive(activeSession.isGroup);
 	}, [activeSession, activeSession.item.status, userData]);
 
-	const { onChange: onDraftMessageChange, loaded: draftLoaded } =
-		useDraftMessage(!isRequestInProgress, setEditorState);
+	const draftActionPath = useMemo(() => {
+		const params = new URLSearchParams(location.search);
+		params.delete('embeddedNotifications');
+		if (threadRootId) {
+			params.set('threadRootId', threadRootId);
+		} else {
+			params.delete('threadRootId');
+		}
+		const query = params.toString();
+		return `${location.pathname}${query ? `?${query}` : ''}`;
+	}, [location.pathname, location.search, threadRootId]);
+
+	const draftTitle = useMemo(() => {
+		const contact = getContact(activeSession);
+		const topicName =
+			typeof activeSession?.item?.topic === 'object'
+				? activeSession?.item?.topic?.name
+				: activeSession?.item?.topic;
+		return (
+			contact?.displayName ||
+			contact?.username ||
+			topicName ||
+			null
+		);
+	}, [activeSession]);
+
+	const {
+		onChange: onDraftMessageChange,
+		loaded: draftLoaded,
+		clearDraftMessage
+	} = useDraftMessage(!isRequestInProgress, setEditorState, {
+		threadRootId: threadRootId || null,
+		actionPath: draftActionPath,
+		sessionId: activeSession?.item?.id ?? null,
+		roomRef: activeSession?.rid ?? null,
+		title: draftTitle
+	});
 
 
 	useEffect(() => {
@@ -898,6 +934,7 @@ export const MessageSubmitInterfaceComponent = ({
 	const handleMessageSendSuccess = useCallback(() => {
 		onMessageSendSuccess?.();
 		setEditorState(EditorState.createEmpty());
+		clearDraftMessage();
 		setActiveInfo('');
 		// Force reset to default height after clearing - use multiple timeouts to ensure DOM updates
 		setTimeout(() => {
@@ -913,7 +950,7 @@ export const MessageSubmitInterfaceComponent = ({
 			resizeTextarea();
 		}, 200);
 		setTimeout(() => setIsRequestInProgress(false), 1200);
-	}, [onMessageSendSuccess, resizeTextarea]);
+	}, [clearDraftMessage, onMessageSendSuccess, resizeTextarea]);
 
 	const sendMessage = useCallback(
 		async (message, attachment: File, isEncrypted) => {

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import {
-	apiGetDraftMessage,
-	apiPostDraftMessage,
+	apiDeleteUserDraft,
+	apiGetUserDraft,
+	apiUpsertUserDraft,
 	FETCH_ERRORS,
-	IDraftMessage
+	IUserDraftItem
 } from '../../api';
 import { decryptText, encryptText } from '../../utils/encryptionHelpers';
 import { apiPostError, ERROR_LEVEL_WARN } from '../../api/apiPostError';
@@ -16,86 +17,164 @@ import {
 	addEventListener,
 	removeEventListener
 } from '../../utils/eventHandler';
+import {
+	REMOTE_DRAFT_INDEX_SCOPE
+} from '../../services/draftStore';
 
-const SAVE_DRAFT_TIMEOUT = 10000;
+const SAVE_DRAFT_TIMEOUT = 1500;
 
 export const useDraftMessage = (
 	enabled: boolean,
-	loadFunction: (state: EditorState) => void
+	loadFunction: (state: EditorState) => void,
+	options?: {
+		threadRootId?: string | null;
+		actionPath?: string | null;
+		sessionId?: number | null;
+		roomRef?: string | null;
+		title?: string | null;
+	}
 ) => {
 	const { activeSession } = useContext(ActiveSessionContext);
 	const { isE2eeEnabled } = useContext(E2EEContext);
 
 	const draftSaveTimeout = useRef(null);
-	const willUnmount = useRef(false);
 
 	const { keyID, key, encrypted, ready } = useE2EE(activeSession.rid);
 
 	const [loaded, setLoaded] = useState(false);
-	const [messageRes, setMessageRes] = useState<IDraftMessage>(null);
+	const [messageRes, setMessageRes] = useState<IUserDraftItem>(null);
 	const [message, setMessage] = useState(null);
+	const scopeId = activeSession?.rid || activeSession?.item?.id;
+	const remoteScopeKey = `scope:${String(scopeId || 'unknown')}|thread:${
+		options?.threadRootId || 'main'
+	}`;
+	const canUseRemoteApi = !!scopeId;
 
 	const setEditorWithMarkdownString = useCallback(
 		(markdownString: string) => {
 			const rawObject = markdownToDraft(markdownString);
 			const draftContent = convertFromRaw(rawObject);
-			loadFunction(EditorState.createWithContent(draftContent));
+			const editorStateWithText = EditorState.createWithContent(draftContent);
+			loadFunction(EditorState.moveFocusToEnd(editorStateWithText));
 		},
 		[loadFunction]
 	);
 
+	const updateRemoteDraftIndex = useCallback(
+		async (draftText?: string) => {
+			if (!canUseRemoteApi) {
+				return;
+			}
+			const upsertPayload = {
+				actionPath: options?.actionPath || null,
+				title: options?.title || null,
+				sessionId: options?.sessionId ?? activeSession?.item?.id ?? null,
+				roomRef: options?.roomRef ?? activeSession?.rid ?? null,
+				threadRootId: options?.threadRootId || null,
+				updatedAt: Date.now()
+			};
+			let indexMap: Record<string, any> = {};
+			try {
+				const indexRes = await apiGetUserDraft(REMOTE_DRAFT_INDEX_SCOPE);
+				indexMap = indexRes?.text ? JSON.parse(indexRes.text) : {};
+			} catch (e: any) {
+				if (e?.message !== FETCH_ERRORS.EMPTY) {
+					indexMap = {};
+				}
+			}
+
+			if (draftText && draftText.trim().length > 0) {
+				indexMap[remoteScopeKey] = upsertPayload;
+			} else {
+				delete indexMap[remoteScopeKey];
+			}
+
+			await apiUpsertUserDraft(REMOTE_DRAFT_INDEX_SCOPE, {
+				text: JSON.stringify(indexMap)
+			}).catch();
+		},
+		[
+			activeSession?.item?.id,
+			activeSession?.rid,
+			canUseRemoteApi,
+			options?.actionPath,
+			options?.roomRef,
+			options?.sessionId,
+			options?.threadRootId,
+			options?.title,
+			remoteScopeKey
+		]
+	);
+
 	// Load the draft message from the api but do not show it because its encrypted
 	useEffect(() => {
-		// MATRIX MIGRATION: Skip draft message loading for Matrix sessions (no rid) or group chats
-		// Group chats use Matrix and don't support draft messages yet
-		if (!activeSession.rid || activeSession.isGroup) {
+		const abortController = new AbortController();
+		setLoaded(false);
+		setMessageRes(null);
+		if (!canUseRemoteApi) {
 			setLoaded(true);
-			return;
+			return () => {
+				abortController?.abort();
+			};
 		}
 
-		const abortController = new AbortController();
-		apiGetDraftMessage(activeSession.rid, abortController.signal)
-			.then(setMessageRes)
+		apiGetUserDraft(remoteScopeKey, abortController.signal)
+			.then((remoteDraft) => {
+				if (!remoteDraft?.text) {
+					setLoaded(true);
+					return;
+				}
+				setMessageRes(remoteDraft);
+			})
 			.catch((e) => {
 				if (e.message === FETCH_ERRORS.EMPTY) {
 					setLoaded(true);
 					return;
 				}
-				// console.error('Error loading Draft Message: ', e);
+				setLoaded(true);
 			});
 
 		return () => {
 			abortController?.abort();
 		};
-	}, [activeSession.rid, activeSession.isGroup]);
+	}, [
+		canUseRemoteApi,
+		remoteScopeKey,
+		setEditorWithMarkdownString
+	]);
 
 	// If everything is ready for decryption, decrypt the draft message
 	useEffect(() => {
-		if (!ready || !messageRes) {
+		if (!messageRes) {
 			return;
 		}
 
-		if (!messageRes.message) {
+		if (!messageRes.text) {
 			setLoaded(true);
 			return;
 		}
 
-		if (!isE2eeEnabled || messageRes.t !== 'e2e') {
-			setEditorWithMarkdownString(messageRes.message);
-			setMessage(messageRes.message);
+		// Plain drafts must never wait for key readiness, otherwise the input can stay locked.
+		if (!isE2eeEnabled || !encrypted) {
+			setEditorWithMarkdownString(messageRes.text);
+			setMessage(messageRes.text);
 			setLoaded(true);
+			return;
+		}
+
+		if (!ready) {
 			return;
 		}
 
 		decryptText(
-			messageRes.message,
+			messageRes.text,
 			keyID,
 			key,
 			encrypted,
-			messageRes.t === 'e2e',
+			false,
 			'enc.'
 		)
-			.catch(() => messageRes.message)
+			.catch(() => messageRes.text)
 			.then((msg) => {
 				setEditorWithMarkdownString(msg);
 				setMessage(msg);
@@ -113,13 +192,11 @@ export const useDraftMessage = (
 
 	const saveDraftMessage = useCallback(
 		async (draftMessage) => {
-			// MATRIX MIGRATION: Skip draft saving for group chats (Matrix-based)
-			if (!enabled || !loaded || !activeSession.rid || activeSession.isGroup) {
+			if (!enabled || !loaded) {
 				return;
 			}
-			const groupId = activeSession.rid;
 			let message = draftMessage ?? '';
-			let encryptType = '';
+
 			if (isE2eeEnabled && encrypted && draftMessage) {
 				try {
 					message = await encryptText(
@@ -128,7 +205,6 @@ export const useDraftMessage = (
 						key,
 						'enc.'
 					);
-					encryptType = 'e2e';
 				} catch (e: any) {
 					await apiPostError({
 						name: e.name,
@@ -139,16 +215,35 @@ export const useDraftMessage = (
 				}
 			}
 
-			await apiPostDraftMessage(groupId, message, encryptType).catch();
+			if (canUseRemoteApi) {
+				await apiUpsertUserDraft(remoteScopeKey, {
+					text: message,
+					actionPath: options?.actionPath || null,
+					title: options?.title || null,
+					sourceSessionId: options?.sessionId ?? activeSession?.item?.id ?? null,
+					roomRef: options?.roomRef ?? activeSession?.rid ?? null,
+					threadRootId: options?.threadRootId || null
+				}).catch();
+				await updateRemoteDraftIndex(draftMessage);
+			}
 		},
 		[
-			activeSession.rid,
+			activeSession?.item?.id,
+			activeSession?.rid,
+			canUseRemoteApi,
 			loaded,
 			encrypted,
 			isE2eeEnabled,
 			enabled,
 			key,
-			keyID
+			keyID,
+			options?.actionPath,
+			options?.roomRef,
+			options?.sessionId,
+			options?.threadRootId,
+			options?.title,
+			remoteScopeKey,
+			updateRemoteDraftIndex
 		]
 	);
 
@@ -170,12 +265,6 @@ export const useDraftMessage = (
 		},
 		[loaded, saveDraftMessage]
 	);
-
-	useEffect(() => {
-		return () => {
-			willUnmount.current = true;
-		};
-	}, []);
 
 	const onLogout = useCallback(
 		async (args) => {
@@ -199,9 +288,6 @@ export const useDraftMessage = (
 
 	useEffect(() => {
 		return () => {
-			if (!willUnmount.current) {
-				return;
-			}
 			if (draftSaveTimeout.current) {
 				clearTimeout(draftSaveTimeout.current);
 				draftSaveTimeout.current = null;
@@ -210,8 +296,17 @@ export const useDraftMessage = (
 		};
 	}, [message, saveDraftMessage]);
 
+	const clearDraftMessage = useCallback(() => {
+		if (canUseRemoteApi) {
+			apiDeleteUserDraft(remoteScopeKey).catch();
+			updateRemoteDraftIndex('').catch();
+		}
+		setMessage('');
+	}, [canUseRemoteApi, remoteScopeKey, updateRemoteDraftIndex]);
+
 	return {
 		onChange,
-		loaded
+		loaded,
+		clearDraftMessage
 	};
 };

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -154,6 +154,31 @@ export const NotificationsCenter = () => {
 		() => resolveThreadRootId(selectedNotification),
 		[selectedNotification]
 	);
+	const canShowChatPreview = selectedNotificationCategory === 'message';
+	const embeddedChatPath = useMemo(() => {
+		if (!canShowChatPreview) {
+			return null;
+		}
+		const basePath = selectedNotification?.actionPath
+			? selectedNotification.actionPath
+			: selectedSessionId
+				? `${getDefaultSessionsPath()}/session/${selectedSessionId}${
+						selectedThreadRootId
+							? `?threadRootId=${encodeURIComponent(selectedThreadRootId)}`
+							: ''
+				  }`
+				: null;
+		if (!basePath) {
+			return null;
+		}
+		const hasQuery = basePath.includes('?');
+		return `${basePath}${hasQuery ? '&' : '?'}embeddedNotifications=1`;
+	}, [
+		canShowChatPreview,
+		selectedNotification?.actionPath,
+		selectedSessionId,
+		selectedThreadRootId
+	]);
 
 	useEffect(() => {
 		setChatReplyText('');
@@ -293,7 +318,6 @@ export const NotificationsCenter = () => {
 
 	const nextUnreadId = getNextNotificationId(selectedNotificationId, true);
 	const selectedRoomRef = resolveRoomRef(selectedNotification);
-	const canShowChatPreview = selectedNotificationCategory === 'message';
 
 	const handleSendChatReply = async () => {
 		if (
@@ -442,7 +466,13 @@ export const NotificationsCenter = () => {
 						))
 					)}
 				</div>
-				<div className="notificationsCenter__detail">
+				<div
+					className={`notificationsCenter__detail ${
+						canShowChatPreview && embeddedChatPath
+							? 'notificationsCenter__detail--embeddedChat'
+							: ''
+					}`}
+				>
 					{selectedNotification ? (
 						<div className="notificationsCenter__detailCard">
 							<h3 className="notificationsCenter__detailTitle">
@@ -475,7 +505,16 @@ export const NotificationsCenter = () => {
 									)}
 								</button>
 							</div>
-							{canShowChatPreview && (
+							{canShowChatPreview && embeddedChatPath && (
+								<div className="notificationsCenter__embeddedSession">
+									<iframe
+										title="notifications-chat-session"
+										src={embeddedChatPath}
+										className="notificationsCenter__embeddedSessionFrame"
+									/>
+								</div>
+							)}
+							{canShowChatPreview && !embeddedChatPath && (
 								<div className="notificationsCenter__chatPreview">
 								<div className="notificationsCenter__chatPreviewHeader">
 									<div className="notificationsCenter__chatPreviewTitle">

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -66,6 +66,18 @@
 		justify-content: center;
 	}
 
+	&__detail--embeddedChat {
+		overflow: hidden;
+		align-items: center;
+		justify-content: flex-start;
+		padding-top: 12px;
+
+		.notificationsCenter__detailCard {
+			padding-top: 40px;
+			margin: 0 auto;
+		}
+	}
+
 	&__listItem {
 		width: 100%;
 		display: flex;
@@ -420,6 +432,26 @@
 			grid-template-columns: 1fr;
 			height: auto;
 		}
+	}
+}
+
+.notificationsCenter {
+	&__embeddedSession {
+		width: 100%;
+		max-width: 1240px;
+		height: min(70vh, 780px);
+		border: 1px solid #f4d1d7;
+		border-radius: 12px;
+		background: #fff;
+		overflow: hidden;
+		margin: 0 auto;
+	}
+
+	&__embeddedSessionFrame {
+		width: 100%;
+		height: 100%;
+		border: 0;
+		background: #fff;
 	}
 }
 

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -76,6 +76,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const { addEventNotification } = useContext(NotificationsContext);
 	const { type } = useContext(SessionTypeContext);
 	const location = useLocation();
+	const isEmbeddedNotificationsView =
+		new URLSearchParams(location.search).get('embeddedNotifications') ===
+		'1';
 	const [isSupervisor, setIsSupervisor] = useState(false);
 
 	// Threads feature toggle (tenant-level). Master switch disables for all chat types.
@@ -619,19 +622,24 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 
 	return (
 		<div className="session">
-			<div ref={headerRef}>
-				<SessionHeaderComponent
-					consultantAbsent={
-						activeSession.consultant &&
-						activeSession.consultant.absent
-							? activeSession.consultant
-							: null
-					}
-					hasUserInitiatedStopOrLeaveRequest={
-						props.hasUserInitiatedStopOrLeaveRequest
-					}
-					bannedUsers={props.bannedUsers}
-				/>
+			<div
+				ref={headerRef}
+				style={isEmbeddedNotificationsView ? { display: 'none' } : undefined}
+			>
+				{!isEmbeddedNotificationsView && (
+					<SessionHeaderComponent
+						consultantAbsent={
+							activeSession.consultant &&
+							activeSession.consultant.absent
+								? activeSession.consultant
+								: null
+						}
+						hasUserInitiatedStopOrLeaveRequest={
+							props.hasUserInitiatedStopOrLeaveRequest
+						}
+						bannedUsers={props.bannedUsers}
+					/>
+				)}
 			</div>
 
 			<div

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -306,3 +306,52 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		opacity: 0;
 	}
 }
+
+.app__wrapper--embeddedNotifications {
+	.contentWrapper__detail {
+		overflow: hidden;
+	}
+
+	.session {
+		height: 100%;
+		min-height: 0;
+	}
+
+	.session__content {
+		overscroll-behavior: contain;
+		overflow-y: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	#session-scroll-container {
+		overflow-y: auto;
+		overflow-x: hidden;
+		overscroll-behavior: contain;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.session__content--withThread {
+		padding-right: $grid-base-three;
+	}
+
+	.session__threadPanel {
+		left: 0;
+		right: 0;
+		width: 100%;
+		border-left: none;
+	}
+
+	.session__submit-interface--withThread {
+		right: 0;
+	}
+
+	/* Header is hidden in embedded mode; ensure composer never becomes a flex filler. */
+	.messageSubmit__wrapper,
+	.session__submit-interface {
+		flex: 0 0 auto !important;
+	}
+
+	.session__threadClose {
+		display: none;
+	}
+}

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1255,6 +1255,7 @@
 			}
 		},
 		"language": "Sprache",
+		"drafts": "Entwürfe",
 		"notifications": "Benachrichtigungen",
 		"overview": "Übersicht",
 		"profile": "Profil",

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1233,6 +1233,7 @@
 			}
 		},
 		"language": "Language",
+		"drafts": "Drafts",
 		"notifications": "Notifications",
 		"overview": "Overview",
 		"profile": "Profile",

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -51,6 +51,7 @@ export const endpoints = {
 	consultingTypeServiceBase: apiUrl + '/service/consultingtypes',
 	deleteAskerAccount: apiUrl + '/service/users/account',
 	draftMessages: apiUrl + '/service/messages/draft',
+	userDrafts: apiUrl + '/service/users/drafts',
 	email: apiUrl + '/service/users/email',
 	error: apiUrl + '/service/logstash',
 	groupChatBase: apiUrl + '/service/users/chat/',

--- a/src/services/draftStore.ts
+++ b/src/services/draftStore.ts
@@ -1,0 +1,108 @@
+export const DRAFT_STORAGE_KEY = 'oriso.chatDrafts.v1';
+export const DRAFTS_UPDATED_EVENT = 'oriso:drafts-updated';
+export const REMOTE_DRAFT_INDEX_SCOPE = 'scope:__draft-index__|thread:main';
+
+export type DraftEntry = {
+	key: string;
+	userId: string;
+	text: string;
+	updatedAt: number;
+	sessionId?: number | null;
+	roomRef?: string | null;
+	threadRootId?: string | null;
+	actionPath?: string | null;
+	title?: string | null;
+};
+
+const safeGetStorage = (): Storage | null => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	try {
+		return window.localStorage;
+	} catch (_e) {
+		return null;
+	}
+};
+
+const parseStore = (): Record<string, DraftEntry> => {
+	const storage = safeGetStorage();
+	if (!storage) {
+		return {};
+	}
+	try {
+		const raw = storage.getItem(DRAFT_STORAGE_KEY);
+		if (!raw) {
+			return {};
+		}
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') {
+			return {};
+		}
+		return parsed;
+	} catch (_e) {
+		return {};
+	}
+};
+
+const persistStore = (store: Record<string, DraftEntry>) => {
+	const storage = safeGetStorage();
+	if (!storage) {
+		return;
+	}
+	storage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(store));
+	if (typeof window !== 'undefined') {
+		window.dispatchEvent(new CustomEvent(DRAFTS_UPDATED_EVENT));
+	}
+};
+
+export const buildDraftKey = (
+	userId: string | number | null | undefined,
+	scopeId: string | number | null | undefined,
+	threadRootId?: string | null
+) => {
+	return [
+		`u:${String(userId || 'anonymous')}`,
+		`scope:${String(scopeId || 'unknown')}`,
+		`thread:${threadRootId || 'main'}`
+	].join('|');
+};
+
+export const saveDraftEntry = (entry: DraftEntry) => {
+	const store = parseStore();
+	if (!entry.text || entry.text.trim().length === 0) {
+		delete store[entry.key];
+		persistStore(store);
+		return;
+	}
+	store[entry.key] = entry;
+	persistStore(store);
+};
+
+export const getDraftEntry = (key: string): DraftEntry | null => {
+	const store = parseStore();
+	return store[key] || null;
+};
+
+export const removeDraftEntry = (key: string) => {
+	const store = parseStore();
+	if (!store[key]) {
+		return;
+	}
+	delete store[key];
+	persistStore(store);
+};
+
+export const getAllDraftEntries = (
+	userId?: string | number | null
+): DraftEntry[] => {
+	const store = parseStore();
+	const values = Object.values(store);
+	const normalizedUserId = String(userId || '');
+	return values
+		.filter((entry) =>
+			normalizedUserId ? entry.userId === normalizedUserId : true
+		)
+		.sort((a, b) => b.updatedAt - a.updatedAt);
+};
+


### PR DESCRIPTION
## What
- add backend drafts API client (`/service/users/drafts`) and wire exports/endpoints
- move composer draft persistence from old/local flow to backend draft records
- add new Drafts Center page and route/navigation entry
- add draft metadata/index support for chat/thread restore behavior
- add i18n labels for Drafts navigation and page

## Fixes included
- prevent chat input lock when draft exists and plaintext draft is loaded
- hide internal draft-index record from Drafts Center list/details
- place caret at end of loaded draft text when reopening chat
- align drafts list fetch to safe page size and avoid error-page redirect behavior in draft API handling

## Verification
- linted changed files (`src/api/apiUserDrafts.ts`, `src/components/draftsCenter/DraftsCenter.tsx`, `src/components/messageSubmitInterface/useDraftMessage.tsx`)
- deployed frontend to dev and verified rollout healthy
- validated that drafts page no longer shows internal JSON entry
- validated that reopening a draft places cursor at message end

## Scope
- Repository: `ORISO-Frontend`
- Target branch: `dev`
- Source branch: `ds-drafts-system`
