### PR TITLE
[codex] Fix public topics auth header

### DIFF
--- a/src/api/apiGetTopicsData.ts
+++ b/src/api/apiGetTopicsData.ts
@@ -9,11 +9,12 @@ export const apiGetTopicsData = async (): Promise<TopicsDataInterface[]> => {
 		url: url,
 		rcValidation: false,
 		responseHandling: [FETCH_ERRORS.EMPTY],
-		method: FETCH_METHODS.GET
+		method: FETCH_METHODS.GET,
+		skipAuth: true
 	}).catch((error) => {
 		if (error.message === FETCH_ERRORS.EMPTY) {
 			return [];
 		}
-		Promise.reject(error);
+		return Promise.reject(error);
 	});
 };


### PR DESCRIPTION
## Problem

Fixes #226.

The login page can render as a blank white screen when the browser has a stale or invalid `keycloak` cookie. During login bootstrapping, the frontend fetches public topic data from `/service/topic/public/`, but `fetchData` automatically attaches the stale bearer token unless the caller opts out. The API returns `401 Unauthorized` for that stale bearer token and the resulting `UNAUTHORIZED` rejection prevents the login UI from rendering.

## Solution

- Mark `apiGetTopicsData` as `skipAuth: true`, matching the other public bootstrap calls.
- Return the non-`EMPTY` rejection from the catch handler so real loading errors are not swallowed.

## Validation

- Confirmed live API behavior:
  - `GET https://api.oriso.org/service/topic/public/` without auth returns `200`.
  - The same request with `Authorization: Bearer stale-token` returns `401`.
- Ran a targeted `ts-node` regression harness; it fails before the fix because `skipAuth` is unset and passes after the fix.
- `npx eslint src/api/apiGetTopicsData.ts`
- `npx tsc --noEmit --pretty false`

## Notes

Cypress was not used for the committed validation because this checkout's Cypress support bundle fails before spec execution with `process is not defined` while importing `getApiBaseUrl.ts`, and the extension config also excludes the existing login spec. The targeted harness covers the changed API wrapper behavior directly.
