### PR TITLE
fix: unblock anonymous live chat start and harden draft loading

### DIFF
--- a/src/api/apiPatchNotificationActiveView.ts
+++ b/src/api/apiPatchNotificationActiveView.ts
@@ -1,5 +1,5 @@
 import { endpoints } from '../resources/scripts/endpoints';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
 
 interface ActiveViewInput {
 	roomId?: string | null;
@@ -20,6 +20,5 @@ export const apiPatchNotificationActiveView = async ({
 			threadRootId: threadRootId || null,
 			active
 		}),
-		responseHandling: []
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
 	});
-

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -17,8 +17,7 @@ import { decryptText, encryptText } from '../../utils/encryptionHelpers';
 import { apiPostError, ERROR_LEVEL_WARN } from '../../api/apiPostError';
 import { useE2EE } from '../../hooks/useE2EE';
 import { E2EEContext, ActiveSessionContext } from '../../globalState';
-import { convertFromRaw, EditorState } from 'draft-js';
-import { markdownToDraft } from 'markdown-draft-js';
+import { EditorState } from 'draft-js';
 import { EVENT_PRE_LOGOUT } from '../logout/logout';
 import {
 	addEventListener,
@@ -80,14 +79,12 @@ export const useDraftMessage = (
 
 	const setEditorWithDraftString = useCallback(
 		(draftString: string) => {
-			const rawObject = markdownToDraft(draftString);
-			const draftContent = convertFromRaw(rawObject);
-			const editorStateWithText =
-				EditorState.createWithContent(draftContent);
-			loadFunction(
-				EditorState.moveFocusToEnd(editorStateWithText),
-				draftString
-			);
+			try {
+				// TipTapComposer reads rawDraft directly (HTML/plain text).
+				loadFunction(EditorState.createEmpty(), draftString || '');
+			} catch {
+				loadFunction(EditorState.createEmpty(), '');
+			}
 		},
 		[loadFunction]
 	);

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -1656,10 +1656,19 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	}, [activeSession.item.id, userData, isSupervisionEnabledForCurrentChat]);
 
 	useEffect(() => {
-		const canWrite = type !== SESSION_LIST_TYPES.ENQUIRY;
-		// console.log('🔥 SessionItemComponent: canWriteMessage =', canWrite, '(type:', type, ', isGroup:', activeSession.isGroup, ', isSupervisor:', isSupervisor, ')');
+		const canWrite =
+			type !== SESSION_LIST_TYPES.ENQUIRY ||
+			(isAnonymousAskerExperience && waitingGateDismissed);
 		setCanWriteMessage(canWrite);
-	}, [type, userData, activeSession, activeSession.isGroup, isSupervisor]);
+	}, [
+		type,
+		isAnonymousAskerExperience,
+		waitingGateDismissed,
+		userData,
+		activeSession,
+		activeSession.isGroup,
+		isSupervisor
+	]);
 
 	useEffect(() => {
 		if (!isAnonymousBreathingGameAvailable) {
@@ -4411,7 +4420,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 			)}
 
 			{type === SESSION_LIST_TYPES.ENQUIRY &&
-				!shouldBlockAnonymousInquiryChat && (
+				!shouldBlockAnonymousInquiryChat &&
+				!isAnonymousAskerExperience && (
 					<AcceptAssign btnLabel={'enquiry.acceptButton.known'} />
 				)}
 


### PR DESCRIPTION
Load drafts into TipTap without Draft.js conversion, allow the composer after the waiting gate dismisses, and keep non-critical API failures from redirecting to the global error page.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

