### PR TITLE
fix: route anonymous live chat sends through Matrix and preload composer

### DIFF
--- a/src/components/messageSubmitInterface/MessageSubmitErrorBoundary.tsx
+++ b/src/components/messageSubmitInterface/MessageSubmitErrorBoundary.tsx
@@ -25,6 +25,8 @@ export class MessageSubmitErrorBoundary extends Component<
 		hasError: false
 	};
 
+	private autoRetryAttempted = false;
+
 	static getDerivedStateFromError(): MessageSubmitErrorBoundaryState {
 		return { hasError: true };
 	}
@@ -39,6 +41,14 @@ export class MessageSubmitErrorBoundary extends Component<
 			},
 			info
 		);
+
+		// Lazy-loaded composer can fail on the first mount while the chunk
+		// initialises; one silent remount usually succeeds.
+		if (!this.autoRetryAttempted) {
+			this.autoRetryAttempted = true;
+			this.setState({ hasError: false });
+			this.props.onRetry?.();
+		}
 	}
 
 	private handleRetry = () => {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -58,16 +58,13 @@ import {
 	ItalicButton,
 	UnorderedListButton
 } from '@draft-js-plugins/buttons';
-import createEmojiPlugin from '@draft-js-plugins/emoji';
 import {
-	emojiPickerCustomClasses,
 	escapeMarkdownChars,
 	handleEditorBeforeInput,
 	handleEditorPastedText,
 	normalizeHighlightColor,
 	toolbarCustomClasses
 } from './richtextHelpers';
-import { ReactComponent as EmojiIcon } from '../../resources/img/icons/smiley-positive.svg';
 import { ReactComponent as AudioOnIcon } from '../../resources/img/icons/audio-on.svg';
 import { ReactComponent as RemoveIcon } from '../../resources/img/icons/x.svg';
 import { ReactComponent as CalendarMonthIcon } from '../../resources/img/icons/calendar-month-navigation.svg';
@@ -150,6 +147,8 @@ export interface MessageSubmitInterfaceComponentProps {
 	language?: string;
 	preselectedFile?: File;
 	handleMessageSendSuccess?: Function;
+	/** Anonymous enquiry after "Jetzt Chat starten" — use live chat send, not enquiry API. */
+	isAnonymousLiveChat?: boolean;
 	isSupervisor?: boolean;
 	threadRootId?: string | null;
 	threadParentPreview?: string | null;
@@ -169,6 +168,7 @@ export const MessageSubmitInterfaceComponent = ({
 	language,
 	preselectedFile,
 	handleMessageSendSuccess: onMessageSendSuccess,
+	isAnonymousLiveChat = false,
 	isSupervisor,
 	threadRootId,
 	threadParentPreview,
@@ -1051,24 +1051,6 @@ export const MessageSubmitInterfaceComponent = ({
 			(editorElement as any).focus({ preventScroll: true });
 		}
 	}, []);
-
-	//Emoji Picker Plugin
-	const emojiPlugin = useMemo(
-		() =>
-			createEmojiPlugin({
-				theme: emojiPickerCustomClasses,
-				useNativeArt: true,
-				disableInlineEmojis: true,
-				selectButtonContent: (
-					<EmojiIcon
-						aria-label={translate('enquiry.write.input.emojies')}
-						title={translate('enquiry.write.input.emojies')}
-					/>
-				)
-			}),
-		[translate]
-	);
-	const { EmojiSelect } = emojiPlugin;
 
 	// This loads the keys for current activeSession.rid which is already set:
 	// to groupChat.groupId on group chats
@@ -2071,7 +2053,8 @@ export const MessageSubmitInterfaceComponent = ({
 
 		if (
 			type === SESSION_LIST_TYPES.ENQUIRY &&
-			hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData)
+			hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
+			!isAnonymousLiveChat
 		) {
 			await sendEnquiry(message, isEncrypted);
 			return;
@@ -2087,6 +2070,7 @@ export const MessageSubmitInterfaceComponent = ({
 		isE2eeEnabled,
 		key,
 		keyID,
+		isAnonymousLiveChat,
 		preselectedFile,
 		sendEnquiry,
 		sendMessage,

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -1841,6 +1841,27 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		isAnonymousEnquiryPhaseSession
 	]);
 
+	const preloadMessageComposer = useCallback(() => {
+		void import(
+			'../messageSubmitInterface/messageSubmitInterfaceComponent'
+		);
+	}, []);
+
+	useEffect(() => {
+		if (
+			shouldShowPseudonymGate &&
+			pseudonymConfirmed &&
+			consultantAccepted
+		) {
+			preloadMessageComposer();
+		}
+	}, [
+		consultantAccepted,
+		preloadMessageComposer,
+		pseudonymConfirmed,
+		shouldShowPseudonymGate
+	]);
+
 	const handleOpenCalmCompanion = useCallback(() => {
 		setShowBriefingNegativeScreen(false);
 		setBriefingScreenIndex(0);
@@ -1853,7 +1874,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	}, []);
 
 	const handleStartAcceptedChat = useCallback(() => {
-		setWaitingGateDismissed(true);
+		void import('../messageSubmitInterface/messageSubmitInterfaceComponent')
+			.then(() => setWaitingGateDismissed(true))
+			.catch(() => setWaitingGateDismissed(true));
 	}, []);
 
 	useEffect(() => {
@@ -2685,12 +2708,10 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const handleMessageSendSuccess = () => {
 		setDraggedFile(null);
 
-		// MATRIX MIGRATION: Refresh messages after sending for Matrix sessions
-		if (!activeSession.rid && props.refreshMessages) {
-			// console.log('🔄 MATRIX: Refreshing messages after send...');
+		if (props.refreshMessages) {
 			setTimeout(() => {
 				props.refreshMessages();
-			}, 500); // Small delay to ensure message is processed
+			}, 500);
 		}
 	};
 
@@ -4500,6 +4521,10 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 							>
 								<MessageSubmitInterfaceComponent
 									key={composerRemountKey}
+									isAnonymousLiveChat={
+										isAnonymousAskerExperience &&
+										waitingGateDismissed
+									}
 									isTyping={props.isTyping}
 									className={clsx(
 										'session__submit-interface',


### PR DESCRIPTION
Use sendMessage instead of sendEnquiry after the waiting gate is dismissed, refresh the message list after every send, preload the lazy composer chunk, and auto-retry the first composer mount failure.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

