### PR TITLE
reduce sidebar width to 85px to match figma (#88)

### DIFF
--- a/src/components/app/authenticatedApp.styles.scss
+++ b/src/components/app/authenticatedApp.styles.scss
@@ -68,7 +68,7 @@ a {
 			flex-direction: column;
 			justify-content: flex-start;
 			position: relative;
-			flex: 0 0 105px;
+			flex: 0 0 85px;
 			height: 100%;
 			order: 1;
 		}
@@ -77,13 +77,13 @@ a {
 			display: none;
 		}
 
-		/* Fixed 105px width for figma nav (all desktop users, consultant + asker) */
+		/* Fixed 85px width for figma nav (all desktop users, consultant + asker) */
 		&--figma-consultant {
 			@include breakpoint($fromLarge) {
-				flex: 0 0 105px !important;
-				width: 105px !important;
-				min-width: 105px !important;
-				max-width: 105px !important;
+				flex: 0 0 85px !important;
+				width: 85px !important;
+				min-width: 85px !important;
+				max-width: 85px !important;
 			}
 		}
 	}


### PR DESCRIPTION
## What
- `flex: 0 0 105px` → `flex: 0 0 85px` on `.navigation__wrapper--figma-consultant` in `authenticatedApp.styles.scss`
- All 4 width properties (width, min-width, max-width, flex-basis) updated to 85px

## Why
Closes #88 — sidebar was 105px, Figma spec is 85px

Screenshot
<img width="624" height="855" alt="Screenshot 2026-06-12 183248" src="https://github.com/user-attachments/assets/b2a16ee5-49a9-43ef-8b17-79765ab18a33" />
