### PR TITLE
Fix hardcoded URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 VITE_PORT=9002
-VITE_API_URL=https://api.oriso.site
+VITE_API_URL=https://api.oriso.org
 VITE_USE_API_URL=true
 VITE_USE_HTTPS=true
 VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-CSRF-Token
 
 # API Url
-REACT_APP_API_URL=https://api.oriso.site
+REACT_APP_API_URL=https://api.oriso.org
 
 # Disable error boundary handling 0/1 (for dev)
 REACT_APP_DISABLE_ERROR_BOUNDARY=1

--- a/.env.example
+++ b/.env.example
@@ -16,15 +16,39 @@ REACT_APP_COOKIES_ALLOWEDLIST=devProxy
 # CSRF whitelist header for local development
 CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-WHITELIST-HEADER
 
-# Matrix Homeserver URL
+# Matrix Synapse / client homeserver (HTTPS in production)
 REACT_APP_MATRIX_HOMESERVER_URL=https://matrix.oriso.site
 VITE_MATRIX_HOMESERVER_URL=https://matrix.oriso.site
 
 # Cookie domain for cross-subdomain sharing
 REACT_APP_COOKIE_DOMAIN=.oriso.site
 
-# Element UI URL
+# Hostnames where the UI-version cookie must not set a shared Domain attribute (comma-separated)
+REACT_APP_HOSTNAMES_WITHOUT_COOKIE_DOMAIN=91.99.219.182,localhost
+
+# Element Web (classic vs new UI redirect target)
 REACT_APP_ELEMENT_URL=https://element.oriso.site
+
+# Element Call deployment base URL (no trailing slash)
+REACT_APP_ELEMENT_CALL_BASE_URL=https://call.oriso.site
+
+# LiveKit WebSocket URL (wss:// in production)
+REACT_APP_LIVEKIT_WS_URL=wss://livekit.oriso.site
+
+# Public / legal / marketing links (override for white-label)
+REACT_APP_ORGANIZATION_HOME_URL=https://www.caritas.de
+REACT_APP_ORGANIZATION_ONLINEBERATUNG_URL=https://www.caritas.de/onlineberatung
+REACT_APP_LEGAL_IMPRINT_URL=https://www.caritas-beratungundhilfe.de/impressum
+REACT_APP_LEGAL_PRIVACY_URL=https://www.caritas-beratungundhilfe.de/datenschutz
+
+# Browser download pages (help / video call)
+REACT_APP_BROWSER_DOWNLOAD_CHROME_URL=https://www.google.com/chrome/
+REACT_APP_BROWSER_DOWNLOAD_EDGE_URL=https://www.microsoft.com/edge
+REACT_APP_BROWSER_DOWNLOAD_SAFARI_URL=https://www.apple.com/de/safari/
 
 # HTTPS flag for secure cookies
 REACT_APP_USE_HTTPS=true
