### PR TITLE
fix: correct Keycloak logout and public-route 401 handling

### DIFF
--- a/src/api/apiLogoutKeycloak.ts
+++ b/src/api/apiLogoutKeycloak.ts
@@ -1,20 +1,31 @@
 import { endpoints } from '../resources/scripts/endpoints';
 import { getValueFromCookie } from '../components/sessionCookie/accessSessionCookie';
 
-export const apiKeycloakLogout = async (): Promise<any> => {
-	const url = endpoints.keycloakLogout;
+export const apiKeycloakLogout = async (): Promise<Response | null> => {
 	const refreshToken = getValueFromCookie('refreshToken');
-	const data = `client_id=app&grant_type=refresh_token&refresh_token=${refreshToken}`;
+	if (!refreshToken) {
+		return null;
+	}
+
+	const accessToken = getValueFromCookie('keycloak');
+	const body = new URLSearchParams({
+		client_id: 'app',
+		refresh_token: refreshToken
+	});
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/x-www-form-urlencoded'
+	};
+
+	if (accessToken) {
+		headers.Authorization = `Bearer ${accessToken}`;
+	}
 
 	return fetch(
-		new Request(url, {
+		new Request(endpoints.keycloakLogout, {
 			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				'cache-control': 'no-cache'
-			},
+			headers,
 			credentials: 'include',
-			body: data
+			body: body.toString()
 		})
 	);
 };

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -4,7 +4,10 @@ import {
 	getErrorCaseForStatus,
 	redirectToErrorPage
 } from '../components/error/errorHandling';
+import { isPublicAuthRoute } from '../components/auth/auth';
 import { logout } from '../components/logout/logout';
+import { removeAllCookies } from '../components/sessionCookie/accessSessionCookie';
+import { removeTokenExpiryFromLocalStorage } from '../components/sessionCookie/accessSessionLocalStorage';
 import { appConfig } from '../utils/appConfig';
 import { RequestLog } from '../utils/requestCollector';
 
@@ -47,6 +50,11 @@ export const X_REASON = {
 
 export const FETCH_SUCCESS = {
 	CONTENT: 'CONTENT'
+};
+
+const invalidateStaleAuthSession = () => {
+	removeAllCookies();
+	removeTokenExpiryFromLocalStorage();
 };
 
 export class FetchErrorWithOptions extends Error {
@@ -97,24 +105,31 @@ export const fetchData = ({
 
 		const csrfToken = generateCsrfToken();
 
-	// MATRIX MIGRATION: rcToken still required by backend for archive endpoints
-	// but no longer exists after Matrix migration. Send dummy token.
+		// MATRIX MIGRATION: rcToken still required by backend for archive endpoints
+		// but no longer exists after Matrix migration. Send dummy token.
 		const rcHeaders = rcValidation
 			? {
-				rcToken: getValueFromCookie('rc_token') || 'matrix-migration-dummy-token',
-					...(getValueFromCookie('rc_uid') && { RCUserId: getValueFromCookie('rc_uid') })
+					rcToken:
+						getValueFromCookie('rc_token') ||
+						'matrix-migration-dummy-token',
+					...(getValueFromCookie('rc_uid') && {
+						RCUserId: getValueFromCookie('rc_uid')
+					})
 				}
 			: null;
 
-		const localDevelopmentHeader = isLocalDevelopment && process.env.REACT_APP_CSRF_WHITELIST_HEADER_PROPERTY
-			? {
-					[process.env.REACT_APP_CSRF_WHITELIST_HEADER_PROPERTY]: csrfToken
-				}
-			: isLocalDevelopment
-			? {
-					'X-WHITELIST-HEADER': csrfToken
-				}
-			: null;
+		const localDevelopmentHeader =
+			isLocalDevelopment &&
+			process.env.REACT_APP_CSRF_WHITELIST_HEADER_PROPERTY
+				? {
+						[process.env.REACT_APP_CSRF_WHITELIST_HEADER_PROPERTY]:
+							csrfToken
+					}
+				: isLocalDevelopment
+					? {
+							'X-WHITELIST-HEADER': csrfToken
+						}
+					: null;
 
 		let controller;
 		controller = new AbortController();
@@ -135,11 +150,14 @@ export const fetchData = ({
 			...rcHeaders,
 			...localDevelopmentHeader
 		};
-		
+
 		// Remove any undefined values and undefined keys
 		const cleanHeaders = Object.fromEntries(
-			Object.entries(allHeaders).filter(([key, value]) => 
-				key !== undefined && value !== undefined && key !== 'undefined'
+			Object.entries(allHeaders).filter(
+				([key, value]) =>
+					key !== undefined &&
+					value !== undefined &&
+					key !== 'undefined'
 			)
 		);
 
@@ -246,9 +264,21 @@ export const fetchData = ({
 					) {
 						reject(new Error(FETCH_ERRORS.GATEWAY_TIMEOUT));
 					} else if (response.status === 401) {
-						// console.log(url);
-						logout(true, appConfig.urls.toLogin);
+						if (isPublicAuthRoute()) {
+							if (!authorization) {
+								invalidateStaleAuthSession();
+							}
+							reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
+						} else {
+							logout(true, appConfig.urls.toLogin);
+							reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
+						}
 					}
+				} else if (response.status === 401 && isPublicAuthRoute()) {
+					if (!authorization) {
+						invalidateStaleAuthSession();
+					}
+					reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
 				} else {
 					const error = getErrorCaseForStatus(response.status);
 					redirectToErrorPage(error);

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -9,6 +9,24 @@ import { appConfig } from '../../utils/appConfig';
 
 export const RENEW_BEFORE_EXPIRY_IN_MS = 10 * 1000; // seconds
 
+export const isPublicAuthRoute = (): boolean => {
+	const { pathname } = window.location;
+	return (
+		/^\/(?:login|registration|error\.401\.html|error\.404\.html|error\.500\.html)(?:\/|$)/.test(
+			pathname
+		) || /^\/[^/]+\/registration(?:\/|$)/.test(pathname)
+	);
+};
+
+export const hasActiveAuthSession = (): boolean => {
+	const tokenExpiry = getTokenExpiryFromLocalStorage();
+	const currentTime = new Date().getTime();
+	return (
+		tokenExpiry.accessTokenValidUntilTime > currentTime ||
+		tokenExpiry.refreshTokenValidUntilTime > currentTime
+	);
+};
+
 export const setTokens = (
 	access_token: string,
 	expires_in: number,

--- a/src/components/error/errorHandling.ts
+++ b/src/components/error/errorHandling.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { isPublicAuthRoute } from '../auth/auth';
 import { logout } from '../logout/logout';
 import { appConfig } from '../../utils/appConfig';
 import { apiPostError, ERROR_LEVEL_ERROR } from '../../api/apiPostError';
@@ -22,6 +23,10 @@ export const getErrorCaseForStatus = (status: number) => {
 };
 
 export const redirectToErrorPage = (error: number) => {
+	if (error === ERROR_TYPES.UNAUTHORIZED && isPublicAuthRoute()) {
+		return;
+	}
+
 	const correlationId = uuidv4();
 	let redirect;
 	switch (error) {


### PR DESCRIPTION
Send the proper logout payload to Keycloak and stop full logout redirects when unauthenticated API calls fail on login pages.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

