### PR TITLE
fix(call): resolve call config at runtime and stop double media capture

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -18,11 +18,38 @@ const pick = (...keys) => {
 };
 
 const apiUrl = pick('REACT_APP_API_URL', 'VITE_API_URL');
+const matrixHomeserverUrl = pick(
+	'REACT_APP_MATRIX_HOMESERVER_URL',
+	'VITE_MATRIX_HOMESERVER_URL',
+	'REACT_APP_MATRIX_URL'
+);
+const elementCallUrl = pick(
+	'REACT_APP_ELEMENT_CALL_BASE_URL',
+	'REACT_APP_ELEMENT_CALL_URL'
+);
+const livekitUrl = pick('REACT_APP_LIVEKIT_WS_URL', 'REACT_APP_LIVEKIT_URL');
+
 const config = {};
 
 if (apiUrl) {
 	config.REACT_APP_API_URL = apiUrl;
 	config.VITE_API_URL = apiUrl;
+}
+
+if (matrixHomeserverUrl) {
+	config.REACT_APP_MATRIX_HOMESERVER_URL = matrixHomeserverUrl;
+	config.VITE_MATRIX_HOMESERVER_URL = matrixHomeserverUrl;
+	config.REACT_APP_MATRIX_URL = matrixHomeserverUrl;
+}
+
+if (elementCallUrl) {
+	config.REACT_APP_ELEMENT_CALL_BASE_URL = elementCallUrl;
+	config.REACT_APP_ELEMENT_CALL_URL = elementCallUrl;
+}
+
+if (livekitUrl) {
+	config.REACT_APP_LIVEKIT_WS_URL = livekitUrl;
+	config.REACT_APP_LIVEKIT_URL = livekitUrl;
 }
 
 const target = process.env.RUNTIME_CONFIG_FILE;

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -28,6 +28,7 @@ import { useCall } from '../../globalState/provider/CallProvider';
 import { RocketChatUserStatusProvider } from '../../globalState/provider/RocketChatUserStatusProvider';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import { E2EEncryptionSupportBanner } from '../E2EEncryptionSupportBanner/E2EEncryptionSupportBanner';
