### PR TITLE
Fix Uneeded Section For Client View #78

### DIFF
--- a/src/components/app/RouterConfig.tsx
+++ b/src/components/app/RouterConfig.tsx
@@ -136,6 +136,12 @@ export const RouterConfigUser = (
 				}
 			},
 			{
+				condition: (userData) => {
+					return !hasUserAuthority(
+						AUTHORITIES.ASKER_DEFAULT,
+						userData
+					);
+				},
 				to: '/notifications',
 				icon: NavActivityIcon,
 				iconHover: NavActivityIconHover,
@@ -146,6 +152,12 @@ export const RouterConfigUser = (
 				}
 			},
 			{
+				condition: (userData) => {
+					return !hasUserAuthority(
+						AUTHORITIES.ASKER_DEFAULT,
+						userData
+					);
+				},
 				to: '/drafts',
 				icon: NavDraftsIcon,
 				iconHover: NavDraftsIconHover,


### PR DESCRIPTION
Bug Fix: Uneeded Section For Client View

Related Issue: https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/78

Summary
Remove uneeded section for client view

Changes Made
- Add condition for user router config, which hiding the activity and draft menu for client view

Tested
- Activity and Draft menu is hidden now
- Counselor menus are still visible for all menu

Screenshots
<img width="1450" height="901" alt="image" src="https://github.com/user-attachments/assets/f47ddb9a-88b5-4ca7-8d46-30b59d78c55b" />
<img width="1499" height="859" alt="image" src="https://github.com/user-attachments/assets/1f33bd20-5bcc-42d5-aa85-a1dee6522c61" />


