### PR TITLE
Use explicit username availability endpoint

### DIFF
--- a/src/api/apiGetIsUsernameAvailable.ts
+++ b/src/api/apiGetIsUsernameAvailable.ts
@@ -3,11 +3,21 @@ import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
 
 export const apiGetIsUsernameAvailable = async (
 	username: string
-): Promise<any> => {
-	return fetchData({
-		url: `${endpoints.baseUserService}/${username}`,
-		method: FETCH_METHODS.GET,
-		headersData: {},
-		responseHandling: [FETCH_ERRORS.EMPTY, FETCH_ERRORS.NO_MATCH]
-	});
+): Promise<boolean> => {
+	try {
+		await fetchData({
+			url: `${endpoints.baseUserService}/availability/${encodeURIComponent(
+				username
+			)}`,
+			method: FETCH_METHODS.GET,
+			headersData: {},
+			responseHandling: [FETCH_ERRORS.CONFLICT]
+		});
+		return true;
+	} catch (error) {
+		if (error instanceof Error && error.message === FETCH_ERRORS.CONFLICT) {
+			return false;
+		}
+		throw error;
+	}
 };

--- a/src/components/registration/accountData/AccountData.tsx
+++ b/src/components/registration/accountData/AccountData.tsx
@@ -125,15 +125,15 @@ export const AccountData: FC<{
 						setIsUsernameAvailable(true);
 						return false;
 					} else {
-						return await apiGetIsUsernameAvailable(val)
-							.then(() => {
-								setIsUsernameAvailable(false);
-								return false;
-							})
-							.catch(() => {
-								setIsUsernameAvailable(true);
-								return true;
-							});
+						try {
+							const usernameAvailable =
+								await apiGetIsUsernameAvailable(val);
+							setIsUsernameAvailable(usernameAvailable);
+							return usernameAvailable;
+						} catch {
+							setIsUsernameAvailable(false);
+							return false;
+						}
 					}
 				}}
 			/>


### PR DESCRIPTION
## Problem
Registration step 4 currently treats a 404 from `GET /service/users/{username}` as the expected "username is available" result. That shows up as a failed network request in the browser and obscures real API failures in the same registration step.

Fixes #145

## Solution
- Call `/service/users/availability/{username}` for username checks.
- Interpret `204` as available and `409` as unavailable.
- Treat unexpected request failures as unavailable so the form does not advance on an uncertain validation result.

## Related PR
Requires OpenResilienceInitiative/ORISO-UserService#95 to provide the new endpoint.

## Checks
- `NODE_PATH=/Users/frankgerhardt/ORISO/ORISO-Frontend/node_modules /Users/frankgerhardt/ORISO/ORISO-Frontend/node_modules/.bin/eslint src/api/apiGetIsUsernameAvailable.ts src/components/registration/accountData/AccountData.tsx`

## Notes
A prior full Cypress run in the existing frontend checkout failed before this flow because the project currently throws `ReferenceError: process is not defined` from shared Cypress/support startup code. I did not mix that separate failure into this PR.