+
+# Node proxy only: LiveKit token service (GET and POST /api/livekit/token)
+# Example for Kubernetes: http://livekit-token-service.caritas.svc.cluster.local:3010
+LIVEKIT_TOKEN_SERVICE_URL=http://livekit-token-service.caritas.svc.cluster.local:3010

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -176,16 +176,22 @@ module.exports = function (webpackEnv) {
 					loader: require.resolve(preProcessor),
 					options: {
 						additionalData: (content) => {
-							let newContent = `@import "${path.resolve(
-								paths.appSrc,
-								'resources/styles/settings.scss'
-							)}"; `;
+							const settingsMain = path
+								.resolve(
+									paths.appSrc,
+									'resources/styles/settings.scss'
+								)
+								.replace(/\\/g, '/');
+							let newContent = `@import "${settingsMain}"; `;
 							const settingsPathExtensions = path.resolve(
 								paths.appExtensions,
 								'resources/styles/settings.scss'
 							);
 							if (fs.existsSync(settingsPathExtensions)) {
-								newContent += `@import "${settingsPathExtensions}"; `;
+								newContent += `@import "${settingsPathExtensions.replace(
+									/\\/g,
+									'/'
+								)}"; `;
 							}
 							return `${newContent} ${content}`;
 						},
@@ -651,7 +657,24 @@ module.exports = function (webpackEnv) {
 			),
 			new CopyPlugin({
 				patterns: [
-					{ from: getTemplate('pages/under-construction.html') }
+					{
+						from: getTemplate('pages/under-construction.html'),
+						transform(content) {
+							const onlineUrl =
+								env.raw
+									.REACT_APP_ORGANIZATION_ONLINEBERATUNG_URL ||
+								'https://www.caritas.de/onlineberatung';
+							return Buffer.from(
+								content
+									.toString()
+									.split(
+										'__REACT_APP_ORGANIZATION_ONLINEBERATUNG_URL__'
+									)
+									.join(onlineUrl),
+								'utf8'
+							);
+						}
+					}
 				]
 			}),
 			// Inlines the webpack runtime script. This script is too small to warrant

--- a/k8s-temp-frontend.yaml
+++ b/k8s-temp-frontend.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 80
         env:
         - name: REACT_APP_API_URL
-          value: "https://api.oriso.site"
+          value: "https://api.oriso.org"
 ---
 apiVersion: v1
 kind: Service

--- a/k8s-temp-frontend.yaml
+++ b/k8s-temp-frontend.yaml
@@ -22,6 +22,15 @@ spec:
         env:
         - name: REACT_APP_API_URL
           value: "https://api.oriso.org"
+        volumeMounts:
+        - name: runtime-config
+          mountPath: /usr/share/nginx/html/config.js
+          subPath: config.js
+          readOnly: true
+      volumes:
+      - name: runtime-config
+        configMap:
+          name: frontend-temp-runtime-config
 ---
 apiVersion: v1
 kind: Service

--- a/k8s-temp-runtime-configmap.yaml
+++ b/k8s-temp-runtime-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-temp-runtime-config
+  namespace: caritas
+data:
+  config.js: |
+    window.__ORISO_RUNTIME_CONFIG__ = {
+      REACT_APP_API_URL: "https://api.oriso.org"
+    };

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -47,24 +47,36 @@ const createServer = async () => {
 		try {
 			console.log('🔑 Proxying LiveKit token request:', req.query);
 			const { roomName, identity } = req.query;
-			
+
 			if (!roomName || !identity) {
-				return res.status(400).json({ error: 'roomName and identity are required' });
+				return res
+					.status(400)
+					.json({ error: 'roomName and identity are required' });
 			}
 
-			const livekitTokenServiceUrl = process.env.LIVEKIT_TOKEN_SERVICE_URL || 'http://livekit-token-service.caritas.svc.cluster.local:3010';
-			const targetUrl = `${livekitTokenServiceUrl}/api/livekit/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(identity)}`;
-			
+			const livekitTokenServiceBase = (
+				process.env.LIVEKIT_TOKEN_SERVICE_URL || ''
+			).replace(/\/+$/, '');
+			if (!livekitTokenServiceBase) {
+				return res.status(503).json({
+					error: 'LIVEKIT_TOKEN_SERVICE_URL is not configured'
+				});
+			}
+			const targetUrl = `${livekitTokenServiceBase}/api/livekit/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(identity)}`;
+
 			console.log('📡 Fetching from:', targetUrl);
-			
+
 			const response = await fetch(targetUrl);
 			const data = await response.json();
-			
+
 			console.log('✅ Token received, forwarding to client');
 			res.json(data);
 		} catch (error) {
 			console.error('❌ LiveKit token proxy error:', error);
-			res.status(500).json({ error: 'Failed to get LiveKit token', details: error.message });
+			res.status(500).json({
+				error: 'Failed to get LiveKit token',
+				details: error.message
+			});
 		}
 	});
 
@@ -82,11 +94,22 @@ const createServer = async () => {
 	// LiveKit token service proxy
 	app.post('/api/livekit/token', async (req, res) => {
 		try {
-			const response = await fetch('http://livekit-token-service.caritas.svc.cluster.local:3010/api/livekit/token', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(req.body)
-			});
+			const livekitTokenServiceBase = (
+				process.env.LIVEKIT_TOKEN_SERVICE_URL || ''
+			).replace(/\/+$/, '');
+			if (!livekitTokenServiceBase) {
+				return res.status(503).json({
+					error: 'LIVEKIT_TOKEN_SERVICE_URL is not configured'
+				});
+			}
+			const response = await fetch(
+				`${livekitTokenServiceBase}/api/livekit/token`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(req.body)
+				}
+			);
 			const data = await response.json();
 			res.json(data);
 		} catch (error) {

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,1 @@
+window.__ORISO_RUNTIME_CONFIG__ = window.__ORISO_RUNTIME_CONFIG__ || {};

--- a/src/api/matrix/matrixClient.ts.backup
+++ b/src/api/matrix/matrixClient.ts.backup
@@ -5,7 +5,10 @@
 
 import * as sdk from 'matrix-js-sdk';
 
-const MATRIX_BASE_URL = process.env.REACT_APP_MATRIX_URL || 'http://91.99.219.182:8089';
+const MATRIX_BASE_URL =
+	process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
+	process.env.REACT_APP_MATRIX_URL ||
+	'';
 const MATRIX_SERVER_NAME = 'caritas.local';
 
 let matrixClient: any = null;

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -55,7 +55,7 @@ export const AuthenticatedApp = ({
 		// CRITICAL: Clear ALL old notifications on app mount (prevents phantom call notifications!)
 		// console.log('🧹 Clearing all old notifications on app mount...');
 		setNotifications([]);
-		
+
 		// When the user has a group chat id that means that we need to join the user in the group chat
 		const gcid = new URLSearchParams(window.location.search).get('gcid');
 		joinGroupChat(gcid);
@@ -90,46 +90,60 @@ export const AuthenticatedApp = ({
 						})
 						.then(async (userProfileData) => {
 							// 🔷 CRITICAL: Initialize Matrix client for all authenticated users
-							const matrixUserId = localStorage.getItem('matrix_user_id');
-							const matrixAccessToken = localStorage.getItem('matrix_access_token');
-							const matrixDeviceId = localStorage.getItem('matrix_device_id');
-							
+							const matrixUserId =
+								localStorage.getItem('matrix_user_id');
+							const matrixAccessToken = localStorage.getItem(
+								'matrix_access_token'
+							);
+							const matrixDeviceId =
+								localStorage.getItem('matrix_device_id');
+
 							if (matrixUserId && matrixAccessToken) {
 								// console.log('🔷 Initializing Matrix client for user:', matrixUserId);
-								
+
 								// CRITICAL: Set rc_uid and rc_token cookies for backend compatibility
 								// Backend still expects these headers even though we're using Matrix
-								const { setValueInCookie } = await import('../sessionCookie/accessSessionCookie');
+								const { setValueInCookie } = await import(
+									'../sessionCookie/accessSessionCookie'
+								);
 								setValueInCookie('rc_uid', matrixUserId);
 								setValueInCookie('rc_token', matrixAccessToken);
 								// console.log('🔷 Matrix credentials saved to cookies (rc_uid, rc_token) for backend compatibility');
-								
+
 								try {
-									const { MatrixClientService } = await import('../../services/matrixClientService');
-									const matrixClientService = new MatrixClientService();
-									
-									// Get homeserver URL from settings or use default
-									const homeserverUrl = process.env.REACT_APP_MATRIX_HOMESERVER_URL || 'http://91.99.219.182:8008';
-									
-								matrixClientService.initializeClient({
-									userId: matrixUserId,
-									accessToken: matrixAccessToken,
-									deviceId: matrixDeviceId || undefined,
-									homeserverUrl: homeserverUrl
-								});
-								
-								// Store globally for components to access
-								(window as any).matrixClientService = matrixClientService;
-								(window as any).callContext = callContext; // Make CallContext globally accessible
-								
-								// console.log('✅ Matrix client initialized successfully!');
-								
-								// CRITICAL: Initialize event bridge IMMEDIATELY after client init
-								// This ensures event listeners are registered BEFORE sync starts
-								const { matrixLiveEventBridge } = await import('../../services/matrixLiveEventBridge');
-								// console.log('📞 Initializing Matrix event bridge early...');
-								matrixLiveEventBridge.initialize(matrixClientService.getClient()!);
-								// console.log('✅ Matrix event bridge ready for call events!');
+									const { MatrixClientService } =
+										await import(
+											'../../services/matrixClientService'
+										);
+									const matrixClientService =
+										new MatrixClientService();
+
+									const homeserverUrl =
+										process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+									if (!homeserverUrl) {
+										// console.warn('⚠️ REACT_APP_MATRIX_HOMESERVER_URL is not set; skipping Matrix client init');
+									} else {
+										matrixClientService.initializeClient({
+											userId: matrixUserId,
+											accessToken: matrixAccessToken,
+											deviceId:
+												matrixDeviceId || undefined,
+											homeserverUrl: homeserverUrl
+										});
+
+										(window as any).matrixClientService =
+											matrixClientService;
+										(window as any).callContext =
+											callContext;
+
+										const { matrixLiveEventBridge } =
+											await import(
+												'../../services/matrixLiveEventBridge'
+											);
+										matrixLiveEventBridge.initialize(
+											matrixClientService.getClient()!
+										);
+									}
 								} catch (error) {
 									// console.warn('⚠️ Matrix client initialization failed:', error);
 									// Don't fail app startup if Matrix fails
@@ -137,7 +151,7 @@ export const AuthenticatedApp = ({
 							} else {
 								// console.warn('⚠️ No Matrix credentials found in localStorage');
 							}
-							
+
 							setAppReady(true);
 						})
 						.catch((error) => {

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -9,480 +9,552 @@ import { callManager, CallData } from '../../services/CallManager';
 import './GroupCallWidget.scss';
 
 export const GroupCallWidget: React.FC = () => {
-    const [callData, setCallData] = useState<CallData | null>(null);
-    const [callState, setCallState] = useState<string | null>(null);
-    const [elementCallUrl, setElementCallUrl] = useState<string>('');
-    const [isDismissed, setIsDismissed] = useState(false);
-    
-    // Dragging state
-    const [isDragging, setIsDragging] = useState(false);
-    const [position, setPosition] = useState({ x: 100, y: 100 });
-    const [isMobileView, setIsMobileView] = useState(false);
-    const [isMobileCompact, setIsMobileCompact] = useState(false);
-    const dragRef = useRef<{ startX: number; startY: number; elemX: number; elemY: number } | null>(null);
-    const iframeRef = useRef<HTMLIFrameElement>(null);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const [isFullscreen, setIsFullscreen] = useState(false);
+	const [callData, setCallData] = useState<CallData | null>(null);
+	const [callState, setCallState] = useState<string | null>(null);
+	const [elementCallUrl, setElementCallUrl] = useState<string>('');
+	const [isDismissed, setIsDismissed] = useState(false);
 
-    // Subscribe to CallManager
-    useEffect(() => {
-        const unsubscribe = callManager.subscribe((newCallData) => {
-            // console.log('📡 GroupCallWidget: CallManager update:', newCallData);
-            setCallData(newCallData);
-            setCallState(newCallData?.state || null);
-            if (newCallData) {
-                setIsDismissed(false);
-            }
-            if (!newCallData) {
-                setElementCallUrl('');
-            }
-        });
-        const currentCall = callManager.getCurrentCall();
-        setCallData(currentCall);
-        setCallState(currentCall?.state || null);
-        return () => unsubscribe();
-    }, []);
+	// Dragging state
+	const [isDragging, setIsDragging] = useState(false);
+	const [position, setPosition] = useState({ x: 100, y: 100 });
+	const [isMobileView, setIsMobileView] = useState(false);
+	const [isMobileCompact, setIsMobileCompact] = useState(false);
+	const dragRef = useRef<{
+		startX: number;
+		startY: number;
+		elemX: number;
+		elemY: number;
+	} | null>(null);
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isFullscreen, setIsFullscreen] = useState(false);
 
-    useEffect(() => {
-        const updateViewport = () => {
-            const mobile = window.innerWidth <= 640;
-            setIsMobileView(mobile);
-            if (!mobile) {
-                // Compact mode is mobile-only; reset it on larger screens.
-                setIsMobileCompact(false);
-            }
-        };
+	// Subscribe to CallManager
+	useEffect(() => {
+		const unsubscribe = callManager.subscribe((newCallData) => {
+			// console.log('📡 GroupCallWidget: CallManager update:', newCallData);
+			setCallData(newCallData);
+			setCallState(newCallData?.state || null);
+			if (newCallData) {
+				setIsDismissed(false);
+			}
+			if (!newCallData) {
+				setElementCallUrl('');
+			}
+		});
+		const currentCall = callManager.getCurrentCall();
+		setCallData(currentCall);
+		setCallState(currentCall?.state || null);
+		return () => unsubscribe();
+	}, []);
 
-        updateViewport();
-        window.addEventListener('resize', updateViewport);
-        return () => window.removeEventListener('resize', updateViewport);
-    }, []);
+	useEffect(() => {
+		const updateViewport = () => {
+			const mobile = window.innerWidth <= 640;
+			setIsMobileView(mobile);
+			if (!mobile) {
+				// Compact mode is mobile-only; reset it on larger screens.
+				setIsMobileCompact(false);
+			}
+		};
 
-    useEffect(() => {
-        if (!callData || !callData.isGroup) return;
+		updateViewport();
+		window.addEventListener('resize', updateViewport);
+		return () => window.removeEventListener('resize', updateViewport);
+	}, []);
 
-        const padding = 16;
-        const maxWidth = 520;
-        const maxHeight = 320;
-        const width = Math.min(maxWidth, window.innerWidth - padding);
-        const height = Math.min(maxHeight, window.innerHeight - padding);
+	useEffect(() => {
+		if (!callData || !callData.isGroup) return;
 
-        if (window.innerWidth <= 640) {
-            setPosition({ x: 0, y: 0 });
-            return;
-        }
+		const padding = 16;
+		const maxWidth = 520;
+		const maxHeight = 320;
+		const width = Math.min(maxWidth, window.innerWidth - padding);
+		const height = Math.min(maxHeight, window.innerHeight - padding);
 
-        setPosition({
-            x: Math.max(padding, window.innerWidth - width - padding),
-            y: Math.max(padding, window.innerHeight - height - padding),
-        });
-    }, [callData, elementCallUrl]);
+		if (window.innerWidth <= 640) {
+			setPosition({ x: 0, y: 0 });
+			return;
+		}
 
-    useEffect(() => {
-        const handleFullscreenChange = () => {
-            setIsFullscreen(!!document.fullscreenElement);
-        };
+		setPosition({
+			x: Math.max(padding, window.innerWidth - width - padding),
+			y: Math.max(padding, window.innerHeight - height - padding)
+		});
+	}, [callData, elementCallUrl]);
 
-        document.addEventListener('fullscreenchange', handleFullscreenChange);
-        return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
-    }, []);
+	useEffect(() => {
+		const handleFullscreenChange = () => {
+			setIsFullscreen(!!document.fullscreenElement);
+		};
 
-    useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            const data = event.data;
-            if (!data || typeof data !== 'object') return;
-            if (data.type !== 'oriso-call-ended') return;
-            // console.log('📴 Element Call ended (message from iframe)');
-            setElementCallUrl('');
-            setCallData(null);
-            setCallState(null);
-            setIsDismissed(true);
-            callManager.endCall();
-        };
-        window.addEventListener('message', handleMessage);
-        return () => window.removeEventListener('message', handleMessage);
-    }, []);
+		document.addEventListener('fullscreenchange', handleFullscreenChange);
+		return () =>
+			document.removeEventListener(
+				'fullscreenchange',
+				handleFullscreenChange
+			);
+	}, []);
 
-    // Handle incoming call answer: once the call is moving past "ringing",
-    // automatically join the Element Call room for the receiver.
-    useEffect(() => {
-        if (!callData || !callData.isGroup || !callData.isIncoming) return;
-        if (elementCallUrl) return; // Already joined
-        if (callState !== 'connecting' && callState !== 'in_call') return;
+	useEffect(() => {
+		const handleMessage = (event: MessageEvent) => {
+			const data = event.data;
+			if (!data || typeof data !== 'object') return;
+			if (data.type !== 'oriso-call-ended') return;
+			// console.log('📴 Element Call ended (message from iframe)');
+			setElementCallUrl('');
+			setCallData(null);
+			setCallState(null);
+			setIsDismissed(true);
+			callManager.endCall();
+		};
+		window.addEventListener('message', handleMessage);
+		return () => window.removeEventListener('message', handleMessage);
+	}, []);
 
-        // console.log('✅ Incoming group call moving to state', callState, '- setting up Element Call for receiver...');
-        setupElementCall();
-    }, [callState, callData, elementCallUrl]);
+	// Handle incoming call answer: once the call is moving past "ringing",
+	// automatically join the Element Call room for the receiver.
+	useEffect(() => {
+		if (!callData || !callData.isGroup || !callData.isIncoming) return;
+		if (elementCallUrl) return; // Already joined
+		if (callState !== 'connecting' && callState !== 'in_call') return;
 
-    // Handle outgoing call
-    useEffect(() => {
-        if (!callData || !callData.isGroup || callData.isIncoming) return;
-        if (elementCallUrl) return; // Already set up
+		// console.log('✅ Incoming group call moving to state', callState, '- setting up Element Call for receiver...');
+		setupElementCall();
+	}, [callState, callData, elementCallUrl]);
 
-        // console.log('📞 Starting outgoing call, setting up Element Call...');
-        setupElementCall();
-    }, [callData]);
+	// Handle outgoing call
+	useEffect(() => {
+		if (!callData || !callData.isGroup || callData.isIncoming) return;
+		if (elementCallUrl) return; // Already set up
 
-    const setupElementCall = () => {
-        if (!callData) return;
+		// console.log('📞 Starting outgoing call, setting up Element Call...');
+		setupElementCall();
+	}, [callData]);
 
-        try {
-            const matrixClientService = (window as any).matrixClientService;
-            const client = matrixClientService?.getClient();
-            if (!client) throw new Error('Matrix client not initialized');
+	const setupElementCall = () => {
+		if (!callData) return;
 
-            // For group calls we use the dedicated Element Call room if present.
-            const roomId = (callData as any).elementCallRoomId || callData.roomId;
-            const homeserverUrl = client.getHomeserverUrl() || 'https://matrix.oriso.site';
-            
-            // Get Matrix credentials
-            const accessToken = (client as any).accessToken || localStorage.getItem('matrix_access_token');
-            const userId = client.getUserId() || localStorage.getItem('matrix_user_id');
-            const deviceId = (client as any).deviceId || localStorage.getItem('matrix_device_id');
-            
-            if (!accessToken || !userId) {
-                throw new Error('Matrix authentication not available');
-            }
+		try {
+			const matrixClientService = (window as any).matrixClientService;
+			const client = matrixClientService?.getClient();
+			if (!client) throw new Error('Matrix client not initialized');
 
-            // Element Call - open the specific Matrix room directly.
-            // We mirror Element Call's own `getRelativeRoomUrl` format:
-            //   /room/#?roomId=...&perParticipantE2EE=...
-            // We also pass Matrix credentials via URL so our auto-auth script can log in.
-            const elementCallBaseUrl =
-                `${(process.env.REACT_APP_ELEMENT_CALL_URL || '').replace(/\/+$/, '')}/room`;
+			// For group calls we use the dedicated Element Call room if present.
+			const roomId =
+				(callData as any).elementCallRoomId || callData.roomId;
+			const homeserverUrl =
+				client.getHomeserverUrl() ||
+				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
+				'';
+			if (!homeserverUrl) {
+				throw new Error(
+					'Matrix homeserver URL is missing. Set REACT_APP_MATRIX_HOMESERVER_URL or ensure the client reports a homeserver URL.'
+				);
+			}
 
-            const params = new URLSearchParams();
-            params.set('roomId', roomId);
-            // Hint Element Call that this is a normal "start call" use-case so
-            // it enables camera & microphone by default.
-            params.set('intent', 'start_call');
-            params.set('homeserver', homeserverUrl);
-            params.set('accessToken', accessToken);
-            params.set('userId', userId);
-            if (deviceId) params.set('deviceId', deviceId);
-            // Skip lobby and go straight into the call UI
-            params.set('skipLobby', 'true');
-            // Keep embedded users inside the current room flow (no home navigation).
-            params.set('confineToRoom', 'true');
-            // Use Element Call without top app bar in embedded popup mode.
-            // This removes the duplicate left collapse control and room title.
-            params.set('header', 'none');
+			// Get Matrix credentials
+			const accessToken =
+				(client as any).accessToken ||
+				localStorage.getItem('matrix_access_token');
+			const userId =
+				client.getUserId() || localStorage.getItem('matrix_user_id');
+			const deviceId =
+				(client as any).deviceId ||
+				localStorage.getItem('matrix_device_id');
 
-            const url = `${elementCallBaseUrl}/#?${params.toString()}`;
-            
-            // console.log('🔗 Element Call URL:', url);
-            // console.log('🔑 Passing Matrix credentials for auto-authentication');
-            setElementCallUrl(url);
+			if (!accessToken || !userId) {
+				throw new Error('Matrix authentication not available');
+			}
 
-            // Send credentials via postMessage immediately when iframe loads
-            const sendCredentials = () => {
-                if (iframeRef.current?.contentWindow) {
-                    // console.log('📤 Sending Matrix credentials to Element Call via postMessage');
-                    
-                    // Send credentials in multiple formats Element Call might accept
-                    iframeRef.current.contentWindow.postMessage({
-                        type: 'matrix-credentials',
-                        accessToken: accessToken,
-                        userId: userId,
-                        deviceId: deviceId,
-                        homeserverUrl: homeserverUrl
-                    }, elementCallBaseUrl);
-                    
-                    iframeRef.current.contentWindow.postMessage({
-                        type: 'auth',
-                        accessToken: accessToken,
-                        userId: userId,
-                        deviceId: deviceId,
-                        baseUrl: homeserverUrl
-                    }, elementCallBaseUrl);
-                }
-            };
-            
-            // Send immediately and also when iframe loads
-            setTimeout(sendCredentials, 500);
-            if (iframeRef.current) {
-                iframeRef.current.onload = sendCredentials;
-            }
+			// Element Call - open the specific Matrix room directly.
+			// We mirror Element Call's own `getRelativeRoomUrl` format:
+			//   /room/#?roomId=...&perParticipantE2EE=...
+			// We also pass Matrix credentials via URL so our auto-auth script can log in.
+			const elementCallOrigin = (
+				process.env.REACT_APP_ELEMENT_CALL_BASE_URL || ''
+			).replace(/\/+$/, '');
+			if (!elementCallOrigin) {
+				throw new Error('REACT_APP_ELEMENT_CALL_BASE_URL is not set');
+			}
+			const elementCallBaseUrl = `${elementCallOrigin}/room`;
 
-        } catch (err) {
-            // console.error('❌ Failed to setup Element Call:', err);
-            alert(`Failed to start call: ${(err as Error).message}`);
-            callManager.endCall();
-        }
-    };
+			const params = new URLSearchParams();
+			params.set('roomId', roomId);
+			// Hint Element Call that this is a normal "start call" use-case so
+			// it enables camera & microphone by default.
+			params.set('intent', 'start_call');
+			params.set('homeserver', homeserverUrl);
+			params.set('accessToken', accessToken);
+			params.set('userId', userId);
+			if (deviceId) params.set('deviceId', deviceId);
+			// Skip lobby and go straight into the call UI
+			params.set('skipLobby', 'true');
+			// Keep embedded users inside the current room flow (no home navigation).
+			params.set('confineToRoom', 'true');
+			// Use Element Call without top app bar in embedded popup mode.
+			// This removes the duplicate left collapse control and room title.
+			params.set('header', 'none');
 
-    // Handle Element Call widget API actions
-    const handleWidgetAction = async (
-        action: string,
-        requestId: string,
-        data: any,
-        client: any,
-        source: Window
-    ) => {
-        try {
-            // console.log(`📞 Element Call widget action: ${action}`, data);
-            
-            // Element Call requests Matrix operations via widget API
-            // We proxy these to our authenticated Matrix client
-            let response: any = { success: false };
-            
-            switch (action) {
-                case 'm.sticker':
-                case 'm.room.message':
-                    // Element Call wants to send a message - not needed for calls
-                    response = { success: true };
-                    break;
-                    
-                case 'io.element.join':
-                    // Element Call ready to join - already handled by URL params
-                    response = { success: true };
-                    break;
-                    
-                default:
-                    // console.log(`ℹ️  Unhandled widget action: ${action}`);
-                    response = { success: true };
-            }
-            
-            // Send response back to Element Call
-            source.postMessage({
-                api: 'toWidget',
-                action: action,
-                requestId: requestId,
-                response: response
-            }, '*');
-            
-        } catch (err) {
-            // console.error('❌ Error handling widget action:', err);
-        }
-    };
+			const url = `${elementCallBaseUrl}/#?${params.toString()}`;
 
-    const handleAnswer = () => {
-        if (!callData || !callData.isIncoming) return;
-        // console.log('✅ User clicked Answer');
-        // Tell Matrix/CallManager that we are accepting the call
-        callManager.answerCall();
+			// console.log('🔗 Element Call URL:', url);
+			// console.log('🔑 Passing Matrix credentials for auto-authentication');
+			setElementCallUrl(url);
 
-        // Proactively start/join the Element Call room so the user lands
-        // directly in the call UI without any extra "Join" step.
-        if (!elementCallUrl) {
-            // console.log('📞 Answer clicked, setting up Element Call immediately for receiver...');
-            setupElementCall();
-        }
-    };
+			// Send credentials via postMessage immediately when iframe loads
+			const sendCredentials = () => {
+				if (iframeRef.current?.contentWindow) {
+					// console.log('📤 Sending Matrix credentials to Element Call via postMessage');
 
-    const handleDecline = () => {
-        // console.log('❌ User declined call');
-        setIsDismissed(true);
-        callManager.endCall();
-    };
+					// Send credentials in multiple formats Element Call might accept
+					iframeRef.current.contentWindow.postMessage(
+						{
+							type: 'matrix-credentials',
+							accessToken: accessToken,
+							userId: userId,
+							deviceId: deviceId,
+							homeserverUrl: homeserverUrl
+						},
+						elementCallBaseUrl
+					);
 
-    const handleEndCall = () => {
-        // console.log('📴 Ending call');
-        
-        // Cleanup widget message handler
-        if (iframeRef.current && (iframeRef.current as any).__widgetMessageHandler) {
-            window.removeEventListener('message', (iframeRef.current as any).__widgetMessageHandler);
-            delete (iframeRef.current as any).__widgetMessageHandler;
-        }
+					iframeRef.current.contentWindow.postMessage(
+						{
+							type: 'auth',
+							accessToken: accessToken,
+							userId: userId,
+							deviceId: deviceId,
+							baseUrl: homeserverUrl
+						},
+						elementCallBaseUrl
+					);
+				}
+			};
 
-        if (iframeRef.current?.contentWindow) {
-            iframeRef.current.contentWindow.postMessage(
-                { type: 'oriso-call-action', action: 'hangup' },
-                '*',
-            );
-        }
-        
-        if (iframeRef.current) {
-            iframeRef.current.src = 'about:blank';
-        }
-        setElementCallUrl('');
-        setCallData(null);
-        setCallState(null);
-        setIsDismissed(true);
-        callManager.endCall();
-    };
+			// Send immediately and also when iframe loads
+			setTimeout(sendCredentials, 500);
+			if (iframeRef.current) {
+				iframeRef.current.onload = sendCredentials;
+			}
+		} catch (err) {
+			// console.error('❌ Failed to setup Element Call:', err);
+			alert(`Failed to start call: ${(err as Error).message}`);
+			callManager.endCall();
+		}
+	};
 
-    const handleToggleFullscreen = () => {
-        if (isMobileView) {
-            setIsMobileCompact((value) => !value);
-            return;
-        }
+	// Handle Element Call widget API actions
+	const handleWidgetAction = async (
+		action: string,
+		requestId: string,
+		data: any,
+		client: any,
+		source: Window
+	) => {
+		try {
+			// console.log(`📞 Element Call widget action: ${action}`, data);
 
-        const container = containerRef.current;
-        if (!container) return;
+			// Element Call requests Matrix operations via widget API
+			// We proxy these to our authenticated Matrix client
+			let response: any = { success: false };
 
-        if (document.fullscreenElement) {
-            document.exitFullscreen?.();
-            return;
-        }
+			switch (action) {
+				case 'm.sticker':
+				case 'm.room.message':
+					// Element Call wants to send a message - not needed for calls
+					response = { success: true };
+					break;
 
-        container.requestFullscreen?.();
-    };
+				case 'io.element.join':
+					// Element Call ready to join - already handled by URL params
+					response = { success: true };
+					break;
 
-    // Dragging handlers (mouse + touch)
-    const handleMouseDown = (e: React.MouseEvent) => {
-        if (isMobileView) return;
-        const target = e.target as HTMLElement;
-        const isDragHandle = !!target.closest('.element-call-drag-handle');
-        if (elementCallUrl && !isDragHandle) return;
-        if (target.closest('.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close')) return;
-        setIsDragging(true);
-        dragRef.current = {
-            startX: e.clientX,
-            startY: e.clientY,
-            elemX: position.x,
-            elemY: position.y
-        };
-    };
+				default:
+					// console.log(`ℹ️  Unhandled widget action: ${action}`);
+					response = { success: true };
+			}
 
-    const handleTouchStart = (e: React.TouchEvent) => {
-        if (isMobileView) return;
-        const target = e.target as HTMLElement;
-        const isDragHandle = !!target.closest('.element-call-drag-handle');
-        if (elementCallUrl && !isDragHandle) return;
-        if (target.closest('.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close')) return;
-        const touch = e.touches[0];
-        setIsDragging(true);
-        dragRef.current = {
-            startX: touch.clientX,
-            startY: touch.clientY,
-            elemX: position.x,
-            elemY: position.y
-        };
-    };
+			// Send response back to Element Call
+			source.postMessage(
+				{
+					api: 'toWidget',
+					action: action,
+					requestId: requestId,
+					response: response
+				},
+				'*'
+			);
+		} catch (err) {
+			// console.error('❌ Error handling widget action:', err);
+		}
+	};
 
-    const handleMouseMove = (e: MouseEvent) => {
-        if (!isDragging || !dragRef.current) return;
-        const dx = e.clientX - dragRef.current.startX;
-        const dy = e.clientY - dragRef.current.startY;
-        setPosition({
-            x: dragRef.current.elemX + dx,
-            y: dragRef.current.elemY + dy
-        });
-    };
+	const handleAnswer = () => {
+		if (!callData || !callData.isIncoming) return;
+		// console.log('✅ User clicked Answer');
+		// Tell Matrix/CallManager that we are accepting the call
+		callManager.answerCall();
 
-    const handleTouchMove = (e: TouchEvent) => {
-        if (!isDragging || !dragRef.current) return;
-        const touch = e.touches[0];
-        const dx = touch.clientX - dragRef.current.startX;
-        const dy = touch.clientY - dragRef.current.startY;
-        setPosition({
-            x: dragRef.current.elemX + dx,
-            y: dragRef.current.elemY + dy
-        });
-    };
+		// Proactively start/join the Element Call room so the user lands
+		// directly in the call UI without any extra "Join" step.
+		if (!elementCallUrl) {
+			// console.log('📞 Answer clicked, setting up Element Call immediately for receiver...');
+			setupElementCall();
+		}
+	};
 
-    const handleMouseUp = () => {
-        setIsDragging(false);
-        dragRef.current = null;
-    };
+	const handleDecline = () => {
+		// console.log('❌ User declined call');
+		setIsDismissed(true);
+		callManager.endCall();
+	};
 
-    const handleTouchEnd = () => {
-        setIsDragging(false);
-        dragRef.current = null;
-    };
+	const handleEndCall = () => {
+		// console.log('📴 Ending call');
 
-    useEffect(() => {
-        if (isDragging) {
-            window.addEventListener('mousemove', handleMouseMove);
-            window.addEventListener('mouseup', handleMouseUp);
-            window.addEventListener('touchmove', handleTouchMove);
-            window.addEventListener('touchend', handleTouchEnd);
-            return () => {
-                window.removeEventListener('mousemove', handleMouseMove);
-                window.removeEventListener('mouseup', handleMouseUp);
-                window.removeEventListener('touchmove', handleTouchMove);
-                window.removeEventListener('touchend', handleTouchEnd);
-            };
-        }
-    }, [isDragging]);
+		// Cleanup widget message handler
+		if (
+			iframeRef.current &&
+			(iframeRef.current as any).__widgetMessageHandler
+		) {
+			window.removeEventListener(
+				'message',
+				(iframeRef.current as any).__widgetMessageHandler
+			);
+			delete (iframeRef.current as any).__widgetMessageHandler;
+		}
 
-    // Only render for group calls
-    if (isDismissed || !callData || !callData.isGroup) return null;
+		if (iframeRef.current?.contentWindow) {
+			iframeRef.current.contentWindow.postMessage(
+				{ type: 'oriso-call-action', action: 'hangup' },
+				'*'
+			);
+		}
 
-    return (
-        <div 
-            className={`group-call-widget ${isDragging ? 'dragging' : ''} ${isMobileView ? 'group-call-widget--mobile' : ''} ${isMobileCompact ? 'group-call-widget--mobile-compact' : ''} ${isFullscreen ? 'group-call-widget--fullscreen' : ''}`}
-            style={{ left: `${position.x}px`, top: `${position.y}px` }}
-            onMouseDown={handleMouseDown}
-            onTouchStart={handleTouchStart}
-        >
-            {/* Incoming call - show answer/decline buttons */}
-            {callData.isIncoming && callData.state === 'ringing' ? (
-                <div className="incoming-call-popup">
-                    <button
-                        className="element-call-close"
-                        onClick={handleDecline}
-                        aria-label="Close call"
-                    >
-                        ×
-                    </button>
-                    <div className="incoming-call-content">
-                        <div className="call-avatar-large">G</div>
-                        <h2>Incoming Call</h2>
-                        <p>Someone is calling...</p>
-                        <div className="incoming-call-actions">
-                            <button className="btn-answer" onClick={handleAnswer}>
-                                Answer
-                            </button>
-                            <button className="btn-decline" onClick={handleDecline}>
-                                Decline
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            ) : elementCallUrl ? (
-                /* Active call - show Element Call iframe */
-                <div className="element-call-container" ref={containerRef}>
-                    <div className="element-call-drag-handle" />
-                    <button className="element-call-close" onClick={handleEndCall} aria-label="Close call">
-                        ×
-                    </button>
-                    <button
-                        className="element-call-fullscreen"
-                        onClick={handleToggleFullscreen}
-                        aria-label={
-                            isMobileView
-                                ? (isMobileCompact ? 'Open full view' : 'Switch to small view')
-                                : (isFullscreen ? 'Exit full screen' : 'Enter full screen')
-                        }
-                        title={
-                            isMobileView
-                                ? (isMobileCompact ? 'Full view' : 'Small view')
-                                : (isFullscreen ? 'Exit full screen' : 'Full screen')
-                        }
-                    >
-                        {isMobileView
-                            ? (isMobileCompact ? '⤢' : '⤡')
-                            : (isFullscreen ? '⤡' : '⤢')}
-                    </button>
-                    <iframe
-                        ref={iframeRef}
-                        src={elementCallUrl}
-                        className="element-call-iframe"
-                        allow="camera; microphone; display-capture; autoplay; fullscreen"
-                        allowFullScreen
-                        title="Group video call"
-                    />
-                </div>
-            ) : (
-                /* Connecting state */
-                <div className="connecting-popup">
-                    <button
-                        className="element-call-close"
-                        onClick={handleEndCall}
-                        aria-label="Close call"
-                    >
-                        ×
-                    </button>
-                    <div className="connecting-content">
-                        <div className="call-avatar-large">G</div>
-                        <h2>Connecting...</h2>
-                        <p>Setting up call</p>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
+		if (iframeRef.current) {
+			iframeRef.current.src = 'about:blank';
+		}
+		setElementCallUrl('');
+		setCallData(null);
+		setCallState(null);
+		setIsDismissed(true);
+		callManager.endCall();
+	};
+
+	const handleToggleFullscreen = () => {
+		if (isMobileView) {
+			setIsMobileCompact((value) => !value);
+			return;
+		}
+
+		const container = containerRef.current;
+		if (!container) return;
+
+		if (document.fullscreenElement) {
+			document.exitFullscreen?.();
+			return;
+		}
+
+		container.requestFullscreen?.();
+	};
+
+	// Dragging handlers (mouse + touch)
+	const handleMouseDown = (e: React.MouseEvent) => {
+		if (isMobileView) return;
+		const target = e.target as HTMLElement;
+		const isDragHandle = !!target.closest('.element-call-drag-handle');
+		if (elementCallUrl && !isDragHandle) return;
+		if (
+			target.closest(
+				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close'
+			)
+		)
+			return;
+		setIsDragging(true);
+		dragRef.current = {
+			startX: e.clientX,
+			startY: e.clientY,
+			elemX: position.x,
+			elemY: position.y
+		};
+	};
+
+	const handleTouchStart = (e: React.TouchEvent) => {
+		if (isMobileView) return;
+		const target = e.target as HTMLElement;
+		const isDragHandle = !!target.closest('.element-call-drag-handle');
+		if (elementCallUrl && !isDragHandle) return;
+		if (
+			target.closest(
+				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close'
+			)
+		)
+			return;
+		const touch = e.touches[0];
+		setIsDragging(true);
+		dragRef.current = {
+			startX: touch.clientX,
+			startY: touch.clientY,
+			elemX: position.x,
+			elemY: position.y
+		};
+	};
+
+	const handleMouseMove = (e: MouseEvent) => {
+		if (!isDragging || !dragRef.current) return;
+		const dx = e.clientX - dragRef.current.startX;
+		const dy = e.clientY - dragRef.current.startY;
+		setPosition({
+			x: dragRef.current.elemX + dx,
+			y: dragRef.current.elemY + dy
+		});
+	};
+
+	const handleTouchMove = (e: TouchEvent) => {
+		if (!isDragging || !dragRef.current) return;
+		const touch = e.touches[0];
+		const dx = touch.clientX - dragRef.current.startX;
+		const dy = touch.clientY - dragRef.current.startY;
+		setPosition({
+			x: dragRef.current.elemX + dx,
+			y: dragRef.current.elemY + dy
+		});
+	};
+
+	const handleMouseUp = () => {
+		setIsDragging(false);
+		dragRef.current = null;
+	};
+
+	const handleTouchEnd = () => {
+		setIsDragging(false);
+		dragRef.current = null;
+	};
+
+	useEffect(() => {
+		if (isDragging) {
+			window.addEventListener('mousemove', handleMouseMove);
+			window.addEventListener('mouseup', handleMouseUp);
+			window.addEventListener('touchmove', handleTouchMove);
+			window.addEventListener('touchend', handleTouchEnd);
+			return () => {
+				window.removeEventListener('mousemove', handleMouseMove);
+				window.removeEventListener('mouseup', handleMouseUp);
+				window.removeEventListener('touchmove', handleTouchMove);
+				window.removeEventListener('touchend', handleTouchEnd);
+			};
+		}
+	}, [isDragging]);
+
+	// Only render for group calls
+	if (isDismissed || !callData || !callData.isGroup) return null;
+
+	return (
+		<div
+			className={`group-call-widget ${isDragging ? 'dragging' : ''} ${isMobileView ? 'group-call-widget--mobile' : ''} ${isMobileCompact ? 'group-call-widget--mobile-compact' : ''} ${isFullscreen ? 'group-call-widget--fullscreen' : ''}`}
+			style={{ left: `${position.x}px`, top: `${position.y}px` }}
+			onMouseDown={handleMouseDown}
+			onTouchStart={handleTouchStart}
+		>
+			{/* Incoming call - show answer/decline buttons */}
+			{callData.isIncoming && callData.state === 'ringing' ? (
+				<div className="incoming-call-popup">
+					<button
+						className="element-call-close"
+						onClick={handleDecline}
+						aria-label="Close call"
+					>
+						×
+					</button>
+					<div className="incoming-call-content">
+						<div className="call-avatar-large">G</div>
+						<h2>Incoming Call</h2>
+						<p>Someone is calling...</p>
+						<div className="incoming-call-actions">
+							<button
+								className="btn-answer"
+								onClick={handleAnswer}
+							>
+								Answer
+							</button>
+							<button
+								className="btn-decline"
+								onClick={handleDecline}
+							>
+								Decline
+							</button>
+						</div>
+					</div>
+				</div>
+			) : elementCallUrl ? (
+				/* Active call - show Element Call iframe */
+				<div className="element-call-container" ref={containerRef}>
+					<div className="element-call-drag-handle" />
+					<button
+						className="element-call-close"
+						onClick={handleEndCall}
+						aria-label="Close call"
+					>
+						×
+					</button>
+					<button
+						className="element-call-fullscreen"
+						onClick={handleToggleFullscreen}
+						aria-label={
+							isMobileView
+								? isMobileCompact
+									? 'Open full view'
+									: 'Switch to small view'
+								: isFullscreen
+									? 'Exit full screen'
+									: 'Enter full screen'
+						}
+						title={
+							isMobileView
+								? isMobileCompact
+									? 'Full view'
+									: 'Small view'
+								: isFullscreen
+									? 'Exit full screen'
+									: 'Full screen'
+						}
+					>
+						{isMobileView
+							? isMobileCompact
+								? '⤢'
+								: '⤡'
+							: isFullscreen
+								? '⤡'
+								: '⤢'}
+					</button>
+					<iframe
+						ref={iframeRef}
+						src={elementCallUrl}
+						className="element-call-iframe"
+						allow="camera; microphone; display-capture; autoplay; fullscreen"
+						allowFullScreen
+						title="Group video call"
+					/>
+				</div>
+			) : (
+				/* Connecting state */
+				<div className="connecting-popup">
+					<button
+						className="element-call-close"
+						onClick={handleEndCall}
+						aria-label="Close call"
+					>
+						×
+					</button>
+					<div className="connecting-content">
+						<div className="call-avatar-large">G</div>
+						<h2>Connecting...</h2>
+						<p>Setting up call</p>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 };
-

--- a/src/components/help/HelpVideoCall.tsx
+++ b/src/components/help/HelpVideoCall.tsx
@@ -8,6 +8,16 @@ import EdgeLogo from '../../resources/img/images/microsoft_edge.png';
 import SafariLogo from '../../resources/img/images/safari.png';
 import { useTranslation } from 'react-i18next';
 
+const browserChromeUrl =
+	process.env.REACT_APP_BROWSER_DOWNLOAD_CHROME_URL ||
+	'https://www.google.com/chrome/';
+const browserEdgeUrl =
+	process.env.REACT_APP_BROWSER_DOWNLOAD_EDGE_URL ||
+	'https://www.microsoft.com/edge';
+const browserSafariUrl =
+	process.env.REACT_APP_BROWSER_DOWNLOAD_SAFARI_URL ||
+	'https://www.apple.com/de/safari/';
+
 interface HelpVideoCallProps {
 	copyLoginLink: Function;
 	consultant: boolean;
@@ -24,7 +34,7 @@ export const BrowserList: React.FC = () => {
 					title={translate('help.googleChrome')}
 				/>
 				<a
-					href="https://www.google.com/chrome/"
+					href={browserChromeUrl}
 					target="_blank"
 					rel="noreferrer"
 					className="button-as-link"
@@ -43,7 +53,7 @@ export const BrowserList: React.FC = () => {
 					title={translate('help.msEdge')}
 				/>
 				<a
-					href="https://www.microsoft.com/edge"
+					href={browserEdgeUrl}
 					target="_blank"
 					rel="noreferrer"
 					className="button-as-link"
@@ -62,7 +72,7 @@ export const BrowserList: React.FC = () => {
 					title={translate('help.safari')}
 				/>
 				<a
-					href="https://www.apple.com/de/safari/"
+					href={browserSafariUrl}
 					target="_blank"
 					rel="noreferrer"
 					className="button-as-link"
@@ -125,7 +135,7 @@ export const HelpVideoCall: React.FC<HelpVideoCallProps> = ({
 					<li>
 						{translate(`${translationPrefix}.steps.1.1`)}
 						<a
-							href="https://www.google.com/chrome/"
+							href={browserChromeUrl}
 							target="_blank"
 							rel="noreferrer"
 							className="button-as-link"
@@ -134,7 +144,7 @@ export const HelpVideoCall: React.FC<HelpVideoCallProps> = ({
 						</a>
 						{translate(`${translationPrefix}.steps.1.2`)}
 						<a
-							href="https://www.microsoft.com/edge"
+							href={browserEdgeUrl}
 							target="_blank"
 							rel="noreferrer"
 							className="button-as-link"
@@ -143,7 +153,7 @@ export const HelpVideoCall: React.FC<HelpVideoCallProps> = ({
 						</a>
 						{translate(`${translationPrefix}.steps.1.2`)}
 						<a
-							href="https://www.apple.com/de/safari/"
+							href={browserSafariUrl}
 							target="_blank"
 							rel="noreferrer"
 							className="button-as-link"

--- a/src/components/matrixCall/MatrixCallView.BROKEN-BACKUP.tsx
+++ b/src/components/matrixCall/MatrixCallView.BROKEN-BACKUP.tsx
@@ -10,414 +10,476 @@ import { matrixCallService } from '../../services/matrixCallService';
 import './MatrixCallView.styles.scss';
 
 interface MatrixCallViewProps {
-    roomId: string;
-    isVideoCall: boolean;
-    incomingCall?: MatrixCall | null;
-    onCallEnd: () => void;
+	roomId: string;
+	isVideoCall: boolean;
+	incomingCall?: MatrixCall | null;
+	onCallEnd: () => void;
 }
 
 export const MatrixCallView: React.FC<MatrixCallViewProps> = ({
-    roomId,
-    isVideoCall,
-    incomingCall,
-    onCallEnd
+	roomId,
+	isVideoCall,
+	incomingCall,
+	onCallEnd
 }) => {
-    const localVideoRef = useRef<HTMLVideoElement>(null);
-    const remoteVideoRef = useRef<HTMLVideoElement>(null);
-    
-    const [callState, setCallState] = useState<CallState | null>(null);
-    const [isMuted, setIsMuted] = useState(false);
-    const [isVideoMuted, setIsVideoMuted] = useState(false);
-    const [activeCall, setActiveCall] = useState<MatrixCall | null>(null);
-    const [error, setError] = useState<string | null>(null);
-    
-    // Guard to prevent multiple call attempts
-    const callInitializedRef = useRef(false);
+	const localVideoRef = useRef<HTMLVideoElement>(null);
+	const remoteVideoRef = useRef<HTMLVideoElement>(null);
 
-    // Start outgoing call
-    const startCall = useCallback(async () => {
-        try {
-            setError(null);
-            
-            // Check if Matrix client is initialized
-            const matrixClientService = (window as any).matrixClientService;
-            if (!matrixClientService || !matrixClientService.getClient()) {
-                console.error('❌ Matrix client not initialized - initializing now...');
-                
-                // Try to get Matrix credentials from localStorage
-                const matrixUserId = localStorage.getItem('matrix_user_id');
-                const matrixAccessToken = localStorage.getItem('matrix_access_token');
-                
-                if (!matrixUserId || !matrixAccessToken) {
-                    throw new Error('Matrix client not initialized and no stored credentials found. Please logout and login again.');
-                }
-                
-                // Initialize Matrix client with stored credentials
-                const { MatrixClientService } = await import('../../services/matrixClientService');
-                const newMatrixClientService = new MatrixClientService();
-                newMatrixClientService.initializeClient({
-                    userId: matrixUserId,
-                    accessToken: matrixAccessToken,
-                    deviceId: localStorage.getItem('matrix_device_id') || '',
-                    homeserverUrl: 'http://91.99.219.182:8008'
-                });
-                
-                (window as any).matrixClientService = newMatrixClientService;
-                
-                // Wait a bit for client to sync
-                await new Promise(resolve => setTimeout(resolve, 2000));
-                
-                console.log('✅ Matrix client initialized');
-            }
-            
-            const call = await matrixCallService.startCall({
-                roomId,
-                isVideoCall,
-                localVideoElement: localVideoRef.current || undefined,
-                remoteVideoElement: remoteVideoRef.current || undefined
-            });
-            setActiveCall(call);
-        } catch (err) {
-            console.error('Failed to start call:', err);
-            setError((err as Error).message);
-        }
-    }, [roomId, isVideoCall]);
+	const [callState, setCallState] = useState<CallState | null>(null);
+	const [isMuted, setIsMuted] = useState(false);
+	const [isVideoMuted, setIsVideoMuted] = useState(false);
+	const [activeCall, setActiveCall] = useState<MatrixCall | null>(null);
+	const [error, setError] = useState<string | null>(null);
 
-    // Answer incoming call
-    const answerCall = useCallback(async () => {
-        if (!incomingCall) return;
-        
-        try {
-            setError(null);
-            await matrixCallService.answerCall(
-                incomingCall,
-                isVideoCall,
-                localVideoRef.current || undefined,
-                remoteVideoRef.current || undefined
-            );
-            setActiveCall(incomingCall);
-        } catch (err) {
-            console.error('Failed to answer call:', err);
-            setError((err as Error).message);
-        }
-    }, [incomingCall, isVideoCall]);
+	// Guard to prevent multiple call attempts
+	const callInitializedRef = useRef(false);
 
-    // Reject incoming call
-    const rejectCall = useCallback(() => {
-        if (incomingCall) {
-            matrixCallService.rejectCall(incomingCall);
-            onCallEnd();
-        }
-    }, [incomingCall, onCallEnd]);
+	// Start outgoing call
+	const startCall = useCallback(async () => {
+		try {
+			setError(null);
 
-    // Hangup call
-    const hangupCall = useCallback(() => {
-        matrixCallService.hangupCall();
-        onCallEnd();
-    }, [onCallEnd]);
+			// Check if Matrix client is initialized
+			const matrixClientService = (window as any).matrixClientService;
+			if (!matrixClientService || !matrixClientService.getClient()) {
+				console.error(
+					'❌ Matrix client not initialized - initializing now...'
+				);
 
-    // Toggle microphone
-    const toggleMicrophone = useCallback(() => {
-        const muted = matrixCallService.toggleMicrophone();
-        setIsMuted(muted);
-    }, []);
+				// Try to get Matrix credentials from localStorage
+				const matrixUserId = localStorage.getItem('matrix_user_id');
+				const matrixAccessToken = localStorage.getItem(
+					'matrix_access_token'
+				);
 
-    // Toggle video
-    const toggleVideo = useCallback(() => {
-        const videoMuted = matrixCallService.toggleVideo();
-        setIsVideoMuted(videoMuted);
-    }, []);
+				if (!matrixUserId || !matrixAccessToken) {
+					throw new Error(
+						'Matrix client not initialized and no stored credentials found. Please logout and login again.'
+					);
+				}
 
-    // Initialize call on mount
-    useEffect(() => {
-        // CRITICAL: Prevent multiple initializations
-        if (callInitializedRef.current) {
-            console.log('⚠️ Call already initialized, skipping...');
-            return;
-        }
-        
-        // Check URL parameter to see if we're answering an incoming call
-        const urlParams = new URLSearchParams(window.location.search);
-        const isAnswering = urlParams.get('answer') === 'true';
-        
-        console.log('📞 MatrixCallView mount - isAnswering:', isAnswering);
-        console.log('📞 incomingCall prop:', !!incomingCall);
-        
-        if (incomingCall) {
-            // Incoming call passed directly - wait for user to answer/reject
-            console.log('📞 Incoming call prop provided, using it');
-            setActiveCall(incomingCall);
-            callInitializedRef.current = true;
-            return; // Exit early - don't check for other calls
-        }
-        
-        // Flag to prevent starting new call if we're answering
-        let shouldStartNewCall = true;
-        
-        // Check if there's already an incoming call for this room
-        const matrixClientService = (window as any).matrixClientService;
-        if (matrixClientService) {
-            const client = matrixClientService.getClient();
-            const calls = client?.callEventHandler?.calls;
-            
-            if (calls) {
-                // CRITICAL: First clean up old/ended calls
-                const allCalls = Array.from(calls.values());
-                const endedCalls = allCalls.filter((call: any) => 
-                    call.state === 'ended' && call.roomId === roomId
-                );
-                
-                if (endedCalls.length > 0) {
-                    console.log(`🧹 Cleaning up ${endedCalls.length} ended calls...`);
-                    endedCalls.forEach((call: any) => {
-                        try {
-                            calls.delete(call.callId);
-                        } catch (e) {
-                            console.warn('Could not delete ended call:', e);
-                        }
-                    });
-                }
-                
-                // Find the MOST RECENT incoming call for this room that's still ringing
-                const incomingCalls = allCalls
-                    .filter((call: any) => 
-                        call.roomId === roomId && 
-                        call.state === 'ringing' &&
-                        call.direction === 'inbound'
-                    )
-                    .sort((a: any, b: any) => {
-                        // Sort by call ID (timestamp-based) to get most recent
-                        return b.callId.localeCompare(a.callId);
-                    });
-                
-                console.log('📞 isAnswering?', isAnswering, '| incomingCalls:', incomingCalls.length);
-                
-                if (isAnswering && incomingCalls.length > 0) {
-                    // ANSWERING MODE: We clicked "Accept" button
-                    const existingCall = incomingCalls[0]; // Most recent
-                    console.log('📞 Found existing incoming call:', (existingCall as any).callId);
-                    console.log('📞 Call state:', (existingCall as any).state, 'direction:', (existingCall as any).direction);
-                    console.log('✅ ANSWERING incoming call (not starting new one!)');
-                    setActiveCall(existingCall as any);
-                    callInitializedRef.current = true; // Mark FIRST!
-                    
-                    // Auto-answer the existing call
-                    matrixCallService.answerCall(
-                        existingCall as any,
-                        isVideoCall,
-                        localVideoRef.current || undefined,
-                        remoteVideoRef.current || undefined
-                    ).catch((err) => {
-                        console.error('Failed to answer existing call:', err);
-                        setError((err as Error).message);
-                    });
-                    
-                    console.log('✅ Answered! Exiting without calling startCall()');
-                    return; // EXIT - don't call startCall()!
-                }
-                
-                if (isAnswering && incomingCalls.length === 0) {
-                    // ANSWERING MODE but no incoming call - Matrix still syncing
-                    console.log('⏳ Answering mode but no incoming call yet - waiting...');
-                    setError('Waiting for incoming call to arrive...');
-                    callInitializedRef.current = true;
-                    return; // EXIT - don't call startCall()!
-                }
-                
-                if (!isAnswering && incomingCalls.length > 0) {
-                    // OUTGOING MODE but incoming call exists - conflict!
-                    console.log('⚠️ Both users clicked call at same time!');
-                }
-            }
-        }
-        
-        // OUTGOING MODE: Start new call
-        console.log('📞 Starting new outgoing call...');
-        callInitializedRef.current = true; // Mark as initialized
-        startCall();
-        
-        // Cleanup on unmount
-        return () => {
-            console.log('🧹 MatrixCallView unmounting - cleaning up ALL calls...');
-            
-            // Hangup current call
-            matrixCallService.hangupCall();
-            
-            // CRITICAL: Clean up ALL calls for this room to prevent self-calling loop on reload
-            const matrixClientService = (window as any).matrixClientService;
-            if (matrixClientService) {
-                const client = matrixClientService.getClient();
-                const calls = client?.callEventHandler?.calls;
-                
-                if (calls) {
-                    const roomCalls = Array.from(calls.values()).filter((call: any) => call.roomId === roomId);
-                    console.log(`🧹 Found ${roomCalls.length} calls for this room, cleaning up...`);
-                    
-                    roomCalls.forEach((call: any) => {
-                        try {
-                            if (call.state !== 'ended') {
-                                console.log(`🧹 Hanging up call ${call.callId} (state: ${call.state})`);
-                                call.hangup();
-                            }
-                            calls.delete(call.callId);
-                        } catch (e) {
-                            console.warn('Could not clean up call:', e);
-                        }
-                    });
-                    
-                    console.log('✅ All calls cleaned up for room:', roomId);
-                }
-            }
-        };
-    }, [incomingCall, roomId, isVideoCall]);  // REMOVED startCall to prevent re-runs!
+				// Initialize Matrix client with stored credentials
+				const { MatrixClientService } = await import(
+					'../../services/matrixClientService'
+				);
+				const newMatrixClientService = new MatrixClientService();
+				newMatrixClientService.initializeClient({
+					userId: matrixUserId,
+					accessToken: matrixAccessToken,
+					deviceId: localStorage.getItem('matrix_device_id') || '',
+					homeserverUrl:
+						process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
+						''
+				});
 
-    // Monitor call state
-    useEffect(() => {
-        if (!activeCall) return;
+				(window as any).matrixClientService = newMatrixClientService;
 
-        const handleStateChange = (state: CallState) => {
-            setCallState(state);
-            if (state === CallState.Ended) {
-                onCallEnd();
-            }
-        };
+				// Wait a bit for client to sync
+				await new Promise((resolve) => setTimeout(resolve, 2000));
 
-        activeCall.on('state' as any, handleStateChange);
+				console.log('✅ Matrix client initialized');
+			}
 
-        return () => {
-            activeCall.off('state' as any, handleStateChange);
-        };
-    }, [activeCall, onCallEnd]);
+			const call = await matrixCallService.startCall({
+				roomId,
+				isVideoCall,
+				localVideoElement: localVideoRef.current || undefined,
+				remoteVideoElement: remoteVideoRef.current || undefined
+			});
+			setActiveCall(call);
+		} catch (err) {
+			console.error('Failed to start call:', err);
+			setError((err as Error).message);
+		}
+	}, [roomId, isVideoCall]);
 
-    // Render call state message
-    const renderCallState = () => {
-        if (error) {
-            return <div className="matrix-call__error">Error: {error}</div>;
-        }
+	// Answer incoming call
+	const answerCall = useCallback(async () => {
+		if (!incomingCall) return;
 
-        if (incomingCall && callState !== CallState.Connected) {
-            return <div className="matrix-call__incoming">Incoming call...</div>;
-        }
+		try {
+			setError(null);
+			await matrixCallService.answerCall(
+				incomingCall,
+				isVideoCall,
+				localVideoRef.current || undefined,
+				remoteVideoRef.current || undefined
+			);
+			setActiveCall(incomingCall);
+		} catch (err) {
+			console.error('Failed to answer call:', err);
+			setError((err as Error).message);
+		}
+	}, [incomingCall, isVideoCall]);
 
-        switch (callState) {
-            case CallState.WaitLocalMedia:
-                return <div className="matrix-call__state">Requesting media access...</div>;
-            case CallState.CreateOffer:
-            case CallState.CreateAnswer:
-                return <div className="matrix-call__state">Connecting...</div>;
-            case CallState.Connecting:
-                return <div className="matrix-call__state">Connecting...</div>;
-            case CallState.Connected:
-                return <div className="matrix-call__state">Connected</div>;
-            case CallState.Ringing:
-                return <div className="matrix-call__state">Ringing...</div>;
-            case CallState.Ended:
-                return <div className="matrix-call__state">Call ended</div>;
-            default:
-                return <div className="matrix-call__state">Initializing...</div>;
-        }
-    };
+	// Reject incoming call
+	const rejectCall = useCallback(() => {
+		if (incomingCall) {
+			matrixCallService.rejectCall(incomingCall);
+			onCallEnd();
+		}
+	}, [incomingCall, onCallEnd]);
 
-    return (
-        <div className="matrix-call">
-            <div className="matrix-call__header">
-                <h2>{isVideoCall ? '📹 Video Call' : '📞 Voice Call'}</h2>
-                {renderCallState()}
-            </div>
+	// Hangup call
+	const hangupCall = useCallback(() => {
+		matrixCallService.hangupCall();
+		onCallEnd();
+	}, [onCallEnd]);
 
-            <div className="matrix-call__videos">
-                {/* Remote video (other person) */}
-                <div className="matrix-call__remote-video">
-                    <video
-                        ref={remoteVideoRef}
-                        className="matrix-call__video matrix-call__video--remote"
-                        autoPlay
-                        playsInline
-                    />
-                    {callState !== CallState.Connected && (
-                        <div className="matrix-call__video-placeholder">
-                            Waiting for connection...
-                        </div>
-                    )}
-                </div>
+	// Toggle microphone
+	const toggleMicrophone = useCallback(() => {
+		const muted = matrixCallService.toggleMicrophone();
+		setIsMuted(muted);
+	}, []);
 
-                {/* Local video (you) */}
-                {isVideoCall && (
-                    <div className="matrix-call__local-video">
-                        <video
-                            ref={localVideoRef}
-                            className="matrix-call__video matrix-call__video--local"
-                            autoPlay
-                            playsInline
-                            muted
-                        />
-                    </div>
-                )}
-            </div>
+	// Toggle video
+	const toggleVideo = useCallback(() => {
+		const videoMuted = matrixCallService.toggleVideo();
+		setIsVideoMuted(videoMuted);
+	}, []);
 
-            <div className="matrix-call__controls">
-                {/* Incoming call actions */}
-                {incomingCall && callState !== CallState.Connected && (
-                    <>
-                        <button
-                            className="matrix-call__button matrix-call__button--answer"
-                            onClick={answerCall}
-                        >
-                            ✅ Answer
-                        </button>
-                        <button
-                            className="matrix-call__button matrix-call__button--reject"
-                            onClick={rejectCall}
-                        >
-                            ❌ Reject
-                        </button>
-                    </>
-                )}
+	// Initialize call on mount
+	useEffect(() => {
+		// CRITICAL: Prevent multiple initializations
+		if (callInitializedRef.current) {
+			console.log('⚠️ Call already initialized, skipping...');
+			return;
+		}
 
-                {/* Active call controls */}
-                {callState === CallState.Connected && (
-                    <>
-                        <button
-                            className={`matrix-call__button ${
-                                isMuted ? 'matrix-call__button--active' : ''
-                            }`}
-                            onClick={toggleMicrophone}
-                            title={isMuted ? 'Unmute' : 'Mute'}
-                        >
-                            {isMuted ? '🎤❌' : '🎤'}
-                        </button>
+		// Check URL parameter to see if we're answering an incoming call
+		const urlParams = new URLSearchParams(window.location.search);
+		const isAnswering = urlParams.get('answer') === 'true';
 
-                        {isVideoCall && (
-                            <button
-                                className={`matrix-call__button ${
-                                    isVideoMuted ? 'matrix-call__button--active' : ''
-                                }`}
-                                onClick={toggleVideo}
-                                title={isVideoMuted ? 'Enable Video' : 'Disable Video'}
-                            >
-                                {isVideoMuted ? '📹❌' : '📹'}
-                            </button>
-                        )}
+		console.log('📞 MatrixCallView mount - isAnswering:', isAnswering);
+		console.log('📞 incomingCall prop:', !!incomingCall);
 
-                        <button
-                            className="matrix-call__button matrix-call__button--hangup"
-                            onClick={hangupCall}
-                        >
-                            📞 Hang Up
-                        </button>
-                    </>
-                )}
+		if (incomingCall) {
+			// Incoming call passed directly - wait for user to answer/reject
+			console.log('📞 Incoming call prop provided, using it');
+			setActiveCall(incomingCall);
+			callInitializedRef.current = true;
+			return; // Exit early - don't check for other calls
+		}
 
-                {/* Hangup for outgoing call before connected */}
-                {!incomingCall && callState !== CallState.Connected && callState !== CallState.Ended && (
-                    <button
-                        className="matrix-call__button matrix-call__button--hangup"
-                        onClick={hangupCall}
-                    >
-                        Cancel
-                    </button>
-                )}
-            </div>
-        </div>
-    );
+		// Flag to prevent starting new call if we're answering
+		let shouldStartNewCall = true;
+
+		// Check if there's already an incoming call for this room
+		const matrixClientService = (window as any).matrixClientService;
+		if (matrixClientService) {
+			const client = matrixClientService.getClient();
+			const calls = client?.callEventHandler?.calls;
+
+			if (calls) {
+				// CRITICAL: First clean up old/ended calls
+				const allCalls = Array.from(calls.values());
+				const endedCalls = allCalls.filter(
+					(call: any) =>
+						call.state === 'ended' && call.roomId === roomId
+				);
+
+				if (endedCalls.length > 0) {
+					console.log(
+						`🧹 Cleaning up ${endedCalls.length} ended calls...`
+					);
+					endedCalls.forEach((call: any) => {
+						try {
+							calls.delete(call.callId);
+						} catch (e) {
+							console.warn('Could not delete ended call:', e);
+						}
+					});
+				}
+
+				// Find the MOST RECENT incoming call for this room that's still ringing
+				const incomingCalls = allCalls
+					.filter(
+						(call: any) =>
+							call.roomId === roomId &&
+							call.state === 'ringing' &&
+							call.direction === 'inbound'
+					)
+					.sort((a: any, b: any) => {
+						// Sort by call ID (timestamp-based) to get most recent
+						return b.callId.localeCompare(a.callId);
+					});
+
+				console.log(
+					'📞 isAnswering?',
+					isAnswering,
+					'| incomingCalls:',
+					incomingCalls.length
+				);
+
+				if (isAnswering && incomingCalls.length > 0) {
+					// ANSWERING MODE: We clicked "Accept" button
+					const existingCall = incomingCalls[0]; // Most recent
+					console.log(
+						'📞 Found existing incoming call:',
+						(existingCall as any).callId
+					);
+					console.log(
+						'📞 Call state:',
+						(existingCall as any).state,
+						'direction:',
+						(existingCall as any).direction
+					);
+					console.log(
+						'✅ ANSWERING incoming call (not starting new one!)'
+					);
+					setActiveCall(existingCall as any);
+					callInitializedRef.current = true; // Mark FIRST!
+
+					// Auto-answer the existing call
+					matrixCallService
+						.answerCall(
+							existingCall as any,
+							isVideoCall,
+							localVideoRef.current || undefined,
+							remoteVideoRef.current || undefined
+						)
+						.catch((err) => {
+							console.error(
+								'Failed to answer existing call:',
+								err
+							);
+							setError((err as Error).message);
+						});
+
+					console.log(
+						'✅ Answered! Exiting without calling startCall()'
+					);
+					return; // EXIT - don't call startCall()!
+				}
+
+				if (isAnswering && incomingCalls.length === 0) {
+					// ANSWERING MODE but no incoming call - Matrix still syncing
+					console.log(
+						'⏳ Answering mode but no incoming call yet - waiting...'
+					);
+					setError('Waiting for incoming call to arrive...');
+					callInitializedRef.current = true;
+					return; // EXIT - don't call startCall()!
+				}
+
+				if (!isAnswering && incomingCalls.length > 0) {
+					// OUTGOING MODE but incoming call exists - conflict!
+					console.log('⚠️ Both users clicked call at same time!');
+				}
+			}
+		}
+
+		// OUTGOING MODE: Start new call
+		console.log('📞 Starting new outgoing call...');
+		callInitializedRef.current = true; // Mark as initialized
+		startCall();
+
+		// Cleanup on unmount
+		return () => {
+			console.log(
+				'🧹 MatrixCallView unmounting - cleaning up ALL calls...'
+			);
+
+			// Hangup current call
+			matrixCallService.hangupCall();
+
+			// CRITICAL: Clean up ALL calls for this room to prevent self-calling loop on reload
+			const matrixClientService = (window as any).matrixClientService;
+			if (matrixClientService) {
+				const client = matrixClientService.getClient();
+				const calls = client?.callEventHandler?.calls;
+
+				if (calls) {
+					const roomCalls = Array.from(calls.values()).filter(
+						(call: any) => call.roomId === roomId
+					);
+					console.log(
+						`🧹 Found ${roomCalls.length} calls for this room, cleaning up...`
+					);
+
+					roomCalls.forEach((call: any) => {
+						try {
+							if (call.state !== 'ended') {
+								console.log(
+									`🧹 Hanging up call ${call.callId} (state: ${call.state})`
+								);
+								call.hangup();
+							}
+							calls.delete(call.callId);
+						} catch (e) {
+							console.warn('Could not clean up call:', e);
+						}
+					});
+
+					console.log('✅ All calls cleaned up for room:', roomId);
+				}
+			}
+		};
+	}, [incomingCall, roomId, isVideoCall]); // REMOVED startCall to prevent re-runs!
+
+	// Monitor call state
+	useEffect(() => {
+		if (!activeCall) return;
+
+		const handleStateChange = (state: CallState) => {
+			setCallState(state);
+			if (state === CallState.Ended) {
+				onCallEnd();
+			}
+		};
+
+		activeCall.on('state' as any, handleStateChange);
+
+		return () => {
+			activeCall.off('state' as any, handleStateChange);
+		};
+	}, [activeCall, onCallEnd]);
+
+	// Render call state message
+	const renderCallState = () => {
+		if (error) {
+			return <div className="matrix-call__error">Error: {error}</div>;
+		}
+
+		if (incomingCall && callState !== CallState.Connected) {
+			return (
+				<div className="matrix-call__incoming">Incoming call...</div>
+			);
+		}
+
+		switch (callState) {
+			case CallState.WaitLocalMedia:
+				return (
+					<div className="matrix-call__state">
+						Requesting media access...
+					</div>
+				);
+			case CallState.CreateOffer:
+			case CallState.CreateAnswer:
+				return <div className="matrix-call__state">Connecting...</div>;
+			case CallState.Connecting:
+				return <div className="matrix-call__state">Connecting...</div>;
+			case CallState.Connected:
+				return <div className="matrix-call__state">Connected</div>;
+			case CallState.Ringing:
+				return <div className="matrix-call__state">Ringing...</div>;
+			case CallState.Ended:
+				return <div className="matrix-call__state">Call ended</div>;
+			default:
+				return (
+					<div className="matrix-call__state">Initializing...</div>
+				);
+		}
+	};
+
+	return (
+		<div className="matrix-call">
+			<div className="matrix-call__header">
+				<h2>{isVideoCall ? '📹 Video Call' : '📞 Voice Call'}</h2>
+				{renderCallState()}
+			</div>
+
+			<div className="matrix-call__videos">
+				{/* Remote video (other person) */}
+				<div className="matrix-call__remote-video">
+					<video
+						ref={remoteVideoRef}
+						className="matrix-call__video matrix-call__video--remote"
+						autoPlay
+						playsInline
+					/>
+					{callState !== CallState.Connected && (
+						<div className="matrix-call__video-placeholder">
+							Waiting for connection...
+						</div>
+					)}
+				</div>
+
+				{/* Local video (you) */}
+				{isVideoCall && (
+					<div className="matrix-call__local-video">
+						<video
+							ref={localVideoRef}
+							className="matrix-call__video matrix-call__video--local"
+							autoPlay
+							playsInline
+							muted
+						/>
+					</div>
+				)}
+			</div>
+
+			<div className="matrix-call__controls">
+				{/* Incoming call actions */}
+				{incomingCall && callState !== CallState.Connected && (
+					<>
+						<button
+							className="matrix-call__button matrix-call__button--answer"
+							onClick={answerCall}
+						>
+							✅ Answer
+						</button>
+						<button
+							className="matrix-call__button matrix-call__button--reject"
+							onClick={rejectCall}
+						>
+							❌ Reject
+						</button>
+					</>
+				)}
+
+				{/* Active call controls */}
+				{callState === CallState.Connected && (
+					<>
+						<button
+							className={`matrix-call__button ${
+								isMuted ? 'matrix-call__button--active' : ''
+							}`}
+							onClick={toggleMicrophone}
+							title={isMuted ? 'Unmute' : 'Mute'}
+						>
+							{isMuted ? '🎤❌' : '🎤'}
+						</button>
+
+						{isVideoCall && (
+							<button
+								className={`matrix-call__button ${
+									isVideoMuted
+										? 'matrix-call__button--active'
+										: ''
+								}`}
+								onClick={toggleVideo}
+								title={
+									isVideoMuted
+										? 'Enable Video'
+										: 'Disable Video'
+								}
+							>
+								{isVideoMuted ? '📹❌' : '📹'}
+							</button>
+						)}
+
+						<button
+							className="matrix-call__button matrix-call__button--hangup"
+							onClick={hangupCall}
+						>
+							📞 Hang Up
+						</button>
+					</>
+				)}
+
+				{/* Hangup for outgoing call before connected */}
+				{!incomingCall &&
+					callState !== CallState.Connected &&
+					callState !== CallState.Ended && (
+						<button
+							className="matrix-call__button matrix-call__button--hangup"
+							onClick={hangupCall}
+						>
+							Cancel
+						</button>
+					)}
+			</div>
+		</div>
+	);
 };

--- a/src/components/registration/agencySelection/AgencySelectionResults.tsx
+++ b/src/components/registration/agencySelection/AgencySelectionResults.tsx
@@ -144,7 +144,9 @@ export const AgencySelectionResults = ({
 							href={
 								fallbackUrl
 									? `${fallbackUrl}${zipcode}/`
-									: 'https://www.caritas.de'
+									: process.env
+											.REACT_APP_ORGANIZATION_HOME_URL ||
+										'https://www.caritas.de'
 							}
 						>
 							{t('registration.agency.noresult.label')}

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -57,6 +57,7 @@ import {
 	SETTING_HIDE_SYSTEM_MESSAGES
 } from '../../api/apiRocketChatSettingsPublic';
 import { messageEventEmitter } from '../../services/messageEventEmitter';
+import { getApiBaseUrl } from '../../resources/scripts/getApiBaseUrl';
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -211,9 +212,7 @@ export const SessionStream = ({
 			activeSession.rid && activeSession.rid.startsWith('!');
 		if ((!activeSession.rid || isMatrixRoom) && activeSession.item?.id) {
 			const sessionId = activeSession.item.id;
-			const apiUrlBase = (window as any).Cypress
-				? (window as any).Cypress.env('REACT_APP_API_URL')
-				: process.env.REACT_APP_API_URL || '';
+			const apiUrlBase = getApiBaseUrl();
 			const matrixUrl = `${apiUrlBase}/service/matrix/sessions/${sessionId}/messages`;
 
 			// console.log('🚀 MATRIX: Fetching messages from Matrix API:', matrixUrl);

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -1,51 +1,60 @@
-import { createClient, MatrixClient } from "matrix-js-sdk";
+import { createClient, MatrixClient } from 'matrix-js-sdk';
 
 export interface MatrixLoginData {
-    accessToken: string;
-    userId: string;
-    deviceId: string;
-    homeserverUrl: string;
+	accessToken: string;
+	userId: string;
+	deviceId: string;
+	homeserverUrl: string;
 }
 
 export const getMatrixAccessToken = (
-    username: string,
-    password: string
+	username: string,
+	password: string
 ): Promise<MatrixLoginData> =>
-    new Promise((resolve, reject) => {
-        // Use existing Matrix Synapse server from environment variable
-        const homeserverUrl = process.env.REACT_APP_MATRIX_HOMESERVER_URL || "http://91.99.219.182:8008";
-        
-        // Create Matrix client
-        const client = createClient({
-            baseUrl: homeserverUrl,
-        });
+	new Promise((resolve, reject) => {
+		const homeserverUrl =
+			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		if (!homeserverUrl) {
+			reject(
+				new Error('REACT_APP_MATRIX_HOMESERVER_URL is not configured')
+			);
+			return;
+		}
 
-        // Login with username and password
-        client.login("m.login.password", {
-            user: username,
-            password: password,
-        })
-        .then((response) => {
-            // console.log("Matrix login successful:", response);
-            resolve({
-                accessToken: response.access_token,
-                userId: response.user_id,
-                deviceId: response.device_id,
-                homeserverUrl: homeserverUrl,
-            });
-        })
-        .catch((error) => {
-            // console.error("Matrix login failed:", error);
-            reject(new Error("matrixLogin"));
-        });
-    });
+		// Create Matrix client
+		const client = createClient({
+			baseUrl: homeserverUrl
+		});
+
+		// Login with username and password
+		client
+			.login('m.login.password', {
+				user: username,
+				password: password
+			})
+			.then((response) => {
+				// console.log("Matrix login successful:", response);
+				resolve({
+					accessToken: response.access_token,
+					userId: response.user_id,
+					deviceId: response.device_id,
+					homeserverUrl: homeserverUrl
+				});
+			})
+			.catch((error) => {
+				// console.error("Matrix login failed:", error);
+				reject(new Error('matrixLogin'));
+			});
+	});
 
 // Helper function to create Matrix client with stored credentials
-export const createMatrixClient = (loginData: MatrixLoginData): MatrixClient => {
-    return createClient({
-        baseUrl: loginData.homeserverUrl,
-        accessToken: loginData.accessToken,
-        userId: loginData.userId,
-        deviceId: loginData.deviceId,
-    });
+export const createMatrixClient = (
+	loginData: MatrixLoginData
+): MatrixClient => {
+	return createClient({
+		baseUrl: loginData.homeserverUrl,
+		accessToken: loginData.accessToken,
+		userId: loginData.userId,
+		deviceId: loginData.deviceId
+	});
 };

--- a/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
+++ b/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
@@ -8,50 +8,78 @@ export const useStartVideoCall = () => {
 		// console.log("═══════════════════════════════════════════════");
 		// console.log("🎬 GROUP VIDEO CALL BUTTON CLICKED!");
 		// console.log("═══════════════════════════════════════════════");
-		
+
 		try {
 			// Get Matrix room ID from active session
-			const roomId = activeSession.item.matrixRoomId || activeSession.item.groupId;
-			
+			const roomId =
+				activeSession.item.matrixRoomId || activeSession.item.groupId;
+
 			// console.log("Room ID:", roomId);
-			
+
 			if (!roomId) {
 				// console.error('❌ No Matrix room ID found for session');
-				alert('Cannot start call: No Matrix room found for this session');
+				alert(
+					'Cannot start call: No Matrix room found for this session'
+				);
 				return;
 			}
 
 			// 🎯 GROUP CALLS: Open Element Call in a new popup window
 			// Element Call handles all the group call UI (grid layout, active speaker, etc.)
 			// console.log('📞 Opening Element Call for group video call...');
-			
+
 			// Get Matrix homeserver from current client
 			const matrixClientService = (window as any).matrixClientService;
 			const client = matrixClientService?.getClient();
-			const homeserverUrl = client?.getHomeserverUrl() || 'https://matrix.oriso.site';
-			
-			// Build Element Call URL
-			// Format: https://call.element.io/{roomId}?homeserver={homeserver}
-			const elementCallUrl = `https://call.element.io/${encodeURIComponent(roomId)}?homeserver=${encodeURIComponent(homeserverUrl)}`;
-			
+			const homeserverUrl =
+				client?.getHomeserverUrl() ||
+				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
+				'';
+
+			if (!homeserverUrl) {
+				alert(
+					'Cannot start call: Matrix homeserver URL is missing. Configure REACT_APP_MATRIX_HOMESERVER_URL.'
+				);
+				return;
+			}
+
+			const elementCallBase = (
+				process.env.REACT_APP_ELEMENT_CALL_BASE_URL || ''
+			).replace(/\/+$/, '');
+
+			if (!elementCallBase) {
+				alert(
+					'Cannot start call: REACT_APP_ELEMENT_CALL_BASE_URL is not configured'
+				);
+				return;
+			}
+
+			// Same shape as GroupCallWidget (Element Call /room route)
+			const params = new URLSearchParams();
+			params.set('roomId', roomId);
+			params.set('homeserver', homeserverUrl);
+			const elementCallUrl = `${elementCallBase}/room/#?${params.toString()}`;
+
 			// console.log('🌐 Opening Element Call URL:', elementCallUrl);
-			
+
 			// Open in a new popup window (sized for video calls)
 			const width = 1200;
 			const height = 800;
 			const left = (window.screen.width - width) / 2;
 			const top = (window.screen.height - height) / 2;
-			
+
 			window.open(
 				elementCallUrl,
 				'ElementCall',
 				`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`
 			);
-			
+
 			// console.log('✅ Element Call popup opened!');
 		} catch (error) {
 			// console.error('💥 ERROR in onStartVideoCall:', error);
-			alert(`Failed to start group call: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			alert(
+				`Failed to start group call: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
 		}
 		// console.log("═══════════════════════════════════════════════");
 	}, [activeSession.item.groupId, activeSession.item.matrixRoomId]);

--- a/src/components/termsandconditions/TermsAndConditions.tsx
+++ b/src/components/termsandconditions/TermsAndConditions.tsx
@@ -71,9 +71,12 @@ export const TermsAndConditions = () => {
 
 	const transformText2DataPrivacyLink = (text: string) => {
 		let hereLabel = translate('termsAndConditionOverlay.labels.here');
+		const privacyHref =
+			process.env.REACT_APP_LEGAL_PRIVACY_URL ||
+			'https://www.caritas-beratungundhilfe.de/datenschutz';
 		return text.replace(
 			hereLabel,
-			`<a class='link' target='_blank' href='https://www.caritas-beratungundhilfe.de/datenschutz'>${hereLabel}</a>`
+			`<a class='link' target='_blank' href='${privacyHref}'>${hereLabel}</a>`
 		);
 	};
 

--- a/src/components/uiVersionToggle/UIVersionToggle.tsx
+++ b/src/components/uiVersionToggle/UIVersionToggle.tsx
@@ -13,7 +13,7 @@ export const UIVersionToggle = () => {
 		// Determine current UI based on port
 		// Port 8087 = Element (New UI), Port 9001 = Classic UI
 		const currentPort = window.location.port;
-		
+
 		// If on Element (8087), toggle should be ON
 		// If on Classic (9001), toggle should be OFF
 		return currentPort === '8087';
@@ -21,55 +21,71 @@ export const UIVersionToggle = () => {
 
 	const toggleUI = () => {
 		const newVersion = useNewUI ? 'classic' : 'new';
-		
+
 		// Save preference
 		localStorage.setItem(UI_VERSION_STORAGE, newVersion);
-		
+
 		// Set cookie with cross-subdomain support
-		const isSubdomain = window.location.hostname !== '91.99.219.182';
-		const cookieDomain = isSubdomain ? '; domain=.oriso.site' : '';
+		const plainHosts = (
+			process.env.REACT_APP_HOSTNAMES_WITHOUT_COOKIE_DOMAIN ||
+			'91.99.219.182,localhost'
+		)
+			.split(',')
+			.map((h) => h.trim())
+			.filter(Boolean);
+		const useSharedCookieDomain =
+			plainHosts.length === 0 ||
+			!plainHosts.includes(window.location.hostname);
+		const cookieDomainFromEnv = process.env.REACT_APP_COOKIE_DOMAIN?.trim();
+		const uiVersionCookieDomain =
+			useSharedCookieDomain && cookieDomainFromEnv
+				? `; domain=${cookieDomainFromEnv}`
+				: '';
 		const secure = window.location.protocol === 'https:' ? '; secure' : '';
 		const expiryDate = new Date();
 		expiryDate.setDate(expiryDate.getDate() + 30);
-		document.cookie = `${UI_VERSION_COOKIE}=${newVersion}; path=/; expires=${expiryDate.toUTCString()}; SameSite=Lax${cookieDomain}${secure}`;
-		
+		document.cookie = `${UI_VERSION_COOKIE}=${newVersion}; path=/; expires=${expiryDate.toUTCString()}; SameSite=Lax${uiVersionCookieDomain}${secure}`;
+
 		// Redirect to Element UI or reload
 		if (newVersion === 'new') {
-			// Get Matrix credentials from localStorage
 			const matrixUserId = localStorage.getItem('matrix_user_id');
-			const matrixAccessToken = localStorage.getItem('matrix_access_token');
+			const matrixAccessToken = localStorage.getItem(
+				'matrix_access_token'
+			);
 			const matrixDeviceId = localStorage.getItem('matrix_device_id');
-			const currentHost = window.location.hostname;
-			// Use environment variable for homeserver URL
-			const homeserverUrl = process.env.REACT_APP_MATRIX_HOMESERVER_URL || `http://${currentHost}:8008`;
-			
-		if (matrixUserId && matrixAccessToken) {
-			// Store Matrix credentials in COOKIES (shared across subdomains!)
-			const cookieDomain = process.env.REACT_APP_COOKIE_DOMAIN;
-			const isSecure = process.env.REACT_APP_USE_HTTPS === 'true';
-			
-			const domainStr = cookieDomain ? `; domain=${cookieDomain}` : '';
-			const secureStr = isSecure ? '; secure' : '';
-			
-			document.cookie = `matrix_sso_user_id=${encodeURIComponent(matrixUserId)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
-			document.cookie = `matrix_sso_access_token=${encodeURIComponent(matrixAccessToken)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
-			document.cookie = `matrix_sso_device_id=${encodeURIComponent(matrixDeviceId || '')}; path=/; SameSite=Lax${domainStr}${secureStr}`;
-			document.cookie = `matrix_sso_hs_url=${encodeURIComponent(homeserverUrl)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
-			
-			// console.log('✅ Matrix credentials stored in cookies for Element SSO');
-			// console.log('📍 User ID:', matrixUserId);
-			// console.log('📍 Homeserver:', homeserverUrl);
-			// console.log('📍 Device ID:', matrixDeviceId);
-			// console.log('📍 Cookie domain:', cookieDomain || 'current host only');
-		} else {
-			// console.warn('⚠️ No Matrix credentials found - Element will require manual login');
-		}
-		
-		// Redirect to Element (Beta UI)
-		// Element's auto-login script will read the cookies and auto-login
-		const elementUrl = process.env.REACT_APP_ELEMENT_URL || `http://${currentHost}:8087`;
-		
-		window.location.href = elementUrl;
+			const homeserverUrl =
+				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+			if (!homeserverUrl) {
+				alert(
+					'REACT_APP_MATRIX_HOMESERVER_URL is not set; cannot sync Matrix cookies for the new UI.'
+				);
+				return;
+			}
+
+			if (matrixUserId && matrixAccessToken) {
+				const matrixCookieDomain = process.env.REACT_APP_COOKIE_DOMAIN;
+				const isSecure = process.env.REACT_APP_USE_HTTPS === 'true';
+
+				const domainStr = matrixCookieDomain
+					? `; domain=${matrixCookieDomain}`
+					: '';
+				const secureStr = isSecure ? '; secure' : '';
+
+				document.cookie = `matrix_sso_user_id=${encodeURIComponent(matrixUserId)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
+				document.cookie = `matrix_sso_access_token=${encodeURIComponent(matrixAccessToken)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
+				document.cookie = `matrix_sso_device_id=${encodeURIComponent(matrixDeviceId || '')}; path=/; SameSite=Lax${domainStr}${secureStr}`;
+				document.cookie = `matrix_sso_hs_url=${encodeURIComponent(homeserverUrl)}; path=/; SameSite=Lax${domainStr}${secureStr}`;
+			}
+
+			const elementUrl = process.env.REACT_APP_ELEMENT_URL?.trim();
+			if (!elementUrl) {
+				alert(
+					'REACT_APP_ELEMENT_URL is not set; cannot open the Element UI.'
+				);
+				return;
+			}
+
+			window.location.href = elementUrl;
 		} else {
 			// Reload to Classic UI
 			window.location.reload();
@@ -77,11 +93,14 @@ export const UIVersionToggle = () => {
 	};
 
 	return (
-		<Box className="ui-version-toggle" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-			<Chip 
-				label="BETA" 
-				size="small" 
-				color="primary" 
+		<Box
+			className="ui-version-toggle"
+			sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+		>
+			<Chip
+				label="BETA"
+				size="small"
+				color="primary"
 				variant="outlined"
 				sx={{ display: useNewUI ? 'none' : 'inline-flex' }}
 			/>
@@ -104,4 +123,3 @@ export const UIVersionToggle = () => {
 		</Box>
 	);
 };
-

--- a/src/pages/app.html
+++ b/src/pages/app.html
@@ -42,6 +42,7 @@
 	</head>
 
 	<body role="document">
+		<script src="%PUBLIC_URL%/config.js"></script>
 		<div class="app__container">
 			<div id="banner" class="banner"></div>
 

--- a/src/pages/under-construction.html
+++ b/src/pages/under-construction.html
@@ -165,7 +165,7 @@
 						können Sie währenddessen die Anwendung nicht nutzen.
 						Versuchen Sie es später noch einmal.
 					</p>
-					<a href="https://www.caritas.de/onlineberatung">
+					<a href="__REACT_APP_ORGANIZATION_ONLINEBERATUNG_URL__">
 						<button class="errorPage__button">
 							Zur Caritas Website
 						</button>

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -19,6 +19,15 @@ import {
 	OVERLAY_TWO_FACTOR_NAG
 } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 
+const organizationHomeUrl =
+	process.env.REACT_APP_ORGANIZATION_HOME_URL || 'https://www.caritas.de';
+const legalImprintUrl =
+	process.env.REACT_APP_LEGAL_IMPRINT_URL ||
+	'https://www.caritas-beratungundhilfe.de/impressum';
+const legalPrivacyUrl =
+	process.env.REACT_APP_LEGAL_PRIVACY_URL ||
+	'https://www.caritas-beratungundhilfe.de/datenschutz';
+
 export const uiUrl = window.location.origin;
 
 export const APP_PATH = 'app';
@@ -59,7 +68,7 @@ export const config: AppConfigInterface = {
 		error401: uiUrl + '/error.401.html',
 		error404: uiUrl + '/error.404.html',
 		error500: uiUrl + '/error.500.html',
-		home: 'https://www.caritas.de',
+		home: organizationHomeUrl,
 		landingpage: '/login',
 		releases: uiUrl + '/releases',
 		redirectToApp: uiUrl + '/' + APP_PATH,
@@ -94,11 +103,11 @@ export const config: AppConfigInterface = {
 	},
 	legalLinks: [
 		{
-			url: 'https://www.caritas-beratungundhilfe.de/impressum',
+			url: legalImprintUrl,
 			label: 'login.legal.infoText.impressum'
 		},
 		{
-			url: 'https://www.caritas-beratungundhilfe.de/datenschutz',
+			url: legalPrivacyUrl,
 			label: 'login.legal.infoText.dataprotection',
 			registration: true
 		}

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -1,14 +1,6 @@
-const apiUrlEnv: string = (window as any).Cypress
-	? (window as any).Cypress.env('REACT_APP_API_URL')
-	: process.env.REACT_APP_API_URL;
+import { getApiBaseUrl } from './getApiBaseUrl';
 
-export let apiUrl = '';
-if (apiUrlEnv) {
-	apiUrl = apiUrlEnv;
-	if (!apiUrl.startsWith('http://') && !apiUrl.startsWith('https://')) {
-		apiUrl = 'https://' + apiUrl;
-	}
-}
+export const apiUrl = getApiBaseUrl();
 
 export const endpoints = {
 	agencyConsultants: apiUrl + '/service/users/consultants',

--- a/src/resources/scripts/getApiBaseUrl.ts
+++ b/src/resources/scripts/getApiBaseUrl.ts
@@ -1,0 +1,25 @@
+const normalizeApiUrl = (value?: string | null): string => {
+	const trimmed = String(value || '').trim();
+	if (!trimmed) {
+		return '';
+	}
+	if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+		return trimmed;
+	}
+	return `https://${trimmed}`;
+};
+
+export const getApiBaseUrl = (): string => {
+	const cypressApiUrl = (window as any)?.Cypress?.env?.('REACT_APP_API_URL');
+	if (cypressApiUrl) {
+		return normalizeApiUrl(cypressApiUrl);
+	}
+
+	const runtimeApiUrl = (window as any)?.__ORISO_RUNTIME_CONFIG__
+		?.REACT_APP_API_URL;
+	if (runtimeApiUrl) {
+		return normalizeApiUrl(runtimeApiUrl);
+	}
+
+	return normalizeApiUrl(process.env.REACT_APP_API_URL);
+};

--- a/src/services/liveKitService.ts
+++ b/src/services/liveKitService.ts
@@ -2,297 +2,347 @@
  * LiveKit Service - Handles group video calls with LiveKit
  */
 
-import { Room, RoomEvent, Track, RemoteParticipant, RemoteTrackPublication, LocalParticipant } from 'livekit-client';
+import {
+	Room,
+	RoomEvent,
+	Track,
+	RemoteParticipant,
+	RemoteTrackPublication,
+	LocalParticipant
+} from 'livekit-client';
 
 export interface LiveKitParticipant {
-    userId: string;
-    displayName: string;
-    videoTrack?: MediaStreamTrack;
-    audioTrack?: MediaStreamTrack;
-    isLocal: boolean;
+	userId: string;
+	displayName: string;
+	videoTrack?: MediaStreamTrack;
+	audioTrack?: MediaStreamTrack;
+	isLocal: boolean;
 }
 
 class LiveKitService {
-    private room: Room | null = null;
-    private onParticipantsChanged?: (participants: LiveKitParticipant[]) => void;
-    private onError?: (error: Error) => void;
-    private subscribers: Set<(participants: LiveKitParticipant[]) => void> = new Set();
-    private currentParticipants: LiveKitParticipant[] = [];
-    private updateTimeout: any = null;
+	private room: Room | null = null;
+	private onParticipantsChanged?: (
+		participants: LiveKitParticipant[]
+	) => void;
+	private onError?: (error: Error) => void;
+	private subscribers: Set<(participants: LiveKitParticipant[]) => void> =
+		new Set();
+	private currentParticipants: LiveKitParticipant[] = [];
+	private updateTimeout: any = null;
 
-    /**
-     * Subscribe to participant updates
-     */
-    public subscribe(callback: (participants: LiveKitParticipant[]) => void): () => void {
-        this.subscribers.add(callback);
-        // Immediately call with current participants
-        callback(this.currentParticipants);
-        // Return unsubscribe function
-        return () => {
-            this.subscribers.delete(callback);
-        };
-    }
+	/**
+	 * Subscribe to participant updates
+	 */
+	public subscribe(
+		callback: (participants: LiveKitParticipant[]) => void
+	): () => void {
+		this.subscribers.add(callback);
+		// Immediately call with current participants
+		callback(this.currentParticipants);
+		// Return unsubscribe function
+		return () => {
+			this.subscribers.delete(callback);
+		};
+	}
 
-    /**
-     * Notify all subscribers of participant changes
-     */
-    private notifySubscribers(participants: LiveKitParticipant[]): void {
-        this.currentParticipants = participants;
-        this.subscribers.forEach(callback => callback(participants));
-    }
+	/**
+	 * Notify all subscribers of participant changes
+	 */
+	private notifySubscribers(participants: LiveKitParticipant[]): void {
+		this.currentParticipants = participants;
+		this.subscribers.forEach((callback) => callback(participants));
+	}
 
-    /**
-     * Connect to LiveKit room
-     */
-    public async connect(
-        roomName: string,
-        userName: string,
-        onParticipantsChanged: (participants: LiveKitParticipant[]) => void,
-        onError: (error: Error) => void
-    ): Promise<void> {
-        this.onParticipantsChanged = onParticipantsChanged;
-        this.onError = onError;
+	/**
+	 * Connect to LiveKit room
+	 */
+	public async connect(
+		roomName: string,
+		userName: string,
+		onParticipantsChanged: (participants: LiveKitParticipant[]) => void,
+		onError: (error: Error) => void
+	): Promise<void> {
+		this.onParticipantsChanged = onParticipantsChanged;
+		this.onError = onError;
 
-        try {
-            // console.log('📞 Connecting to LiveKit room:', roomName);
+		try {
+			// console.log('📞 Connecting to LiveKit room:', roomName);
 
-            // Create room
-            this.room = new Room({
-                adaptiveStream: true,
-                dynacast: true,
-                videoCaptureDefaults: {
-                    resolution: {
-                        width: 1280,
-                        height: 720,
-                        frameRate: 30
-                    }
-                }
-            });
+			// Create room
+			this.room = new Room({
+				adaptiveStream: true,
+				dynacast: true,
+				videoCaptureDefaults: {
+					resolution: {
+						width: 1280,
+						height: 720,
+						frameRate: 30
+					}
+				}
+			});
 
-            // Set up event listeners
-            this.setupRoomListeners();
+			// Set up event listeners
+			this.setupRoomListeners();
 
-            // Get access token from backend
-            const token = await this.getAccessToken(roomName, userName);
+			// Get access token from backend
+			const token = await this.getAccessToken(roomName, userName);
 
-            // Connect to LiveKit server
-            const wsUrl = 'wss://livekit.oriso.site';
-            // console.log('🔌 Connecting to:', wsUrl);
-            
-            await this.room.connect(wsUrl, token);
+			// Connect to LiveKit server (configure via REACT_APP_LIVEKIT_WS_URL)
+			const wsUrl = process.env.REACT_APP_LIVEKIT_WS_URL?.trim();
+			if (!wsUrl) {
+				throw new Error('REACT_APP_LIVEKIT_WS_URL is not set');
+			}
+			// console.log('🔌 Connecting to:', wsUrl);
 
-            // console.log('✅ Connected to LiveKit room');
+			await this.room.connect(wsUrl, token);
 
-            // Enable camera and microphone
-            await this.room.localParticipant.setCameraEnabled(true);
-            await this.room.localParticipant.setMicrophoneEnabled(true);
+			// console.log('✅ Connected to LiveKit room');
 
-            // Update participants after a short delay to let tracks publish
-            setTimeout(() => this.updateParticipants(), 500);
+			// Enable camera and microphone
+			await this.room.localParticipant.setCameraEnabled(true);
+			await this.room.localParticipant.setMicrophoneEnabled(true);
 
-        } catch (error) {
-            // console.error('❌ Failed to connect to LiveKit:', error);
-            if (this.onError) {
-                this.onError(error as Error);
-            }
-            throw error;
-        }
-    }
+			// Update participants after a short delay to let tracks publish
+			setTimeout(() => this.updateParticipants(), 500);
+		} catch (error) {
+			// console.error('❌ Failed to connect to LiveKit:', error);
+			if (this.onError) {
+				this.onError(error as Error);
+			}
+			throw error;
+		}
+	}
 
-    /**
-     * Get access token from backend
-     */
-    private async getAccessToken(roomName: string, userName: string): Promise<string> {
-        try {
-            // console.log('🔑 Requesting LiveKit token for:', { roomName, userName });
-            
-            const url = `/api/livekit/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(userName)}&_t=${Date.now()}`;
-            // console.log('📡 Fetching from URL:', url);
-            
-            const response = await fetch(url, {
-                method: 'GET',
-                headers: { 
-                    'Content-Type': 'application/json',
-                    'Cache-Control': 'no-cache, no-store, must-revalidate',
-                    'Pragma': 'no-cache'
-                },
-                cache: 'no-store'
-            });
-            
-            // console.log('📥 Response status:', response.status, response.statusText);
-            
-            const responseText = await response.text();
-            
-            if (!response.ok) {
-                throw new Error(`Token request failed: ${response.status} ${response.statusText}`);
-            }
-            
-            const data = JSON.parse(responseText);
-            
-            if (!data.token) {
-                throw new Error('No token received from server');
-            }
-            
-            // console.log('✅ Received LiveKit token');
-            return data.token;
-            
-        } catch (error) {
-            // console.error('❌ Failed to get LiveKit token:', error);
-            throw new Error(`Could not establish signal connection: ${(error as Error).message}`);
-        }
-    }
+	/**
+	 * Get access token from backend
+	 */
+	private async getAccessToken(
+		roomName: string,
+		userName: string
+	): Promise<string> {
+		try {
+			// console.log('🔑 Requesting LiveKit token for:', { roomName, userName });
 
-    /**
-     * Set up room event listeners
-     */
-    private setupRoomListeners(): void {
-        if (!this.room) return;
+			const url = `/api/livekit/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(userName)}&_t=${Date.now()}`;
+			// console.log('📡 Fetching from URL:', url);
 
-        // console.log('🎧 Setting up LiveKit listeners...');
+			const response = await fetch(url, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+					'Cache-Control': 'no-cache, no-store, must-revalidate',
+					'Pragma': 'no-cache'
+				},
+				cache: 'no-store'
+			});
 
-        // Participant joined - wait for tracks before updating
-        this.room.on(RoomEvent.ParticipantConnected, (participant: RemoteParticipant) => {
-            // console.log('👤 Participant connected:', participant.identity);
-            this.scheduleUpdate();
-        });
+			// console.log('📥 Response status:', response.status, response.statusText);
 
-        // Participant left
-        this.room.on(RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
-            // console.log('👋 Participant disconnected:', participant.identity);
-            this.scheduleUpdate();
-        });
+			const responseText = await response.text();
 
-        // Track subscribed - CRITICAL for remote video
-        this.room.on(RoomEvent.TrackSubscribed, (track: any, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
-            // console.log('📡 Track subscribed:', track.kind, 'from', participant.identity);
-            this.scheduleUpdate();
-        });
+			if (!response.ok) {
+				throw new Error(
+					`Token request failed: ${response.status} ${response.statusText}`
+				);
+			}
 
-        // Track unsubscribed
-        this.room.on(RoomEvent.TrackUnsubscribed, (track: any, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
-            // console.log('📴 Track unsubscribed:', track.kind, 'from', participant.identity);
-            this.scheduleUpdate();
-        });
+			const data = JSON.parse(responseText);
 
-        // Local track published
-        this.room.on(RoomEvent.LocalTrackPublished, (publication: any) => {
-            // console.log('📤 Local track published:', publication.kind);
-            this.scheduleUpdate();
-        });
+			if (!data.token) {
+				throw new Error('No token received from server');
+			}
 
-        // Connection state changed
-        this.room.on(RoomEvent.ConnectionStateChanged, (state: any) => {
-            // console.log('🔄 Connection state:', state);
-        });
+			// console.log('✅ Received LiveKit token');
+			return data.token;
+		} catch (error) {
+			// console.error('❌ Failed to get LiveKit token:', error);
+			throw new Error(
+				`Could not establish signal connection: ${(error as Error).message}`
+			);
+		}
+	}
 
-        // Disconnected
-        this.room.on(RoomEvent.Disconnected, () => {
-            // console.log('📴 Disconnected from room');
-        });
+	/**
+	 * Set up room event listeners
+	 */
+	private setupRoomListeners(): void {
+		if (!this.room) return;
 
-        // console.log('✅ LiveKit listeners set up');
-    }
+		// console.log('🎧 Setting up LiveKit listeners...');
 
-    /**
-     * Schedule update with debouncing to prevent rapid re-renders
-     */
-    private scheduleUpdate(): void {
-        if (this.updateTimeout) {
-            clearTimeout(this.updateTimeout);
-        }
-        this.updateTimeout = setTimeout(() => {
-            this.updateParticipants();
-        }, 200); // 200ms debounce
-    }
+		// Participant joined - wait for tracks before updating
+		this.room.on(
+			RoomEvent.ParticipantConnected,
+			(participant: RemoteParticipant) => {
+				// console.log('👤 Participant connected:', participant.identity);
+				this.scheduleUpdate();
+			}
+		);
 
-    /**
-     * Update participants list
-     */
-    private updateParticipants(): void {
-        if (!this.room) return;
+		// Participant left
+		this.room.on(
+			RoomEvent.ParticipantDisconnected,
+			(participant: RemoteParticipant) => {
+				// console.log('👋 Participant disconnected:', participant.identity);
+				this.scheduleUpdate();
+			}
+		);
 
-        const participants: LiveKitParticipant[] = [];
+		// Track subscribed - CRITICAL for remote video
+		this.room.on(
+			RoomEvent.TrackSubscribed,
+			(
+				track: any,
+				publication: RemoteTrackPublication,
+				participant: RemoteParticipant
+			) => {
+				// console.log('📡 Track subscribed:', track.kind, 'from', participant.identity);
+				this.scheduleUpdate();
+			}
+		);
 
-        // Add local participant
-        const localParticipant = this.room.localParticipant;
-        const localVideoPublication = Array.from(localParticipant.videoTrackPublications.values())[0];
-        const localAudioPublication = Array.from(localParticipant.audioTrackPublications.values())[0];
-        
-        participants.push({
-            userId: localParticipant.identity,
-            displayName: localParticipant.name || localParticipant.identity,
-            videoTrack: localVideoPublication?.track?.mediaStreamTrack,
-            audioTrack: localAudioPublication?.track?.mediaStreamTrack,
-            isLocal: true
-        });
+		// Track unsubscribed
+		this.room.on(
+			RoomEvent.TrackUnsubscribed,
+			(
+				track: any,
+				publication: RemoteTrackPublication,
+				participant: RemoteParticipant
+			) => {
+				// console.log('📴 Track unsubscribed:', track.kind, 'from', participant.identity);
+				this.scheduleUpdate();
+			}
+		);
 
-        // Add remote participants - use subscribed tracks
-        this.room.remoteParticipants.forEach((participant: RemoteParticipant) => {
-            const videoPublication = Array.from(participant.videoTrackPublications.values())[0];
-            const audioPublication = Array.from(participant.audioTrackPublications.values())[0];
-            
-            const videoTrack = videoPublication?.track?.mediaStreamTrack;
-            const audioTrack = audioPublication?.track?.mediaStreamTrack;
+		// Local track published
+		this.room.on(RoomEvent.LocalTrackPublished, (publication: any) => {
+			// console.log('📤 Local track published:', publication.kind);
+			this.scheduleUpdate();
+		});
 
-            participants.push({
-                userId: participant.identity,
-                displayName: participant.name || participant.identity,
-                videoTrack,
-                audioTrack,
-                isLocal: false
-            });
-        });
+		// Connection state changed
+		this.room.on(RoomEvent.ConnectionStateChanged, (state: any) => {
+			// console.log('🔄 Connection state:', state);
+		});
 
-        // console.log('👥 Participants updated:', participants.length, participants.map(p => `${p.displayName} (video: ${!!p.videoTrack})`));
-        
-        // Notify subscribers
-        this.notifySubscribers(participants);
-        
-        // Also call legacy callback if set
-        if (this.onParticipantsChanged) {
-            this.onParticipantsChanged(participants);
-        }
-    }
+		// Disconnected
+		this.room.on(RoomEvent.Disconnected, () => {
+			// console.log('📴 Disconnected from room');
+		});
 
-    /**
-     * Toggle microphone
-     */
-    public async setMicrophoneEnabled(enabled: boolean): Promise<void> {
-        if (this.room) {
-            await this.room.localParticipant.setMicrophoneEnabled(enabled);
-        }
-    }
+		// console.log('✅ LiveKit listeners set up');
+	}
 
-    /**
-     * Toggle camera
-     */
-    public async setCameraEnabled(enabled: boolean): Promise<void> {
-        if (this.room) {
-            await this.room.localParticipant.setCameraEnabled(enabled);
-        }
-    }
+	/**
+	 * Schedule update with debouncing to prevent rapid re-renders
+	 */
+	private scheduleUpdate(): void {
+		if (this.updateTimeout) {
+			clearTimeout(this.updateTimeout);
+		}
+		this.updateTimeout = setTimeout(() => {
+			this.updateParticipants();
+		}, 200); // 200ms debounce
+	}
 
-    /**
-     * Disconnect from room
-     */
-    public async disconnect(): Promise<void> {
-        if (this.room) {
-            // console.log('📴 Disconnecting from LiveKit...');
-            if (this.updateTimeout) {
-                clearTimeout(this.updateTimeout);
-            }
-            await this.room.disconnect();
-            this.room = null;
-            // console.log('✅ Disconnected');
-        }
-    }
+	/**
+	 * Update participants list
+	 */
+	private updateParticipants(): void {
+		if (!this.room) return;
 
-    /**
-     * Check if connected
-     */
-    public isConnected(): boolean {
-        return this.room !== null && this.room.state === 'connected';
-    }
+		const participants: LiveKitParticipant[] = [];
+
+		// Add local participant
+		const localParticipant = this.room.localParticipant;
+		const localVideoPublication = Array.from(
+			localParticipant.videoTrackPublications.values()
+		)[0];
+		const localAudioPublication = Array.from(
+			localParticipant.audioTrackPublications.values()
+		)[0];
+
+		participants.push({
+			userId: localParticipant.identity,
+			displayName: localParticipant.name || localParticipant.identity,
+			videoTrack: localVideoPublication?.track?.mediaStreamTrack,
+			audioTrack: localAudioPublication?.track?.mediaStreamTrack,
+			isLocal: true
+		});
+
+		// Add remote participants - use subscribed tracks
+		this.room.remoteParticipants.forEach(
+			(participant: RemoteParticipant) => {
+				const videoPublication = Array.from(
+					participant.videoTrackPublications.values()
+				)[0];
+				const audioPublication = Array.from(
+					participant.audioTrackPublications.values()
+				)[0];
+
+				const videoTrack = videoPublication?.track?.mediaStreamTrack;
+				const audioTrack = audioPublication?.track?.mediaStreamTrack;
+
+				participants.push({
+					userId: participant.identity,
+					displayName: participant.name || participant.identity,
+					videoTrack,
+					audioTrack,
+					isLocal: false
+				});
+			}
+		);
+
+		// console.log('👥 Participants updated:', participants.length, participants.map(p => `${p.displayName} (video: ${!!p.videoTrack})`));
+
+		// Notify subscribers
+		this.notifySubscribers(participants);
+
+		// Also call legacy callback if set
+		if (this.onParticipantsChanged) {
+			this.onParticipantsChanged(participants);
+		}
+	}
+
+	/**
+	 * Toggle microphone
+	 */
+	public async setMicrophoneEnabled(enabled: boolean): Promise<void> {
+		if (this.room) {
+			await this.room.localParticipant.setMicrophoneEnabled(enabled);
+		}
+	}
+
+	/**
+	 * Toggle camera
+	 */
+	public async setCameraEnabled(enabled: boolean): Promise<void> {
+		if (this.room) {
+			await this.room.localParticipant.setCameraEnabled(enabled);
+		}
+	}
+
+	/**
+	 * Disconnect from room
+	 */
+	public async disconnect(): Promise<void> {
+		if (this.room) {
+			// console.log('📴 Disconnecting from LiveKit...');
+			if (this.updateTimeout) {
+				clearTimeout(this.updateTimeout);
+			}
+			await this.room.disconnect();
+			this.room = null;
+			// console.log('✅ Disconnected');
+		}
+	}
+
+	/**
+	 * Check if connected
+	 */
+	public isConnected(): boolean {
+		return this.room !== null && this.room.state === 'connected';
+	}
 }
 
 // Export singleton instance

--- a/src/services/matrixRegistrationService.ts
+++ b/src/services/matrixRegistrationService.ts
@@ -1,113 +1,128 @@
-import { createClient } from "matrix-js-sdk";
+import { createClient } from 'matrix-js-sdk';
 
 export interface MatrixRegistrationData {
-    username: string;
-    password: string;
-    displayName?: string;
+	username: string;
+	password: string;
+	displayName?: string;
 }
 
 export interface MatrixRegistrationResult {
-    success: boolean;
-    userId?: string;
-    accessToken?: string;
-    deviceId?: string;
-    error?: string;
+	success: boolean;
+	userId?: string;
+	accessToken?: string;
+	deviceId?: string;
+	error?: string;
 }
 
 export const registerMatrixUser = async (
-    registrationData: MatrixRegistrationData
+	registrationData: MatrixRegistrationData
 ): Promise<MatrixRegistrationResult> => {
-    try {
-        // console.log("🔧 Attempting Matrix registration for user:", registrationData.username);
-        
-        // Matrix server URL from environment variable
-        const homeserverUrl = process.env.REACT_APP_MATRIX_HOMESERVER_URL || "http://91.99.219.182:8008";
-        
-        // Create Matrix client
-        const client = createClient({
-            baseUrl: homeserverUrl,
-        });
+	try {
+		// console.log("🔧 Attempting Matrix registration for user:", registrationData.username);
 
-        // Register user with proper type casting
-        const response = await client.register(
-            registrationData.username,
-            registrationData.password,
-            null, // auth
-            {
-                initial_device_display_name: "Caritas Frontend",
-                ...(registrationData.displayName && { displayname: registrationData.displayName })
-            } as any
-        );
+		const homeserverUrl =
+			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		if (!homeserverUrl) {
+			return {
+				success: false,
+				error: 'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			};
+		}
 
-        // console.log("✅ Matrix registration successful:", response);
-        
-        return {
-            success: true,
-            userId: response.user_id,
-            accessToken: response.access_token,
-            deviceId: response.device_id,
-        };
-        
-    } catch (error: any) {
-        // console.error("❌ Matrix registration failed:", error);
-        
-        // If user already exists, try to login instead
-        if (error.errcode === "M_USER_IN_USE") {
-            // console.log("🔄 User exists, attempting login instead...");
-            try {
-                const loginResult = await loginMatrixUser(registrationData.username, registrationData.password);
-                return loginResult;
-            } catch (loginError: any) {
-                return {
-                    success: false,
-                    error: `User exists but login failed: ${loginError.message || "Unknown error"}`,
-                };
-            }
-        }
-        
-        return {
-            success: false,
-            error: error.message || "Registration failed",
-        };
-    }
+		// Create Matrix client
+		const client = createClient({
+			baseUrl: homeserverUrl
+		});
+
+		// Register user with proper type casting
+		const response = await client.register(
+			registrationData.username,
+			registrationData.password,
+			null, // auth
+			{
+				initial_device_display_name: 'Caritas Frontend',
+				...(registrationData.displayName && {
+					displayname: registrationData.displayName
+				})
+			} as any
+		);
+
+		// console.log("✅ Matrix registration successful:", response);
+
+		return {
+			success: true,
+			userId: response.user_id,
+			accessToken: response.access_token,
+			deviceId: response.device_id
+		};
+	} catch (error: any) {
+		// console.error("❌ Matrix registration failed:", error);
+
+		// If user already exists, try to login instead
+		if (error.errcode === 'M_USER_IN_USE') {
+			// console.log("🔄 User exists, attempting login instead...");
+			try {
+				const loginResult = await loginMatrixUser(
+					registrationData.username,
+					registrationData.password
+				);
+				return loginResult;
+			} catch (loginError: any) {
+				return {
+					success: false,
+					error: `User exists but login failed: ${loginError.message || 'Unknown error'}`
+				};
+			}
+		}
+
+		return {
+			success: false,
+			error: error.message || 'Registration failed'
+		};
+	}
 };
 
 export const loginMatrixUser = async (
-    username: string,
-    password: string
+	username: string,
+	password: string
 ): Promise<MatrixRegistrationResult> => {
-    try {
-        // console.log("🔧 Attempting Matrix login for user:", username);
-        
-        // Matrix server URL from environment variable
-        const homeserverUrl = process.env.REACT_APP_MATRIX_HOMESERVER_URL || "http://91.99.219.182:8008";
-        
-        // Create Matrix client
-        const client = createClient({
-            baseUrl: homeserverUrl,
-        });
+	try {
+		// console.log("🔧 Attempting Matrix login for user:", username);
 
-        // Login user
-        const response = await client.login("m.login.password", {
-            user: username,
-            password: password,
-        });
+		const homeserverUrl =
+			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		if (!homeserverUrl) {
+			return {
+				success: false,
+				error: 'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			};
+		}
 
-        // console.log("✅ Matrix login successful:", response);
-        
-        return {
-            success: true,
-            userId: response.user_id,
-            accessToken: response.access_token,
-            deviceId: response.device_id,
-        };
-        
-    } catch (error: any) {
-        // console.error("❌ Matrix login failed:", error);
-        
-        return {
-            success: false,
-            error: error.message || "Login failed",
-        };
-    }
+		// Create Matrix client
+		const client = createClient({
+			baseUrl: homeserverUrl
+		});
+
+		// Login user
+		const response = await client.login('m.login.password', {
+			user: username,
+			password: password
+		});
+
+		// console.log("✅ Matrix login successful:", response);
+
+		return {
+			success: true,
+			userId: response.user_id,
+			accessToken: response.access_token,
+			deviceId: response.device_id
+		};
+	} catch (error: any) {
+		// console.error("❌ Matrix login failed:", error);
+
+		return {
+			success: false,
+			error: error.message || 'Login failed'
+		};
+	}
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
 		"downlevelIteration": true,
 		"typeRoots": ["node_modules/@types"]
 	},
-	"include": ["src", "cypress/support", ".storybook"],
+	"include": ["src", ".storybook"],
 	"exclude": ["node_modules", "src/extensions/cypress/**/*.cy.ts"],
 	"ts-node": {
 		"compilerOptions": {


### PR DESCRIPTION
- Removed hardcoded URLs from code
- Added environment-based URL handling
- Tested on local setup

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes hardcoded IP addresses and domain URLs scattered across the codebase and replaces them with environment variables, guarded with explicit missing-config errors. A new `getApiBaseUrl()` helper centralizes API URL resolution with support for Cypress overrides, a runtime config object (`window.__ORISO_RUNTIME_CONFIG__`), and build-time env vars; supporting k8s manifests wire this up via a ConfigMap.

- Hardcoded URLs (`91.99.219.182`, `wss://livekit.oriso.site`, `https://call.element.io`, etc.) are replaced with `process.env.REACT_APP_*` reads across ~15 source files, each failing with a descriptive error rather than silently using the old IP.
- A new runtime config layer (`public/config.js` + `window.__ORISO_RUNTIME_CONFIG__`) lets k8s override `REACT_APP_API_URL` post-build via a ConfigMap without a Docker rebuild; other URLs (`REACT_APP_MATRIX_HOMESERVER_URL`, `REACT_APP_ELEMENT_CALL_BASE_URL`, etc.) still require a build-time env var.
- The `UIVersionToggle` receives new env-var guards for `homeserverUrl` and `elementUrl` before redirecting, though `localStorage` and the UI-version cookie are still written before those guards execute.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The URL-hardcoding goal is substantially achieved; the remaining concern is UIVersionToggle writing localStorage and the UI-version cookie before its env-var guards, leaving the toggle in a corrupted state when either REACT_APP_MATRIX_HOMESERVER_URL or REACT_APP_ELEMENT_URL is absent.

The bulk of the changes are mechanical and correct: hardcoded IPs and domains are replaced with env-var reads that fail with clear errors, the new getApiBaseUrl helper is sound, and the k8s ConfigMap wiring is correct. The UIVersionToggle state-corruption defect (localStorage + cookie written before the missing-env-var guards) is still present in this revision and was noted in the previous review; that unresolved defect is what keeps the score from 5.

src/components/uiVersionToggle/UIVersionToggle.tsx — env-var guards should be evaluated before any state is written.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/resources/scripts/getApiBaseUrl.ts | New helper that resolves the API base URL from Cypress env, runtime config, or process.env in that order — logic is correct and properly normalized. |
| src/resources/scripts/endpoints.ts | Delegates to getApiBaseUrl(); behavior is equivalent to before (Cypress support preserved, https prefix added when missing). |
| src/components/uiVersionToggle/UIVersionToggle.tsx | Adds env-var guards for homeserverUrl and elementUrl before redirect, but localStorage and the UI-version cookie are still written unconditionally before those guards execute — the previously-flagged toggle-state-corruption bug persists. |
| proxy/server.js | Replaces hardcoded LiveKit token service URL with LIVEKIT_TOKEN_SERVICE_URL env var with proper 503 guard; upstream HTTP status still not forwarded (previously flagged). |
| src/components/call/GroupCallWidget.tsx | Switches from REACT_APP_ELEMENT_CALL_URL to REACT_APP_ELEMENT_CALL_BASE_URL with proper missing-config guard; access token still placed in iframe URL (previously flagged). |
| src/services/liveKitService.ts | Replaces hardcoded wss://livekit.oriso.site with REACT_APP_LIVEKIT_WS_URL; throws a clear error if not set. No functional regression. |
| k8s-temp-runtime-configmap.yaml | New ConfigMap that overrides only REACT_APP_API_URL at runtime; other client URLs (Matrix, LiveKit, Element Call) are not covered and still require a rebuild to change. |
| src/components/app/AuthenticatedApp.tsx | Matrix client initialization is skipped (not errored) when REACT_APP_MATRIX_HOMESERVER_URL is absent; the warning comment is suppressed, leaving no observable signal if the env var is missing in production. |
| src/components/sessionCookie/getMatrixAccessToken.ts | Removes hardcoded fallback IP; now rejects the promise with a clear error when REACT_APP_MATRIX_HOMESERVER_URL is missing. |
| public/config.js | New stub that initializes window.__ORISO_RUNTIME_CONFIG__ if not already set; serves as the fallback when the k8s ConfigMap is not mounted. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant config.js as public/config.js (or k8s ConfigMap)
    participant Bundle as JS Bundle (endpoints.ts / getApiBaseUrl.ts)
    participant App as React App
    participant Proxy as Node Proxy (server.js)
    participant LiveKitSvc as LiveKit Token Service

    Browser->>config.js: Load script (sync, before bundle)
    config.js-->>Browser: "window.__ORISO_RUNTIME_CONFIG__ = { REACT_APP_API_URL }"

    Browser->>Bundle: Evaluate module (once at load)
    Note over Bundle: getApiBaseUrl() checks:<br/>1. window.Cypress.env<br/>2. window.__ORISO_RUNTIME_CONFIG__<br/>3. process.env.REACT_APP_API_URL
    Bundle-->>App: apiUrl (frozen const)

    App->>App: AuthenticatedApp mounts, reads REACT_APP_MATRIX_HOMESERVER_URL (process.env only)
    App->>App: GroupCallWidget reads REACT_APP_ELEMENT_CALL_BASE_URL (process.env only)

    App->>Proxy: GET /api/livekit/token
    Note over Proxy: Reads LIVEKIT_TOKEN_SERVICE_URL, returns 503 if unset
    Proxy->>LiveKitSvc: GET /api/livekit/token (forwarded)
    LiveKitSvc-->>Proxy: "{ token }"
    Proxy-->>App: res.json(data)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/api/matrix/matrixClient.ts.backup`, line 1-15 ([link](https://github.com/openresilienceinitiative/oriso-frontend/blob/0949af83c35451d26573837a9ba563510ac8210a/src/api/matrix/matrixClient.ts.backup#L1-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Backup files tracked in version control**

   `matrixClient.ts.backup` and `MatrixCallView.BROKEN-BACKUP.tsx` are being actively updated as part of this PR. These files are not imported anywhere in the build and the `.BROKEN-BACKUP` name signals they contain known-broken logic. Keeping them in the repository risks confusion about which file is canonical and can mislead reviewers or static analysis tools. They should be removed from the repository and, if needed, preserved as named git branches or stash entries instead.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openresilienceinitiative%2Foriso-frontend%22%20on%20the%20existing%20branch%20%22fixing-hardcoded-urls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fixing-hardcoded-urls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fapi%2Fmatrix%2FmatrixClient.ts.backup%0ALine%3A%201-15%0A%0AComment%3A%0A**Backup%20files%20tracked%20in%20version%20control**%0A%0A%60matrixClient.ts.backup%60%20and%20%60MatrixCallView.BROKEN-BACKUP.tsx%60%20are%20being%20actively%20updated%20as%20part%20of%20this%20PR.%20These%20files%20are%20not%20imported%20anywhere%20in%20the%20build%20and%20the%20%60.BROKEN-BACKUP%60%20name%20signals%20they%20contain%20known-broken%20logic.%20Keeping%20them%20in%20the%20repository%20risks%20confusion%20about%20which%20file%20is%20canonical%20and%20can%20mislead%20reviewers%20or%20static%20analysis%20tools.%20They%20should%20be%20removed%20from%20the%20repository%20and%2C%20if%20needed%2C%20preserved%20as%20named%20git%20branches%20or%20stash%20entries%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fapi%2Fmatrix%2FmatrixClient.ts.backup%0ALine%3A%201-15%0A%0AComment%3A%0A**Backup%20files%20tracked%20in%20version%20control**%0A%0A%60matrixClient.ts.backup%60%20and%20%60MatrixCallView.BROKEN-BACKUP.tsx%60%20are%20being%20actively%20updated%20as%20part%20of%20this%20PR.%20These%20files%20are%20not%20imported%20anywhere%20in%20the%20build%20and%20the%20%60.BROKEN-BACKUP%60%20name%20signals%20they%20contain%20known-broken%20logic.%20Keeping%20them%20in%20the%20repository%20risks%20confusion%20about%20which%20file%20is%20canonical%20and%20can%20mislead%20reviewers%20or%20static%20analysis%20tools.%20They%20should%20be%20removed%20from%20the%20repository%20and%2C%20if%20needed%2C%20preserved%20as%20named%20git%20branches%20or%20stash%20entries%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=openresilienceinitiative%2Foriso-frontend&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fapi%2Fmatrix%2FmatrixClient.ts.backup%0ALine%3A%201-15%0A%0AComment%3A%0A**Backup%20files%20tracked%20in%20version%20control**%0A%0A%60matrixClient.ts.backup%60%20and%20%60MatrixCallView.BROKEN-BACKUP.tsx%60%20are%20being%20actively%20updated%20as%20part%20of%20this%20PR.%20These%20files%20are%20not%20imported%20anywhere%20in%20the%20build%20and%20the%20%60.BROKEN-BACKUP%60%20name%20signals%20they%20contain%20known-broken%20logic.%20Keeping%20them%20in%20the%20repository%20risks%20confusion%20about%20which%20file%20is%20canonical%20and%20can%20mislead%20reviewers%20or%20static%20analysis%20tools.%20They%20should%20be%20removed%20from%20the%20repository%20and%2C%20if%20needed%2C%20preserved%20as%20named%20git%20branches%20or%20stash%20entries%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `src/components/uiVersionToggle/UIVersionToggle.tsx`, line 2588-2693 ([link](https://github.com/openresilienceinitiative/oriso-frontend/blob/0dec78db04f941ca889d74bdc3306635f78a4c36/src/components/uiVersionToggle/UIVersionToggle.tsx#L2588-L2693)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Toggle state permanently stuck when env vars are missing**

   `localStorage` and the `UI_VERSION_COOKIE` are written unconditionally at the top of `toggleUI`, before either the `homeserverUrl` or `elementUrl` guard check. If either env var is absent, the function shows an alert and returns early — but by then both the localStorage entry and the cookie have already been flipped to `'new'`. On the next page load the toggle renders as "on" (new UI selected) and `useNewUI` evaluates to `true`, yet the redirect never happened. The user is stuck: the toggle shows the new UI as active, but the page is still the classic UI and clicking the toggle again is a no-op (it would try to switch back to `'classic'` and `window.location.reload()` would keep them on the classic app). The fix is to validate `homeserverUrl` and `elementUrl` before writing any state.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openresilienceinitiative%2Foriso-frontend%22%20on%20the%20existing%20branch%20%22fixing-hardcoded-urls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fixing-hardcoded-urls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FuiVersionToggle%2FUIVersionToggle.tsx%0ALine%3A%202588-2693%0A%0AComment%3A%0A**Toggle%20state%20permanently%20stuck%20when%20env%20vars%20are%20missing**%0A%0A%60localStorage%60%20and%20the%20%60UI_VERSION_COOKIE%60%20are%20written%20unconditionally%20at%20the%20top%20of%20%60toggleUI%60%2C%20before%20either%20the%20%60homeserverUrl%60%20or%20%60elementUrl%60%20guard%20check.%20If%20either%20env%20var%20is%20absent%2C%20the%20function%20shows%20an%20alert%20and%20returns%20early%20%E2%80%94%20but%20by%20then%20both%20the%20localStorage%20entry%20and%20the%20cookie%20have%20already%20been%20flipped%20to%20%60'new'%60.%20On%20the%20next%20page%20load%20the%20toggle%20renders%20as%20%22on%22%20%28new%20UI%20selected%29%20and%20%60useNewUI%60%20evaluates%20to%20%60true%60%2C%20yet%20the%20redirect%20never%20happened.%20The%20user%20is%20stuck%3A%20the%20toggle%20shows%20the%20new%20UI%20as%20active%2C%20but%20the%20page%20is%20still%20the%20classic%20UI%20and%20clicking%20the%20toggle%20again%20is%20a%20no-op%20%28it%20would%20try%20to%20switch%20back%20to%20%60'classic'%60%20and%20%60window.location.reload%28%29%60%20would%20keep%20them%20on%20the%20classic%20app%29.%20The%20fix%20is%20to%20validate%20%60homeserverUrl%60%20and%20%60elementUrl%60%20before%20writing%20any%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FuiVersionToggle%2FUIVersionToggle.tsx%0ALine%3A%202588-2693%0A%0AComment%3A%0A**Toggle%20state%20permanently%20stuck%20when%20env%20vars%20are%20missing**%0A%0A%60localStorage%60%20and%20the%20%60UI_VERSION_COOKIE%60%20are%20written%20unconditionally%20at%20the%20top%20of%20%60toggleUI%60%2C%20before%20either%20the%20%60homeserverUrl%60%20or%20%60elementUrl%60%20guard%20check.%20If%20either%20env%20var%20is%20absent%2C%20the%20function%20shows%20an%20alert%20and%20returns%20early%20%E2%80%94%20but%20by%20then%20both%20the%20localStorage%20entry%20and%20the%20cookie%20have%20already%20been%20flipped%20to%20%60'new'%60.%20On%20the%20next%20page%20load%20the%20toggle%20renders%20as%20%22on%22%20%28new%20UI%20selected%29%20and%20%60useNewUI%60%20evaluates%20to%20%60true%60%2C%20yet%20the%20redirect%20never%20happened.%20The%20user%20is%20stuck%3A%20the%20toggle%20shows%20the%20new%20UI%20as%20active%2C%20but%20the%20page%20is%20still%20the%20classic%20UI%20and%20clicking%20the%20toggle%20again%20is%20a%20no-op%20%28it%20would%20try%20to%20switch%20back%20to%20%60'classic'%60%20and%20%60window.location.reload%28%29%60%20would%20keep%20them%20on%20the%20classic%20app%29.%20The%20fix%20is%20to%20validate%20%60homeserverUrl%60%20and%20%60elementUrl%60%20before%20writing%20any%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=openresilienceinitiative%2Foriso-frontend&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FuiVersionToggle%2FUIVersionToggle.tsx%0ALine%3A%202588-2693%0A%0AComment%3A%0A**Toggle%20state%20permanently%20stuck%20when%20env%20vars%20are%20missing**%0A%0A%60localStorage%60%20and%20the%20%60UI_VERSION_COOKIE%60%20are%20written%20unconditionally%20at%20the%20top%20of%20%60toggleUI%60%2C%20before%20either%20the%20%60homeserverUrl%60%20or%20%60elementUrl%60%20guard%20check.%20If%20either%20env%20var%20is%20absent%2C%20the%20function%20shows%20an%20alert%20and%20returns%20early%20%E2%80%94%20but%20by%20then%20both%20the%20localStorage%20entry%20and%20the%20cookie%20have%20already%20been%20flipped%20to%20%60'new'%60.%20On%20the%20next%20page%20load%20the%20toggle%20renders%20as%20%22on%22%20%28new%20UI%20selected%29%20and%20%60useNewUI%60%20evaluates%20to%20%60true%60%2C%20yet%20the%20redirect%20never%20happened.%20The%20user%20is%20stuck%3A%20the%20toggle%20shows%20the%20new%20UI%20as%20active%2C%20but%20the%20page%20is%20still%20the%20classic%20UI%20and%20clicking%20the%20toggle%20again%20is%20a%20no-op%20%28it%20would%20try%20to%20switch%20back%20to%20%60'classic'%60%20and%20%60window.location.reload%28%29%60%20would%20keep%20them%20on%20the%20classic%20app%29.%20The%20fix%20is%20to%20validate%20%60homeserverUrl%60%20and%20%60elementUrl%60%20before%20writing%20any%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openresilienceinitiative%2Foriso-frontend%22%20on%20the%20existing%20branch%20%22fixing-hardcoded-urls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fixing-hardcoded-urls%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fapp%2FAuthenticatedApp.tsx%3A336-338%0A**Silent%20Matrix%20init%20skip%20leaves%20no%20diagnostic%20trace**%0A%0AWhen%20%60REACT_APP_MATRIX_HOMESERVER_URL%60%20is%20absent%20the%20block%20is%20silently%20skipped%3A%20%60window.matrixClientService%60%20is%20never%20assigned%2C%20the%20Matrix%20event%20bridge%20is%20never%20started%2C%20and%20no%20incoming-call%20events%20are%20ever%20registered.%20The%20commented-out%20%60console.warn%60%20means%20an%20operator%20whose%20deployment%20is%20missing%20the%20env%20var%20will%20see%20zero%20indication%20of%20this%20in%20any%20log%20%E2%80%94%20the%20first%20symptom%20will%20be%20users%20reporting%20that%20calls%20never%20ring%20or%20connect.%20Reinstating%20at%20least%20a%20%60console.warn%60%20%28which%20is%20production-safe%20at%20the%20%22warn%22%20level%29%20would%20make%20this%20failure%20immediately%20visible.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fapp%2FAuthenticatedApp.tsx%3A336-338%0A**Silent%20Matrix%20init%20skip%20leaves%20no%20diagnostic%20trace**%0A%0AWhen%20%60REACT_APP_MATRIX_HOMESERVER_URL%60%20is%20absent%20the%20block%20is%20silently%20skipped%3A%20%60window.matrixClientService%60%20is%20never%20assigned%2C%20the%20Matrix%20event%20bridge%20is%20never%20started%2C%20and%20no%20incoming-call%20events%20are%20ever%20registered.%20The%20commented-out%20%60console.warn%60%20means%20an%20operator%20whose%20deployment%20is%20missing%20the%20env%20var%20will%20see%20zero%20indication%20of%20this%20in%20any%20log%20%E2%80%94%20the%20first%20symptom%20will%20be%20users%20reporting%20that%20calls%20never%20ring%20or%20connect.%20Reinstating%20at%20least%20a%20%60console.warn%60%20%28which%20is%20production-safe%20at%20the%20%22warn%22%20level%29%20would%20make%20this%20failure%20immediately%20visible.%0A%0A&repo=openresilienceinitiative%2Foriso-frontend&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fapp%2FAuthenticatedApp.tsx%3A336-338%0A**Silent%20Matrix%20init%20skip%20leaves%20no%20diagnostic%20trace**%0A%0AWhen%20%60REACT_APP_MATRIX_HOMESERVER_URL%60%20is%20absent%20the%20block%20is%20silently%20skipped%3A%20%60window.matrixClientService%60%20is%20never%20assigned%2C%20the%20Matrix%20event%20bridge%20is%20never%20started%2C%20and%20no%20incoming-call%20events%20are%20ever%20registered.%20The%20commented-out%20%60console.warn%60%20means%20an%20operator%20whose%20deployment%20is%20missing%20the%20env%20var%20will%20see%20zero%20indication%20of%20this%20in%20any%20log%20%E2%80%94%20the%20first%20symptom%20will%20be%20users%20reporting%20that%20calls%20never%20ring%20or%20connect.%20Reinstating%20at%20least%20a%20%60console.warn%60%20%28which%20is%20production-safe%20at%20the%20%22warn%22%20level%29%20would%20make%20this%20failure%20immediately%20visible.%0A%0A&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat: add getApiBaseUrl function to norm..."](https://github.com/openresilienceinitiative/oriso-frontend/commit/24c9e5b943295ba2c784cc79d32f8aa9ed922570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32108641)</sub>

<!-- /greptile_comment -->