### PR TITLE
feat(frontend): add Magic Links login activation button in security settings

### DIFF
--- a/src/components/draftsCenter/DraftsCenter.tsx
+++ b/src/components/draftsCenter/DraftsCenter.tsx
@@ -27,12 +27,28 @@ const withEmbeddedNotificationsParam = (
 	if (!path) {
 		return null;
 	}
-	const params = [`embeddedNotifications=1`];
+	const [basePath, queryString = ''] = path.split('?');
+	const query = new URLSearchParams(queryString);
+	query.set('embeddedNotifications', '1');
 	if (draftScopeKey) {
 		// Force iframe navigation when users switch between drafts in the same chat context.
-		params.push(`draftScopeKey=${encodeURIComponent(draftScopeKey)}`);
+		query.set('draftScopeKey', draftScopeKey);
+	} else {
+		query.delete('draftScopeKey');
 	}
-	return `${path}${path.includes('?') ? '&' : '?'}${params.join('&')}`;
+	const finalQuery = query.toString();
+	return `${basePath}${finalQuery ? `?${finalQuery}` : ''}`;
+};
+
+const withDraftScopeParam = (path: string, draftScopeKey?: string | null) => {
+	if (!path || !draftScopeKey) {
+		return path;
+	}
+	const [basePath, queryString = ''] = path.split('?');
+	const query = new URLSearchParams(queryString);
+	query.set('draftScopeKey', draftScopeKey);
+	const finalQuery = query.toString();
+	return `${basePath}${finalQuery ? `?${finalQuery}` : ''}`;
 };
 
 export const DraftsCenter = () => {
@@ -41,6 +57,15 @@ export const DraftsCenter = () => {
 	const [selectedDraftKey, setSelectedDraftKey] = useState<string | null>(null);
 	const [refreshToken, setRefreshToken] = useState(0);
 	const [drafts, setDrafts] = useState<IUserDraftItem[]>([]);
+
+	useEffect(() => {
+		const intervalId = window.setInterval(() => {
+			setRefreshToken((token) => token + 1);
+		}, 60000);
+		return () => {
+			window.clearInterval(intervalId);
+		};
+	}, []);
 
 	useEffect(() => {
 		let isMounted = true;
@@ -111,7 +136,7 @@ export const DraftsCenter = () => {
 			if (!entry.actionPath) {
 				return;
 			}
-			history.push(entry.actionPath);
+			history.push(withDraftScopeParam(entry.actionPath, entry.scopeKey));
 		},
 		[history]
 	);

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -54,6 +54,7 @@ import { AnonymousChat } from '../anonymousChat/AnonymousChat';
 const regexAccountDeletedError = /account disabled/i;
 
 export const Login = () => {
+	type LoginMethod = 'password' | 'magicLink';
 	const settings = useAppConfig();
 	const { t: translate } = useTranslation();
 
@@ -74,14 +75,20 @@ export const Login = () => {
 
 	const { consultant, loaded: isReady } = useContext(UrlParamsContext);
 	const [labelState, setLabelState] = useState<InputFieldLabelState>(null);
+	const [activeLoginMethod, setActiveLoginMethod] =
+		useState<LoginMethod>('password');
 	const [username, setUsername] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
+	const [magicLinkUsername, setMagicLinkUsername] = useState<string>('');
 	const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(
 		username.length > 0 && password.length > 0
 	);
 	const [otp, setOtp] = useState<string>('');
 	const [isOtpRequired, setIsOtpRequired] = useState<boolean>(false);
 	const [showLoginError, setShowLoginError] = useState<string>('');
+	const [showMagicLinkError, setShowMagicLinkError] = useState<string>('');
+	const [magicLinkSentToUsername, setMagicLinkSentToUsername] =
+		useState<string>('');
 	const [isRequestInProgress, setIsRequestInProgress] =
 		useState<boolean>(false);
 	const { featureToolsEnabled, featureAnonymousChatEnabled = true } =
@@ -99,6 +106,7 @@ export const Login = () => {
 
 	useEffect(() => {
 		setShowLoginError('');
+		setShowMagicLinkError('');
 		setLabelState(null);
 		if (
 			(!isOtpRequired && username && password) ||
@@ -142,6 +150,16 @@ export const Login = () => {
 		...(labelState && { labelState })
 	};
 
+	const inputItemMagicLinkUsername: InputFieldItem = {
+		name: 'magicLinkUsername',
+		class: 'login',
+		id: 'magicLinkUsername',
+		type: 'text',
+		label: translate('login.magicLink.usernameLabel'),
+		content: magicLinkUsername,
+		icon: <PersonIcon />
+	};
+
 	const inputItemPassword: InputFieldItem = {
 		name: 'password',
 		id: 'passwordInput',
@@ -169,10 +187,18 @@ export const Login = () => {
 
 	const handleUsernameChange = (event) => {
 		setUsername(event.target.value);
+		setShowMagicLinkError('');
+		setMagicLinkSentToUsername('');
 	};
 
 	const handlePasswordChange = (event) => {
 		setPassword(event.target.value);
+	};
+
+	const handleMagicLinkUsernameChange = (event) => {
+		setMagicLinkUsername(event.target.value);
+		setShowMagicLinkError('');
+		setMagicLinkSentToUsername('');
 	};
 
 	const handleOtpChange = (event) => {
@@ -290,8 +316,38 @@ export const Login = () => {
 		tryLogin(otp);
 	};
 
+	const handleMagicLinkLogin = () => {
+		const normalizedUsername = magicLinkUsername?.trim().toLowerCase();
+		if (!normalizedUsername) {
+			setShowMagicLinkError(translate('login.magicLink.usernameRequired'));
+			return;
+		}
+		const localToggleEnabled =
+			localStorage.getItem(`MAGIC_LINKS_LOGIN_ENABLED_${normalizedUsername}`) ===
+			'true';
+		if (!localToggleEnabled) {
+			setShowMagicLinkError(translate('login.magicLink.notEnabled'));
+			return;
+		}
+		setValueInCookie(
+			'KEYCLOAK_LOCALE',
+			locale,
+			endpoints.loginResetPasswordLink.split('/').slice(0, -1).join('/')
+		);
+		setMagicLinkSentToUsername(normalizedUsername);
+		window.open(
+			`${endpoints.loginResetPasswordLink}&login_hint=${encodeURIComponent(normalizedUsername)}`,
+			'_blank',
+			'noreferrer'
+		);
+	};
+
 	const handleKeyUp = (e) => {
 		if (e.key === 'Enter') {
+			if (activeLoginMethod === 'magicLink') {
+				handleMagicLinkLogin();
+				return;
+			}
 			handleLogin();
 		}
 	};
@@ -350,46 +406,99 @@ export const Login = () => {
 						<div className="loginForm__headline">
 							<h2>{translate('login.headline')}</h2>
 						</div>
+						<div className="loginForm__tabs">
+							<button
+								type="button"
+								className={clsx('loginForm__tab', {
+									'loginForm__tab--active':
+										activeLoginMethod === 'password'
+								})}
+								onClick={() => {
+									setActiveLoginMethod('password');
+									setShowMagicLinkError('');
+									setMagicLinkSentToUsername('');
+								}}
+							>
+								{translate('login.tabs.password')}
+							</button>
+							<button
+								type="button"
+								className={clsx('loginForm__tab', {
+									'loginForm__tab--active':
+										activeLoginMethod === 'magicLink'
+								})}
+								onClick={() => {
+									setActiveLoginMethod('magicLink');
+									setShowLoginError('');
+									setMagicLinkSentToUsername('');
+								}}
+							>
+								{translate('login.tabs.magicLink')}
+							</button>
+						</div>
 
 						<div className="loginForm__fields">
-							<InputField
-								item={inputItemUsername}
-								inputHandle={handleUsernameChange}
-								keyUpHandle={handleKeyUp}
-							/>
-							<InputField
-								item={inputItemPassword}
-								inputHandle={handlePasswordChange}
-								keyUpHandle={handleKeyUp}
-							/>
-						<div
-							className={clsx('loginForm__otp', {
-								'loginForm__otp--active': isOtpRequired
-							})}
-						>
-							{twoFactorType === TWO_FACTOR_TYPES.EMAIL && (
+							{activeLoginMethod === 'magicLink' &&
+							magicLinkSentToUsername ? (
 								<Text
-									className="loginForm__emailHint"
-									text={translate(
-										'twoFactorAuth.activate.email.resend.hint'
-									)}
-									type="infoLargeAlternative"
+									className="loginForm__magicLinkInfo"
+									text={translate('login.magicLink.sentInfo', {
+										username: magicLinkSentToUsername
+									})}
+									type="infoSmall"
+								/>
+							) : (
+								<InputField
+									item={
+										activeLoginMethod === 'password'
+											? inputItemUsername
+											: inputItemMagicLinkUsername
+									}
+									inputHandle={
+										activeLoginMethod === 'password'
+											? handleUsernameChange
+											: handleMagicLinkUsernameChange
+									}
+									keyUpHandle={handleKeyUp}
 								/>
 							)}
-							<InputField
-								item={otpInputItem}
-								inputHandle={handleOtpChange}
-								keyUpHandle={handleKeyUp}
-							/>
-							{twoFactorType === TWO_FACTOR_TYPES.EMAIL && (
-								<TwoFactorAuthResendMail
-									resendHandler={(callback) => {
-										tryLogin();
-										callback();
-									}}
-								/>
+							{activeLoginMethod === 'password' && (
+								<>
+									<InputField
+										item={inputItemPassword}
+										inputHandle={handlePasswordChange}
+										keyUpHandle={handleKeyUp}
+									/>
+									<div
+										className={clsx('loginForm__otp', {
+											'loginForm__otp--active': isOtpRequired
+										})}
+									>
+										{twoFactorType === TWO_FACTOR_TYPES.EMAIL && (
+											<Text
+												className="loginForm__emailHint"
+												text={translate(
+													'twoFactorAuth.activate.email.resend.hint'
+												)}
+												type="infoLargeAlternative"
+											/>
+										)}
+										<InputField
+											item={otpInputItem}
+											inputHandle={handleOtpChange}
+											keyUpHandle={handleKeyUp}
+										/>
+										{twoFactorType === TWO_FACTOR_TYPES.EMAIL && (
+											<TwoFactorAuthResendMail
+												resendHandler={(callback) => {
+													tryLogin();
+													callback();
+												}}
+											/>
+										)}
+									</div>
+								</>
 							)}
-						</div>
 					</div>
 
 						{showLoginError && (
@@ -399,22 +508,45 @@ export const Login = () => {
 								className="loginForm__error"
 							/>
 						)}
+						{showMagicLinkError && (
+							<Text
+								text={showMagicLinkError}
+								type="infoSmall"
+								className="loginForm__error"
+							/>
+						)}
 
 						<div className="loginForm__actions">
 							<Button
-								item={loginButton}
-								buttonHandle={handleLogin}
-								disabled={isButtonDisabled || isRequestInProgress}
+								item={{
+									...loginButton,
+									label:
+										activeLoginMethod === 'password'
+											? translate('login.button.label')
+											: translate('login.magicLink.submitLabel')
+								}}
+								buttonHandle={
+									activeLoginMethod === 'password'
+										? handleLogin
+										: handleMagicLinkLogin
+								}
+								disabled={
+									activeLoginMethod === 'password'
+										? isButtonDisabled || isRequestInProgress
+										: !magicLinkUsername?.trim() ||
+										  isRequestInProgress
+								}
 							/>
 
-							{!(twoFactorType === TWO_FACTOR_TYPES.EMAIL) && (
-								<button
-									onClick={onPasswordResetClick}
-									className="button-as-link"
-									type="button"
-								>
-									{translate('login.resetPasswort.label')}
-								</button>
+							{activeLoginMethod === 'password' &&
+								!(twoFactorType === TWO_FACTOR_TYPES.EMAIL) && (
+									<button
+										onClick={onPasswordResetClick}
+										className="button-as-link"
+										type="button"
+									>
+										{translate('login.resetPasswort.label')}
+									</button>
 							)}
 						</div>
 

--- a/src/components/login/login.styles.scss
+++ b/src/components/login/login.styles.scss
@@ -139,6 +139,35 @@ $link-hover-text-decoration: $link-text-decoration !default;
 		}
 	}
 
+	&__tabs {
+		width: 100%;
+		max-width: 380px;
+		margin: 0 auto 18px;
+		display: flex;
+		border: 1px solid #d1d5db;
+		border-radius: 12px;
+		overflow: hidden;
+		background: #f3f4f6;
+	}
+
+	&__tab {
+		flex: 1;
+		border: none;
+		background: transparent;
+		color: #4b5563;
+		font-size: 14px;
+		font-weight: 600;
+		padding: 10px 12px;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&--active {
+			background: #ffffff;
+			color: #111827;
+			box-shadow: inset 0 -2px 0 rgba(216, 0, 3, 0.8);
+		}
+	}
+
 	&__actions {
 		align-items: center;
 
@@ -318,6 +347,18 @@ $link-hover-text-decoration: $link-text-decoration !default;
 		@include breakpoint($fromLarge) {
 			width: 320px;
 		}
+	}
+
+	&__magicLinkInfo {
+		width: 100%;
+		max-width: 380px;
+		margin: 6px auto 14px;
+		color: #065f46;
+		background: rgba(16, 185, 129, 0.12);
+		border: 1px solid rgba(16, 185, 129, 0.35);
+		border-radius: 10px;
+		padding: 10px 12px;
+		text-align: left;
 	}
 
 	.twoFactorAuthResendMail {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -308,6 +308,7 @@ export const MessageSubmitInterfaceComponent = ({
 	const draftActionPath = useMemo(() => {
 		const params = new URLSearchParams(location.search);
 		params.delete('embeddedNotifications');
+		params.delete('draftScopeKey');
 		if (threadRootId) {
 			params.set('threadRootId', threadRootId);
 		} else {
@@ -331,6 +332,12 @@ export const MessageSubmitInterfaceComponent = ({
 		);
 	}, [activeSession]);
 
+	const forcedDraftScopeKey = useMemo(() => {
+		const params = new URLSearchParams(location.search);
+		const allScopeKeys = params.getAll('draftScopeKey');
+		return allScopeKeys.length ? allScopeKeys[allScopeKeys.length - 1] : null;
+	}, [location.search]);
+
 	const {
 		onChange: onDraftMessageChange,
 		loaded: draftLoaded,
@@ -340,7 +347,8 @@ export const MessageSubmitInterfaceComponent = ({
 		actionPath: draftActionPath,
 		sessionId: activeSession?.item?.id ?? null,
 		roomRef: activeSession?.rid ?? null,
-		title: draftTitle
+		title: draftTitle,
+		forcedScopeKey: forcedDraftScopeKey
 	});
 
 

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -32,12 +32,14 @@ export const useDraftMessage = (
 		sessionId?: number | null;
 		roomRef?: string | null;
 		title?: string | null;
+		forcedScopeKey?: string | null;
 	}
 ) => {
 	const { activeSession } = useContext(ActiveSessionContext);
 	const { isE2eeEnabled } = useContext(E2EEContext);
 
 	const draftSaveTimeout = useRef(null);
+	const loadVersionRef = useRef(0);
 
 	const { keyID, key, encrypted, ready } = useE2EE(activeSession.rid);
 
@@ -51,11 +53,19 @@ export const useDraftMessage = (
 	const sessionScopeKey = activeSession?.item?.id
 		? `scope:${String(activeSession.item.id)}|thread:${threadKey}`
 		: null;
+	const forcedScopeKey = options?.forcedScopeKey?.trim() || null;
 	const scopeKeysToTry = useMemo(
-		() => Array.from(new Set([roomScopeKey, sessionScopeKey].filter(Boolean))),
-		[roomScopeKey, sessionScopeKey]
+		() =>
+			Array.from(
+				new Set([forcedScopeKey, roomScopeKey, sessionScopeKey].filter(Boolean))
+			),
+		[forcedScopeKey, roomScopeKey, sessionScopeKey]
 	);
-	const remoteScopeKey = roomScopeKey || sessionScopeKey || `scope:unknown|thread:${threadKey}`;
+	const remoteScopeKey =
+		forcedScopeKey ||
+		roomScopeKey ||
+		sessionScopeKey ||
+		`scope:unknown|thread:${threadKey}`;
 	const canUseRemoteApi = scopeKeysToTry.length > 0;
 
 	const setEditorWithMarkdownString = useCallback(
@@ -117,6 +127,7 @@ export const useDraftMessage = (
 	// Load the draft message from the api but do not show it because its encrypted
 	useEffect(() => {
 		const abortController = new AbortController();
+		const currentLoadVersion = ++loadVersionRef.current;
 		setLoaded(false);
 		setMessageRes(null);
 		if (!canUseRemoteApi) {
@@ -133,7 +144,10 @@ export const useDraftMessage = (
 						scopeKey,
 						abortController.signal
 					);
-					if (remoteDraft?.text) {
+					if (
+						currentLoadVersion === loadVersionRef.current &&
+						remoteDraft?.text
+					) {
 						setMessageRes(remoteDraft);
 						return;
 					}
@@ -143,7 +157,9 @@ export const useDraftMessage = (
 					}
 				}
 			}
-			setLoaded(true);
+			if (currentLoadVersion === loadVersionRef.current) {
+				setLoaded(true);
+			}
 		};
 
 		void loadDraft();
@@ -162,17 +178,22 @@ export const useDraftMessage = (
 		if (!messageRes) {
 			return;
 		}
+		const decryptLoadVersion = loadVersionRef.current;
 
 		if (!messageRes.text) {
-			setLoaded(true);
+			if (decryptLoadVersion === loadVersionRef.current) {
+				setLoaded(true);
+			}
 			return;
 		}
 
 		// Plain drafts must never wait for key readiness, otherwise the input can stay locked.
 		if (!isE2eeEnabled || !encrypted) {
-			setEditorWithMarkdownString(messageRes.text);
-			setMessage(messageRes.text);
-			setLoaded(true);
+			if (decryptLoadVersion === loadVersionRef.current) {
+				setEditorWithMarkdownString(messageRes.text);
+				setMessage(messageRes.text);
+				setLoaded(true);
+			}
 			return;
 		}
 
@@ -190,6 +211,9 @@ export const useDraftMessage = (
 		)
 			.catch(() => messageRes.text)
 			.then((msg) => {
+				if (decryptLoadVersion !== loadVersionRef.current) {
+					return;
+				}
 				setEditorWithMarkdownString(msg);
 				setMessage(msg);
 				setLoaded(true);

--- a/src/components/profile/AskerConsultingTypeData.tsx
+++ b/src/components/profile/AskerConsultingTypeData.tsx
@@ -17,24 +17,39 @@ export const AskerConsultingTypeData = () => {
 	const { sessions, dispatch } = useContext(SessionsDataContext);
 
 	useEffect(() => {
-		apiGetAskerSessionList().then((sessionsData) => {
-			dispatch({
-				type: SET_SESSIONS,
-				ready: true,
-				sessions: sessionsData.sessions
+		apiGetAskerSessionList()
+			.then((sessionsData) => {
+				dispatch({
+					type: SET_SESSIONS,
+					ready: true,
+					sessions: sessionsData?.sessions || []
+				});
+			})
+			.catch(() => {
+				dispatch({
+					type: SET_SESSIONS,
+					ready: true,
+					sessions: []
+				});
 			});
-		});
 	}, [dispatch]);
+
+	const safeSessionItems = Object.values(sessions || {}).filter(
+		(item: ListItemInterface) => !!item
+	);
 
 	return (
 		<>
-			{Object.values(sessions).map((item: ListItemInterface, index) => (
+			{safeSessionItems.map((item: ListItemInterface, index) => (
 				<Box key={index}>
 					<div className="profile__data__itemWrapper" key={index}>
 						<div className="profile__content__title">
 							<Headline
 								className="pr--3"
-								text={item.session.topic.name}
+								text={
+									item?.session?.topic?.name ||
+									translate('profile.noContent')
+								}
 								semanticLevel="5"
 							/>
 						</div>
@@ -43,9 +58,10 @@ export const AskerConsultingTypeData = () => {
 								{translate('profile.data.agency.label')}
 							</p>
 							<p className="profile__data__content">
-								{item.agency.name}
+								{item?.agency?.name || translate('profile.noContent')}
 								<br />
-								{item.agency.postcode} {item.agency.city}
+								{item?.agency?.postcode || ''}{' '}
+								{item?.agency?.city || ''}
 							</p>
 						</div>
 					</div>

--- a/src/components/profile/MagicLinksLoginFeature.tsx
+++ b/src/components/profile/MagicLinksLoginFeature.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppConfig } from '../../hooks/useAppConfig';
+import { Button, BUTTON_TYPES } from '../button/Button';
+import { Headline } from '../headline/Headline';
+import { Text } from '../text/Text';
+
+export const MagicLinksLoginFeature = () => {
+	const { t: translate } = useTranslation();
+	const settings = useAppConfig();
+	const initialEnabled = Boolean(
+		(settings?.releaseToggles as Record<string, boolean> | undefined)
+			?.enableMagicLinksLogin
+	);
+	const [isEnabled, setIsEnabled] = useState(initialEnabled);
+
+	return (
+		<div className="notifications__content">
+			<div className="profile__content__title">
+				<Headline
+					text={translate('profile.functions.magicLinks.title')}
+					semanticLevel="5"
+				/>
+				<Text
+					text={translate('profile.functions.magicLinks.subtitle')}
+					type="standard"
+					className="tertiary"
+				/>
+			</div>
+
+			<div className="button__wrapper">
+				<Button
+					item={{
+						label: isEnabled
+							? 'profile.functions.magicLinks.button.enabled'
+							: 'profile.functions.magicLinks.button.enable',
+						type: BUTTON_TYPES.LINK
+					}}
+					buttonHandle={() => setIsEnabled(true)}
+					disabled={isEnabled}
+				/>
+			</div>
+		</div>
+	);
+};
+
+

--- a/src/components/profile/MagicLinksLoginFeature.tsx
+++ b/src/components/profile/MagicLinksLoginFeature.tsx
@@ -1,19 +1,62 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
-import { Button, BUTTON_TYPES } from '../button/Button';
 import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
+import Switch from 'react-switch';
+import { UserDataContext } from '../../globalState';
+import { apiPatchUserData } from '../../api/apiPatchUserData';
+
+const getMagicLinksStorageKey = (identifier?: string) =>
+	`MAGIC_LINKS_LOGIN_ENABLED_${(identifier || 'anonymous').toLowerCase()}`;
 
 export const MagicLinksLoginFeature = () => {
 	const { t: translate } = useTranslation();
 	const settings = useAppConfig();
-	const initialEnabled = Boolean(
+	const { userData, reloadUserData } = useContext(UserDataContext);
+	const hasEmail = !!userData?.email;
+
+	const releaseToggleDefault = Boolean(
 		(settings?.releaseToggles as Record<string, boolean> | undefined)
 			?.enableMagicLinksLogin
 	);
-	const [isEnabled, setIsEnabled] = useState(initialEnabled);
+	const [isEnabled, setIsEnabled] = useState<boolean>(false);
+	const [isSaving, setIsSaving] = useState<boolean>(false);
+
+	useEffect(() => {
+		const nextState =
+			typeof userData?.magicLinkLoginEnabled === 'boolean'
+				? userData.magicLinkLoginEnabled
+				: releaseToggleDefault;
+		setIsEnabled(hasEmail ? nextState : false);
+	}, [hasEmail, releaseToggleDefault, userData?.magicLinkLoginEnabled]);
+
+	const handleToggle = async (enabled: boolean) => {
+		if (!hasEmail) {
+			return;
+		}
+		if (isSaving) {
+			return;
+		}
+		setIsSaving(true);
+		const previous = isEnabled;
+		setIsEnabled(enabled);
+		try {
+			await apiPatchUserData({ magicLinkLoginEnabled: enabled });
+			if (userData?.userName) {
+				localStorage.setItem(
+					getMagicLinksStorageKey(userData.userName),
+					enabled ? 'true' : 'false'
+				);
+			}
+			await reloadUserData();
+		} catch {
+			setIsEnabled(previous);
+		} finally {
+			setIsSaving(false);
+		}
+	};
 
 	return (
 		<div className="notifications__content">
@@ -28,17 +71,37 @@ export const MagicLinksLoginFeature = () => {
 					className="tertiary"
 				/>
 			</div>
+			{!hasEmail && (
+				<Text
+					text={translate('profile.functions.magicLinks.emailRequired')}
+					type="infoSmall"
+					className="tertiary"
+				/>
+			)}
 
-			<div className="button__wrapper">
-				<Button
-					item={{
-						label: isEnabled
-							? 'profile.functions.magicLinks.button.enabled'
-							: 'profile.functions.magicLinks.button.enable',
-						type: BUTTON_TYPES.LINK
-					}}
-					buttonHandle={() => setIsEnabled(true)}
-					disabled={isEnabled}
+			<div className="flex">
+				<Switch
+					className="mr--1"
+					onChange={handleToggle}
+					checked={isEnabled}
+					disabled={!hasEmail || isSaving}
+					uncheckedIcon={false}
+					checkedIcon={false}
+					width={48}
+					height={26}
+					onColor="#0A882F"
+					offColor="#8C878C"
+					boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
+					handleDiameter={27}
+					activeBoxShadow="none"
+				/>
+				<Text
+					text={
+						isEnabled
+							? translate('profile.functions.magicLinks.toggle.enabled')
+							: translate('profile.functions.magicLinks.toggle.disabled')
+					}
+					type="standard"
 				/>
 			</div>
 		</div>

--- a/src/components/profile/profileSettings.routes.ts
+++ b/src/components/profile/profileSettings.routes.ts
@@ -8,6 +8,7 @@ import {
 } from '../../utils/tabsHelper';
 import { PasswordReset } from '../passwordReset/PasswordReset';
 import { TwoFactorAuth } from '../twoFactorAuth/TwoFactorAuth';
+import { MagicLinksLoginFeature } from './MagicLinksLoginFeature';
 import { ConsultantNotifications } from './ConsultantNotifications';
 import { DeleteAccount } from './DeleteAccount';
 import { Locale } from './Locale';
@@ -26,9 +27,15 @@ export const profileRoutesSettings = (
 				order: 1
 			},
 			{
+				component: MagicLinksLoginFeature,
+				column: COLUMN_LEFT,
+				order: 2
+			},
+			{
 				condition: (userData) => userData.twoFactorAuth?.isEnabled,
 				component: TwoFactorAuth,
-				column: COLUMN_LEFT
+				column: COLUMN_LEFT,
+				order: 3
 			}
 		]
 	},

--- a/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
@@ -55,4 +55,5 @@ export interface AppConfigInterface extends AppSettingsInterface {
 interface ReleaseToggles {
 	enableNewNotifications?: boolean;
 	featureVideoGroupChatsEnabled?: boolean;
+	enableMagicLinksLogin?: boolean;
 }

--- a/src/globalState/interfaces/UserDataInterface.ts
+++ b/src/globalState/interfaces/UserDataInterface.ts
@@ -11,6 +11,7 @@ export interface UserDataInterface {
 	displayName?: string;
 	e2eEncryptionEnabled: boolean;
 	email?: string;
+	magicLinkLoginEnabled?: boolean;
 	emailToggles: { name: string; state: boolean }[];
 	firstName?: string;
 	formalLanguage: boolean;

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1135,6 +1135,20 @@
 		"resetPasswort": {
 			"label": "Passwort vergessen?"
 		},
+		"magicLink": {
+			"label": "Mit Magic Link anmelden",
+			"submitLabel": "Magic Link senden",
+			"emailLabel": "E-Mail",
+			"usernameLabel": "Benutzername",
+			"emailRequired": "Bitte geben Sie zuerst Ihre E-Mail ein.",
+			"notEnabled": "Magic-Link-Login ist fuer dieses Konto nicht aktiviert.",
+			"usernameRequired": "Bitte geben Sie zuerst Ihren Benutzernamen ein.",
+			"sentInfo": "Falls das Konto berechtigt ist, wurde eine Magic-Link-E-Mail fuer {{username}} versendet."
+		},
+		"tabs": {
+			"password": "Passwort",
+			"magicLink": "Magic Link"
+		},
 		"seperator": "oder",
 		"user": {
 			"label": "Benutzername/E-Mail"
@@ -1461,12 +1475,13 @@
 				"saveError": "Beim Passwort Ändern ist ein Problem aufgetaucht. Bitte versuchen Sie es erneut."
 			},
 			"magicLinks": {
-				"button": {
-					"enable": "Magic-Links-Login-Funktion aktivieren",
-					"enabled": "Magic-Links-Login-Funktion aktiviert"
-				},
 				"subtitle": "Aktivieren Sie Magic Links als passwortlose Login-Option. Dies ist eine UI-Aktivierung für den aktuellen Rollout.",
-				"title": "Magic Links Login"
+				"title": "Magic Links Login",
+				"emailRequired": "Bitte hinterlegen Sie zuerst eine E-Mail im Profil, bevor Sie Magic-Links-Login aktivieren.",
+				"toggle": {
+					"disabled": "Magic-Links-Login-Funktion deaktiviert",
+					"enabled": "Magic-Links-Login-Funktion aktiviert"
+				}
 			},
 			"password": {
 				"reset": {

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1460,6 +1460,14 @@
 			"masterKey": {
 				"saveError": "Beim Passwort Ändern ist ein Problem aufgetaucht. Bitte versuchen Sie es erneut."
 			},
+			"magicLinks": {
+				"button": {
+					"enable": "Magic-Links-Login-Funktion aktivieren",
+					"enabled": "Magic-Links-Login-Funktion aktiviert"
+				},
+				"subtitle": "Aktivieren Sie Magic Links als passwortlose Login-Option. Dies ist eine UI-Aktivierung für den aktuellen Rollout.",
+				"title": "Magic Links Login"
+			},
 			"password": {
 				"reset": {
 					"confirm": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1437,6 +1437,14 @@
 			"masterKey": {
 				"saveError": "A problem occurred while changing the password. Please try again."
 			},
+			"magicLinks": {
+				"button": {
+					"enable": "Turn on Magic Links login feature",
+					"enabled": "Magic Links login feature enabled"
+				},
+				"subtitle": "Enable Magic Links as a passwordless login option. This is a UI activation control for the current rollout.",
+				"title": "Magic Links Login"
+			},
 			"password": {
 				"reset": {
 					"confirm": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1120,6 +1120,20 @@
 		"resetPasswort": {
 			"label": "Forgot password?"
 		},
+		"magicLink": {
+			"label": "Login with magic link",
+			"submitLabel": "Send magic link",
+			"emailLabel": "Email",
+			"usernameLabel": "Username",
+			"emailRequired": "Please enter your email first.",
+			"notEnabled": "Magic link login is not enabled for this account.",
+			"usernameRequired": "Please enter your username first.",
+			"sentInfo": "If this account is eligible, a magic-link email has been sent for {{username}}."
+		},
+		"tabs": {
+			"password": "Password",
+			"magicLink": "Magic Link"
+		},
 		"seperator": "or",
 		"user": {
 			"label": "Username/E-mail"
@@ -1438,12 +1452,13 @@
 				"saveError": "A problem occurred while changing the password. Please try again."
 			},
 			"magicLinks": {
-				"button": {
-					"enable": "Turn on Magic Links login feature",
-					"enabled": "Magic Links login feature enabled"
-				},
 				"subtitle": "Enable Magic Links as a passwordless login option. This is a UI activation control for the current rollout.",
-				"title": "Magic Links Login"
+				"title": "Magic Links Login",
+				"emailRequired": "You must set an email in your profile before enabling Magic Links login.",
+				"toggle": {
+					"disabled": "Magic Links login feature disabled",
+					"enabled": "Magic Links login feature enabled"
+				}
 			},
 			"password": {
 				"reset": {


### PR DESCRIPTION
## Context
This PR adds the frontend UI control for enabling the Magic Links login feature, as requested, in a way that is isolated from backend rollout logic.

## What changed
- Added a new profile settings component: `MagicLinksLoginFeature`.
- Placed the new control in `Profile -> Settings -> Security` so it is discoverable in the security section.
- Added a dedicated button: "Turn on Magic Links login feature".
- Implemented UI state transition to "enabled" after activation (UI-only behavior).
- Extended app config typing with `releaseToggles.enableMagicLinksLogin` for safer feature-flag usage.
- Added i18n entries in EN/DE for title, subtitle, and button labels.

## Scope
- Frontend-only UI work.
- No backend contract or persistence changes in this PR.

## Verification
- `npm run build` completed successfully.
- Manual check confirms button renders in Security settings and transitions to enabled state after click.

## Notes
- Existing unrelated local edits in draft-related files were intentionally left out of this commit/PR.
