### PR TITLE
fix: harden anonymous live chat composer against crashes and logout c…

### DIFF
--- a/src/components/app/ErrorBoundary.tsx
+++ b/src/components/app/ErrorBoundary.tsx
@@ -6,7 +6,6 @@ import {
 } from '../../api/apiPostError';
 import { redirectToErrorPage } from '../error/errorHandling';
 import { Loading } from './Loading';
-import { removeAllCookies } from '../sessionCookie/accessSessionCookie';
 import { STORAGE_KEY_ERROR_BOUNDARY } from '../devToolbar/DevToolbar';
 
 type ErrorBoundaryProps = {
@@ -75,7 +74,6 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 		}
 
 		apiPostError(errorBoundaryError, info).finally(() => {
-			removeAllCookies();
 			redirectToErrorPage(500);
 		});
 	}

--- a/src/components/error/errorHandling.ts
+++ b/src/components/error/errorHandling.ts
@@ -76,5 +76,16 @@ export const redirectToErrorPage = (error: number) => {
 		null,
 		correlationId
 	);
-	void logout(true, redirect);
+
+	// Only auth failures should tear down the session. Server/UI errors should
+	// not trigger Keycloak logout (which was surfacing as a 400 in Network tab
+	// and cancelling in-flight requests such as draft loads).
+	if (error === ERROR_TYPES.UNAUTHORIZED) {
+		void logout(true, redirect);
+		return;
+	}
+
+	if (redirect) {
+		window.location.href = redirect;
+	}
 };

--- a/src/components/messageSubmitInterface/MessageSubmitErrorBoundary.tsx
+++ b/src/components/messageSubmitInterface/MessageSubmitErrorBoundary.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { Component, ReactNode } from 'react';
+import { apiPostError, ERROR_LEVEL_ERROR } from '../../api/apiPostError';
+import { Button, BUTTON_TYPES } from '../button/Button';
+
+type MessageSubmitErrorBoundaryProps = {
+	children: ReactNode;
+	onRetry?: () => void;
+};
+
+type MessageSubmitErrorBoundaryState = {
+	hasError: boolean;
+};
+
+/**
+ * Keeps composer mount failures local so a TipTap/draft crash does not bubble
+ * to the app-wide ErrorBoundary (which clears cookies and sends users to
+ * error.500.html).
+ */
+export class MessageSubmitErrorBoundary extends Component<
+	MessageSubmitErrorBoundaryProps,
+	MessageSubmitErrorBoundaryState
+> {
+	state: MessageSubmitErrorBoundaryState = {
+		hasError: false
+	};
+
+	static getDerivedStateFromError(): MessageSubmitErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error, info: React.ErrorInfo) {
+		void apiPostError(
+			{
+				name: error.name,
+				message: error.message,
+				stack: error.stack,
+				level: ERROR_LEVEL_ERROR
+			},
+			info
+		);
+	}
+
+	private handleRetry = () => {
+		this.setState({ hasError: false });
+		this.props.onRetry?.();
+	};
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div className="messageSubmit__wrapper messageSubmit__wrapper--error">
+					<p>
+						Der Chat-Eingabebereich konnte nicht geladen werden.
+						Bitte versuchen Sie es erneut.
+					</p>
+					<Button
+						buttonHandle={this.handleRetry}
+						item={{
+							type: BUTTON_TYPES.PRIMARY,
+							label: 'Erneut versuchen'
+						}}
+					/>
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/src/components/messageSubmitInterface/TipTapComposer.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.tsx
@@ -334,8 +334,16 @@ export const TipTapComposer = forwardRef<
 				return;
 			}
 			setIsSyncingFromValue(true);
-			editor.commands.setContent(normalizedValue);
-			editor.commands.setTextAlign('left');
+			try {
+				editor.commands.setContent(normalizedValue);
+				editor.commands.setTextAlign('left');
+			} catch {
+				try {
+					editor.commands.clearContent();
+				} catch {
+					// Ignore — a corrupt stored draft must never break the composer.
+				}
+			}
 			setTimeout(() => setIsSyncingFromValue(false), 0);
 		}, [editor, value]);
 

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -1122,14 +1122,21 @@ export const MessageSubmitInterfaceComponent = ({
 		return `${location.pathname}${query ? `?${query}` : ''}`;
 	}, [location.pathname, location.search, threadRootId]);
 
