### PR TITLE
fix: truncate messagePreview to 100 chars before notification endpoint

### DIFF
--- a/src/api/apiSendMessage.ts
+++ b/src/api/apiSendMessage.ts
@@ -8,7 +8,7 @@ export const apiSendMessage = (
 	sendMailNotification: boolean,
 	isEncrypted: boolean,
 	sessionId?: number,
-	matrixRoomId?: string,  // NEW: Accept Matrix room ID directly
+	matrixRoomId?: string, // NEW: Accept Matrix room ID directly
 	threadRootId?: string | null,
 	supervisorMessage?: boolean,
 	senderDisplayName?: string | null,
@@ -17,60 +17,63 @@ export const apiSendMessage = (
 	// MATRIX MIGRATION: Use Matrix SDK directly for INSTANT local echo (like Element!)
 	if (sessionId && matrixRoomId) {
 		// console.log('🚀 MATRIX: Sending message via Matrix SDK for INSTANT sync');
-		
+
 		// Get Matrix client
 		const matrixClientService = (window as any).matrixClientService;
-		
+
 		if (matrixClientService) {
 			const client = matrixClientService.getClient();
-			
+
 			if (client) {
 				// console.log('✅ Sending via Matrix SDK to room:', matrixRoomId);
-				
+
 				// Send via Matrix SDK (this gives INSTANT local echo!)
-				return (client as any).sendMessage(matrixRoomId, {
-					msgtype: 'm.text',
-					body: messageData
-				}).then((response: any) => {
-					// console.log('✅ Matrix SDK send complete - Room.timeline will fire INSTANTLY!');
-					
-					// The Room.timeline event fires IMMEDIATELY with the sent message!
-					// This is how Element achieves instant sync!
-					
-					apiPostMessageEventNotification({
-						roomId: matrixRoomId,
-						messagePreview: messageData,
-						matrixRoom: true,
-						threadRootId: threadRootId || null,
-						supervisorMessage: !!supervisorMessage,
-						senderDisplayName: senderDisplayName || null,
-						threadParentPreview: threadParentPreview || null
-					}).catch(() => undefined);
-					return { success: true, event_id: response.event_id };
-				}).catch((error: any) => {
-					// console.error('❌ Matrix SDK send failed, using REST API fallback:', error);
-					const matrixUrl = `${apiUrl}/service/matrix/sessions/${sessionId}/messages`;
-					return fetchData({
-						url: matrixUrl,
-						method: FETCH_METHODS.POST,
-						bodyData: JSON.stringify({ message: messageData }),
-						responseHandling: []
-					}).then((fallbackResponse) => {
+				return (client as any)
+					.sendMessage(matrixRoomId, {
+						msgtype: 'm.text',
+						body: messageData
+					})
+					.then((response: any) => {
+						// console.log('✅ Matrix SDK send complete - Room.timeline will fire INSTANTLY!');
+
+						// The Room.timeline event fires IMMEDIATELY with the sent message!
+						// This is how Element achieves instant sync!
+
 						apiPostMessageEventNotification({
 							roomId: matrixRoomId,
-							messagePreview: messageData,
+							messagePreview: messageData?.substring(0, 100),
 							matrixRoom: true,
 							threadRootId: threadRootId || null,
 							supervisorMessage: !!supervisorMessage,
 							senderDisplayName: senderDisplayName || null,
 							threadParentPreview: threadParentPreview || null
 						}).catch(() => undefined);
-						return fallbackResponse;
+						return { success: true, event_id: response.event_id };
+					})
+					.catch((error: any) => {
+						// console.error('❌ Matrix SDK send failed, using REST API fallback:', error);
+						const matrixUrl = `${apiUrl}/service/matrix/sessions/${sessionId}/messages`;
+						return fetchData({
+							url: matrixUrl,
+							method: FETCH_METHODS.POST,
+							bodyData: JSON.stringify({ message: messageData }),
+							responseHandling: []
+						}).then((fallbackResponse) => {
+							apiPostMessageEventNotification({
+								roomId: matrixRoomId,
+								messagePreview: messageData?.substring(0, 100),
+								matrixRoom: true,
+								threadRootId: threadRootId || null,
+								supervisorMessage: !!supervisorMessage,
+								senderDisplayName: senderDisplayName || null,
+								threadParentPreview: threadParentPreview || null
+							}).catch(() => undefined);
+							return fallbackResponse;
+						});
 					});
-				});
 			}
 		}
-		
+
 		// Fallback: Use REST API if Matrix client not available
 		// console.log('⚠️ Matrix client not available, using REST API fallback');
 		const matrixUrl = `${apiUrl}/service/matrix/sessions/${sessionId}/messages`;
@@ -83,7 +86,7 @@ export const apiSendMessage = (
 			// console.log('🚀 MATRIX: Message sent via REST API:', response);
 			apiPostMessageEventNotification({
 				roomId: matrixRoomId,
-				messagePreview: messageData,
+				messagePreview: messageData?.substring(0, 100),
 				matrixRoom: true,
 				threadRootId: threadRootId || null,
 				supervisorMessage: !!supervisorMessage,

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -381,7 +381,7 @@ export const NotificationsCenter = () => {
 			if (selectedRoomRef) {
 				void apiPostMessageEventNotification({
 					roomId: selectedRoomRef,
-					messagePreview: cleanMessage,
+					messagePreview: cleanMessage?.substring(0, 100),
 					matrixRoom: selectedRoomRef.startsWith('!'),
 					threadRootId: selectedThreadRootId || null,
 					supervisorMessage: false,


### PR DESCRIPTION
## What
- Truncated `messagePreview` to 100 characters in `apiSendMessage.ts` (3 call sites) and `NotificationsCenter.tsx` (1 call site) before passing to `apiPostMessageEventNotification()`

## Why
Closes #168 — full counselling message text was being sent as `messagePreview` to the UserService notification endpoint without truncation, causing complete session content to appear in API logs in plaintext.

## Test
- [ ] Send a message longer than 100 chars — confirm notification payload contains only the first 100 chars
- [ ] Confirm no console errors in browser during message send