+import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 
 interface AuthenticatedAppProps {
 	onAppReady: Function;
@@ -119,7 +120,7 @@ export const AuthenticatedApp = ({
 										new MatrixClientService();
 
 									const homeserverUrl =
-										process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+										getMatrixHomeserverUrl();
 									if (!homeserverUrl) {
 										// console.warn('⚠️ REACT_APP_MATRIX_HOMESERVER_URL is not set; skipping Matrix client init');
 									} else {

--- a/src/components/call/FloatingCallWidget.tsx
+++ b/src/components/call/FloatingCallWidget.tsx
@@ -9,380 +9,478 @@ import { matrixCallService } from '../../services/matrixCallService';
 import './FloatingCallWidget.scss';
 
 export const FloatingCallWidget: React.FC = () => {
-    const [callData, setCallData] = useState<CallData | null>(null);
-    const [callDuration, setCallDuration] = useState(0);
-    const [isMuted, setIsMuted] = useState(false);
-    const [isVideoOff, setIsVideoOff] = useState(false);
-    const [isFullscreen, setIsFullscreen] = useState(false);
-    const [isMinimized, setIsMinimized] = useState(false);
-    const [otherUserInitial, setOtherUserInitial] = useState<string>('U');
-    const [, forceUpdate] = useState(0); // 🔥 Force re-render trigger
-    
-    const [isDragging, setIsDragging] = useState(false);
-    const [position, setPosition] = useState(() => {
-        // Center the popup initially
-        const popupWidth = 460;
-        const popupHeight = 560;
-        return {
-            x: (window.innerWidth - popupWidth) / 2,
-            y: (window.innerHeight - popupHeight) / 2
-        };
-    });
-    const dragStartPos = useRef({ x: 0, y: 0 });
-    
-    const localVideoRef = useRef<HTMLVideoElement>(null);
-    const remoteVideoRef = useRef<HTMLVideoElement>(null);
-    const callInitiatedRef = useRef(false);
-    const widgetRef = useRef<HTMLDivElement>(null);
+	const [callData, setCallData] = useState<CallData | null>(null);
+	const [callDuration, setCallDuration] = useState(0);
+	const [isMuted, setIsMuted] = useState(false);
+	const [isVideoOff, setIsVideoOff] = useState(false);
+	const [isFullscreen, setIsFullscreen] = useState(false);
+	const [isMinimized, setIsMinimized] = useState(false);
+	const [otherUserInitial, setOtherUserInitial] = useState<string>('U');
+	const [, forceUpdate] = useState(0); // 🔥 Force re-render trigger
 
-    // Subscribe to CallManager
-    useEffect(() => {
-        const unsubscribe = callManager.subscribe((newCallData) => {
-            setCallData(newCallData);
-            if (!newCallData) {
-                callInitiatedRef.current = false;
-                setCallDuration(0);
-            } else {
-                // Reset callInitiatedRef for new calls
-                callInitiatedRef.current = false;
-            }
-        });
-        setCallData(callManager.getCurrentCall());
-        return () => unsubscribe();
-    }, []);
+	const [isDragging, setIsDragging] = useState(false);
+	const [position, setPosition] = useState(() => {
+		// Center the popup initially
+		const popupWidth = 460;
+		const popupHeight = 560;
+		return {
+			x: (window.innerWidth - popupWidth) / 2,
+			y: (window.innerHeight - popupHeight) / 2
+		};
+	});
+	const dragStartPos = useRef({ x: 0, y: 0 });
 
-    // Get other user's initial from Matrix room
-    useEffect(() => {
-        if (!callData) return;
-        
-        // 🚫 SKIP if this is a group call - GroupCallWidget will handle it
-        if (callData.isGroup) return;
+	const localVideoRef = useRef<HTMLVideoElement>(null);
+	const remoteVideoRef = useRef<HTMLVideoElement>(null);
+	const callInitiatedRef = useRef(false);
+	const widgetRef = useRef<HTMLDivElement>(null);
 
-        const matrixClientService = (window as any).matrixClientService;
-        if (!matrixClientService) return;
+	// Subscribe to CallManager
+	useEffect(() => {
+		const unsubscribe = callManager.subscribe((newCallData) => {
+			setCallData(newCallData);
+			if (!newCallData) {
+				callInitiatedRef.current = false;
+				setCallDuration(0);
+			} else {
+				// Reset callInitiatedRef for new calls
+				callInitiatedRef.current = false;
+			}
+		});
+		setCallData(callManager.getCurrentCall());
+		return () => unsubscribe();
+	}, []);
 
-        const client = matrixClientService.getClient();
-        if (!client) return;
+	// Get other user's initial from Matrix room
+	useEffect(() => {
+		if (!callData) return;
 
-        const room = client.getRoom(callData.roomId);
-        if (!room) return;
+		// 🚫 SKIP if this is a group call - GroupCallWidget will handle it
+		if (callData.isGroup) return;
 
-        // Get room members
-        const members = room.getMembers();
-        const myUserId = client.getUserId();
+		const matrixClientService = (window as any).matrixClientService;
+		if (!matrixClientService) return;
 
-        // Find the OTHER user (not me)
-        const otherUser = members.find((m: any) => m.userId !== myUserId);
+		const client = matrixClientService.getClient();
+		if (!client) return;
 
-        if (otherUser) {
-            const username = otherUser.name || otherUser.userId;
-            const initial = username.replace('@', '').charAt(0).toUpperCase();
-            // console.log('👤 Other user:', username, '→ Initial:', initial);
-            setOtherUserInitial(initial);
-        } else {
-            // Fallback: use callerUserId if incoming
-            if (callData.callerUserId) {
-                const initial = callData.callerUserId.replace('@', '').charAt(0).toUpperCase();
-                setOtherUserInitial(initial);
-            }
-        }
-    }, [callData]);
+		const room = client.getRoom(callData.roomId);
+		if (!room) return;
 
-    // Handle outgoing call initiation
-    useEffect(() => {
-        if (!callData || callData.isIncoming || callInitiatedRef.current || callData.matrixCall) return;
-        
-        // 🚫 SKIP if this is a group call - GroupCallWidget will handle it with LiveKit
-        if (callData.isGroup) {
-            // console.log('🚫 FloatingCallWidget: Skipping group call (handled by GroupCallWidget)');
-            return;
-        }
-        
-        callInitiatedRef.current = true;
-        
-        // 🔥 MOBILE FIX: Check if media stream was pre-requested in button click handler
-        const preRequestedStream = (window as any).__preRequestedMediaStream;
-        const preRequestedTime = (window as any).__preRequestedMediaStreamTime;
-        const isStreamFresh = preRequestedTime && (Date.now() - preRequestedTime < 5000); // Within 5 seconds
-        
-        if (preRequestedStream && isStreamFresh) {
-            // console.log('✅ Using pre-requested media stream (mobile-friendly!)');
-            (window as any).__activeMediaStream = preRequestedStream;
-            
-            // Clear the pre-requested stream
-            delete (window as any).__preRequestedMediaStream;
-            delete (window as any).__preRequestedMediaStreamTime;
-            
-            // Start the call immediately
-            matrixCallService.startCall({
-                roomId: callData.roomId,
-                isVideoCall: callData.isVideo,
-                localVideoElement: localVideoRef.current || undefined,
-                remoteVideoElement: remoteVideoRef.current || undefined
-            })
-            .then((matrixCall) => {
-                callManager.setMatrixCall(matrixCall);
-            })
-            .catch((err) => {
-                // console.error("Failed to start call:", err);
-                alert(`Failed to start call: ${(err as Error).message}`);
-                callManager.endCall();
-            });
-        } else {
-            // console.log('⚠️ No pre-requested stream, requesting now (may fail on mobile)');
-            navigator.mediaDevices.getUserMedia({ video: callData.isVideo, audio: true })
-                .then((stream) => {
-                    (window as any).__activeMediaStream = stream;
-                    return matrixCallService.startCall({
-                        roomId: callData.roomId,
-                        isVideoCall: callData.isVideo,
-                        localVideoElement: localVideoRef.current || undefined,
-                        remoteVideoElement: remoteVideoRef.current || undefined
-                    });
-                })
-                .then((matrixCall) => {
-                    callManager.setMatrixCall(matrixCall);
-                })
-                .catch((err) => {
-                    // console.error("Failed to start call:", err);
-                    alert(`Failed to start call: ${(err as Error).message}`);
-                    callManager.endCall();
-                });
-        }
-    }, [callData]);
+		// Get room members
+		const members = room.getMembers();
+		const myUserId = client.getUserId();
 
-    // Call duration timer
-    useEffect(() => {
-        if (callData?.state === 'connected') {
-            const interval = setInterval(() => setCallDuration(prev => prev + 1), 1000);
-            return () => clearInterval(interval);
-        } else {
-            setCallDuration(0);
-        }
-    }, [callData?.state]);
+		// Find the OTHER user (not me)
+		const otherUser = members.find((m: any) => m.userId !== myUserId);
 
-    // Dragging
-    const handleMouseDown = (e: React.MouseEvent) => {
-        if ((e.target as HTMLElement).closest('.call-controls') || 
-            (e.target as HTMLElement).closest('.window-controls')) return;
-        setIsDragging(true);
-        dragStartPos.current = { x: e.clientX - position.x, y: e.clientY - position.y };
-    };
+		if (otherUser) {
+			const username = otherUser.name || otherUser.userId;
+			const initial = username.replace('@', '').charAt(0).toUpperCase();
+			// console.log('👤 Other user:', username, '→ Initial:', initial);
+			setOtherUserInitial(initial);
+		} else {
+			// Fallback: use callerUserId if incoming
+			if (callData.callerUserId) {
+				const initial = callData.callerUserId
+					.replace('@', '')
+					.charAt(0)
+					.toUpperCase();
+				setOtherUserInitial(initial);
+			}
+		}
+	}, [callData]);
 
-    useEffect(() => {
-        const handleMouseMove = (e: MouseEvent) => {
-            if (!isDragging) return;
-            setPosition({ x: e.clientX - dragStartPos.current.x, y: e.clientY - dragStartPos.current.y });
-        };
-        const handleMouseUp = () => isDragging && setIsDragging(false);
-        if (isDragging) {
-            window.addEventListener('mousemove', handleMouseMove);
-            window.addEventListener('mouseup', handleMouseUp);
-        }
-        return () => {
-            window.removeEventListener('mousemove', handleMouseMove);
-            window.removeEventListener('mouseup', handleMouseUp);
-        };
-    }, [isDragging, position]);
+	// Handle outgoing call initiation
+	useEffect(() => {
+		if (
+			!callData ||
+			callData.isIncoming ||
+			callInitiatedRef.current ||
+			callData.matrixCall
+		)
+			return;
 
-    // Cleanup
-    useEffect(() => {
-        return () => {
-            const stream = (window as any).__activeMediaStream;
-            if (stream) {
-                stream.getTracks().forEach((track: any) => track.stop());
-                delete (window as any).__activeMediaStream;
-            }
-        };
-    }, []);
+		// 🚫 SKIP if this is a group call - GroupCallWidget will handle it with LiveKit
+		if (callData.isGroup) {
+			// console.log('🚫 FloatingCallWidget: Skipping group call (handled by GroupCallWidget)');
+			return;
+		}
 
-    // Handlers
-    const handleAnswer = async () => {
-        if (!callData || !callData.isIncoming) return;
-        try {
-            const matrixClientService = (window as any).matrixClientService;
-            const client = matrixClientService?.getClient();
-            if (!client) throw new Error("Matrix client not available");
+		callInitiatedRef.current = true;
 
-            const calls = client.callEventHandler?.calls;
-            if (!calls) throw new Error("Call handler not available");
+		// The call button pre-requests camera/mic to keep the mobile user
+		// gesture alive for the permission prompt. matrix-js-sdk's placeCall()
+		// acquires its OWN media internally, so we must release the
+		// pre-requested stream first — opening the same device twice fails with
+		// NotReadableError on Windows/Android and leaves an orphaned capture.
+		const preRequestedStream = (window as any).__preRequestedMediaStream;
+		if (preRequestedStream) {
+			try {
+				preRequestedStream
+					.getTracks()
+					.forEach((track: MediaStreamTrack) => track.stop());
+			} catch {
+				// ignore
+			}
+			delete (window as any).__preRequestedMediaStream;
+			delete (window as any).__preRequestedMediaStreamTime;
+		}
 
-            const incomingCall = Array.from(calls.values()).find((call: any) => 
-                call.roomId === callData.roomId && call.direction === 'inbound' && call.state === 'ringing'
-            );
-            if (!incomingCall) throw new Error("No incoming call found");
+		matrixCallService
+			.startCall({
+				roomId: callData.roomId,
+				isVideoCall: callData.isVideo,
+				localVideoElement: localVideoRef.current || undefined,
+				remoteVideoElement: remoteVideoRef.current || undefined
+			})
+			.then((matrixCall) => {
+				callManager.setMatrixCall(matrixCall);
+			})
+			.catch((err) => {
+				// console.error("Failed to start call:", err);
+				alert(`Failed to start call: ${(err as Error).message}`);
+				callManager.endCall();
+			});
+	}, [callData]);
 
-            const stream = await navigator.mediaDevices.getUserMedia({ video: callData.isVideo, audio: true });
-            (window as any).__activeMediaStream = stream;
+	// Call duration timer
+	useEffect(() => {
+		if (callData?.state === 'connected') {
+			const interval = setInterval(
+				() => setCallDuration((prev) => prev + 1),
+				1000
+			);
+			return () => clearInterval(interval);
+		} else {
+			setCallDuration(0);
+		}
+	}, [callData?.state]);
 
-            callManager.answerCall();
-            await matrixCallService.answerCall(
-                incomingCall as any, callData.isVideo,
-                localVideoRef.current || undefined, remoteVideoRef.current || undefined
-            );
-            callManager.setMatrixCall(incomingCall as any);
-            
-            // 🔥 Force UI re-render to hide Answer/Decline buttons and show call controls
-            setTimeout(() => forceUpdate(prev => prev + 1), 100);
-        } catch (err) {
-            // console.error("Failed to answer:", err);
-            alert(`Failed to answer: ${(err as Error).message}`);
-            callManager.endCall();
-        }
-    };
+	// Dragging
+	const handleMouseDown = (e: React.MouseEvent) => {
+		if (
+			(e.target as HTMLElement).closest('.call-controls') ||
+			(e.target as HTMLElement).closest('.window-controls')
+		)
+			return;
+		setIsDragging(true);
+		dragStartPos.current = {
+			x: e.clientX - position.x,
+			y: e.clientY - position.y
+		};
+	};
 
-    const handleReject = () => callManager.rejectCall();
-    const handleHangup = () => callManager.endCall();
-    const toggleMute = () => {
-        if (callData?.matrixCall) {
-            (callData.matrixCall as any).setMicrophoneMuted(!isMuted);
-            setIsMuted(!isMuted);
-        }
-    };
-    const toggleVideo = () => {
-        if (callData?.matrixCall) {
-            (callData.matrixCall as any).setLocalVideoMuted(!isVideoOff);
-            setIsVideoOff(!isVideoOff);
-        }
-    };
-    const toggleFullscreen = () => {
-        setIsFullscreen(!isFullscreen);
-        if (!isFullscreen) setIsMinimized(false);
-    };
-    const toggleMinimized = () => {
-        setIsMinimized(!isMinimized);
-        if (!isMinimized) setIsFullscreen(false);
-    };
+	useEffect(() => {
+		const handleMouseMove = (e: MouseEvent) => {
+			if (!isDragging) return;
+			setPosition({
+				x: e.clientX - dragStartPos.current.x,
+				y: e.clientY - dragStartPos.current.y
+			});
+		};
+		const handleMouseUp = () => isDragging && setIsDragging(false);
+		if (isDragging) {
+			window.addEventListener('mousemove', handleMouseMove);
+			window.addEventListener('mouseup', handleMouseUp);
+		}
+		return () => {
+			window.removeEventListener('mousemove', handleMouseMove);
+			window.removeEventListener('mouseup', handleMouseUp);
+		};
+	}, [isDragging, position]);
 
-    const formatDuration = (seconds: number) => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-    };
+	// Cleanup
+	useEffect(() => {
+		return () => {
+			const stream = (window as any).__activeMediaStream;
+			if (stream) {
+				stream.getTracks().forEach((track: any) => track.stop());
+				delete (window as any).__activeMediaStream;
+			}
+		};
+	}, []);
 
-    const getStatusText = () => {
-        if (callData.isIncoming && callData.state === 'ringing') return 'Incoming Call';
-        if (!callData.isIncoming && callData.state === 'ringing') return 'Calling...';
-        if (callData.state === 'connecting') return 'Connecting...';
-        if (callData.state === 'connected') return formatDuration(callDuration);
-        return 'Call Active';
-    };
+	// Handlers
+	const handleAnswer = async () => {
+		if (!callData || !callData.isIncoming) return;
+		try {
+			const matrixClientService = (window as any).matrixClientService;
+			const client = matrixClientService?.getClient();
+			if (!client) throw new Error('Matrix client not available');
 
-    // Only render for 1-on-1 calls (not group calls)
-    // Group calls are handled by GroupCallWidget
-    if (!callData || callData.isGroup) return null;
+			const calls = client.callEventHandler?.calls;
+			if (!calls) throw new Error('Call handler not available');
 
-    const widgetClass = `floating-call-widget ${isFullscreen ? 'fullscreen' : isMinimized ? 'minimized' : 'normal'}`;
+			const incomingCall = Array.from(calls.values()).find(
+				(call: any) =>
+					call.roomId === callData.roomId &&
+					call.direction === 'inbound' &&
+					call.state === 'ringing'
+			);
+			if (!incomingCall) throw new Error('No incoming call found');
 
-    return (
-        <div 
-            ref={widgetRef}
-            className={widgetClass}
-            style={{
-                position: 'fixed',
-                left: isFullscreen ? 0 : `${position.x}px`,
-                top: isFullscreen ? 0 : `${position.y}px`,
-                cursor: isDragging ? 'grabbing' : 'default'
-            }}
-            onMouseDown={handleMouseDown}
-        >
-            {/* Header - Element style */}
-            <div className="call-header" style={{ cursor: isFullscreen ? 'default' : 'grab' }}>
-                <div className="call-header-left">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M20.01 15.38c-1.23 0-2.42-.2-3.53-.56-.35-.12-.74-.03-1.01.24l-1.57 1.97c-2.83-1.35-5.48-3.9-6.89-6.83l1.95-1.66c.27-.28.35-.67.24-1.02-.37-1.11-.56-2.3-.56-3.53 0-.54-.45-.99-.99-.99H4.19C3.65 3 3 3.24 3 3.99 3 13.28 10.73 21 20.01 21c.71 0 .99-.63.99-1.18v-3.45c0-.54-.45-.99-.99-.99z"/>
-                    </svg>
-                    <span>Call</span>
-                </div>
-                
-                <button className="fullscreen-toggle" onClick={(e) => { e.stopPropagation(); toggleFullscreen(); }} title="Fullscreen">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
-                        </svg>
-                    </button>
-            </div>
+			// Request permission within this click gesture (needed on mobile),
+			// then release it immediately — matrixCallService.answerCall() opens
+			// its own media, so holding this stream would double-open the device.
+			const stream = await navigator.mediaDevices.getUserMedia({
+				video: callData.isVideo,
+				audio: true
+			});
+			try {
+				stream.getTracks().forEach((track) => track.stop());
+			} catch {
+				// ignore
+			}
 
-            {/* Video area */}
-            <div className="call-video-area">
-                {/* Video elements */}
-                {callData.isVideo && (
-                    <>
-                        <video 
-                            ref={remoteVideoRef} autoPlay playsInline className="remote-video"
-                            style={{ display: callData.state === 'ringing' ? 'none' : 'block' }}
-                        />
-                        <video 
-                            ref={localVideoRef} autoPlay playsInline muted className="local-video"
-                            style={{ display: callData.state === 'ringing' ? 'none' : 'block' }}
-                        />
-                    </>
-                )}
-                
-                {/* Large avatar - always show for voice or when ringing */}
-                {(!callData.isVideo || callData.state === 'ringing') && (
-                    <div className="call-avatar-large">
-                        {otherUserInitial}
-                    </div>
-                )}
-            </div>
+			callManager.answerCall();
+			await matrixCallService.answerCall(
+				incomingCall as any,
+				callData.isVideo,
+				localVideoRef.current || undefined,
+				remoteVideoRef.current || undefined
+			);
+			callManager.setMatrixCall(incomingCall as any);
 
-            {/* Controls - Element exact design */}
-            <div className="call-controls">
-                {(callData.state === 'ringing' || (callData.isIncoming && !callData.matrixCall)) ? (
-                    <>
-                        <button className="call-btn answer-btn" onClick={handleAnswer} title="Answer">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M20.01 15.38c-1.23 0-2.42-.2-3.53-.56-.35-.12-.74-.03-1.01.24l-1.57 1.97c-2.83-1.35-5.48-3.9-6.89-6.83l1.95-1.66c.27-.28.35-.67.24-1.02-.37-1.11-.56-2.3-.56-3.53 0-.54-.45-.99-.99-.99H4.19C3.65 3 3 3.24 3 3.99 3 13.28 10.73 21 20.01 21c.71 0 .99-.63.99-1.18v-3.45c0-.54-.45-.99-.99-.99z"/>
-                            </svg>
-                        </button>
-                        <button className="call-btn reject-btn" onClick={handleReject} title="Reject">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 9c-1.6 0-3.15.25-4.6.72v3.1c0 .39-.23.74-.56.9-.98.49-1.87 1.12-2.66 1.85-.18.18-.43.28-.7.28-.28 0-.53-.11-.71-.29L.29 13.08c-.18-.17-.29-.42-.29-.7 0-.28.11-.53.29-.71C3.34 8.78 7.46 7 12 7s8.66 1.78 11.71 4.67c.18.18.29.43.29.71 0 .28-.11.53-.29.71l-2.48 2.48c-.18.18-.43.29-.71.29-.27 0-.52-.11-.7-.28-.79-.74-1.69-1.36-2.67-1.85-.33-.16-.56-.5-.56-.9v-3.1C15.15 9.25 13.6 9 12 9z"/>
-                            </svg>
-                        </button>
-                    </>
-                ) : (
-                    <>
-                        {/* Microphone - NO dropdown arrow */}
-                        <button className={`call-btn ${isMuted ? 'muted' : ''}`} onClick={toggleMute} title={isMuted ? 'Unmute' : 'Mute'}>
-                            <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
-                                {isMuted ? (
-                                    <>
-                                        <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879L5.158 2.037A3.001 3.001 0 0 1 11 3z"/>
-                                        <path d="M9.486 10.607 5 6.12V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z"/>
-                                    </>
-                                ) : (
-                                    <>
-                                        <path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0V3z"/>
-                                        <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z"/>
-                                    </>
-                                )}
-                            </svg>
-                        </button>
+			// 🔥 Force UI re-render to hide Answer/Decline buttons and show call controls
+			setTimeout(() => forceUpdate((prev) => prev + 1), 100);
+		} catch (err) {
+			// console.error("Failed to answer:", err);
+			alert(`Failed to answer: ${(err as Error).message}`);
+			callManager.endCall();
+		}
+	};
 
-                        {/* Camera - NO dropdown arrow */}
-                        {callData.isVideo && (
-                            <button className={`call-btn ${isVideoOff ? 'video-off' : ''}`} onClick={toggleVideo} title={isVideoOff ? 'Turn on video' : 'Turn off video'}>
-                                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                                    {isVideoOff ? (
-                                        <path d="M21 6.5l-4 4V7c0-.55-.45-1-1-1H9.82L21 17.18V6.5zM3.27 2L2 3.27 4.73 6H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.21 0 .39-.08.54-.18L19.73 21 21 19.73 3.27 2z"/>
-                                    ) : (
-                                        <path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"/>
-                                    )}
-                                </svg>
-                            </button>
-                        )}
+	const handleReject = () => callManager.rejectCall();
+	const handleHangup = () => callManager.endCall();
+	const toggleMute = () => {
+		if (callData?.matrixCall) {
+			(callData.matrixCall as any).setMicrophoneMuted(!isMuted);
+			setIsMuted(!isMuted);
+		}
+	};
+	const toggleVideo = () => {
+		if (callData?.matrixCall) {
+			(callData.matrixCall as any).setLocalVideoMuted(!isVideoOff);
+			setIsVideoOff(!isVideoOff);
+		}
+	};
+	const toggleFullscreen = () => {
+		setIsFullscreen(!isFullscreen);
+		if (!isFullscreen) setIsMinimized(false);
+	};
+	const toggleMinimized = () => {
+		setIsMinimized(!isMinimized);
+		if (!isMinimized) setIsFullscreen(false);
+	};
 
-                        {/* Screen share - Hidden for now */}
-                        {/* <button className="call-btn" title="Share screen">
+	const formatDuration = (seconds: number) => {
+		const mins = Math.floor(seconds / 60);
+		const secs = seconds % 60;
+		return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+	};
+
+	const getStatusText = () => {
+		if (callData.isIncoming && callData.state === 'ringing')
+			return 'Incoming Call';
+		if (!callData.isIncoming && callData.state === 'ringing')
+			return 'Calling...';
+		if (callData.state === 'connecting') return 'Connecting...';
+		if (callData.state === 'connected') return formatDuration(callDuration);
+		return 'Call Active';
+	};
+
+	// Only render for 1-on-1 calls (not group calls)
+	// Group calls are handled by GroupCallWidget
+	if (!callData || callData.isGroup) return null;
+
+	const widgetClass = `floating-call-widget ${isFullscreen ? 'fullscreen' : isMinimized ? 'minimized' : 'normal'}`;
+
+	return (
+		<div
+			ref={widgetRef}
+			className={widgetClass}
+			style={{
+				position: 'fixed',
+				left: isFullscreen ? 0 : `${position.x}px`,
+				top: isFullscreen ? 0 : `${position.y}px`,
+				cursor: isDragging ? 'grabbing' : 'default'
+			}}
+			onMouseDown={handleMouseDown}
+		>
+			{/* Header - Element style */}
+			<div
+				className="call-header"
+				style={{ cursor: isFullscreen ? 'default' : 'grab' }}
+			>
+				<div className="call-header-left">
+					<svg
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path d="M20.01 15.38c-1.23 0-2.42-.2-3.53-.56-.35-.12-.74-.03-1.01.24l-1.57 1.97c-2.83-1.35-5.48-3.9-6.89-6.83l1.95-1.66c.27-.28.35-.67.24-1.02-.37-1.11-.56-2.3-.56-3.53 0-.54-.45-.99-.99-.99H4.19C3.65 3 3 3.24 3 3.99 3 13.28 10.73 21 20.01 21c.71 0 .99-.63.99-1.18v-3.45c0-.54-.45-.99-.99-.99z" />
+					</svg>
+					<span>Call</span>
+				</div>
+
+				<button
+					className="fullscreen-toggle"
+					onClick={(e) => {
+						e.stopPropagation();
+						toggleFullscreen();
+					}}
+					title="Fullscreen"
+				>
+					<svg
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+					</svg>
+				</button>
+			</div>
+
+			{/* Video area */}
+			<div className="call-video-area">
+				{/* Video elements */}
+				{callData.isVideo && (
+					<>
+						<video
+							ref={remoteVideoRef}
+							autoPlay
+							playsInline
+							className="remote-video"
+							style={{
+								display:
+									callData.state === 'ringing'
+										? 'none'
+										: 'block'
+							}}
+						/>
+						<video
+							ref={localVideoRef}
+							autoPlay
+							playsInline
+							muted
+							className="local-video"
+							style={{
+								display:
+									callData.state === 'ringing'
+										? 'none'
+										: 'block'
+							}}
+						/>
+					</>
+				)}
+
+				{/* Large avatar - always show for voice or when ringing */}
+				{(!callData.isVideo || callData.state === 'ringing') && (
+					<div className="call-avatar-large">{otherUserInitial}</div>
+				)}
+			</div>
+
+			{/* Controls - Element exact design */}
+			<div className="call-controls">
+				{callData.state === 'ringing' ||
+				(callData.isIncoming && !callData.matrixCall) ? (
+					<>
+						<button
+							className="call-btn answer-btn"
+							onClick={handleAnswer}
+							title="Answer"
+						>
+							<svg
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+							>
+								<path d="M20.01 15.38c-1.23 0-2.42-.2-3.53-.56-.35-.12-.74-.03-1.01.24l-1.57 1.97c-2.83-1.35-5.48-3.9-6.89-6.83l1.95-1.66c.27-.28.35-.67.24-1.02-.37-1.11-.56-2.3-.56-3.53 0-.54-.45-.99-.99-.99H4.19C3.65 3 3 3.24 3 3.99 3 13.28 10.73 21 20.01 21c.71 0 .99-.63.99-1.18v-3.45c0-.54-.45-.99-.99-.99z" />
+							</svg>
+						</button>
+						<button
+							className="call-btn reject-btn"
+							onClick={handleReject}
+							title="Reject"
+						>
+							<svg
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+							>
+								<path d="M12 9c-1.6 0-3.15.25-4.6.72v3.1c0 .39-.23.74-.56.9-.98.49-1.87 1.12-2.66 1.85-.18.18-.43.28-.7.28-.28 0-.53-.11-.71-.29L.29 13.08c-.18-.17-.29-.42-.29-.7 0-.28.11-.53.29-.71C3.34 8.78 7.46 7 12 7s8.66 1.78 11.71 4.67c.18.18.29.43.29.71 0 .28-.11.53-.29.71l-2.48 2.48c-.18.18-.43.29-.71.29-.27 0-.52-.11-.7-.28-.79-.74-1.69-1.36-2.67-1.85-.33-.16-.56-.5-.56-.9v-3.1C15.15 9.25 13.6 9 12 9z" />
+							</svg>
+						</button>
+					</>
+				) : (
+					<>
+						{/* Microphone - NO dropdown arrow */}
+						<button
+							className={`call-btn ${isMuted ? 'muted' : ''}`}
+							onClick={toggleMute}
+							title={isMuted ? 'Unmute' : 'Mute'}
+						>
+							<svg
+								width="20"
+								height="20"
+								viewBox="0 0 16 16"
+								fill="currentColor"
+							>
+								{isMuted ? (
+									<>
+										<path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879L5.158 2.037A3.001 3.001 0 0 1 11 3z" />
+										<path d="M9.486 10.607 5 6.12V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
+									</>
+								) : (
+									<>
+										<path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0V3z" />
+										<path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z" />
+									</>
+								)}
+							</svg>
+						</button>
+
+						{/* Camera - NO dropdown arrow */}
+						{callData.isVideo && (
+							<button
+								className={`call-btn ${isVideoOff ? 'video-off' : ''}`}
+								onClick={toggleVideo}
+								title={
+									isVideoOff
+										? 'Turn on video'
+										: 'Turn off video'
+								}
+							>
+								<svg
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="currentColor"
+								>
+									{isVideoOff ? (
+										<path d="M21 6.5l-4 4V7c0-.55-.45-1-1-1H9.82L21 17.18V6.5zM3.27 2L2 3.27 4.73 6H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.21 0 .39-.08.54-.18L19.73 21 21 19.73 3.27 2z" />
+									) : (
+										<path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z" />
+									)}
+								</svg>
+							</button>
+						)}
+
+						{/* Screen share - Hidden for now */}
+						{/* <button className="call-btn" title="Share screen">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M9 7l5-5v4h6v2h-6v4l-5-5z"/>
                                 <rect x="3" y="15" width="18" height="2" fill="currentColor"/>
                             </svg>
                         </button> */}
 
-                        {/* More options - Hidden */}
-                        {/* <button className="call-btn" title="More options">
+						{/* More options - Hidden */}
+						{/* <button className="call-btn" title="More options">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                                 <circle cx="6" cy="12" r="2"/>
                                 <circle cx="12" cy="12" r="2"/>
@@ -390,16 +488,24 @@ export const FloatingCallWidget: React.FC = () => {
                             </svg>
                         </button> */}
 
-                        {/* Hang up */}
-                        <button className="call-btn hangup-btn" onClick={handleHangup} title="End call">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 9c-1.6 0-3.15.25-4.6.72v3.1c0 .39-.23.74-.56.9-.98.49-1.87 1.12-2.66 1.85-.18.18-.43.28-.7.28-.28 0-.53-.11-.71-.29L.29 13.08c-.18-.17-.29-.42-.29-.70 0-.28.11-.53.29-.71C3.34 8.78 7.46 7 12 7s8.66 1.78 11.71 4.67c.18.18.29.43.29.71 0 .28-.11.53-.29.71l-2.48 2.48c-.18.18-.43.29-.71.29-.27 0-.52-.11-.7-.28-.79-.74-1.69-1.36-2.67-1.85-.33-.16-.56-.5-.56-.9v-3.1C15.15 9.25 13.6 9 12 9z"/>
-                            </svg>
-                        </button>
-                    </>
-                )}
-            </div>
-        </div>
-    );
+						{/* Hang up */}
+						<button
+							className="call-btn hangup-btn"
+							onClick={handleHangup}
+							title="End call"
+						>
+							<svg
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+							>
+								<path d="M12 9c-1.6 0-3.15.25-4.6.72v3.1c0 .39-.23.74-.56.9-.98.49-1.87 1.12-2.66 1.85-.18.18-.43.28-.7.28-.28 0-.53-.11-.71-.29L.29 13.08c-.18-.17-.29-.42-.29-.70 0-.28.11-.53.29-.71C3.34 8.78 7.46 7 12 7s8.66 1.78 11.71 4.67c.18.18.29.43.29.71 0 .28-.11.53-.29.71l-2.48 2.48c-.18.18-.43.29-.71.29-.27 0-.52-.11-.7-.28-.79-.74-1.69-1.36-2.67-1.85-.33-.16-.56-.5-.56-.9v-3.1C15.15 9.25 13.6 9 12 9z" />
+							</svg>
+						</button>
+					</>
+				)}
+			</div>
+		</div>
+	);
 };
-

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -6,6 +6,10 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import { callManager, CallData } from '../../services/CallManager';
+import {
+	getElementCallBaseUrl,
+	getMatrixHomeserverUrl
+} from '../../resources/scripts/runtimeConfig';
 import './GroupCallWidget.scss';
 
 export const GroupCallWidget: React.FC = () => {
@@ -144,9 +148,7 @@ export const GroupCallWidget: React.FC = () => {
 			const roomId =
 				(callData as any).elementCallRoomId || callData.roomId;
 			const homeserverUrl =
-				client.getHomeserverUrl() ||
-				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
-				'';
+				client.getHomeserverUrl() || getMatrixHomeserverUrl();
 			if (!homeserverUrl) {
 				throw new Error(
 					'Matrix homeserver URL is missing. Set REACT_APP_MATRIX_HOMESERVER_URL or ensure the client reports a homeserver URL.'
@@ -171,9 +173,7 @@ export const GroupCallWidget: React.FC = () => {
 			// We mirror Element Call's own `getRelativeRoomUrl` format:
 			//   /room/#?roomId=...&perParticipantE2EE=...
 			// We also pass Matrix credentials via URL so our auto-auth script can log in.
-			const elementCallOrigin = (
-				process.env.REACT_APP_ELEMENT_CALL_BASE_URL || ''
-			).replace(/\/+$/, '');
+			const elementCallOrigin = getElementCallBaseUrl();
 			if (!elementCallOrigin) {
 				throw new Error('REACT_APP_ELEMENT_CALL_BASE_URL is not set');
 			}

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -1,4 +1,5 @@
 import { createClient, MatrixClient } from 'matrix-js-sdk';
+import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 
 export interface MatrixLoginData {
 	accessToken: string;
@@ -12,8 +13,7 @@ export const getMatrixAccessToken = (
 	password: string
 ): Promise<MatrixLoginData> =>
 	new Promise((resolve, reject) => {
-		const homeserverUrl =
-			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		const homeserverUrl = getMatrixHomeserverUrl();
 		if (!homeserverUrl) {
 			reject(
 				new Error('REACT_APP_MATRIX_HOMESERVER_URL is not configured')

--- a/src/components/sessionHeader/GroupChatHeader/index.tsx
+++ b/src/components/sessionHeader/GroupChatHeader/index.tsx
@@ -238,9 +238,16 @@ export const GroupChatHeader = ({
 				});
 				// console.log('✅ Media permissions granted!', stream);
 
-				// Store stream globally
-				(window as any).__preRequestedMediaStream = stream;
-				(window as any).__preRequestedMediaStreamTime = Date.now();
+				// Group calls render Element Call in an iframe which acquires its
+				// own media (on its own origin). Release this warm-up stream so
+				// the camera/mic don't stay on in the parent page.
+				try {
+					stream
+						.getTracks()
+						.forEach((track: MediaStreamTrack) => track.stop());
+				} catch {
+					// ignore
+				}
 			} catch (mediaError: any) {
 				// console.error('❌ Media permission denied:', mediaError);
 

--- a/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
+++ b/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
@@ -1,5 +1,9 @@
 import { useCallback, useContext } from 'react';
 import { ActiveSessionContext } from '../../../../globalState';
+import {
+	getElementCallBaseUrl,
+	getMatrixHomeserverUrl
+} from '../../../../resources/scripts/runtimeConfig';
 
 export const useStartVideoCall = () => {
 	const { activeSession } = useContext(ActiveSessionContext);
@@ -32,9 +36,7 @@ export const useStartVideoCall = () => {
 			const matrixClientService = (window as any).matrixClientService;
 			const client = matrixClientService?.getClient();
 			const homeserverUrl =
-				client?.getHomeserverUrl() ||
-				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim() ||
-				'';
+				client?.getHomeserverUrl() || getMatrixHomeserverUrl();
 
 			if (!homeserverUrl) {
 				alert(
@@ -43,9 +45,7 @@ export const useStartVideoCall = () => {
 				return;
 			}
 
-			const elementCallBase = (
-				process.env.REACT_APP_ELEMENT_CALL_BASE_URL || ''
-			).replace(/\/+$/, '');
+			const elementCallBase = getElementCallBaseUrl();
 
 			if (!elementCallBase) {
 				alert(

--- a/src/components/uiVersionToggle/UIVersionToggle.tsx
+++ b/src/components/uiVersionToggle/UIVersionToggle.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { Switch, FormControlLabel, Box, Chip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import './uiVersionToggle.styles.scss';
 
 const UI_VERSION_COOKIE = 'ui-version';
@@ -53,8 +54,7 @@ export const UIVersionToggle = () => {
 				'matrix_access_token'
 			);
 			const matrixDeviceId = localStorage.getItem('matrix_device_id');
-			const homeserverUrl =
-				process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+			const homeserverUrl = getMatrixHomeserverUrl();
 			if (!homeserverUrl) {
 				alert(
 					'REACT_APP_MATRIX_HOMESERVER_URL is not set; cannot sync Matrix cookies for the new UI.'

--- a/src/resources/scripts/runtimeConfig.ts
+++ b/src/resources/scripts/runtimeConfig.ts
@@ -1,0 +1,118 @@
+/**
+ * Centralized access to environment-derived configuration.
+ *
+ * Values are resolved in this order:
+ *   1. `window.__ORISO_RUNTIME_CONFIG__` (injected at container start by
+ *      scripts/docker-entrypoint.sh, so a single built image can be pointed at
+ *      different environments without rebuilding).
+ *   2. Build-time `process.env.*` (Create React App inlines these at build).
+ *
+ * Each getter accepts multiple key aliases because the deployment and the code
+ * historically used different names (e.g. `REACT_APP_ELEMENT_CALL_URL` vs
+ * `REACT_APP_ELEMENT_CALL_BASE_URL`).
+ */
+
+type RuntimeConfig = Record<string, string | undefined>;
+
+const getRuntimeConfig = (): RuntimeConfig => {
+	if (typeof window === 'undefined') {
+		return {};
+	}
+	return ((window as any).__ORISO_RUNTIME_CONFIG__ as RuntimeConfig) || {};
+};
+
+const firstNonEmpty = (
+	source: RuntimeConfig,
+	keys: string[]
+): string | undefined => {
+	for (const key of keys) {
+		const value = source[key];
+		if (value !== undefined && String(value).trim() !== '') {
+			return String(value).trim();
+		}
+	}
+	return undefined;
+};
+
+/**
+ * Look up a value by trying runtime config first, then build-time env, across
+ * all provided key aliases.
+ */
+const pickValue = (...keys: string[]): string | undefined => {
+	const runtimeValue = firstNonEmpty(getRuntimeConfig(), keys);
+	if (runtimeValue) {
+		return runtimeValue;
+	}
+	return firstNonEmpty(process.env as RuntimeConfig, keys);
+};
+
+const stripTrailingSlashes = (value: string): string =>
+	value.replace(/\/+$/, '');
+
+/**
+ * Ensure an http(s) URL. Bare hostnames are upgraded to https.
+ */
+const ensureHttps = (value?: string): string => {
+	const trimmed = String(value || '').trim();
+	if (!trimmed) {
+		return '';
+	}
+	if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+		return trimmed;
+	}
+	return `https://${trimmed}`;
+};
+
+/**
+ * Ensure a websocket URL. The LiveKit client needs ws(s)://, but deployments
+ * frequently provide http(s):// — convert instead of failing.
+ */
+const ensureWebsocket = (value?: string): string => {
+	const trimmed = String(value || '').trim();
+	if (!trimmed) {
+		return '';
+	}
+	if (trimmed.startsWith('wss://') || trimmed.startsWith('ws://')) {
+		return trimmed;
+	}
+	if (trimmed.startsWith('https://')) {
+		return `wss://${trimmed.slice('https://'.length)}`;
+	}
+	if (trimmed.startsWith('http://')) {
+		return `ws://${trimmed.slice('http://'.length)}`;
+	}
+	return `wss://${trimmed}`;
+};
+
+/**
+ * Matrix homeserver base URL (https). Used for login, client init, Element Call.
+ */
+export const getMatrixHomeserverUrl = (): string =>
+	ensureHttps(
+		pickValue(
+			'REACT_APP_MATRIX_HOMESERVER_URL',
+			'VITE_MATRIX_HOMESERVER_URL',
+			'REACT_APP_MATRIX_URL'
+		)
+	);
+
+/**
+ * Element Call deployment origin (https), with any trailing slashes removed.
+ */
+export const getElementCallBaseUrl = (): string =>
+	stripTrailingSlashes(
+		ensureHttps(
+			pickValue(
+				'REACT_APP_ELEMENT_CALL_BASE_URL',
+				'REACT_APP_ELEMENT_CALL_URL'
+			)
+		)
+	);
+
+/**
+ * LiveKit signalling websocket URL (wss).
+ */
+export const getLiveKitWsUrl = (): string =>
+	ensureWebsocket(
+		pickValue('REACT_APP_LIVEKIT_WS_URL', 'REACT_APP_LIVEKIT_URL')
+	);

--- a/src/services/liveKitService.ts
+++ b/src/services/liveKitService.ts
@@ -10,6 +10,7 @@ import {
 	RemoteTrackPublication,
 	LocalParticipant
 } from 'livekit-client';
+import { getLiveKitWsUrl } from '../resources/scripts/runtimeConfig';
 
 export interface LiveKitParticipant {
 	userId: string;
@@ -88,7 +89,7 @@ class LiveKitService {
 			const token = await this.getAccessToken(roomName, userName);
 
 			// Connect to LiveKit server (configure via REACT_APP_LIVEKIT_WS_URL)
-			const wsUrl = process.env.REACT_APP_LIVEKIT_WS_URL?.trim();
+			const wsUrl = getLiveKitWsUrl();
 			if (!wsUrl) {
 				throw new Error('REACT_APP_LIVEKIT_WS_URL is not set');
 			}

--- a/src/services/matrixRegistrationService.ts
+++ b/src/services/matrixRegistrationService.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'matrix-js-sdk';
+import { getMatrixHomeserverUrl } from '../resources/scripts/runtimeConfig';
 
 export interface MatrixRegistrationData {
 	username: string;
@@ -20,8 +21,7 @@ export const registerMatrixUser = async (
 	try {
 		// console.log("🔧 Attempting Matrix registration for user:", registrationData.username);
 
-		const homeserverUrl =
-			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		const homeserverUrl = getMatrixHomeserverUrl();
 		if (!homeserverUrl) {
 			return {
 				success: false,
@@ -89,8 +89,7 @@ export const loginMatrixUser = async (
 	try {
 		// console.log("🔧 Attempting Matrix login for user:", username);
 
-		const homeserverUrl =
-			process.env.REACT_APP_MATRIX_HOMESERVER_URL?.trim();
+		const homeserverUrl = getMatrixHomeserverUrl();
 		if (!homeserverUrl) {
 			return {
 				success: false,


### PR DESCRIPTION
Element Call / LiveKit / Matrix homeserver URLs were read from build-time process.env, which is empty in the shipped bundle, so group calls aborted with "REACT_APP_ELEMENT_CALL_BASE_URL is not set".

- Add runtimeConfig helper that reads window.__ORISO_RUNTIME_CONFIG__ with a build-time env fallback, accepts both env-name variants (REACT_APP_ELEMENT_CALL_URL/_BASE_URL, REACT_APP_LIVEKIT_URL/_WS_URL, REACT_APP_MATRIX_URL/_HOMESERVER_URL) and normalizes protocol (wss for LiveKit).
- Route Element Call, LiveKit and Matrix homeserver reads through the helper.
- Emit call/matrix URLs into the runtime config from docker-entrypoint.sh.
- Release the pre-acquired media stream before placeCall()/answer() so the 1:1 device is not opened twice (NotReadableError) and the camera does not leak; also release the group-call warm-up stream.

Refs #70

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