+	const contact = getContact(activeSession);
+	const isAnonymousChat =
+		activeSession.item.postcode === 0 ||
+		activeSession.item.postcode?.toString() === '00000' ||
+		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
+		contact?.username?.startsWith('Anonymous-') ||
+		activeSession.user?.username?.startsWith('Anonymous-');
+
 	const draftTitle = useMemo(() => {
-		const contact = getContact(activeSession);
 		const topicName =
 			typeof activeSession?.item?.topic === 'object'
 				? activeSession?.item?.topic?.name
 				: activeSession?.item?.topic;
 		return contact?.displayName || contact?.username || topicName || null;
-	}, [activeSession]);
+	}, [activeSession, contact]);
 
 	const forcedDraftScopeKey = useMemo(() => {
 		const params = new URLSearchParams(location.search);
@@ -1141,42 +1148,57 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const loadDraftIntoComposer = useCallback(
 		(loadedState: EditorState, rawDraft?: string) => {
-			setEditorState(loadedState);
-			const draftValue = (rawDraft || '').trim();
-			if (draftValue) {
-				// TipTap drafts are saved as HTML now; load raw draft directly to preserve formatting.
-				const normalizedDraft = normalizeInitialAlignment(
-					rawDraft || ''
+			try {
+				setEditorState(loadedState);
+				const draftValue = (rawDraft || '').trim();
+				if (draftValue) {
+					// TipTap drafts are saved as HTML now; load raw draft directly to preserve formatting.
+					const normalizedDraft = normalizeInitialAlignment(
+						rawDraft || ''
+					);
+					setComposerText(normalizedDraft || '');
+					composerRef.current?.setText(normalizedDraft || '');
+					return;
+				}
+				// Backward fallback for any legacy empty/raw conversion edge-cases.
+				const contentState = loadedState.getCurrentContent();
+				const rawObject = convertToRaw(
+					escapeMarkdownChars(contentState)
 				);
-				setComposerText(normalizedDraft || '');
-				composerRef.current?.setText(normalizedDraft || '');
-				return;
+				const markdownString = draftToMarkdown(rawObject, {
+					escapeMarkdownCharacters: false
+				});
+				const normalizedDraft =
+					normalizeInitialAlignment(markdownString);
+				setComposerText(normalizedDraft);
+				composerRef.current?.setText(normalizedDraft);
+			} catch {
+				setComposerText('');
+				composerRef.current?.clear();
 			}
-			// Backward fallback for any legacy empty/raw conversion edge-cases.
-			const contentState = loadedState.getCurrentContent();
-			const rawObject = convertToRaw(escapeMarkdownChars(contentState));
-			const markdownString = draftToMarkdown(rawObject, {
-				escapeMarkdownCharacters: false
-			});
-			const normalizedDraft = normalizeInitialAlignment(markdownString);
-			setComposerText(normalizedDraft);
-			composerRef.current?.setText(normalizedDraft);
 		},
 		[normalizeInitialAlignment]
 	);
+
+	const isAnonymousEnquiryComposer =
+		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
 
 	const {
 		onChange: onDraftMessageChange,
 		loaded: draftLoaded,
 		clearDraftMessage
-	} = useDraftMessage(!isRequestInProgress, loadDraftIntoComposer, {
-		threadRootId: threadRootId || null,
-		actionPath: draftActionPath,
-		sessionId: activeSession?.item?.id ?? null,
-		roomRef: activeSession?.rid ?? null,
-		title: draftTitle,
-		forcedScopeKey: forcedDraftScopeKey
-	});
+	} = useDraftMessage(
+		!isRequestInProgress && !isAnonymousEnquiryComposer,
+		loadDraftIntoComposer,
+		{
+			threadRootId: threadRootId || null,
+			actionPath: draftActionPath,
+			sessionId: activeSession?.item?.id ?? null,
+			roomRef: activeSession?.rid ?? null,
+			title: draftTitle,
+			forcedScopeKey: forcedDraftScopeKey
+		}
+	);
 
 	const handleComposerChange = useCallback(
 		(nextValue: string) => {
@@ -2290,13 +2312,6 @@ export const MessageSubmitInterfaceComponent = ({
 			(type === SESSION_LIST_TYPES.ENQUIRY &&
 				!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData))) &&
 		!tenant?.settings?.featureAttachmentUploadDisabled;
-	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
 	const currentChatType: 'anonymous' | 'oneOnOne' | 'group' | 'supervision' =
 		isSupervisor
 			? 'supervision'
@@ -3674,17 +3689,22 @@ export const MessageSubmitInterfaceComponent = ({
 		[setIsExpandedComposer]
 	);
 
-	// MATRIX MIGRATION: Skip E2EE check for Matrix sessions (no rid)
-	if (!e2EEReady && activeSession.rid) {
+	const matrixRoomId = activeSession?.rid?.startsWith('!')
+		? activeSession.rid
+		: activeSession?.item?.matrixRoomId?.startsWith('!')
+			? activeSession.item.matrixRoomId
+			: null;
+
+	// MATRIX MIGRATION: legacy RocketChat E2EE gates do not apply to Matrix rooms.
+	if (!e2EEReady && activeSession.rid && !matrixRoomId) {
 		return null;
 	}
 
-	if (subscriptionKeyLost && activeSession.rid) {
+	if (subscriptionKeyLost && activeSession.rid && !matrixRoomId) {
 		return <SubscriptionKeyLost />;
 	}
 
-	// Ignore the missing room if session has no roomId
-	if (roomNotFound && activeSession.rid) {
+	if (roomNotFound && activeSession.rid && !matrixRoomId) {
 		return <RoomNotFound />;
 	}
 

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -151,7 +151,7 @@ export const useDraftMessage = (
 		const currentLoadVersion = ++loadVersionRef.current;
 		setLoaded(false);
 		setMessageRes(null);
-		if (!canUseRemoteApi) {
+		if (!enabled || !canUseRemoteApi) {
 			setLoaded(true);
 			return () => {
 				abortController?.abort();
@@ -188,7 +188,7 @@ export const useDraftMessage = (
 		return () => {
 			abortController?.abort();
 		};
-	}, [canUseRemoteApi, scopeKeysToTry, setEditorWithDraftString]);
+	}, [enabled, canUseRemoteApi, scopeKeysToTry, setEditorWithDraftString]);
 
 	// If everything is ready for decryption, decrypt the draft message
 	useEffect(() => {

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -54,6 +54,7 @@ import useDebounceCallback from '../../hooks/useDebounceCallback';
 import { apiPostError, TError } from '../../api/apiPostError';
 import { useE2EE } from '../../hooks/useE2EE';
 import { MessageSubmitInterfaceSkeleton } from '../messageSubmitInterface/messageSubmitInterfaceSkeleton';
+import { MessageSubmitErrorBoundary } from '../messageSubmitInterface/MessageSubmitErrorBoundary';
 import { Text } from '../text/Text';
 import { EncryptionBanner } from './EncryptionBanner';
 import { apiGetSessionSupervisors } from '../../api/apiGetSessionSupervisors';
@@ -1554,6 +1555,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const dragCancelRef = useRef<NodeJS.Timeout | null>(null);
 	const [newMessages, setNewMessages] = useState(0);
 	const [canWriteMessage, setCanWriteMessage] = useState(false);
+	const [composerRemountKey, setComposerRemountKey] = useState(0);
 	const [supervisionReason, setSupervisionReason] = useState<string | null>(
 		null
 	);
@@ -4491,34 +4493,43 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 								/>
 							}
 						>
-							<MessageSubmitInterfaceComponent
-								isTyping={props.isTyping}
-								className={clsx(
-									'session__submit-interface',
-									!isScrolledToBottom &&
-										'session__submit-interface--scrolled-up',
-									activeThreadRootId &&
-										'session__submit-interface--withThread'
-								)}
-								placeholder={getPlaceholder()}
-								typingUsers={props.typingUsers}
-								preselectedFile={draggedFile}
-								handleMessageSendSuccess={
-									handleMessageSendSuccess
+							<MessageSubmitErrorBoundary
+								onRetry={() =>
+									setComposerRemountKey((key) => key + 1)
 								}
-								isSupervisor={isSupervisor}
-								mobileUnreadCount={newMessages}
-								mobileIsScrolledToBottom={isScrolledToBottom}
-								onMobileNavigateBack={
-									handleMobileNavigateBackClick
-								}
-								onMobileNavigateDown={
-									handleMobileNavigateStepDownClick
-								}
-								onMobileNavigateBottom={
-									handleScrollToBottomButtonClick
-								}
-							/>
+							>
+								<MessageSubmitInterfaceComponent
+									key={composerRemountKey}
+									isTyping={props.isTyping}
+									className={clsx(
+										'session__submit-interface',
+										!isScrolledToBottom &&
+											'session__submit-interface--scrolled-up',
+										activeThreadRootId &&
+											'session__submit-interface--withThread'
+									)}
+									placeholder={getPlaceholder()}
+									typingUsers={props.typingUsers}
+									preselectedFile={draggedFile}
+									handleMessageSendSuccess={
+										handleMessageSendSuccess
+									}
+									isSupervisor={isSupervisor}
+									mobileUnreadCount={newMessages}
+									mobileIsScrolledToBottom={
+										isScrolledToBottom
+									}
+									onMobileNavigateBack={
+										handleMobileNavigateBackClick
+									}
+									onMobileNavigateDown={
+										handleMobileNavigateStepDownClick
+									}
+									onMobileNavigateBottom={
+										handleScrollToBottomButtonClick
+									}
+								/>
+							</MessageSubmitErrorBoundary>
 						</Suspense>
 					)}
 					{areRobotMessagesComplete &&


### PR DESCRIPTION
…ascade

Stop composer failures from redirecting to error.500 with Keycloak logout. Skip draft loading for anonymous enquiries and wrap the composer in a local error boundary so TipTap/draft issues do not tear down the whole session.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

