### PR TITLE
Fix UI issue in Live Chat Card (Issue #85)

### DIFF
--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -36,7 +36,10 @@ import {
 	SessionsDataContext,
 	REMOVE_SESSIONS
 } from '../../globalState';
-import { TopicSessionInterface } from '../../globalState/interfaces';
+import {
+	TopicSessionInterface,
+	STATUS_ENQUIRY
+} from '../../globalState/interfaces';
 import { getGroupChatDate } from '../session/sessionDateHelpers';
 import { markdownToDraft } from 'markdown-draft-js';
 import { convertFromRaw } from 'draft-js';
@@ -926,7 +929,8 @@ export const SessionListItemComponent = ({
 		activeSession.item.postcode === 0 ||
 		activeSession.item.postcode?.toString() === '00000' ||
 		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+		activeSession.user?.username?.startsWith('Anonymous-') ||
+		activeSession.item.status === STATUS_ENQUIRY;
 
 	return (
 		<div
@@ -1333,21 +1337,15 @@ export const SessionListItemComponent = ({
 						/>
 					)}
 					{(() => {
-						/* Anonymous askers (Live-Chat queue users —
-						   username prefixed "Anonymous-") render with the
-						   dedicated Live Chat headset-wave icon + label
-						   instead of the 1-1 Beratung combined mark. The
-						   --liveChat modifier sits on the OUTER container
-						   so its CSS can override the base -12px right
-						   margin that would clip the text. */
-						const askerName =
-							(activeSession as any)?.user?.username ||
-							(activeSession as any)?.item?.askerUserName ||
-							'';
-						const isAnonymousAsker =
-							typeof askerName === 'string' &&
-							askerName.startsWith('Anonymous-');
-						if (isAnonymousAsker) {
+						/* Sessions with status ENQUIRY (Live-Chat queue)
+						   render with the dedicated Live Chat headset-wave
+						   icon + label instead of the 1-1 Beratung combined
+						   mark. The --liveChat modifier sits on the OUTER
+						   container so its CSS can override the base -12px
+						   right margin that would clip the text. */
+						const isLiveChatSession =
+							activeSession.item.status === STATUS_ENQUIRY;
+						if (isLiveChatSession) {
 							return (
 								<div
 									className={clsx(


### PR DESCRIPTION
Bug Fix: Live Chat Not Showing In Session Card

Related Issue: https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/85

Summary
- Fixed UI Issues in the Anonymous User Live Chat status in Session Card.
- Topic is not displayed because its a new session that created by anonymous user

Changes Made
- Use session status to validate if its live chat or not, (Session Status = 1 = New = Live Chat)

Testing
- Verified session card showing "Live Chat"

<img width="1906" height="898" alt="image" src="https://github.com/user-attachments/assets/c4eb5732-89a2-405a-a13b-90bf24bf9afb" />
