### PR TITLE
fix #116 sessions list gap and update coloring to match figma #116 

### DIFF
--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -85,7 +85,7 @@ $tabBarHeightDesktop: 53px;
 		flex-direction: column;
 		justify-content: stretch;
 		align-items: stretch;
-		padding-top: 15px;
+		padding-top: 0;
 		min-height: 0;
 	}
 
@@ -112,7 +112,7 @@ $tabBarHeightDesktop: 53px;
 	}
 
 	&__scrollContainer {
-		padding-top: $grid-base-three;
+		padding-top: $grid-base; // Reduced from $grid-base-three — closes the gap above first card
 		overflow: auto;
 		flex: 1;
 		padding-right: 12px;

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -93,7 +93,7 @@ $session-postcode-border: #ffd1d1;
 		padding-right: 6px;
 		padding-top: 12px;
 		margin: 0 $grid-base-two;
-		background-color: $sessions-list-background-color-secondary;
+		background-color: $session-list-item-background-default;
 		border: 1px solid $session-light-border;
 		border-radius: 0;
 		transition: all 0.6s ease;

--- a/src/resources/styles/settings.scss
+++ b/src/resources/styles/settings.scss
@@ -268,9 +268,11 @@ $session-header-background-color: $background-light;
 $session-header-background-color-large: $background-lighter;
 $session-list-item-background-active: $background-lighter;
 $session-list-item-border-radius: 4px;
-/* Session list column + card rest state: match app shell #f5f5f5 */
-$sessions-list-background-color-primary: #f5f5f5;
-$sessions-list-background-color-secondary: #f5f5f5;
+/* Session list sidebar background: white per Figma design */
+$sessions-list-background-color-primary: #ffffff;
+$sessions-list-background-color-secondary: #ffffff;
+/* Session card default (unread) background: light salmon per Figma */
+$session-list-item-background-default: #fef0f0;
 $session-menu-legal-links-color: white;
 $statistics-highlight-color: $primary;
 $tab-border-radius: 25px;


### PR DESCRIPTION
## What
- sidebar background changed from gray (#f5f5f5) to white (#ffffff)
- session card default background changed from gray to light salmon (#fef0f0) matching Figma design
- removed excess top padding above first card: `__innerWrapper` 15px ? 0, `__scrollContainer` 24px ? 8px
- added `\-list-item-background-default` variable to settings.scss

## Why
Closes #116 - sessions list sidebar had wrong gray background color and stacked top padding creating a visible gap above the first card; card default color didn't match the Figma salmon/pink design spec