### PR TITLE
fix: enquiry search toolbar for councelors + idle state grphics

### DIFF
--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -566,185 +566,218 @@ export const SessionMenu = (props: SessionMenuProps) => {
 						/>
 					</span>
 
-				{props.showMobileEndAnonymousChatAction && (
-					<div
-						className={`sessionMenu__item sessionMenu__item--mobile ${
-							props.mobileEndAnonymousChatDisabled
-								? 'sessionMenu__item--disabled'
-								: ''
-						}`}
-						onClick={() => {
-							if (props.mobileEndAnonymousChatDisabled) {
-								return;
-							}
-							setFlyoutOpen(false);
-							props.onMobileEndAnonymousChatAction?.();
-						}}
-						data-cy="session-menu-end-anonymous-chat"
-					>
-						{translate(
-							'sessionHeader.anonymous.endChat.label',
-							'End chat'
-						)}
-					</div>
-				)}
-
-				{props.showMobileDeleteAnonymousAccountAction && (
-					<div
-						id="flyout"
-						className={`sessionMenu__content ${
-							flyoutOpen && 'sessionMenu__content--open'
-						}`}
-					>
-						{/* REMOVED: Mobile dropdown video call items - now using desktop buttons on mobile too */}
-						{false && hasVideoCallFeatures() && (
-							<>
-								<div
-									className="sessionMenu__item sessionMenu__item--mobile"
-									onClick={() => handleStartVideoCall(true)}
-								>
-									{translate(
-										'videoCall.button.startVideoCall'
-									)}
-								</div>
-								<div
-									className="sessionMenu__item sessionMenu__item--mobile"
-									onClick={() => handleStartVideoCall()}
-								>
-									{translate('videoCall.button.startCall')}
-								</div>
-							</>
-						)}
-
-						{props.isAskerInfoAvailable && (
-							<Link
-								className="sessionMenu__item"
-								to={userProfileLink}
-							>
-								{translate('chatFlyout.askerProfil')}
-							</Link>
-						)}
-
-						{props.showMobileSupervisionAction && (
-							<div
-								className="sessionMenu__item sessionMenu__item--mobile"
-								onClick={() => {
-									setFlyoutOpen(false);
-									props.onMobileSupervisionAction?.();
-								}}
-							>
-								{translate(
-									'sessionHeader.supervisor.modal.title',
-									'Supervisor verwalten'
-								)}
-							</div>
-						)}
-
-						{props.showMobileDeleteAnonymousAccountAction && (
-							<div
-								className={`sessionMenu__item sessionMenu__item--mobile ${
-									props.mobileDeleteAnonymousAccountDisabled
-										? 'sessionMenu__item--disabled'
-										: ''
-								}`}
-								onClick={() => {
-									if (
-										props.mobileDeleteAnonymousAccountDisabled
-									) {
-										return;
-									}
-									setFlyoutOpen(false);
-									props.onMobileDeleteAnonymousAccountAction?.();
-								}}
-							>
-								{translate(
-									'sessionHeader.anonymous.deleteAccount.label',
-									'Konto löschen'
-								)}
-							</div>
-						)}
-
-						{!hasUserAuthority(
-							AUTHORITIES.ASKER_DEFAULT,
-							userData
-						) &&
-							type !== SESSION_LIST_TYPES.ENQUIRY &&
-							activeSession.isSession &&
-							!props.isSupervisor && (
+					{props.showMobileEndAnonymousChatAction && (
+						<div
+							className={`sessionMenu__item sessionMenu__item--mobile ${
+								props.mobileEndAnonymousChatDisabled
+									? 'sessionMenu__item--disabled'
+									: ''
+							}`}
+							onClick={() => {
+								if (props.mobileEndAnonymousChatDisabled) {
+									return;
+								}
+								setFlyoutOpen(false);
+								props.onMobileEndAnonymousChatAction?.();
+							}}
+							data-cy="session-menu-end-anonymous-chat"
+						>
+							{translate(
+								'sessionHeader.anonymous.endChat.label',
+								'End chat'
+							)}
+						</div>
+					)}
+					{props.showMobileDeleteAnonymousAccountAction && (
+						<div
+							id="flyout"
+							className={`sessionMenu__content ${
+								flyoutOpen && 'sessionMenu__content--open'
+							}`}
+						>
+							{/* REMOVED: Mobile dropdown video call items - now using desktop buttons on mobile too */}
+							{false && hasVideoCallFeatures() && (
 								<>
-									{sessionListTab !==
-									SESSION_LIST_TAB_ARCHIVE ? (
-										<div
-											onClick={handleArchiveSession}
-											className="sessionMenu__item"
-										>
-											{translate('chatFlyout.archive')}
-										</div>
-									) : (
-										<div
-											onClick={handleDearchiveSession}
-											className="sessionMenu__item"
-										>
-											{translate('chatFlyout.dearchive')}
-										</div>
-									)}
+									<div
+										className="sessionMenu__item sessionMenu__item--mobile"
+										onClick={() =>
+											handleStartVideoCall(true)
+										}
+									>
+										{translate(
+											'videoCall.button.startVideoCall'
+										)}
+									</div>
+									<div
+										className="sessionMenu__item sessionMenu__item--mobile"
+										onClick={() => handleStartVideoCall()}
+									>
+										{translate(
+											'videoCall.button.startCall'
+										)}
+									</div>
 								</>
 							)}
 
-						{hasUserAuthority(
-							AUTHORITIES.CONSULTANT_DEFAULT,
-							userData
-						) &&
-							type !== SESSION_LIST_TYPES.ENQUIRY &&
-							activeSession.isSession &&
-							!props.isSupervisor && (
-								<DeleteSession
-									chatId={activeSession.item.id}
-									onSuccess={onSuccessDeleteSession}
+							{props.isAskerInfoAvailable && (
+								<Link
+									className="sessionMenu__item"
+									to={userProfileLink}
 								>
-									{(onClick) => (
-										<div
-											onClick={onClick}
-											className="sessionMenu__item"
-										>
-											{translate('chatFlyout.remove')}
-										</div>
-									)}
-								</DeleteSession>
+									{translate('chatFlyout.askerProfil')}
+								</Link>
 							)}
 
-						{activeSession.isGroup && (
-							<SessionMenuFlyoutGroup
-								editGroupChatSettingsLink={
-									editGroupChatSettingsLink
-								}
-								groupChatInfoLink={groupChatInfoLink}
-								handleLeaveGroupChat={handleLeaveGroupChat}
-								handleStopGroupChat={handleStopGroupChat}
-								bannedUsers={props.bannedUsers}
-							/>
-						)}
+							{props.showMobileSupervisionAction && (
+								<div
+									className="sessionMenu__item sessionMenu__item--mobile"
+									onClick={() => {
+										setFlyoutOpen(false);
+										props.onMobileSupervisionAction?.();
+									}}
+								>
+									{translate(
+										'sessionHeader.supervisor.modal.title',
+										'Supervisor verwalten'
+									)}
+								</div>
+							)}
 
-						<div className="legalInformationLinks--menu">
-							<LegalLinks
-								legalLinks={legalLinks}
-								params={{ aid: activeSession?.agency?.id }}
-							>
-								{(label, url) => (
-									<a
-										href={url}
-										target="_blank"
-										rel="noreferrer"
-									>
-										<Text
-											type="infoLargeAlternative"
-											text={label}
-										/>
-									</a>
+							{props.showMobileEndAnonymousChatAction && (
+								<div
+									className={`sessionMenu__item sessionMenu__item--mobile ${
+										props.mobileEndAnonymousChatDisabled
+											? 'sessionMenu__item--disabled'
+											: ''
+									}`}
+									onClick={() => {
+										if (
+											props.mobileEndAnonymousChatDisabled
+										) {
+											return;
+										}
+										setFlyoutOpen(false);
+										props.onMobileEndAnonymousChatAction?.();
+									}}
+									data-cy="session-menu-end-anonymous-chat"
+								>
+									{translate(
+										'sessionHeader.anonymous.endChat.label',
+										'End chat'
+									)}
+								</div>
+							)}
+
+							{props.showMobileDeleteAnonymousAccountAction && (
+								<div
+									className={`sessionMenu__item sessionMenu__item--mobile ${
+										props.mobileDeleteAnonymousAccountDisabled
+											? 'sessionMenu__item--disabled'
+											: ''
+									}`}
+									onClick={() => {
+										if (
+											props.mobileDeleteAnonymousAccountDisabled
+										) {
+											return;
+										}
+										setFlyoutOpen(false);
+										props.onMobileDeleteAnonymousAccountAction?.();
+									}}
+								>
+									{translate(
+										'sessionHeader.anonymous.deleteAccount.label',
+										'Konto löschen'
+									)}
+								</div>
+							)}
+
+							{!hasUserAuthority(
+								AUTHORITIES.ASKER_DEFAULT,
+								userData
+							) &&
+								type !== SESSION_LIST_TYPES.ENQUIRY &&
+								activeSession.isSession &&
+								!props.isSupervisor && (
+									<>
+										{sessionListTab !==
+										SESSION_LIST_TAB_ARCHIVE ? (
+											<div
+												onClick={handleArchiveSession}
+												className="sessionMenu__item"
+											>
+												{translate(
+													'chatFlyout.archive'
+												)}
+											</div>
+										) : (
+											<div
+												onClick={handleDearchiveSession}
+												className="sessionMenu__item"
+											>
+												{translate(
+													'chatFlyout.dearchive'
+												)}
+											</div>
+										)}
+									</>
 								)}
-							</LegalLinks>
+
+							{hasUserAuthority(
+								AUTHORITIES.CONSULTANT_DEFAULT,
+								userData
+							) &&
+								type !== SESSION_LIST_TYPES.ENQUIRY &&
+								activeSession.isSession &&
+								!props.isSupervisor && (
+									<DeleteSession
+										chatId={activeSession.item.id}
+										onSuccess={onSuccessDeleteSession}
+									>
+										{(onClick) => (
+											<div
+												onClick={onClick}
+												className="sessionMenu__item"
+											>
+												{translate('chatFlyout.remove')}
+											</div>
+										)}
+									</DeleteSession>
+								)}
+
+							{activeSession.isGroup && (
+								<SessionMenuFlyoutGroup
+									editGroupChatSettingsLink={
+										editGroupChatSettingsLink
+									}
+									groupChatInfoLink={groupChatInfoLink}
+									handleLeaveGroupChat={handleLeaveGroupChat}
+									handleStopGroupChat={handleStopGroupChat}
+									bannedUsers={props.bannedUsers}
+								/>
+							)}
+
+							<div className="legalInformationLinks--menu">
+								<LegalLinks
+									legalLinks={legalLinks}
+									params={{ aid: activeSession?.agency?.id }}
+								>
+									{(label, url) => (
+										<a
+											href={url}
+											target="_blank"
+											rel="noreferrer"
+										>
+											<Text
+												type="infoLargeAlternative"
+												text={label}
+											/>
+										</a>
+									)}
+								</LegalLinks>
+							</div>
 						</div>
-					</div>
+					)}
 				</>
 			)}
 			{overlayActive && (

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -1188,7 +1188,9 @@ export const SessionsList = ({
 		type === SESSION_LIST_TYPES.MY_SESSION &&
 		!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
 
-	const showMySessionToolbar = type === SESSION_LIST_TYPES.MY_SESSION;
+	const showMySessionToolbar =
+		type === SESSION_LIST_TYPES.MY_SESSION ||
+		type === SESSION_LIST_TYPES.ENQUIRY;
 	/**
 	 * Enquiry tab gets its own compact chip row (Chats + Live Chat). It
 	 * shares the same `sessionToolbarChip` state as the Gespräch toolbar so
@@ -1502,14 +1504,14 @@ export const SessionsList = ({
 
 	return (
 		<div className="sessionsList__innerWrapper">
-			{showEnquiryFilterChips && (
+			{/* {showEnquiryFilterChips && (
 				<EnquiryFilterChips
 					translate={translate}
 					activeChip={sessionToolbarChip}
 					onChipToggle={handleToolbarChipToggle}
 					showLiveChatChip={liveChatAvailable}
 				/>
-			)}
+			)} */}
 			{showMySessionToolbar && (
 				<SessionsListToolbar
 					translate={translate}

--- a/src/components/sessionsList/SessionsListWrapper.tsx
+++ b/src/components/sessionsList/SessionsListWrapper.tsx
@@ -62,17 +62,6 @@ export const SessionsListWrapper = ({
 					position: 'relative'
 				}}
 			>
-				<div
-					className="sessionsList__header"
-					data-cy="session-list-header"
-				>
-					<h2
-						className="sessionsList__headline"
-						data-cy="session-list-headline"
-					>
-						{translate('sessionList.user.headline')}
-					</h2>
-				</div>
 				<SessionsList
 					defaultLanguage={fixedLanguages[0]}
 					sessionTypes={sessionTypes}
@@ -95,20 +84,6 @@ export const SessionsListWrapper = ({
 				position: 'relative'
 			}}
 		>
-			{type !== SESSION_LIST_TYPES.MY_SESSION && (
-				<div
-					className="sessionsList__header"
-					data-cy="session-list-header"
-				>
-					<h2
-						className="sessionsList__headline"
-						data-cy="session-list-headline"
-					>
-						{translate('sessionList.preview.headline')}
-					</h2>
-					<div className="sessionMenuPlaceholder"></div>
-				</div>
-			)}
 			<SessionsList
 				defaultLanguage={fixedLanguages[0]}
 				sessionTypes={sessionTypes}


### PR DESCRIPTION
## Summary

- **[#152 — Enquiry search](https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/152):** Add the session list search toolbar to the Anfragen (enquiry) tab for counselors, consistent with the Gespräche list. Clients do not see search on Anfragen; on their allowed lists they get a stripped-down text-only search without extra filter labels/chips.
- **[#151 — Idle state graphics](https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/151):** Replace outdated, misaligned empty/idle placeholders with the updated design assets and layout (session list empty state + no-session-selected view).

## Related issues

- https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/151
- https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/152

## Test plan

### Counselor — Anfragen (#152)
- [ ] Log in as counselor → open **Anfragen**
- [ ] Search bar is visible and matches Gespräche styling/behavior
- [ ] Text search filters enquiries as expected
- [ ] People/filter chips work where applicable (neu, 1:1, groups, live chat, etc.)
- [ ] Empty search/filter result shows the correct empty message

### Client — search limits (#152)
- [ ] Log in as client → open **Anfragen** → **no search field** is shown
- [ ] Open **Gespräche** (or client chat list) → search is **text-only** (no extra labels/chips)
- [ ] Search only matches allowed session content; no consultant-only filters leak through

### Idle / empty states (#151)
- [ ] Counselor: open session list with no items → illustration + text centered and aligned
- [ ] Client: same empty-list states render correctly on mobile and desktop
- [ ] No session selected (idle chat pane) → updated placeholder graphic and copy alignment
- [ ] Archive / enquiry / my-sessions empty variants still show correct headlines

### Regression
- [ ] Session list scrolling, resize handle, and item selection still work
- [ ] No console errors or layout shift when toggling search dropdown

## Screenshots
<img width="1545" height="897" alt="image" src="https://github.com/user-attachments/assets/8c5db01f-0458-41a9-a358-a807209ea003" />
<img width="1272" height="935" alt="image" src="https://github.com/user-attachments/assets/6dac1764-e693-41d4-9005-1102798839ed" />

