### PR TITLE
fix: proxy server crash on unhandledRejection

### DIFF
--- a/proxy/server.js
+++ b/proxy/server.js
@@ -9,7 +9,7 @@ dotenvExpand(dotenv.config());
 app.disable('x-powered-by');
 
 process.on('unhandledRejection', (err) => {
-	throw err;
+	console.error('Unhandled promise rejection in proxy server:', err);
 });
 
 const port = parseInt(process.env.PORT, 10) || 3000;


### PR DESCRIPTION
## What
- Changed process.on('unhandledRejection') handler in proxy/server.js to log the error instead of re-throwing it

## Why
Closes #174 — re-throwing inside unhandledRejection crashes the entire Node.js process. One failed promise kills the pod for all connected users. Logging keeps the server alive and surfaces the error without a full crash.

## Test
- [x] Simulate an unhandled rejection in the proxy — confirm the server stays up and logs the error