### PR TITLE
fix: add 30s default timeout to fetchData

### DIFF
--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -131,11 +131,9 @@ export const fetchData = ({
 						}
 					: null;
 
-		let controller;
-		controller = new AbortController();
-		if (timeout) {
-			setTimeout(() => controller.abort(), timeout);
-		}
+		const controller = new AbortController();
+		const timeoutMs = timeout ?? 30_000;
+		setTimeout(() => controller.abort(), timeoutMs);
 		if (signal) {
 			signal.addEventListener('abort', () => controller.abort());
 		}


### PR DESCRIPTION
## What
- Added const timeoutMs = timeout ?? 30_000 default in src/api/fetchData.ts
- Cleaned up dead let controller pattern to const

## Why
Closes #175 — fetchData had timeout as optional with no default. All callers that omit it could hang indefinitely on network failure or a slow API response. 30s default ensures requests fail gracefully.

## Test
- [x] Throttle network in devtools to Slow 3G, trigger any API call — confirm it fails with TIMEOUT error after ~30s rather than hanging forever