### PR TITLE
FE-H03 disable unauthenticated livekit token proxy endpoints

### DIFF
--- a/proxy/server.js
+++ b/proxy/server.js
@@ -42,42 +42,14 @@ const createServer = async () => {
 
 	app.use((await import('compression')).default());
 
-	// LiveKit Token Service Proxy
-	app.get('/api/livekit/token', async (req, res) => {
-		try {
-			console.log('🔑 Proxying LiveKit token request:', req.query);
-			const { roomName, identity } = req.query;
-
-			if (!roomName || !identity) {
-				return res
-					.status(400)
-					.json({ error: 'roomName and identity are required' });
-			}
-
-			const livekitTokenServiceBase = (
-				process.env.LIVEKIT_TOKEN_SERVICE_URL || ''
-			).replace(/\/+$/, '');
-			if (!livekitTokenServiceBase) {
-				return res.status(503).json({
-					error: 'LIVEKIT_TOKEN_SERVICE_URL is not configured'
-				});
-			}
-			const targetUrl = `${livekitTokenServiceBase}/api/livekit/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(identity)}`;
-
-			console.log('📡 Fetching from:', targetUrl);
-
-			const response = await fetch(targetUrl);
-			const data = await response.json();
-
-			console.log('✅ Token received, forwarding to client');
-			res.json(data);
-		} catch (error) {
-			console.error('❌ LiveKit token proxy error:', error);
-			res.status(500).json({
-				error: 'Failed to get LiveKit token',
-				details: error.message
-			});
-		}
+	// LiveKit Token Service Proxy — endpoint deprecated.
+	// Active group calls use Matrix/Element Call (livekit.oriso-dev.site/livekit/jwt).
+	// This proxy endpoint is unauthenticated and the only in-repo consumer
+	// (liveKitService.ts) is not imported anywhere. Disabled to close the attack surface.
+	app.get('/api/livekit/token', (_req, res) => {
+		res.status(410).json({
+			error: 'This endpoint has been removed. Use the Matrix video call flow.'
+		});
 	});
 
 	const serveStatic = await import('serve-static');
@@ -103,31 +75,10 @@ const createServer = async () => {
 	);
 	app.use(serveStatic.default(buildPath, { index: 'beratung-hilfe.html' }));
 
-	// LiveKit token service proxy
-	app.post('/api/livekit/token', async (req, res) => {
-		try {
-			const livekitTokenServiceBase = (
-				process.env.LIVEKIT_TOKEN_SERVICE_URL || ''
-			).replace(/\/+$/, '');
-			if (!livekitTokenServiceBase) {
-				return res.status(503).json({
-					error: 'LIVEKIT_TOKEN_SERVICE_URL is not configured'
-				});
-			}
-			const response = await fetch(
-				`${livekitTokenServiceBase}/api/livekit/token`,
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(req.body)
-				}
-			);
-			const data = await response.json();
-			res.json(data);
-		} catch (error) {
-			console.error('LiveKit token proxy error:', error);
-			res.status(500).json({ error: 'Failed to generate token' });
-		}
+	app.post('/api/livekit/token', (_req, res) => {
+		res.status(410).json({
+			error: 'This endpoint has been removed. Use the Matrix video call flow.'
+		});
 	});
 
 	const middlewareConfigs = require('./routes')(storagePath);


### PR DESCRIPTION
## What
- Replaced the LiveKit token proxy GET and POST handlers in \proxy/server.js\ with \410 Gone\ responses
- Removed all debug \console.log\ statements from the proxy file
- Added explanatory comment: the only in-repo consumer (\liveKitService.ts\) is dead code — not imported anywhere

## Why
The LiveKit token proxy was publicly accessible with no authentication — any request could obtain a valid LiveKit room token. Active group calls already use the Matrix/Element Call flow (\livekit.oriso-dev.site/livekit/jwt\). Closing the endpoint eliminates the attack surface. Part of security audit finding FE-H03.

## Test
- [ ] \GET /api/livekit/token\ returns \410 Gone\ with JSON error message
- [ ] \POST /api/livekit/token\ returns \410 Gone\ with JSON error message
- [ ] Group video calls via Matrix/Element Call still work normally (unaffected — different endpoint)