### PR TITLE
fix: center group call widget on screen

### DIFF
--- a/src/components/call/FloatingCallWidget.tsx
+++ b/src/components/call/FloatingCallWidget.tsx
@@ -77,7 +77,6 @@ export const FloatingCallWidget: React.FC = () => {
 		if (otherUser) {
 			const username = otherUser.name || otherUser.userId;
 			const initial = username.replace('@', '').charAt(0).toUpperCase();
-			// console.log('👤 Other user:', username, '→ Initial:', initial);
 			setOtherUserInitial(initial);
 		} else {
 			// Fallback: use callerUserId if incoming
@@ -103,7 +102,6 @@ export const FloatingCallWidget: React.FC = () => {
 
 		// 🚫 SKIP if this is a group call - GroupCallWidget will handle it with LiveKit
 		if (callData.isGroup) {
-			// console.log('🚫 FloatingCallWidget: Skipping group call (handled by GroupCallWidget)');
 			return;
 		}
 
@@ -138,7 +136,6 @@ export const FloatingCallWidget: React.FC = () => {
 				callManager.setMatrixCall(matrixCall);
 			})
 			.catch((err) => {
-				// console.error("Failed to start call:", err);
 				alert(`Failed to start call: ${(err as Error).message}`);
 				callManager.endCall();
 			});
@@ -245,7 +242,6 @@ export const FloatingCallWidget: React.FC = () => {
 			// 🔥 Force UI re-render to hide Answer/Decline buttons and show call controls
 			setTimeout(() => forceUpdate((prev) => prev + 1), 100);
 		} catch (err) {
-			// console.error("Failed to answer:", err);
 			alert(`Failed to answer: ${(err as Error).message}`);
 			callManager.endCall();
 		}

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -67,14 +67,14 @@ export const GroupCallWidget: React.FC = () => {
 		return () => window.removeEventListener('resize', updateViewport);
 	}, []);
 
-	useEffect(() => {
+	const centerWidget = () => {
 		if (!callData || !callData.isGroup) return;
 
 		const padding = 16;
-		const maxWidth = 520;
-		const maxHeight = 320;
-		const width = Math.min(maxWidth, window.innerWidth - padding);
-		const height = Math.min(maxHeight, window.innerHeight - padding);
+		const maxWidth = elementCallUrl ? 520 : 420;
+		const maxHeight = elementCallUrl ? 320 : 280;
+		const width = Math.min(maxWidth, window.innerWidth - padding * 2);
+		const height = Math.min(maxHeight, window.innerHeight - padding * 2);
 
 		if (window.innerWidth <= 640) {
 			setPosition({ x: 0, y: 0 });
@@ -82,9 +82,20 @@ export const GroupCallWidget: React.FC = () => {
 		}
 
 		setPosition({
-			x: Math.max(padding, window.innerWidth - width - padding),
-			y: Math.max(padding, window.innerHeight - height - padding)
+			x: Math.max(padding, (window.innerWidth - width) / 2),
+			y: Math.max(padding, (window.innerHeight - height) / 2)
 		});
+	};
+
+	useEffect(() => {
+		centerWidget();
+	}, [callData, elementCallUrl]);
+
+	useEffect(() => {
+		if (!callData || !callData.isGroup) return;
+
+		window.addEventListener('resize', centerWidget);
+		return () => window.removeEventListener('resize', centerWidget);
 	}, [callData, elementCallUrl]);
 
 	useEffect(() => {

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -194,9 +194,12 @@ export const GroupCallWidget: React.FC = () => {
 
 			const params = new URLSearchParams();
 			params.set('roomId', roomId);
-			// Hint Element Call that this is a normal "start call" use-case so
-			// it enables camera & microphone by default.
-			params.set('intent', 'start_call');
+			// Match call type: video uses start_call, audio-only uses start_call_dm_voice
+			// so Element Call leaves the camera off by default.
+			params.set(
+				'intent',
+				callData.isVideo ? 'start_call' : 'start_call_dm_voice'
+			);
 			params.set('homeserver', homeserverUrl);
 			params.set('accessToken', accessToken);
 			params.set('userId', userId);

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -4,7 +4,7 @@
  * https://github.com/element-hq/element-call
  */
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { callManager, CallData } from '../../services/CallManager';
 import {
 	getElementCallBaseUrl,
@@ -67,8 +67,10 @@ export const GroupCallWidget: React.FC = () => {
 		return () => window.removeEventListener('resize', updateViewport);
 	}, []);
 
-	const centerWidget = () => {
-		if (!callData || !callData.isGroup) return;
+	const isGroupCall = Boolean(callData?.isGroup);
+
+	const centerWidget = useCallback(() => {
+		if (!isGroupCall) return;
 
 		const padding = 16;
 		const maxWidth = elementCallUrl ? 520 : 420;
@@ -85,18 +87,18 @@ export const GroupCallWidget: React.FC = () => {
 			x: Math.max(padding, (window.innerWidth - width) / 2),
 			y: Math.max(padding, (window.innerHeight - height) / 2)
 		});
-	};
+	}, [isGroupCall, elementCallUrl]);
 
 	useEffect(() => {
 		centerWidget();
-	}, [callData, elementCallUrl]);
+	}, [centerWidget]);
 
 	useEffect(() => {
-		if (!callData || !callData.isGroup) return;
+		if (!isGroupCall) return;
 
 		window.addEventListener('resize', centerWidget);
 		return () => window.removeEventListener('resize', centerWidget);
-	}, [callData, elementCallUrl]);
+	}, [isGroupCall, centerWidget]);
 
 	useEffect(() => {
 		const handleFullscreenChange = () => {

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -36,7 +36,6 @@ export const GroupCallWidget: React.FC = () => {
 	// Subscribe to CallManager
 	useEffect(() => {
 		const unsubscribe = callManager.subscribe((newCallData) => {
-			// console.log('📡 GroupCallWidget: CallManager update:', newCallData);
 			setCallData(newCallData);
 			setCallState(newCallData?.state || null);
 			if (newCallData) {
@@ -118,7 +117,6 @@ export const GroupCallWidget: React.FC = () => {
 			const data = event.data;
 			if (!data || typeof data !== 'object') return;
 			if (data.type !== 'oriso-call-ended') return;
-			// console.log('📴 Element Call ended (message from iframe)');
 			setElementCallUrl('');
 			setCallData(null);
 			setCallState(null);
@@ -136,7 +134,6 @@ export const GroupCallWidget: React.FC = () => {
 		if (elementCallUrl) return; // Already joined
 		if (callState !== 'connecting' && callState !== 'in_call') return;
 
-		// console.log('✅ Incoming group call moving to state', callState, '- setting up Element Call for receiver...');
 		setupElementCall();
 	}, [callState, callData, elementCallUrl]);
 
@@ -145,7 +142,6 @@ export const GroupCallWidget: React.FC = () => {
 		if (!callData || !callData.isGroup || callData.isIncoming) return;
 		if (elementCallUrl) return; // Already set up
 
-		// console.log('📞 Starting outgoing call, setting up Element Call...');
 		setupElementCall();
 	}, [callData]);
 
@@ -214,15 +210,11 @@ export const GroupCallWidget: React.FC = () => {
 
 			const url = `${elementCallBaseUrl}/#?${params.toString()}`;
 
-			// console.log('🔗 Element Call URL:', url);
-			// console.log('🔑 Passing Matrix credentials for auto-authentication');
 			setElementCallUrl(url);
 
 			// Send credentials via postMessage immediately when iframe loads
 			const sendCredentials = () => {
 				if (iframeRef.current?.contentWindow) {
-					// console.log('📤 Sending Matrix credentials to Element Call via postMessage');
-
 					// Send credentials in multiple formats Element Call might accept
 					iframeRef.current.contentWindow.postMessage(
 						{
@@ -254,7 +246,6 @@ export const GroupCallWidget: React.FC = () => {
 				iframeRef.current.onload = sendCredentials;
 			}
 		} catch (err) {
-			// console.error('❌ Failed to setup Element Call:', err);
 			alert(`Failed to start call: ${(err as Error).message}`);
 			callManager.endCall();
 		}
@@ -269,8 +260,6 @@ export const GroupCallWidget: React.FC = () => {
 		source: Window
 	) => {
 		try {
-			// console.log(`📞 Element Call widget action: ${action}`, data);
-
 			// Element Call requests Matrix operations via widget API
 			// We proxy these to our authenticated Matrix client
 			let response: any = { success: false };
@@ -288,7 +277,6 @@ export const GroupCallWidget: React.FC = () => {
 					break;
 
 				default:
-					// console.log(`ℹ️  Unhandled widget action: ${action}`);
 					response = { success: true };
 			}
 
@@ -302,34 +290,26 @@ export const GroupCallWidget: React.FC = () => {
 				},
 				'*'
 			);
-		} catch (err) {
-			// console.error('❌ Error handling widget action:', err);
-		}
+		} catch (err) {}
 	};
 
 	const handleAnswer = () => {
 		if (!callData || !callData.isIncoming) return;
-		// console.log('✅ User clicked Answer');
-		// Tell Matrix/CallManager that we are accepting the call
 		callManager.answerCall();
 
 		// Proactively start/join the Element Call room so the user lands
 		// directly in the call UI without any extra "Join" step.
 		if (!elementCallUrl) {
-			// console.log('📞 Answer clicked, setting up Element Call immediately for receiver...');
 			setupElementCall();
 		}
 	};
 
 	const handleDecline = () => {
-		// console.log('❌ User declined call');
 		setIsDismissed(true);
 		callManager.endCall();
 	};
 
 	const handleEndCall = () => {
-		// console.log('📴 Ending call');
-
 		// Cleanup widget message handler
 		if (
 			iframeRef.current &&

--- a/src/components/sessionHeader/GroupChatHeader/index.tsx
+++ b/src/components/sessionHeader/GroupChatHeader/index.tsx
@@ -60,11 +60,9 @@ export const GroupChatHeader = ({
 		activeSession.item.matrixRoomId || activeSession.item.groupId;
 
 	useEffect(() => {
-		// console.log('🔍 GroupChatHeader: Fetching Matrix members for room:', matrixRoomId);
 		setIsLoadingMembers(true);
 
 		if (!matrixRoomId) {
-			// console.log('❌ GroupChatHeader: No matrixRoomId found');
 			setMatrixMembers([]);
 			setIsLoadingMembers(false);
 			return;
@@ -89,24 +87,18 @@ export const GroupChatHeader = ({
 			if (!client) {
 				retryCount++;
 				if (retryCount < maxRetries) {
-					// console.log(`⏳ GroupChatHeader: Matrix client not ready yet, retrying... (${retryCount}/${maxRetries})`);
 					setTimeout(tryLoadMembers, 500);
 					return;
 				} else {
-					// console.log('❌ GroupChatHeader: Matrix client not available after retries');
 					setMatrixMembers([]);
 					setIsLoadingMembers(false);
 					return;
 				}
 			}
 
-			// console.log('✅ GroupChatHeader: Matrix client found, getting room...');
 			const room = client.getRoom(matrixRoomId);
 
 			if (!room) {
-				// console.log('⏳ GroupChatHeader: Room not found yet, waiting for sync...');
-				// console.log('📋 Available rooms:', client.getRooms().map((r: any) => r.roomId));
-
 				// Wait for room to appear (up to 10 seconds)
 				let roomRetryCount = 0;
 				const maxRoomRetries = 20;
@@ -120,7 +112,6 @@ export const GroupChatHeader = ({
 						if (roomRetryCount < maxRoomRetries) {
 							setTimeout(tryGetRoom, 500);
 						} else {
-							// console.log('❌ GroupChatHeader: Room not found after waiting:', matrixRoomId);
 							setMatrixMembers([]);
 							setIsLoadingMembers(false);
 						}
@@ -149,7 +140,6 @@ export const GroupChatHeader = ({
 				}
 			});
 
-			// console.log('✅ GroupChatHeader: Found', allMembers?.length || 0, 'total members,', activeMembers?.length || 0, 'active members:', activeMembers?.map((m: any) => m.userId || m.name));
 			setMatrixMembers(activeMembers || []);
 			setIsLoadingMembers(false);
 
@@ -161,7 +151,6 @@ export const GroupChatHeader = ({
 					if (updatedRoom) {
 						const updatedMembers = updatedRoom.getJoinedMembers();
 						if (updatedMembers?.length !== matrixMembers.length) {
-							// console.log('🔄 GroupChatHeader: Members updated:', updatedMembers?.length);
 							setMatrixMembers(updatedMembers || []);
 						}
 					}
@@ -195,16 +184,11 @@ export const GroupChatHeader = ({
 
 	// Use CallManager for group calls (same as SessionMenu)
 	const handleStartVideoCall = async (isVideoActivated: boolean = true) => {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🎬 GROUP CALL BUTTON CLICKED (GroupChatHeader)!");
-		// console.log("═══════════════════════════════════════════════");
-
 		try {
 			const roomId =
 				activeSession.item.matrixRoomId || activeSession.item.groupId;
 
 			if (!roomId) {
-				// console.error('❌ No Matrix room ID found for session');
 				alert(
 					'Cannot start call: No Matrix room found for this session'
 				);
@@ -213,7 +197,6 @@ export const GroupChatHeader = ({
 
 			// Check HTTPS
 			if (window.location.protocol !== 'https:') {
-				// console.error('❌ Not on HTTPS! Safari requires HTTPS for camera/microphone access');
 				const httpsUrl = window.location.href.replace(
 					'http://',
 					'https://'
@@ -229,14 +212,12 @@ export const GroupChatHeader = ({
 			}
 
 			// Request media permissions IMMEDIATELY in click handler
-			// console.log('🎤 Requesting media permissions (SYNC with user click)...');
 
 			try {
 				const stream = await navigator.mediaDevices.getUserMedia({
 					video: isVideoActivated,
 					audio: true
 				});
-				// console.log('✅ Media permissions granted!', stream);
 
 				// Group calls render Element Call in an iframe which acquires its
 				// own media (on its own origin). Release this warm-up stream so
@@ -249,8 +230,6 @@ export const GroupChatHeader = ({
 					// ignore
 				}
 			} catch (mediaError: any) {
-				// console.error('❌ Media permission denied:', mediaError);
-
 				let errorMsg = 'Cannot access camera/microphone. ';
 				if (mediaError.name === 'NotAllowedError') {
 					errorMsg +=
@@ -268,21 +247,14 @@ export const GroupChatHeader = ({
 				return;
 			}
 
-			// console.log('📞 Starting call via CallManager with roomId:', roomId);
-			// console.log('🎯 This is a GROUP CHAT - forcing isGroup=true');
-
 			// Use CallManager (works for both 1-on-1 and group calls!)
 			const { callManager } = require('../../../services/CallManager');
 			callManager.startCall(roomId, isVideoActivated, true); // Force isGroup=true for group chats
-
-			// console.log('✅ Call initiated!');
 		} catch (error) {
-			// console.error('💥 ERROR in handleStartVideoCall:', error);
 			alert(
 				`Call failed: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
 		}
-		// console.log("═══════════════════════════════════════════════");
 	};
 
 	const sessionTabPath = `${

--- a/src/components/sessionHeader/GroupChatHeader/useJoinVideoCall/index.ts
+++ b/src/components/sessionHeader/GroupChatHeader/useJoinVideoCall/index.ts
@@ -23,20 +23,18 @@ export const useJoinVideoCall = () => {
 	const openVideoWindow = useCallback(
 		(roomIdOrUrl: string, videoActivated: boolean) => {
 			// MATRIX MIGRATION: Open Matrix call in new tab
-			
+
 			// Check if already a full URL (starts with /videoanruf/)
 			if (roomIdOrUrl.startsWith('/videoanruf/')) {
-				// console.log('📞 Opening call in new tab with existing URL:', roomIdOrUrl);
 				window.open(roomIdOrUrl, '_blank');
 				return;
 			}
-			
+
 			// Otherwise, build the URL from room ID
 			const encodedRoomId = encodeURIComponent(roomIdOrUrl);
 			const callType = videoActivated ? 'video' : 'voice';
 			const callUrl = `/videoanruf/${encodedRoomId}/${callType}`;
-			
-			// console.log('📞 Opening call in new tab:', callUrl);
+
 			window.open(callUrl, '_blank');
 		},
 		[urls.videoCall]
@@ -45,7 +43,6 @@ export const useJoinVideoCall = () => {
 	const onJoinConsultantCall = useCallback(
 		(roomId, videoActivated: boolean) => {
 			// MATRIX MIGRATION: Join Matrix call directly
-			// console.log('📞 Joining Matrix call for room:', roomId);
 			openVideoWindow(roomId, videoActivated);
 		},
 		[openVideoWindow]

--- a/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
+++ b/src/components/sessionHeader/GroupChatHeader/useStartVideoCall/index.ts
@@ -9,19 +9,12 @@ export const useStartVideoCall = () => {
 	const { activeSession } = useContext(ActiveSessionContext);
 
 	const onStartVideoCall = useCallback(() => {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🎬 GROUP VIDEO CALL BUTTON CLICKED!");
-		// console.log("═══════════════════════════════════════════════");
-
 		try {
 			// Get Matrix room ID from active session
 			const roomId =
 				activeSession.item.matrixRoomId || activeSession.item.groupId;
 
-			// console.log("Room ID:", roomId);
-
 			if (!roomId) {
-				// console.error('❌ No Matrix room ID found for session');
 				alert(
 					'Cannot start call: No Matrix room found for this session'
 				);
@@ -30,7 +23,6 @@ export const useStartVideoCall = () => {
 
 			// 🎯 GROUP CALLS: Open Element Call in a new popup window
 			// Element Call handles all the group call UI (grid layout, active speaker, etc.)
-			// console.log('📞 Opening Element Call for group video call...');
 
 			// Get Matrix homeserver from current client
 			const matrixClientService = (window as any).matrixClientService;
@@ -60,8 +52,6 @@ export const useStartVideoCall = () => {
 			params.set('homeserver', homeserverUrl);
 			const elementCallUrl = `${elementCallBase}/room/#?${params.toString()}`;
 
-			// console.log('🌐 Opening Element Call URL:', elementCallUrl);
-
 			// Open in a new popup window (sized for video calls)
 			const width = 1200;
 			const height = 800;
@@ -73,15 +63,11 @@ export const useStartVideoCall = () => {
 				'ElementCall',
 				`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`
 			);
-
-			// console.log('✅ Element Call popup opened!');
 		} catch (error) {
-			// console.error('💥 ERROR in onStartVideoCall:', error);
 			alert(
 				`Failed to start group call: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
 		}
-		// console.log("═══════════════════════════════════════════════");
 	}, [activeSession.item.groupId, activeSession.item.matrixRoomId]);
 
 	return {

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../globalState';
 import { SessionItemInterface } from '../../globalState/interfaces';
 import { getTenantSettings } from '../../utils/tenantSettingsHelper';
+import { callManager } from '../../services/CallManager';
 import {
 	SESSION_LIST_TAB,
 	SESSION_LIST_TAB_ARCHIVE,
@@ -183,9 +184,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 					setFlyoutOpen(false);
 				}, 1000);
 			})
-			.catch((error) => {
-				// console.error(error);
-			});
+			.catch((error) => {});
 	};
 
 	const handleOverlayAction = (buttonFunction: string) => {
@@ -249,9 +248,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 					mobileListView();
 					history.push(listPath);
 				})
-				.catch((error) => {
-					// console.error(error);
-				})
+				.catch((error) => {})
 				.finally(() => {
 					setOverlayActive(false);
 					setOverlayItem(null);
@@ -380,42 +377,25 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 	const hasVideoCallFeatures = () =>
 		hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) &&
-		(activeSession.isSession || activeSession.isGroup) && // 🎯 Enable for both 1-on-1 AND group chats
+		(activeSession.isSession || activeSession.isGroup) &&
 		type !== SESSION_LIST_TYPES.ENQUIRY &&
 		consultingType.isVideoCallAllowed;
 
-	const handleStartVideoCall = async (isVideoActivated: boolean = false) => {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🎬 CALL BUTTON CLICKED!");
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("Video activated?", isVideoActivated);
-		// console.log("Is group chat?", activeSession.isGroup);
-
+	const handleStartVideoCall = async (isVideoActivated = false) => {
 		try {
-			// Get Matrix room ID from active session
-			// For 1-on-1 sessions: use activeSession.rid (the actual Matrix room ID)
-			// For group chats: use activeSession.item.matrixRoomId or groupId
 			const roomId =
 				activeSession.rid ||
 				activeSession.item.matrixRoomId ||
 				activeSession.item.groupId;
 
-			// console.log("Room ID:", roomId);
-			// console.log("activeSession.rid:", activeSession.rid);
-			// console.log("activeSession.item.matrixRoomId:", activeSession.item.matrixRoomId);
-			// console.log("activeSession.item.groupId:", activeSession.item.groupId);
-
 			if (!roomId) {
-				// console.error('❌ No Matrix room ID found for session');
 				alert(
 					'Cannot start call: No Matrix room found for this session'
 				);
 				return;
 			}
 
-			// 🍎 SAFARI iOS FIX: Check if we're on HTTPS (required for getUserMedia on Safari)
 			if (window.location.protocol !== 'https:') {
-				// console.error('❌ Not on HTTPS! Safari requires HTTPS for camera/microphone access');
 				const httpsUrl = window.location.href.replace(
 					'http://',
 					'https://'
@@ -430,18 +410,12 @@ export const SessionMenu = (props: SessionMenuProps) => {
 				return;
 			}
 
-			// 🔥 CRITICAL FOR MOBILE: Request media permissions IMMEDIATELY in click handler
-			// This keeps the "user gesture" alive for mobile browsers (prevents popup blocking)
-			// console.log('🎤 Requesting media permissions (SYNC with user click)...');
-			// console.log('Requesting:', { video: isVideoActivated, audio: true });
-
+			// Request media in the click handler to preserve the user gesture on mobile.
 			try {
 				const stream = await navigator.mediaDevices.getUserMedia({
 					video: isVideoActivated,
 					audio: true
 				});
-				// console.log('✅ Media permissions granted!', stream);
-				// console.log('Stream tracks:', stream.getTracks().map(t => ({ kind: t.kind, enabled: t.enabled })));
 
 				if (activeSession.isGroup) {
 					// Group calls use Element Call in an iframe (separate origin).
@@ -459,10 +433,6 @@ export const SessionMenu = (props: SessionMenuProps) => {
 					(window as any).__preRequestedMediaStreamTime = Date.now();
 				}
 			} catch (mediaError: any) {
-				// console.error('❌ Media permission denied:', mediaError);
-				// console.error('Error name:', mediaError.name);
-				// console.error('Error message:', mediaError.message);
-
 				let errorMsg = 'Cannot access camera/microphone. ';
 				if (mediaError.name === 'NotAllowedError') {
 					errorMsg +=
@@ -480,22 +450,12 @@ export const SessionMenu = (props: SessionMenuProps) => {
 				return;
 			}
 
-			// console.log('📞 Starting call via CallManager with roomId:', roomId);
-
-			// Use CallManager directly (works for both 1-on-1 and group calls!)
-			const { callManager } = require('../../services/CallManager');
-			// SessionMenu is only used for 1-on-1 sessions; do not auto-upgrade to
-			// Element Call when the Matrix room has extra members (e.g. supervisors).
 			callManager.startCall(roomId, isVideoActivated, false);
-
-			// console.log('✅ Call initiated!');
 		} catch (error) {
-			// console.error('💥 ERROR in handleStartVideoCall:', error);
 			alert(
 				`Call failed: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
 		}
-		// console.log("═══════════════════════════════════════════════");
 	};
 
 	return (

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -484,7 +484,9 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 			// Use CallManager directly (works for both 1-on-1 and group calls!)
 			const { callManager } = require('../../services/CallManager');
-			callManager.startCall(roomId, isVideoActivated);
+			// SessionMenu is only used for 1-on-1 sessions; do not auto-upgrade to
+			// Element Call when the Matrix room has extra members (e.g. supervisors).
+			callManager.startCall(roomId, isVideoActivated, false);
 
 			// console.log('✅ Call initiated!');
 		} catch (error) {

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -50,11 +50,7 @@ class CallManager {
 	private currentCall: CallData | null = null;
 	private listeners: Set<CallStateChangeListener> = new Set();
 
-	private constructor() {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📞 CallManager initialized (singleton)");
-		// console.log("═══════════════════════════════════════════════");
-	}
+	private constructor() {}
 
 	public static getInstance(): CallManager {
 		if (!CallManager.instance) {
@@ -68,12 +64,10 @@ class CallManager {
 	 */
 	public subscribe(listener: CallStateChangeListener): () => void {
 		this.listeners.add(listener);
-		// console.log(`📡 CallManager: Added listener (total: ${this.listeners.size})`);
 
 		// Return unsubscribe function
 		return () => {
 			this.listeners.delete(listener);
-			// console.log(`📡 CallManager: Removed listener (total: ${this.listeners.size})`);
 		};
 	}
 
@@ -81,14 +75,11 @@ class CallManager {
 	 * Notify all listeners of state change
 	 */
 	private notifyListeners(): void {
-		// console.log(`🔔 CallManager: Notifying ${this.listeners.size} listener(s)`);
-		// console.log(`   Current call state:`, this.currentCall);
-
 		this.listeners.forEach((listener) => {
 			try {
 				listener(this.currentCall);
-			} catch (error) {
-				// console.error('❌ Error in call state listener:', error);
+			} catch {
+				// Ignore listener errors so one subscriber cannot break call state.
 			}
 		});
 	}
@@ -104,20 +95,10 @@ class CallManager {
 		isVideo: boolean,
 		forceIsGroup?: boolean
 	): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🚀 CallManager.startCall()");
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("   Room ID:", roomId);
-		// console.log("   Is Video:", isVideo);
-		// console.log("   Force Group:", forceIsGroup);
-
 		if (this.currentCall) {
-			// console.warn("⚠️  Already have an active call, cleaning up first...");
 			this.endCall();
 		}
 
-		// Detect if this is a group call.
-		// forceIsGroup: true = group, false = 1-on-1, undefined = auto-detect from room size.
 		let isGroup = false;
 
 		if (forceIsGroup === true) {
@@ -125,53 +106,24 @@ class CallManager {
 		} else if (forceIsGroup === false) {
 			isGroup = false;
 		} else {
-			// Auto-detect based on room member count
 			try {
 				const matrixClientService = (window as any).matrixClientService;
 				const client = matrixClientService?.getClient();
-				// console.log(`   Matrix client available: ${!!client}`);
+				const room = client?.getRoom(roomId);
 
-				if (client) {
-					const room = client.getRoom(roomId);
-					// console.log(`   Room found: ${!!room}`);
+				if (room) {
+					const activeMemberCount = room
+						.getJoinedMembers()
+						.filter((member) => {
+							const powerLevel =
+								room.getMember(member.userId)?.powerLevel || 0;
+							return powerLevel !== 10;
+						}).length;
 
-					if (room) {
-						const allMembers = room.getJoinedMembers();
-						const memberCount = allMembers.length;
-
-						// Filter supervisors from member count (supervisors have power level 10)
-						// Get supervisors from API to filter them out
-						let activeMemberCount = memberCount;
-						try {
-							// Get session ID from room name or other source if available
-							// For now, we'll filter by power level
-							const activeMembers = allMembers.filter(
-								(m: any) => {
-									const powerLevel =
-										room.getMember(m.userId)?.powerLevel ||
-										0;
-									return powerLevel !== 10; // Exclude supervisors (power level 10)
-								}
-							);
-							activeMemberCount = activeMembers.length;
-						} catch (err) {
-							// console.warn('Could not filter supervisors from member count:', err);
-						}
-
-						// 1-on-1 = 2 members (consultant + asker), group = more than 2
-						isGroup = activeMemberCount > 2;
-
-						// console.log(`   ✅ Room member count: ${memberCount} (active: ${activeMemberCount})`);
-						// console.log(`   ✅ Joined members:`, allMembers.map(m => m.userId));
-						// console.log(`   ✅ Is group call (auto-detected): ${isGroup}`);
-					} else {
-						// console.warn(`   ⚠️  Room not found in Matrix client! RoomId: ${roomId}`);
-					}
-				} else {
-					// console.warn(`   ⚠️  Matrix client not available!`);
+					isGroup = activeMemberCount > 2;
 				}
-			} catch (err) {
-				// console.error('❌ Error detecting group call:', err);
+			} catch {
+				// Fall back to 1-on-1 when member detection fails.
 			}
 		}
 
@@ -201,20 +153,11 @@ class CallManager {
 				isGroup,
 				state: 'connecting',
 				elementCallRoomId: elementCallRoomId || roomId,
-				signalRoomId: isGroup ? roomId : roomId
+				signalRoomId: roomId
 			};
 
-			// console.log("✅ Outgoing call created:", this.currentCall);
-			// console.log("═══════════════════════════════════════════════");
-
 			if (isGroup) {
-				// Make sure the Element Call room allows membership events from
-				// regular users (matches Element Call's own room creation).
-				this.ensureGroupCallPermissions(this.currentCall.roomId).catch(
-					(err) => {
-						// console.error("❌ Failed to ensure group call room permissions:", err);
-					}
-				);
+				void this.ensureGroupCallPermissions(this.currentCall.roomId);
 
 				// Send Matrix call invite event to the original session room so
 				// the other participant sees the incoming call notification.
@@ -228,7 +171,6 @@ class CallManager {
 
 			this.notifyListeners();
 		})().catch((err: any) => {
-			// console.error("❌ Error while starting call:", err);
 			alert(`Failed to start call: ${(err as Error).message}`);
 			this.endCall();
 		});
@@ -250,8 +192,6 @@ class CallManager {
 		}
 
 		const name = `Group call for ${sourceRoomId}`;
-
-		// console.log("🔧 Creating dedicated Element Call room for group call, source room:", sourceRoomId);
 
 		const result = await client.createRoom({
 			// Not publicly listed, but we want easy joins via ID
@@ -286,13 +226,6 @@ class CallManager {
 			}
 		} as any);
 
-		// console.log(
-		// "✅ Created Element Call room",
-		// result.room_id,
-		// "for session room",
-		// sourceRoomId,
-		// );
-
 		return result.room_id;
 	}
 	/**
@@ -312,13 +245,11 @@ class CallManager {
 			const client = matrixClientService?.getClient();
 
 			if (!client) {
-				// console.warn("⚠️  Matrix client not available, cannot adjust power levels for group call");
 				return;
 			}
 
 			const room = client.getRoom(roomId);
 			if (!room) {
-				// console.warn("⚠️  Room not found when trying to adjust power levels for group call:", roomId);
 				return;
 			}
 
@@ -337,7 +268,6 @@ class CallManager {
 
 			// If it's already open enough, nothing to do.
 			if (currentLevelForCallMember === 0) {
-				// console.log("✅ Group call permissions already allow org.matrix.msc3401.call.member at level 0");
 				return;
 			}
 
@@ -351,11 +281,6 @@ class CallManager {
 				}
 			};
 
-			// console.log(
-			// "🔧 Updating m.room.power_levels to allow org.matrix.msc3401.call.member at level 0 for room:",
-			// roomId,
-			// );
-
 			// matrix-js-sdk signature: sendStateEvent(roomId, eventType, content, stateKey?)
 			// We must NOT pass the content as the stateKey (it becomes "[object Object]" in the URL).
 			await client.sendStateEvent(
@@ -364,9 +289,8 @@ class CallManager {
 				updatedContent,
 				''
 			);
-			// console.log("✅ Updated power levels for group call room:", roomId);
-		} catch (error) {
-			// console.error("❌ Error while updating group call room power levels:", error);
+		} catch {
+			// Permission updates are best-effort.
 		}
 	}
 
@@ -389,37 +313,27 @@ class CallManager {
 			const client = matrixClientService?.getClient();
 
 			if (!client) {
-				// console.error('❌ Matrix client not available to send call invite');
 				return;
 			}
 
-			// console.log('📤 Sending m.call.invite to Matrix room:', signallingRoomId);
-
-			// Send m.call.invite event
-			client
+			void client
 				.sendEvent(signallingRoomId, 'm.call.invite', {
 					call_id: callId,
 					version: '1',
-					lifetime: 60000, // 60 seconds
+					lifetime: 60000,
 					offer: {
 						type: 'offer',
-						sdp: '' // Empty for LiveKit calls (not using Matrix WebRTC)
+						sdp: ''
 					},
-					invitee: undefined, // Group call - no specific invitee
+					invitee: undefined,
 					party_id: client.getDeviceId() || 'unknown',
-					is_group_call: true, // Custom field to indicate group call
+					is_group_call: true,
 					is_video: isVideo,
-					// Custom: tell receivers which Matrix room Element Call should use.
 					call_room_id: elementCallRoomId
 				})
-				.then(() => {
-					// console.log('✅ m.call.invite sent successfully');
-				})
-				.catch((err: Error) => {
-					// console.error('❌ Failed to send m.call.invite:', err);
-				});
-		} catch (error) {
-			// console.error('❌ Error sending group call invite:', error);
+				.catch(() => undefined);
+		} catch {
+			// Invite delivery is best-effort.
 		}
 	}
 
@@ -441,19 +355,7 @@ class CallManager {
 		isGroup: boolean,
 		signallingRoomId?: string
 	): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📞 CallManager.receiveCall()");
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("   Call ID:", callId);
-		// console.log("   Call Room ID:", callRoomId);
-		if (signallingRoomId && signallingRoomId !== callRoomId) {
-			// console.log("   Signalling Room ID:", signallingRoomId);
-		}
-		// console.log("   Is Video:", isVideo);
-		// console.log("   Caller:", callerUserId);
-
 		if (this.currentCall) {
-			// console.warn("⚠️  Already have an active call, ignoring incoming call");
 			return;
 		}
 
@@ -469,9 +371,6 @@ class CallManager {
 			signalRoomId: signallingRoomId || callRoomId
 		};
 
-		// console.log("✅ Incoming call created:", this.currentCall);
-		// console.log("═══════════════════════════════════════════════");
-
 		this.notifyListeners();
 	}
 
@@ -479,24 +378,15 @@ class CallManager {
 	 * Answer the current incoming call
 	 */
 	public answerCall(): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("✅ CallManager.answerCall()");
-		// console.log("═══════════════════════════════════════════════");
-
 		if (!this.currentCall) {
-			// console.error("❌ No call to answer!");
 			return;
 		}
 
 		if (!this.currentCall.isIncoming) {
-			// console.error("❌ Cannot answer outgoing call!");
 			return;
 		}
 
 		this.currentCall.state = 'connecting';
-
-		// console.log("✅ Call state changed to connecting");
-		// console.log("═══════════════════════════════════════════════");
 
 		this.notifyListeners();
 	}
@@ -505,28 +395,19 @@ class CallManager {
 	 * Reject the current incoming call
 	 */
 	public rejectCall(): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("❌ CallManager.rejectCall()");
-		// console.log("═══════════════════════════════════════════════");
-
 		if (!this.currentCall) {
-			// console.error("❌ No call to reject!");
 			return;
 		}
 
 		if (this.currentCall.matrixCall) {
-			// console.log("📞 Rejecting Matrix call object...");
 			try {
 				(this.currentCall.matrixCall as any).reject();
-			} catch (err) {
-				// console.error("❌ Error rejecting Matrix call:", err);
+			} catch {
+				// Ignore reject errors during cleanup.
 			}
 		}
 
 		this.currentCall = null;
-
-		// console.log("✅ Call rejected and cleared");
-		// console.log("═══════════════════════════════════════════════");
 
 		this.notifyListeners();
 	}
@@ -535,42 +416,29 @@ class CallManager {
 	 * End the current call
 	 */
 	public endCall(): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📴 CallManager.endCall()");
-		// console.log("═══════════════════════════════════════════════");
-
 		if (!this.currentCall) {
-			// console.log("ℹ️  No active call to end");
 			return;
 		}
 
 		// Hangup Matrix call (this will send m.call.hangup event to other side)
 		if (this.currentCall.matrixCall) {
-			// console.log("📞 Hanging up Matrix call object...");
 			try {
 				(this.currentCall.matrixCall as any).hangup();
-				// console.log("✅ Matrix call hangup sent (other side will receive it)");
-			} catch (err) {
-				// console.error("❌ Error hanging up Matrix call:", err);
+			} catch {
+				// Ignore hangup errors during cleanup.
 			}
 		}
 
 		// Stop local media streams
 		const stream = (window as any).__activeMediaStream;
 		if (stream) {
-			// console.log("🧹 Stopping local media stream...");
 			stream.getTracks().forEach((track: any) => {
 				track.stop();
-				// console.log(`   Stopped ${track.kind} track`);
 			});
 			delete (window as any).__activeMediaStream;
-			// console.log("✅ Local media stream stopped");
 		}
 
 		this.currentCall = null;
-
-		// console.log("✅ Call ended and cleared");
-		// console.log("═══════════════════════════════════════════════");
 
 		this.notifyListeners();
 	}
@@ -579,28 +447,16 @@ class CallManager {
 	 * Attach Matrix call object to current call
 	 */
 	public setMatrixCall(matrixCall: MatrixCall): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🔗 CallManager.setMatrixCall()");
-		// console.log("═══════════════════════════════════════════════");
-
 		if (!this.currentCall) {
-			// console.error("❌ No current call to attach Matrix call to!");
 			return;
 		}
 
 		this.currentCall.matrixCall = matrixCall;
 		this.currentCall.state = 'connected';
 
-		// console.log("✅ Matrix call object attached");
-		// console.log("✅ Call state changed to connected");
-		// console.log("═══════════════════════════════════════════════");
-
 		// Set up state change listener on Matrix call
 		(matrixCall as any).on('state', (newState: string) => {
-			// console.log(`📞 Matrix call state changed: ${newState}`);
-
 			if (newState === 'ended') {
-				// console.log("📴 Matrix call ended, cleaning up...");
 				this.endCall();
 			}
 		});

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -122,9 +122,7 @@ class CallManager {
 
 					isGroup = activeMemberCount > 2;
 				}
-			} catch {
-				// Fall back to 1-on-1 when member detection fails.
-			}
+			} catch {}
 		}
 
 		const callId = `call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -1,6 +1,6 @@
 /**
  * CallManager - Centralized Call State Management
- * 
+ *
  * This is a singleton service that manages all Matrix call state.
  * It prevents multiple initializations, race conditions, and ensures
  * clean state transitions.
@@ -8,591 +8,620 @@
 
 import { MatrixCall } from 'matrix-js-sdk/lib/webrtc/call';
 
-export type CallState = 'idle' | 'ringing' | 'connecting' | 'connected' | 'ended';
+export type CallState =
+	| 'idle'
+	| 'ringing'
+	| 'connecting'
+	| 'connected'
+	| 'ended';
 
 export interface CallData {
-    callId: string;
-    /**
-     * Matrix room that the call itself uses.
-     *  - For 1:1 Matrix WebRTC calls, this is the chat room.
-     *  - For Element Call group calls, this is the dedicated Element Call room.
-     */
-    roomId: string;
-    isVideo: boolean;
-    isIncoming: boolean;
-    isGroup?: boolean; // Flag to determine if this is a group call
-    callerUserId?: string;
-    matrixCall?: MatrixCall;
-    state: CallState;
-    /**
-     * Optional: the dedicated Element Call room for group calls. For backwards
-     * compatibility, this is usually the same as `roomId`, but we keep it
-     * separate so we can continue to send signalling events in the original
-     * session room while Element Call uses its own room.
-     */
-    elementCallRoomId?: string;
-    /**
-     * Optional: original signalling/session room where `m.call.invite` was sent.
-     * For 1:1 calls this is identical to `roomId`.
-     */
-    signalRoomId?: string;
+	callId: string;
+	/**
+	 * Matrix room that the call itself uses.
+	 *  - For 1:1 Matrix WebRTC calls, this is the chat room.
+	 *  - For Element Call group calls, this is the dedicated Element Call room.
+	 */
+	roomId: string;
+	isVideo: boolean;
+	isIncoming: boolean;
+	isGroup?: boolean; // Flag to determine if this is a group call
+	callerUserId?: string;
+	matrixCall?: MatrixCall;
+	state: CallState;
+	/**
+	 * Optional: the dedicated Element Call room for group calls. For backwards
+	 * compatibility, this is usually the same as `roomId`, but we keep it
+	 * separate so we can continue to send signalling events in the original
+	 * session room while Element Call uses its own room.
+	 */
+	elementCallRoomId?: string;
+	/**
+	 * Optional: original signalling/session room where `m.call.invite` was sent.
+	 * For 1:1 calls this is identical to `roomId`.
+	 */
+	signalRoomId?: string;
 }
 
 type CallStateChangeListener = (callData: CallData | null) => void;
 
 class CallManager {
-    private static instance: CallManager;
-    private currentCall: CallData | null = null;
-    private listeners: Set<CallStateChangeListener> = new Set();
+	private static instance: CallManager;
+	private currentCall: CallData | null = null;
+	private listeners: Set<CallStateChangeListener> = new Set();
 
-    private constructor() {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("📞 CallManager initialized (singleton)");
-        // console.log("═══════════════════════════════════════════════");
-    }
+	private constructor() {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("📞 CallManager initialized (singleton)");
+		// console.log("═══════════════════════════════════════════════");
+	}
 
-    public static getInstance(): CallManager {
-        if (!CallManager.instance) {
-            CallManager.instance = new CallManager();
-        }
-        return CallManager.instance;
-    }
+	public static getInstance(): CallManager {
+		if (!CallManager.instance) {
+			CallManager.instance = new CallManager();
+		}
+		return CallManager.instance;
+	}
 
-    /**
-     * Subscribe to call state changes
-     */
-    public subscribe(listener: CallStateChangeListener): () => void {
-        this.listeners.add(listener);
-        // console.log(`📡 CallManager: Added listener (total: ${this.listeners.size})`);
-        
-        // Return unsubscribe function
-        return () => {
-            this.listeners.delete(listener);
-            // console.log(`📡 CallManager: Removed listener (total: ${this.listeners.size})`);
-        };
-    }
+	/**
+	 * Subscribe to call state changes
+	 */
+	public subscribe(listener: CallStateChangeListener): () => void {
+		this.listeners.add(listener);
+		// console.log(`📡 CallManager: Added listener (total: ${this.listeners.size})`);
 
-    /**
-     * Notify all listeners of state change
-     */
-    private notifyListeners(): void {
-        // console.log(`🔔 CallManager: Notifying ${this.listeners.size} listener(s)`);
-        // console.log(`   Current call state:`, this.currentCall);
-        
-        this.listeners.forEach(listener => {
-            try {
-                listener(this.currentCall);
-            } catch (error) {
-                // console.error('❌ Error in call state listener:', error);
-            }
-        });
-    }
+		// Return unsubscribe function
+		return () => {
+			this.listeners.delete(listener);
+			// console.log(`📡 CallManager: Removed listener (total: ${this.listeners.size})`);
+		};
+	}
 
-    /**
-     * Start an outgoing call
-     * @param roomId - Matrix room ID
-     * @param isVideo - Whether to enable video
-     * @param forceIsGroup - Force this to be treated as a group call (for group chats)
-     */
-    public startCall(roomId: string, isVideo: boolean, forceIsGroup?: boolean): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("🚀 CallManager.startCall()");
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("   Room ID:", roomId);
-        // console.log("   Is Video:", isVideo);
-        // console.log("   Force Group:", forceIsGroup);
+	/**
+	 * Notify all listeners of state change
+	 */
+	private notifyListeners(): void {
+		// console.log(`🔔 CallManager: Notifying ${this.listeners.size} listener(s)`);
+		// console.log(`   Current call state:`, this.currentCall);
 
-        if (this.currentCall) {
-            // console.warn("⚠️  Already have an active call, cleaning up first...");
-            this.endCall();
-        }
+		this.listeners.forEach((listener) => {
+			try {
+				listener(this.currentCall);
+			} catch (error) {
+				// console.error('❌ Error in call state listener:', error);
+			}
+		});
+	}
 
-        // Detect if this is a group call
-        let isGroup = forceIsGroup || false; // Use forceIsGroup if provided
-        
-        if (!forceIsGroup) {
-            // Auto-detect based on room member count
-            try {
-                const matrixClientService = (window as any).matrixClientService;
-                const client = matrixClientService?.getClient();
-                // console.log(`   Matrix client available: ${!!client}`);
-                
-                if (client) {
-                    const room = client.getRoom(roomId);
-                    // console.log(`   Room found: ${!!room}`);
-                    
-                    if (room) {
-                        const allMembers = room.getJoinedMembers();
-                        const memberCount = allMembers.length;
-                        
-                        // Filter supervisors from member count (supervisors have power level 10)
-                        // Get supervisors from API to filter them out
-                        let activeMemberCount = memberCount;
-                        try {
-                            // Get session ID from room name or other source if available
-                            // For now, we'll filter by power level
-                            const activeMembers = allMembers.filter((m: any) => {
-                                const powerLevel = room.getMember(m.userId)?.powerLevel || 0;
-                                return powerLevel !== 10; // Exclude supervisors (power level 10)
-                            });
-                            activeMemberCount = activeMembers.length;
-                        } catch (err) {
-                            // console.warn('Could not filter supervisors from member count:', err);
-                        }
-                        
-                        // 1-on-1 = 2 members (consultant + asker), group = more than 2
-                        isGroup = activeMemberCount > 2;
-                        
-                        // console.log(`   ✅ Room member count: ${memberCount} (active: ${activeMemberCount})`);
-                        // console.log(`   ✅ Joined members:`, allMembers.map(m => m.userId));
-                        // console.log(`   ✅ Is group call (auto-detected): ${isGroup}`);
-                    } else {
-                        // console.warn(`   ⚠️  Room not found in Matrix client! RoomId: ${roomId}`);
-                    }
-                } else {
-                    // console.warn(`   ⚠️  Matrix client not available!`);
-                }
-            } catch (err) {
-                // console.error('❌ Error detecting group call:', err);
-            }
-        } else {
-            // console.log(`   ✅ Is group call (forced): ${isGroup}`);
-        }
+	/**
+	 * Start an outgoing call
+	 * @param roomId - Matrix room ID
+	 * @param isVideo - Whether to enable video
+	 * @param forceIsGroup - true forces group call, false forces 1-on-1, omit to auto-detect
+	 */
+	public startCall(
+		roomId: string,
+		isVideo: boolean,
+		forceIsGroup?: boolean
+	): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("🚀 CallManager.startCall()");
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("   Room ID:", roomId);
+		// console.log("   Is Video:", isVideo);
+		// console.log("   Force Group:", forceIsGroup);
 
-        const callId = `call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+		if (this.currentCall) {
+			// console.warn("⚠️  Already have an active call, cleaning up first...");
+			this.endCall();
+		}
 
-        // Run the heavy work asynchronously so callers don't have to `await`
-        // but we can still create a dedicated Element Call room before
-        // notifying listeners.
-        (async () => {
-            let elementCallRoomId: string | undefined = undefined;
+		// Detect if this is a group call.
+		// forceIsGroup: true = group, false = 1-on-1, undefined = auto-detect from room size.
+		let isGroup = false;
 
-            // For group calls, create a fresh dedicated Element Call room rather
-            // than re-using the session room. This matches the "direct" usage of
-            // call.oriso.site where each call lives in its own Matrix room with
-            // appropriate power levels.
-            if (isGroup) {
-                elementCallRoomId = await this.createElementCallRoom(roomId);
-            }
+		if (forceIsGroup === true) {
+			isGroup = true;
+		} else if (forceIsGroup === false) {
+			isGroup = false;
+		} else {
+			// Auto-detect based on room member count
+			try {
+				const matrixClientService = (window as any).matrixClientService;
+				const client = matrixClientService?.getClient();
+				// console.log(`   Matrix client available: ${!!client}`);
 
-            this.currentCall = {
-                callId,
-                // For group calls this will be the dedicated Element Call room;
-                // for 1:1 calls it's the session/chat room.
-                roomId: elementCallRoomId || roomId,
-                isVideo,
-                isIncoming: false,
-                isGroup,
-                state: 'connecting',
-                elementCallRoomId: elementCallRoomId || roomId,
-                signalRoomId: isGroup ? roomId : roomId,
-            };
+				if (client) {
+					const room = client.getRoom(roomId);
+					// console.log(`   Room found: ${!!room}`);
 
-            // console.log("✅ Outgoing call created:", this.currentCall);
-            // console.log("═══════════════════════════════════════════════");
+					if (room) {
+						const allMembers = room.getJoinedMembers();
+						const memberCount = allMembers.length;
 
-            if (isGroup) {
-                // Make sure the Element Call room allows membership events from
-                // regular users (matches Element Call's own room creation).
-                this.ensureGroupCallPermissions(this.currentCall.roomId).catch((err) => {
-                    // console.error("❌ Failed to ensure group call room permissions:", err);
-                });
+						// Filter supervisors from member count (supervisors have power level 10)
+						// Get supervisors from API to filter them out
+						let activeMemberCount = memberCount;
+						try {
+							// Get session ID from room name or other source if available
+							// For now, we'll filter by power level
+							const activeMembers = allMembers.filter(
+								(m: any) => {
+									const powerLevel =
+										room.getMember(m.userId)?.powerLevel ||
+										0;
+									return powerLevel !== 10; // Exclude supervisors (power level 10)
+								}
+							);
+							activeMemberCount = activeMembers.length;
+						} catch (err) {
+							// console.warn('Could not filter supervisors from member count:', err);
+						}
 
-                // Send Matrix call invite event to the original session room so
-                // the other participant sees the incoming call notification.
-                this.sendGroupCallInvite(
-                    roomId,
-                    callId,
-                    isVideo,
-                    this.currentCall.roomId,
-                );
-            }
+						// 1-on-1 = 2 members (consultant + asker), group = more than 2
+						isGroup = activeMemberCount > 2;
 
-            this.notifyListeners();
-        })().catch((err: any) => {
-            // console.error("❌ Error while starting call:", err);
-            alert(`Failed to start call: ${(err as Error).message}`);
-            this.endCall();
-        });
-    }
+						// console.log(`   ✅ Room member count: ${memberCount} (active: ${activeMemberCount})`);
+						// console.log(`   ✅ Joined members:`, allMembers.map(m => m.userId));
+						// console.log(`   ✅ Is group call (auto-detected): ${isGroup}`);
+					} else {
+						// console.warn(`   ⚠️  Room not found in Matrix client! RoomId: ${roomId}`);
+					}
+				} else {
+					// console.warn(`   ⚠️  Matrix client not available!`);
+				}
+			} catch (err) {
+				// console.error('❌ Error detecting group call:', err);
+			}
+		}
 
-    /**
-     * Create a dedicated Matrix room for an Element Call group call. This
-     * mirrors Element Call's own `createRoom` behaviour closely enough for our
-     * use-case (notably the power levels for `org.matrix.msc3401.call.member`).
-     */
-    private async createElementCallRoom(sourceRoomId: string): Promise<string> {
-        const matrixClientService = (window as any).matrixClientService;
-        const client = matrixClientService?.getClient();
+		const callId = `call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-        if (!client) {
-            throw new Error("Matrix client not available to create Element Call room");
-        }
+		// Run the heavy work asynchronously so callers don't have to `await`
+		// but we can still create a dedicated Element Call room before
+		// notifying listeners.
+		(async () => {
+			let elementCallRoomId: string | undefined = undefined;
 
-        const name = `Group call for ${sourceRoomId}`;
+			// For group calls, create a fresh dedicated Element Call room rather
+			// than re-using the session room. This matches the "direct" usage of
+			// call.oriso.site where each call lives in its own Matrix room with
+			// appropriate power levels.
+			if (isGroup) {
+				elementCallRoomId = await this.createElementCallRoom(roomId);
+			}
 
-        // console.log("🔧 Creating dedicated Element Call room for group call, source room:", sourceRoomId);
+			this.currentCall = {
+				callId,
+				// For group calls this will be the dedicated Element Call room;
+				// for 1:1 calls it's the session/chat room.
+				roomId: elementCallRoomId || roomId,
+				isVideo,
+				isIncoming: false,
+				isGroup,
+				state: 'connecting',
+				elementCallRoomId: elementCallRoomId || roomId,
+				signalRoomId: isGroup ? roomId : roomId
+			};
 
-        const result = await client.createRoom({
-            // Not publicly listed, but we want easy joins via ID
-            visibility: "private",
-            // Same as Element Call: a room suitable for group chats
-            preset: "public_chat",
-            name,
-            power_level_content_override: {
-                invite: 100,
-                kick: 100,
-                ban: 100,
-                redact: 50,
-                state_default: 0,
-                events_default: 0,
-                users_default: 0,
-                events: {
-                    "m.room.power_levels": 100,
-                    "m.room.history_visibility": 100,
-                    "m.room.tombstone": 100,
-                    "m.room.encryption": 100,
-                    "m.room.name": 50,
-                    "m.room.message": 0,
-                    "m.room.encrypted": 50,
-                    "m.sticker": 50,
-                    // IMPORTANT: allow everyone to send group call membership
-                    // events so Element Call can join from any participant.
-                    "org.matrix.msc3401.call.member": 0,
-                },
-                users: {
-                    [client.getUserId()!]: 100,
-                },
-            },
-        } as any);
+			// console.log("✅ Outgoing call created:", this.currentCall);
+			// console.log("═══════════════════════════════════════════════");
 
-        // console.log(
-        // "✅ Created Element Call room",
-        // result.room_id,
-        // "for session room",
-        // sourceRoomId,
-        // );
+			if (isGroup) {
+				// Make sure the Element Call room allows membership events from
+				// regular users (matches Element Call's own room creation).
+				this.ensureGroupCallPermissions(this.currentCall.roomId).catch(
+					(err) => {
+						// console.error("❌ Failed to ensure group call room permissions:", err);
+					}
+				);
 
-        return result.room_id;
-    }
-    /**
-     * Ensure the Matrix room's power levels allow Element Call to send
-     * `org.matrix.msc3401.call.member` state events from normal participants.
-     *
-     * Direct Element Call rooms are created with:
-     *   power_level_content_override.events["org.matrix.msc3401.call.member"] = 0
-     * so that any user (power level 0) can join the MatrixRTC session.
-     *
-     * Our session rooms currently require level 50 for that event which causes
-     * M_FORBIDDEN for users like `ali_user` and leads to "Connection lost".
-     */
-    private async ensureGroupCallPermissions(roomId: string): Promise<void> {
-        try {
-            const matrixClientService = (window as any).matrixClientService;
-            const client = matrixClientService?.getClient();
+				// Send Matrix call invite event to the original session room so
+				// the other participant sees the incoming call notification.
+				this.sendGroupCallInvite(
+					roomId,
+					callId,
+					isVideo,
+					this.currentCall.roomId
+				);
+			}
 
-            if (!client) {
-                // console.warn("⚠️  Matrix client not available, cannot adjust power levels for group call");
-                return;
-            }
+			this.notifyListeners();
+		})().catch((err: any) => {
+			// console.error("❌ Error while starting call:", err);
+			alert(`Failed to start call: ${(err as Error).message}`);
+			this.endCall();
+		});
+	}
 
-            const room = client.getRoom(roomId);
-            if (!room) {
-                // console.warn("⚠️  Room not found when trying to adjust power levels for group call:", roomId);
-                return;
-            }
+	/**
+	 * Create a dedicated Matrix room for an Element Call group call. This
+	 * mirrors Element Call's own `createRoom` behaviour closely enough for our
+	 * use-case (notably the power levels for `org.matrix.msc3401.call.member`).
+	 */
+	private async createElementCallRoom(sourceRoomId: string): Promise<string> {
+		const matrixClientService = (window as any).matrixClientService;
+		const client = matrixClientService?.getClient();
 
-            const plEvent = room.currentState.getStateEvents("m.room.power_levels", "") as any;
-            const currentContent = plEvent?.getContent?.() || {};
-            const events = currentContent.events || {};
+		if (!client) {
+			throw new Error(
+				'Matrix client not available to create Element Call room'
+			);
+		}
 
-            const currentLevelForCallMember =
-                events["org.matrix.msc3401.call.member"] ??
-                currentContent.state_default ??
-                currentContent.events_default ??
-                50;
+		const name = `Group call for ${sourceRoomId}`;
 
-            // If it's already open enough, nothing to do.
-            if (currentLevelForCallMember === 0) {
-                // console.log("✅ Group call permissions already allow org.matrix.msc3401.call.member at level 0");
-                return;
-            }
+		// console.log("🔧 Creating dedicated Element Call room for group call, source room:", sourceRoomId);
 
-            const updatedContent = {
-                ...currentContent,
-                events: {
-                    ...events,
-                    // Match Element Call's own room creation logic: allow everyone
-                    // to send call membership events so they can join the MatrixRTC session.
-                    "org.matrix.msc3401.call.member": 0,
-                },
-            };
+		const result = await client.createRoom({
+			// Not publicly listed, but we want easy joins via ID
+			visibility: 'private',
+			// Same as Element Call: a room suitable for group chats
+			preset: 'public_chat',
+			name,
+			power_level_content_override: {
+				invite: 100,
+				kick: 100,
+				ban: 100,
+				redact: 50,
+				state_default: 0,
+				events_default: 0,
+				users_default: 0,
+				events: {
+					'm.room.power_levels': 100,
+					'm.room.history_visibility': 100,
+					'm.room.tombstone': 100,
+					'm.room.encryption': 100,
+					'm.room.name': 50,
+					'm.room.message': 0,
+					'm.room.encrypted': 50,
+					'm.sticker': 50,
+					// IMPORTANT: allow everyone to send group call membership
+					// events so Element Call can join from any participant.
+					'org.matrix.msc3401.call.member': 0
+				},
+				users: {
+					[client.getUserId()!]: 100
+				}
+			}
+		} as any);
 
-            // console.log(
-            // "🔧 Updating m.room.power_levels to allow org.matrix.msc3401.call.member at level 0 for room:",
-            // roomId,
-            // );
+		// console.log(
+		// "✅ Created Element Call room",
+		// result.room_id,
+		// "for session room",
+		// sourceRoomId,
+		// );
 
-            // matrix-js-sdk signature: sendStateEvent(roomId, eventType, content, stateKey?)
-            // We must NOT pass the content as the stateKey (it becomes "[object Object]" in the URL).
-            await client.sendStateEvent(roomId, "m.room.power_levels", updatedContent, "");
-            // console.log("✅ Updated power levels for group call room:", roomId);
-        } catch (error) {
-            // console.error("❌ Error while updating group call room power levels:", error);
-        }
-    }
+		return result.room_id;
+	}
+	/**
+	 * Ensure the Matrix room's power levels allow Element Call to send
+	 * `org.matrix.msc3401.call.member` state events from normal participants.
+	 *
+	 * Direct Element Call rooms are created with:
+	 *   power_level_content_override.events["org.matrix.msc3401.call.member"] = 0
+	 * so that any user (power level 0) can join the MatrixRTC session.
+	 *
+	 * Our session rooms currently require level 50 for that event which causes
+	 * M_FORBIDDEN for users like `ali_user` and leads to "Connection lost".
+	 */
+	private async ensureGroupCallPermissions(roomId: string): Promise<void> {
+		try {
+			const matrixClientService = (window as any).matrixClientService;
+			const client = matrixClientService?.getClient();
 
-    /**
-     * Send m.call.invite event to Matrix room for group calls
-     *
-     * @param signallingRoomId - The existing session/chat room where the invite should appear
-     * @param callId - Logical call identifier
-     * @param isVideo - Whether this is a video call
-     * @param elementCallRoomId - The dedicated Element Call room that should be joined
-     */
-    private sendGroupCallInvite(
-        signallingRoomId: string,
-        callId: string,
-        isVideo: boolean,
-        elementCallRoomId?: string,
-    ): void {
-        try {
-            const matrixClientService = (window as any).matrixClientService;
-            const client = matrixClientService?.getClient();
-            
-            if (!client) {
-                // console.error('❌ Matrix client not available to send call invite');
-                return;
-            }
+			if (!client) {
+				// console.warn("⚠️  Matrix client not available, cannot adjust power levels for group call");
+				return;
+			}
 
-            // console.log('📤 Sending m.call.invite to Matrix room:', signallingRoomId);
-            
-            // Send m.call.invite event
-            client.sendEvent(signallingRoomId, 'm.call.invite', {
-                call_id: callId,
-                version: '1',
-                lifetime: 60000, // 60 seconds
-                offer: {
-                    type: 'offer',
-                    sdp: '' // Empty for LiveKit calls (not using Matrix WebRTC)
-                },
-                invitee: undefined, // Group call - no specific invitee
-                party_id: client.getDeviceId() || 'unknown',
-                is_group_call: true, // Custom field to indicate group call
-                is_video: isVideo,
-                // Custom: tell receivers which Matrix room Element Call should use.
-                call_room_id: elementCallRoomId,
-            }).then(() => {
-                // console.log('✅ m.call.invite sent successfully');
-            }).catch((err: Error) => {
-                // console.error('❌ Failed to send m.call.invite:', err);
-            });
-            
-        } catch (error) {
-            // console.error('❌ Error sending group call invite:', error);
-        }
-    }
+			const room = client.getRoom(roomId);
+			if (!room) {
+				// console.warn("⚠️  Room not found when trying to adjust power levels for group call:", roomId);
+				return;
+			}
 
-    /**
-     * Receive an incoming call
-     *
-     * @param callRoomId - Matrix room used by the call itself (Element Call room for group calls)
-     * @param isVideo - Whether this is a video call
-     * @param callId - Logical call identifier
-     * @param callerUserId - Matrix user id of the caller
-     * @param isGroup - Whether this is a group call (Element Call)
-     * @param signallingRoomId - Optional original session/chat room where the invite was sent
-     */
-    public receiveCall(
-        callRoomId: string,
-        isVideo: boolean,
-        callId: string,
-        callerUserId: string,
-        isGroup: boolean,
-        signallingRoomId?: string,
-    ): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("📞 CallManager.receiveCall()");
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("   Call ID:", callId);
-        // console.log("   Call Room ID:", callRoomId);
-        if (signallingRoomId && signallingRoomId !== callRoomId) {
-            // console.log("   Signalling Room ID:", signallingRoomId);
-        }
-        // console.log("   Is Video:", isVideo);
-        // console.log("   Caller:", callerUserId);
+			const plEvent = room.currentState.getStateEvents(
+				'm.room.power_levels',
+				''
+			) as any;
+			const currentContent = plEvent?.getContent?.() || {};
+			const events = currentContent.events || {};
 
-        if (this.currentCall) {
-            // console.warn("⚠️  Already have an active call, ignoring incoming call");
-            return;
-        }
+			const currentLevelForCallMember =
+				events['org.matrix.msc3401.call.member'] ??
+				currentContent.state_default ??
+				currentContent.events_default ??
+				50;
 
-        this.currentCall = {
-            callId,
-            roomId: callRoomId,
-            isVideo,
-            isIncoming: true,
-            isGroup, // Set isGroup for incoming calls
-            callerUserId,
-            state: 'ringing',
-            elementCallRoomId: callRoomId,
-            signalRoomId: signallingRoomId || callRoomId,
-        };
+			// If it's already open enough, nothing to do.
+			if (currentLevelForCallMember === 0) {
+				// console.log("✅ Group call permissions already allow org.matrix.msc3401.call.member at level 0");
+				return;
+			}
 
-        // console.log("✅ Incoming call created:", this.currentCall);
-        // console.log("═══════════════════════════════════════════════");
-        
-        this.notifyListeners();
-    }
+			const updatedContent = {
+				...currentContent,
+				events: {
+					...events,
+					// Match Element Call's own room creation logic: allow everyone
+					// to send call membership events so they can join the MatrixRTC session.
+					'org.matrix.msc3401.call.member': 0
+				}
+			};
 
-    /**
-     * Answer the current incoming call
-     */
-    public answerCall(): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("✅ CallManager.answerCall()");
-        // console.log("═══════════════════════════════════════════════");
+			// console.log(
+			// "🔧 Updating m.room.power_levels to allow org.matrix.msc3401.call.member at level 0 for room:",
+			// roomId,
+			// );
 
-        if (!this.currentCall) {
-            // console.error("❌ No call to answer!");
-            return;
-        }
+			// matrix-js-sdk signature: sendStateEvent(roomId, eventType, content, stateKey?)
+			// We must NOT pass the content as the stateKey (it becomes "[object Object]" in the URL).
+			await client.sendStateEvent(
+				roomId,
+				'm.room.power_levels',
+				updatedContent,
+				''
+			);
+			// console.log("✅ Updated power levels for group call room:", roomId);
+		} catch (error) {
+			// console.error("❌ Error while updating group call room power levels:", error);
+		}
+	}
 
-        if (!this.currentCall.isIncoming) {
-            // console.error("❌ Cannot answer outgoing call!");
-            return;
-        }
+	/**
+	 * Send m.call.invite event to Matrix room for group calls
+	 *
+	 * @param signallingRoomId - The existing session/chat room where the invite should appear
+	 * @param callId - Logical call identifier
+	 * @param isVideo - Whether this is a video call
+	 * @param elementCallRoomId - The dedicated Element Call room that should be joined
+	 */
+	private sendGroupCallInvite(
+		signallingRoomId: string,
+		callId: string,
+		isVideo: boolean,
+		elementCallRoomId?: string
+	): void {
+		try {
+			const matrixClientService = (window as any).matrixClientService;
+			const client = matrixClientService?.getClient();
 
-        this.currentCall.state = 'connecting';
-        
-        // console.log("✅ Call state changed to connecting");
-        // console.log("═══════════════════════════════════════════════");
-        
-        this.notifyListeners();
-    }
+			if (!client) {
+				// console.error('❌ Matrix client not available to send call invite');
+				return;
+			}
 
-    /**
-     * Reject the current incoming call
-     */
-    public rejectCall(): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("❌ CallManager.rejectCall()");
-        // console.log("═══════════════════════════════════════════════");
+			// console.log('📤 Sending m.call.invite to Matrix room:', signallingRoomId);
 
-        if (!this.currentCall) {
-            // console.error("❌ No call to reject!");
-            return;
-        }
+			// Send m.call.invite event
+			client
+				.sendEvent(signallingRoomId, 'm.call.invite', {
+					call_id: callId,
+					version: '1',
+					lifetime: 60000, // 60 seconds
+					offer: {
+						type: 'offer',
+						sdp: '' // Empty for LiveKit calls (not using Matrix WebRTC)
+					},
+					invitee: undefined, // Group call - no specific invitee
+					party_id: client.getDeviceId() || 'unknown',
+					is_group_call: true, // Custom field to indicate group call
+					is_video: isVideo,
+					// Custom: tell receivers which Matrix room Element Call should use.
+					call_room_id: elementCallRoomId
+				})
+				.then(() => {
+					// console.log('✅ m.call.invite sent successfully');
+				})
+				.catch((err: Error) => {
+					// console.error('❌ Failed to send m.call.invite:', err);
+				});
+		} catch (error) {
+			// console.error('❌ Error sending group call invite:', error);
+		}
+	}
 
-        if (this.currentCall.matrixCall) {
-            // console.log("📞 Rejecting Matrix call object...");
-            try {
-                (this.currentCall.matrixCall as any).reject();
-            } catch (err) {
-                // console.error("❌ Error rejecting Matrix call:", err);
-            }
-        }
+	/**
+	 * Receive an incoming call
+	 *
+	 * @param callRoomId - Matrix room used by the call itself (Element Call room for group calls)
+	 * @param isVideo - Whether this is a video call
+	 * @param callId - Logical call identifier
+	 * @param callerUserId - Matrix user id of the caller
+	 * @param isGroup - Whether this is a group call (Element Call)
+	 * @param signallingRoomId - Optional original session/chat room where the invite was sent
+	 */
+	public receiveCall(
+		callRoomId: string,
+		isVideo: boolean,
+		callId: string,
+		callerUserId: string,
+		isGroup: boolean,
+		signallingRoomId?: string
+	): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("📞 CallManager.receiveCall()");
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("   Call ID:", callId);
+		// console.log("   Call Room ID:", callRoomId);
+		if (signallingRoomId && signallingRoomId !== callRoomId) {
+			// console.log("   Signalling Room ID:", signallingRoomId);
+		}
+		// console.log("   Is Video:", isVideo);
+		// console.log("   Caller:", callerUserId);
 
-        this.currentCall = null;
-        
-        // console.log("✅ Call rejected and cleared");
-        // console.log("═══════════════════════════════════════════════");
-        
-        this.notifyListeners();
-    }
+		if (this.currentCall) {
+			// console.warn("⚠️  Already have an active call, ignoring incoming call");
+			return;
+		}
 
-    /**
-     * End the current call
-     */
-    public endCall(): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("📴 CallManager.endCall()");
-        // console.log("═══════════════════════════════════════════════");
+		this.currentCall = {
+			callId,
+			roomId: callRoomId,
+			isVideo,
+			isIncoming: true,
+			isGroup, // Set isGroup for incoming calls
+			callerUserId,
+			state: 'ringing',
+			elementCallRoomId: callRoomId,
+			signalRoomId: signallingRoomId || callRoomId
+		};
 
-        if (!this.currentCall) {
-            // console.log("ℹ️  No active call to end");
-            return;
-        }
+		// console.log("✅ Incoming call created:", this.currentCall);
+		// console.log("═══════════════════════════════════════════════");
 
-        // Hangup Matrix call (this will send m.call.hangup event to other side)
-        if (this.currentCall.matrixCall) {
-            // console.log("📞 Hanging up Matrix call object...");
-            try {
-                (this.currentCall.matrixCall as any).hangup();
-                // console.log("✅ Matrix call hangup sent (other side will receive it)");
-            } catch (err) {
-                // console.error("❌ Error hanging up Matrix call:", err);
-            }
-        }
+		this.notifyListeners();
+	}
 
-        // Stop local media streams
-        const stream = (window as any).__activeMediaStream;
-        if (stream) {
-            // console.log("🧹 Stopping local media stream...");
-            stream.getTracks().forEach((track: any) => {
-                track.stop();
-                // console.log(`   Stopped ${track.kind} track`);
-            });
-            delete (window as any).__activeMediaStream;
-            // console.log("✅ Local media stream stopped");
-        }
+	/**
+	 * Answer the current incoming call
+	 */
+	public answerCall(): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("✅ CallManager.answerCall()");
+		// console.log("═══════════════════════════════════════════════");
 
-        this.currentCall = null;
-        
-        // console.log("✅ Call ended and cleared");
-        // console.log("═══════════════════════════════════════════════");
-        
-        this.notifyListeners();
-    }
+		if (!this.currentCall) {
+			// console.error("❌ No call to answer!");
+			return;
+		}
 
-    /**
-     * Attach Matrix call object to current call
-     */
-    public setMatrixCall(matrixCall: MatrixCall): void {
-        // console.log("═══════════════════════════════════════════════");
-        // console.log("🔗 CallManager.setMatrixCall()");
-        // console.log("═══════════════════════════════════════════════");
+		if (!this.currentCall.isIncoming) {
+			// console.error("❌ Cannot answer outgoing call!");
+			return;
+		}
 
-        if (!this.currentCall) {
-            // console.error("❌ No current call to attach Matrix call to!");
-            return;
-        }
+		this.currentCall.state = 'connecting';
 
-        this.currentCall.matrixCall = matrixCall;
-        this.currentCall.state = 'connected';
-        
-        // console.log("✅ Matrix call object attached");
-        // console.log("✅ Call state changed to connected");
-        // console.log("═══════════════════════════════════════════════");
-        
-        // Set up state change listener on Matrix call
-        (matrixCall as any).on('state', (newState: string) => {
-            // console.log(`📞 Matrix call state changed: ${newState}`);
-            
-            if (newState === 'ended') {
-                // console.log("📴 Matrix call ended, cleaning up...");
-                this.endCall();
-            }
-        });
-        
-        this.notifyListeners();
-    }
+		// console.log("✅ Call state changed to connecting");
+		// console.log("═══════════════════════════════════════════════");
 
-    /**
-     * Get current call data
-     */
-    public getCurrentCall(): CallData | null {
-        return this.currentCall;
-    }
+		this.notifyListeners();
+	}
 
-    /**
-     * Check if there's an active call
-     */
-    public hasActiveCall(): boolean {
-        return this.currentCall !== null;
-    }
+	/**
+	 * Reject the current incoming call
+	 */
+	public rejectCall(): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("❌ CallManager.rejectCall()");
+		// console.log("═══════════════════════════════════════════════");
+
+		if (!this.currentCall) {
+			// console.error("❌ No call to reject!");
+			return;
+		}
+
+		if (this.currentCall.matrixCall) {
+			// console.log("📞 Rejecting Matrix call object...");
+			try {
+				(this.currentCall.matrixCall as any).reject();
+			} catch (err) {
+				// console.error("❌ Error rejecting Matrix call:", err);
+			}
+		}
+
+		this.currentCall = null;
+
+		// console.log("✅ Call rejected and cleared");
+		// console.log("═══════════════════════════════════════════════");
+
+		this.notifyListeners();
+	}
+
+	/**
+	 * End the current call
+	 */
+	public endCall(): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("📴 CallManager.endCall()");
+		// console.log("═══════════════════════════════════════════════");
+
+		if (!this.currentCall) {
+			// console.log("ℹ️  No active call to end");
+			return;
+		}
+
+		// Hangup Matrix call (this will send m.call.hangup event to other side)
+		if (this.currentCall.matrixCall) {
+			// console.log("📞 Hanging up Matrix call object...");
+			try {
+				(this.currentCall.matrixCall as any).hangup();
+				// console.log("✅ Matrix call hangup sent (other side will receive it)");
+			} catch (err) {
+				// console.error("❌ Error hanging up Matrix call:", err);
+			}
+		}
+
+		// Stop local media streams
+		const stream = (window as any).__activeMediaStream;
+		if (stream) {
+			// console.log("🧹 Stopping local media stream...");
+			stream.getTracks().forEach((track: any) => {
+				track.stop();
+				// console.log(`   Stopped ${track.kind} track`);
+			});
+			delete (window as any).__activeMediaStream;
+			// console.log("✅ Local media stream stopped");
+		}
+
+		this.currentCall = null;
+
+		// console.log("✅ Call ended and cleared");
+		// console.log("═══════════════════════════════════════════════");
+
+		this.notifyListeners();
+	}
+
+	/**
+	 * Attach Matrix call object to current call
+	 */
+	public setMatrixCall(matrixCall: MatrixCall): void {
+		// console.log("═══════════════════════════════════════════════");
+		// console.log("🔗 CallManager.setMatrixCall()");
+		// console.log("═══════════════════════════════════════════════");
+
+		if (!this.currentCall) {
+			// console.error("❌ No current call to attach Matrix call to!");
+			return;
+		}
+
+		this.currentCall.matrixCall = matrixCall;
+		this.currentCall.state = 'connected';
+
+		// console.log("✅ Matrix call object attached");
+		// console.log("✅ Call state changed to connected");
+		// console.log("═══════════════════════════════════════════════");
+
+		// Set up state change listener on Matrix call
+		(matrixCall as any).on('state', (newState: string) => {
+			// console.log(`📞 Matrix call state changed: ${newState}`);
+
+			if (newState === 'ended') {
+				// console.log("📴 Matrix call ended, cleaning up...");
+				this.endCall();
+			}
+		});
+
+		this.notifyListeners();
+	}
+
+	/**
+	 * Get current call data
+	 */
+	public getCurrentCall(): CallData | null {
+		return this.currentCall;
+	}
+
+	/**
+	 * Check if there's an active call
+	 */
+	public hasActiveCall(): boolean {
+		return this.currentCall !== null;
+	}
 }
 
 // Export singleton instance
 export const callManager = CallManager.getInstance();
-

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -9,56 +9,32 @@ import { callManager } from './CallManager';
 export class MatrixLiveEventBridge {
 	private client: MatrixClient | null = null;
 	private eventCallbacks: Map<string, Set<(event: any) => void>> = new Map();
-	private initialized: boolean = false;
-	private processedCallInvites: Set<string> = new Set(); // Track processed call IDs
+	private initialized = false;
+	private processedCallInvites = new Set<string>();
 
-	/**
-	 * Initialize the bridge with a Matrix client.
-	 * This sets up event listeners for real-time Matrix events.
-	 */
 	public initialize(client: MatrixClient): void {
 		if (this.initialized) {
-			// console.warn("⚠️ MatrixLiveEventBridge already initialized");
 			return;
 		}
 
 		this.client = client;
 		this.setupEventListeners();
 		this.initialized = true;
-
-		// console.log("✅ MatrixLiveEventBridge initialized - listening to Matrix events");
 	}
 
-	/**
-	 * Set up listeners for Matrix events.
-	 */
 	private setupEventListeners(): void {
 		if (!this.client) {
 			return;
 		}
 
-		// Listen to Room.timeline events (new messages, state changes)
 		this.client.on(
 			'Room.timeline' as any,
 			(event: MatrixEvent, room: Room, toStartOfTimeline: boolean) => {
-				// Ignore historical events (when scrolling back)
 				if (toStartOfTimeline) {
 					return;
 				}
 
-				const eventType = event.getType();
-				const roomId = room.roomId;
-				const senderId = event.getSender();
-
-				// console.log("📩 Matrix event:", {
-				// type: eventType,
-				// roomId: roomId,
-				// sender: senderId,
-				// timestamp: event.getTs()
-				// });
-
-				// Handle different event types
-				switch (eventType) {
+				switch (event.getType()) {
 					case 'm.room.message':
 					case 'm.room.encrypted':
 						this.handleRoomMessage(event, room);
@@ -77,51 +53,28 @@ export class MatrixLiveEventBridge {
 						break;
 
 					default:
-						// Ignore other events
 						break;
 				}
 			}
 		);
-
-		// Listen to sync state changes
-		this.client.on(
-			'sync' as any,
-			(state: string, prevState: string | null) => {
-				// console.log("🔄 Matrix sync state:", state, "(previous:", prevState, ")");
-			}
-		);
 	}
 
-	/**
-	 * Handle m.room.message events (new messages).
-	 */
 	private handleRoomMessage(event: MatrixEvent, room: Room): void {
 		const sender = event.getSender();
 		const content = event.getContent();
-		const msgtype = content.msgtype;
-		const body = content.body;
-
 		const myUserId = this.client?.getUserId();
-		const isOwnMessage = sender === myUserId;
 
-		// console.log("📬 New message from", sender, "in room", room.roomId);
-		// console.log("   Content:", body?.substring(0, 100));
-
-		// Trigger 'directMessage' event (simulating LiveService)
 		this.triggerEvent('directMessage', {
 			roomId: room.roomId,
-			sender: sender,
-			isOwnMessage: isOwnMessage,
-			msgtype: msgtype,
-			body: body,
+			sender,
+			isOwnMessage: sender === myUserId,
+			msgtype: content.msgtype,
+			body: content.body,
 			eventId: event.getId(),
 			timestamp: event.getTs()
 		});
 	}
 
-	/**
-	 * Determine whether a call invite is for video or audio-only.
-	 */
 	private isVideoCallInvite(content: Record<string, any>): boolean {
 		if (content.is_video === true) {
 			return true;
@@ -132,239 +85,110 @@ export class MatrixLiveEventBridge {
 
 		const sdp = content.offer?.sdp;
 		if (typeof sdp === 'string' && sdp.length > 0) {
-			// Voice-only Matrix WebRTC offers omit video or set m=video port 0.
 			return /\nm=video [1-9]/.test(sdp);
 		}
 
 		return false;
 	}
 
-	/**
-	 * Handle m.call.invite events (incoming calls).
-	 */
 	private handleCallInvite(event: MatrixEvent, room: Room): void {
 		const sender = event.getSender();
 		const content = event.getContent();
 		const callId = content.call_id;
-		const eventTimestamp = event.getTs();
-		const now = Date.now();
-		const ageSeconds = Math.floor((now - eventTimestamp) / 1000);
+		const ageSeconds = Math.floor((Date.now() - event.getTs()) / 1000);
 		const callRoomId = content.call_room_id || room.roomId;
 
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("🔔 CALL INVITE EVENT RECEIVED");
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📞 Call ID:", callId);
-		// console.log("👤 Sender:", sender);
-		// console.log("🏠 Room:", room.roomId);
-		// console.log("⏰ Event timestamp:", new Date(eventTimestamp).toISOString());
-		// console.log("⏱️  Age:", ageSeconds, "seconds old");
-		// console.log("═══════════════════════════════════════════════");
-
-		// CRITICAL: Ignore old call invites (> 10 seconds = from history/replay!)
-		// This prevents phantom notifications on login/reload
 		if (ageSeconds > 10) {
-			// console.log("🚫 IGNORING OLD CALL INVITE (from history, not a new call!)");
-			// console.log("═══════════════════════════════════════════════");
 			this.processedCallInvites.add(callId);
 			return;
 		}
 
-		// CRITICAL: Check if we've already processed this call invite (prevent duplicate!)
 		if (this.processedCallInvites.has(callId)) {
-			// console.log("🚫 DUPLICATE CALL INVITE (already processed)");
-			// console.log("═══════════════════════════════════════════════");
 			return;
 		}
 
-		// Don't notify for our own call initiations
-		const myUserId = this.client?.getUserId();
-		// console.log("🔍 Checking sender - My ID:", myUserId);
-
-		if (sender === myUserId) {
-			// console.log("🚫 OWN CALL INVITE (not showing notification to myself)");
-			// console.log("═══════════════════════════════════════════════");
+		if (sender === this.client?.getUserId()) {
 			this.processedCallInvites.add(callId);
 			return;
 		}
 
-		// Check if this is a LiveKit group call (custom field)
 		const isGroupCall = content.is_group_call === true;
 		const isVideo = this.isVideoCallInvite(content);
 
-		if (isGroupCall) {
-			// console.log("✅ LIVEKIT GROUP CALL DETECTED!");
-			// console.log("📞 From:", sender);
-			// console.log("📞 To me:", myUserId);
-			// console.log("🎥 Is Video:", isVideo);
-			// console.log("🏠 Element Call room:", callRoomId);
-
-			// Mark as processed BEFORE triggering event
-			this.processedCallInvites.add(callId);
-			// console.log("✅ Marked as processed (won't process again)");
-
-			// Use CallManager directly (clean architecture!)
-			// console.log("🔔 CALLING CallManager.receiveCall()");
-			// console.log("═══════════════════════════════════════════════");
-
-			callManager.receiveCall(
-				callRoomId,
-				isVideo,
-				callId,
-				sender,
-				true,
-				room.roomId
-			);
-			return;
-		}
-
-		// console.log("✅ VALID NEW INCOMING CALL (Matrix WebRTC)!");
-		// console.log("📞 From:", sender);
-		// console.log("📞 To me:", myUserId);
-
-		// Mark as processed BEFORE triggering event
 		this.processedCallInvites.add(callId);
-		// console.log("✅ Marked as processed (won't process again)");
-
-		// Use CallManager directly (clean architecture!)
-		// console.log("🔔 CALLING CallManager.receiveCall()");
-		// console.log("═══════════════════════════════════════════════");
 
 		callManager.receiveCall(
-			room.roomId,
-			this.isVideoCallInvite(content),
+			isGroupCall ? callRoomId : room.roomId,
+			isVideo,
 			callId,
 			sender,
-			false,
+			isGroupCall,
 			room.roomId
 		);
 	}
 
-	/**
-	 * Handle m.call.answer events.
-	 */
 	private handleCallAnswer(event: MatrixEvent, room: Room): void {
-		const sender = event.getSender();
 		const content = event.getContent();
-		const callId = content.call_id;
-
-		// console.log("📞 Call answered by", sender, "in room", room.roomId);
 
 		this.triggerEvent('callAnswered', {
 			roomId: room.roomId,
-			sender: sender,
-			callId: callId
+			sender: event.getSender(),
+			callId: content.call_id
 		});
 	}
 
-	/**
-	 * Handle m.call.hangup events.
-	 */
-	private handleCallHangup(event: MatrixEvent, room: Room): void {
-		const sender = event.getSender();
-		const content = event.getContent();
-		const callId = content.call_id;
-		const eventTimestamp = event.getTs();
-		const now = Date.now();
-		const ageSeconds = Math.floor((now - eventTimestamp) / 1000);
+	private handleCallHangup(event: MatrixEvent, _room: Room): void {
+		const ageSeconds = Math.floor((Date.now() - event.getTs()) / 1000);
 
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📴 CALL HANGUP EVENT RECEIVED");
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📞 Call ID:", callId);
-		// console.log("👤 Sender:", sender);
-		// console.log("🏠 Room:", room.roomId);
-		// console.log("⏰ Event timestamp:", new Date(eventTimestamp).toISOString());
-		// console.log("⏱️  Age:", ageSeconds, "seconds old");
-		// console.log("═══════════════════════════════════════════════");
-
-		// CRITICAL: Ignore old hangup events (> 10 seconds = from history!)
 		if (ageSeconds > 10) {
-			// console.log("🚫 IGNORING OLD HANGUP EVENT (from history, not a new hangup!)");
-			// console.log("═══════════════════════════════════════════════");
 			return;
 		}
 
-		// console.log("✅ VALID NEW HANGUP EVENT!");
-		// console.log("📴 Call ended by", sender);
-		// console.log("═══════════════════════════════════════════════");
-
-		// Use CallManager directly (clean architecture!)
-		// console.log("🔔 CALLING CallManager.endCall()");
 		callManager.endCall();
 	}
 
-	/**
-	 * Register a callback for a specific event type.
-	 * This allows components to listen to Matrix events.
-	 */
 	public on(eventType: string, callback: (event: any) => void): void {
 		if (!this.eventCallbacks.has(eventType)) {
 			this.eventCallbacks.set(eventType, new Set());
 		}
 		this.eventCallbacks.get(eventType)!.add(callback);
-
-		// console.log(`📡 Registered callback for event type: ${eventType}`);
 	}
 
-	/**
-	 * Unregister a callback for a specific event type.
-	 */
 	public off(eventType: string, callback: (event: any) => void): void {
-		const callbacks = this.eventCallbacks.get(eventType);
-		if (callbacks) {
-			callbacks.delete(callback);
-		}
+		this.eventCallbacks.get(eventType)?.delete(callback);
 	}
 
-	/**
-	 * Trigger an event to all registered callbacks.
-	 */
 	private triggerEvent(eventType: string, eventData: any): void {
 		const callbacks = this.eventCallbacks.get(eventType);
-		if (callbacks && callbacks.size > 0) {
-			// console.log(`🔔 Triggering ${callbacks.size} callback(s) for event: ${eventType}`);
-			callbacks.forEach((callback) => {
-				try {
-					callback(eventData);
-				} catch (error) {
-					// console.error(`❌ Error in event callback for ${eventType}:`, error);
-				}
-			});
-		} else {
-			// console.log(`📭 No callbacks registered for event: ${eventType}`);
+		if (!callbacks?.size) {
+			return;
 		}
+
+		callbacks.forEach((callback) => {
+			try {
+				callback(eventData);
+			} catch {
+				// Ignore callback errors so one listener cannot break the bridge.
+			}
+		});
 	}
 
-	/**
-	 * Get the Matrix client instance.
-	 */
 	public getClient(): MatrixClient | null {
 		return this.client;
 	}
 
-	/**
-	 * Check if the bridge is initialized.
-	 */
 	public isInitialized(): boolean {
 		return this.initialized;
 	}
 
-	/**
-	 * Clean up and remove all listeners.
-	 */
 	public destroy(): void {
 		if (this.client) {
 			this.client.removeAllListeners('Room.timeline' as any);
-			this.client.removeAllListeners('sync' as any);
 		}
 		this.eventCallbacks.clear();
 		this.initialized = false;
 		this.client = null;
-
-		// console.log("🧹 MatrixLiveEventBridge destroyed");
 	}
 }
 
-// Singleton instance
 export const matrixLiveEventBridge = new MatrixLiveEventBridge();

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -76,11 +76,8 @@ export class MatrixLiveEventBridge {
 	}
 
 	private isVideoCallInvite(content: Record<string, any>): boolean {
-		if (content.is_video === true) {
-			return true;
-		}
-		if (content.is_video === false) {
-			return false;
+		if (typeof content.is_video === 'boolean') {
+			return content.is_video;
 		}
 
 		const sdp = content.offer?.sdp;

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -120,6 +120,26 @@ export class MatrixLiveEventBridge {
 	}
 
 	/**
+	 * Determine whether a call invite is for video or audio-only.
+	 */
+	private isVideoCallInvite(content: Record<string, any>): boolean {
+		if (content.is_video === true) {
+			return true;
+		}
+		if (content.is_video === false) {
+			return false;
+		}
+
+		const sdp = content.offer?.sdp;
+		if (typeof sdp === 'string' && sdp.length > 0) {
+			// Voice-only Matrix WebRTC offers omit video or set m=video port 0.
+			return /\nm=video [1-9]/.test(sdp);
+		}
+
+		return false;
+	}
+
+	/**
 	 * Handle m.call.invite events (incoming calls).
 	 */
 	private handleCallInvite(event: MatrixEvent, room: Room): void {
@@ -170,7 +190,7 @@ export class MatrixLiveEventBridge {
 
 		// Check if this is a LiveKit group call (custom field)
 		const isGroupCall = content.is_group_call === true;
-		const isVideo = content.is_video !== false; // Default to video
+		const isVideo = this.isVideoCallInvite(content);
 
 		if (isGroupCall) {
 			// console.log("✅ LIVEKIT GROUP CALL DETECTED!");
@@ -212,7 +232,7 @@ export class MatrixLiveEventBridge {
 
 		callManager.receiveCall(
 			room.roomId,
-			true, // Assume video for now (can be enhanced)
+			this.isVideoCallInvite(content),
 			callId,
 			sender,
 			false,


### PR DESCRIPTION
## Summary
- Open the group call popup in the center of the viewport instead of the bottom-right corner.
- Recenter the widget on window resize for desktop layouts.
- Keep existing mobile full-screen and compact behavior unchanged.
- Change Audio call behavior to only Audio calls

## Test plan
- [ ] Start or receive a group call on desktop and confirm the call box opens centered on screen.
- [ ] Resize the browser window during an active group call and confirm the widget stays centered.
- [ ] Verify mobile view still opens full screen and compact mode still docks to the bottom-right.
- [ ] Confirm the call box can still be dragged by the top handle after opening.


Made with [Cursor](https://cursor.com)