### PR TITLE
fix(call): restore call URLs when runtime config is incomplete

### DIFF
--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -443,9 +443,21 @@ export const SessionMenu = (props: SessionMenuProps) => {
 				// console.log('✅ Media permissions granted!', stream);
 				// console.log('Stream tracks:', stream.getTracks().map(t => ({ kind: t.kind, enabled: t.enabled })));
 
-				// Store stream globally so FloatingCallWidget/GroupCallWidget can use it
-				(window as any).__preRequestedMediaStream = stream;
-				(window as any).__preRequestedMediaStreamTime = Date.now();
+				if (activeSession.isGroup) {
+					// Group calls use Element Call in an iframe (separate origin).
+					// Release this warm-up stream so the device is not left open.
+					try {
+						stream
+							.getTracks()
+							.forEach((track: MediaStreamTrack) => track.stop());
+					} catch {
+						// ignore
+					}
+				} else {
+					// 1:1 calls: FloatingCallWidget releases this before placeCall().
+					(window as any).__preRequestedMediaStream = stream;
+					(window as any).__preRequestedMediaStreamTime = Date.now();
+				}
 			} catch (mediaError: any) {
 				// console.error('❌ Media permission denied:', mediaError);
 				// console.error('Error name:', mediaError.name);

--- a/src/resources/scripts/runtimeConfig.ts
+++ b/src/resources/scripts/runtimeConfig.ts
@@ -21,6 +21,32 @@ const getRuntimeConfig = (): RuntimeConfig => {
 	return ((window as any).__ORISO_RUNTIME_CONFIG__ as RuntimeConfig) || {};
 };
 
+/**
+ * When the container runtime config is incomplete (e.g. production config.js
+ * only has REACT_APP_API_URL), derive sibling service URLs from the app host.
+ * `app.oriso.org` -> `api.oriso.org`, `matrix.oriso.org`, `call.oriso.org`, etc.
+ */
+const inferFromAppHostname = (): RuntimeConfig => {
+	if (typeof window === 'undefined') {
+		return {};
+	}
+	const host = window.location.hostname;
+	const match = host.match(/^(?:app|www)\.(.+)$/);
+	if (!match) {
+		return {};
+	}
+	const base = match[1];
+	return {
+		REACT_APP_API_URL: `https://api.${base}`,
+		REACT_APP_MATRIX_HOMESERVER_URL: `https://matrix.${base}`,
+		REACT_APP_MATRIX_URL: `https://matrix.${base}`,
+		REACT_APP_ELEMENT_CALL_BASE_URL: `https://call.${base}`,
+		REACT_APP_ELEMENT_CALL_URL: `https://call.${base}`,
+		REACT_APP_LIVEKIT_WS_URL: `wss://livekit.${base}`,
+		REACT_APP_LIVEKIT_URL: `wss://livekit.${base}`
+	};
+};
+
 const firstNonEmpty = (
 	source: RuntimeConfig,
 	keys: string[]
@@ -43,7 +69,11 @@ const pickValue = (...keys: string[]): string | undefined => {
 	if (runtimeValue) {
 		return runtimeValue;
 	}
-	return firstNonEmpty(process.env as RuntimeConfig, keys);
+	const buildValue = firstNonEmpty(process.env as RuntimeConfig, keys);
+	if (buildValue) {
+		return buildValue;
+	}
+	return firstNonEmpty(inferFromAppHostname(), keys);
 };
 
 const stripTrailingSlashes = (value: string): string =>


### PR DESCRIPTION
Production config.js often only includes REACT_APP_API_URL, so Element Call / LiveKit / Matrix URLs were empty and group calls failed after the earlier fix was deployed.

- Infer call service URLs from the app hostname (app.oriso.org -> call.oriso.org, matrix.oriso.org, wss://livekit.oriso.org) when runtime config and build-time env are both missing.
- Release the permission warm-up media stream for group calls started from SessionMenu so the camera/mic are not left open.

Refs #70

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

