### PR TITLE
fix: add NODE_ENV guards to DevToolbar flags at consummption sites (FE-M10)

### DIFF
--- a/src/components/message/MessageAttachment.tsx
+++ b/src/components/message/MessageAttachment.tsx
@@ -58,7 +58,9 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 	);
 	const audioRef = useRef<HTMLAudioElement | null>(null);
 	const [isAudioPlaying, setIsAudioPlaying] = React.useState(false);
-	const [audioDurationSec, setAudioDurationSec] = React.useState<number | null>(null);
+	const [audioDurationSec, setAudioDurationSec] = React.useState<
+		number | null
+	>(null);
 	const [audioCurrentTimeSec, setAudioCurrentTimeSec] = React.useState(0);
 
 	const decryptFile = useCallback(
@@ -68,9 +70,14 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 				attachmentStatus === DECRYPTION_ERROR
 			)
 				return;
-			const isAttachmentEncryptionEnabledDevTools = parseInt(
-				getDevToolbarOption(STORAGE_KEY_ATTACHMENT_ENCRYPTION)
-			);
+			const isAttachmentEncryptionEnabledDevTools =
+				process.env.NODE_ENV !== 'production'
+					? parseInt(
+							getDevToolbarOption(
+								STORAGE_KEY_ATTACHMENT_ENCRYPTION
+							)
+						)
+					: 1;
 			setAttachmentStatus(IS_DECRYPTING);
 
 			const data = await fetchData({
@@ -169,7 +176,9 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 	}, []);
 
 	// Check if it's an image to display preview
-	const isImage = props.file.type?.startsWith('image/') || props.attachment.type === 'image';
+	const isImage =
+		props.file.type?.startsWith('image/') ||
+		props.attachment.type === 'image';
 	const isAudio = props.file.type?.startsWith('audio/');
 	const imageUrl = isImage ? buildUrl(props.attachment.title_link) : null;
 
@@ -219,7 +228,13 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 	const resolvedDurationSec = durationFromFileName ?? audioDurationSec;
 	const playbackProgress =
 		resolvedDurationSec && resolvedDurationSec > 0
-			? Math.min(100, Math.max(0, (audioCurrentTimeSec / resolvedDurationSec) * 100))
+			? Math.min(
+					100,
+					Math.max(
+						0,
+						(audioCurrentTimeSec / resolvedDurationSec) * 100
+					)
+				)
 			: 0;
 
 	const renderVoiceAttachment = useCallback(
@@ -265,7 +280,9 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 						setAudioCurrentTimeSec(0);
 					}}
 					onTimeUpdate={() => {
-						setAudioCurrentTimeSec(audioRef.current?.currentTime || 0);
+						setAudioCurrentTimeSec(
+							audioRef.current?.currentTime || 0
+						);
 					}}
 					onLoadedMetadata={() => {
 						if (durationFromFileName != null) {
@@ -280,7 +297,9 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 							) {
 								setAudioDurationSec(duration);
 							} else {
-								setAudioDurationSec(getVoiceDurationFromFileName());
+								setAudioDurationSec(
+									getVoiceDurationFromFileName()
+								);
 							}
 						}
 						setAudioCurrentTimeSec(0);
@@ -297,129 +316,168 @@ export const MessageAttachment = (props: MessageAttachmentProps) => {
 			getVoiceDurationFromFileName
 		]
 	);
-	
+
 	return (
 		<>
 			{props.t !== 'e2e' ? (
 				isAudio ? (
 					renderVoiceAttachment(downloadUrl)
 				) : (
-				<a
-					href={downloadUrl}
-					download={props.file.name}
-					rel="noopener noreferrer"
-					className="messageItem__message__attachment"
-					style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
-				>
-					{/* Show image preview for image files */}
-					{isImage && imageUrl && (
-						<div className="messageItem__message__attachment__preview">
-							<img 
-								src={imageUrl} 
-								alt={props.attachment.title}
-							/>
-						</div>
-					)}
-					
-					{/* File info BELOW image */}
-					<div className="messageItem__message__attachment__info">
-						<span className="messageItem__message__attachment__icon">
-							{!isImage && getAttachmentIcon(props.file.type)}
-						</span>
-						<span className="messageItem__message__attachment__title">
-							<p className="messageItem__message__attachment__filename">{props.attachment.title}</p>
-							<p className="messageItem__message__attachment__meta">
-								{translate(
-									ATTACHMENT_TRANSLATE_FOR_TYPE[props.file.type]
-								)}{' '}
-								{props.attachment.image_size
-									? `| ${
-											(
-												getAttachmentSizeMBForKB(
-													props.attachment.image_size * 1000
-												) / 1000
-											).toFixed(2) +
-											translate('attachments.type.label.mb')
-										}`
-									: null}
-							</p>
-						</span>
-					</div>
-				</a>
-				)
-			) : (
-				// Encrypted file - clickable to decrypt/download
-				encryptedFile && attachmentStatus === DECRYPTION_FINISHED ? (
-					isAudio ? (
-						renderVoiceAttachment(encryptedFile)
-					) : (
 					<a
-						href={encryptedFile}
+						href={downloadUrl}
 						download={props.file.name}
 						rel="noopener noreferrer"
 						className="messageItem__message__attachment"
-						style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
+						style={{
+							textDecoration: 'none',
+							color: 'inherit',
+							cursor: 'pointer'
+						}}
 					>
-						{isImage && (
+						{/* Show image preview for image files */}
+						{isImage && imageUrl && (
 							<div className="messageItem__message__attachment__preview">
-								<img src={encryptedFile} alt={props.attachment.title} />
+								<img
+									src={imageUrl}
+									alt={props.attachment.title}
+								/>
 							</div>
 						)}
-						
+
+						{/* File info BELOW image */}
 						<div className="messageItem__message__attachment__info">
 							<span className="messageItem__message__attachment__icon">
 								{!isImage && getAttachmentIcon(props.file.type)}
 							</span>
 							<span className="messageItem__message__attachment__title">
-								<p className="messageItem__message__attachment__filename">{props.attachment.title}</p>
+								<p className="messageItem__message__attachment__filename">
+									{props.attachment.title}
+								</p>
 								<p className="messageItem__message__attachment__meta">
-									{translate(ATTACHMENT_TRANSLATE_FOR_TYPE[props.file.type])}{' '}
+									{translate(
+										ATTACHMENT_TRANSLATE_FOR_TYPE[
+											props.file.type
+										]
+									)}{' '}
 									{props.attachment.image_size
 										? `| ${
 												(
 													getAttachmentSizeMBForKB(
-														Math.floor(
-															(props.attachment.image_size -
-																KEY_ID_LENGTH -
-																MAX_PREFIX_LENGTH -
-																VERSION_SEPERATOR.length -
-																ENCRYPTION_VERSION_ACTIVE.length -
-																100) /
-																2 -
-																VECTOR_LENGTH * 2
-														) * 1000
+														props.attachment
+															.image_size * 1000
 													) / 1000
-												).toFixed(2) + translate('attachments.type.label.mb')
+												).toFixed(2) +
+												translate(
+													'attachments.type.label.mb'
+												)
 											}`
 										: null}
 								</p>
 							</span>
 						</div>
 					</a>
-					)
+				)
+			) : // Encrypted file - clickable to decrypt/download
+			encryptedFile && attachmentStatus === DECRYPTION_FINISHED ? (
+				isAudio ? (
+					renderVoiceAttachment(encryptedFile)
 				) : (
-					<div 
+					<a
+						href={encryptedFile}
+						download={props.file.name}
+						rel="noopener noreferrer"
 						className="messageItem__message__attachment"
-						onClick={() => attachmentStatus === ENCRYPTED && decryptFile(buildUrl(props.attachment.title_link))}
-						style={{ cursor: attachmentStatus === ENCRYPTED ? 'pointer' : 'default' }}
+						style={{
+							textDecoration: 'none',
+							color: 'inherit',
+							cursor: 'pointer'
+						}}
 					>
+						{isImage && (
+							<div className="messageItem__message__attachment__preview">
+								<img
+									src={encryptedFile}
+									alt={props.attachment.title}
+								/>
+							</div>
+						)}
+
 						<div className="messageItem__message__attachment__info">
 							<span className="messageItem__message__attachment__icon">
-								{attachmentStatus === IS_DECRYPTING ? (
-									<LoadingSpinner />
-								) : (
-									getAttachmentIcon(props.file.type)
-								)}
+								{!isImage && getAttachmentIcon(props.file.type)}
 							</span>
 							<span className="messageItem__message__attachment__title">
-								<p className="messageItem__message__attachment__filename">{props.attachment.title}</p>
+								<p className="messageItem__message__attachment__filename">
+									{props.attachment.title}
+								</p>
 								<p className="messageItem__message__attachment__meta">
-									{translate(`e2ee.attachment.${attachmentStatus}`)}
+									{translate(
+										ATTACHMENT_TRANSLATE_FOR_TYPE[
+											props.file.type
+										]
+									)}{' '}
+									{props.attachment.image_size
+										? `| ${
+												(
+													getAttachmentSizeMBForKB(
+														Math.floor(
+															(props.attachment
+																.image_size -
+																KEY_ID_LENGTH -
+																MAX_PREFIX_LENGTH -
+																VERSION_SEPERATOR.length -
+																ENCRYPTION_VERSION_ACTIVE.length -
+																100) /
+																2 -
+																VECTOR_LENGTH *
+																	2
+														) * 1000
+													) / 1000
+												).toFixed(2) +
+												translate(
+													'attachments.type.label.mb'
+												)
+											}`
+										: null}
 								</p>
 							</span>
 						</div>
-					</div>
+					</a>
 				)
+			) : (
+				<div
+					className="messageItem__message__attachment"
+					onClick={() =>
+						attachmentStatus === ENCRYPTED &&
+						decryptFile(buildUrl(props.attachment.title_link))
+					}
+					style={{
+						cursor:
+							attachmentStatus === ENCRYPTED
+								? 'pointer'
+								: 'default'
+					}}
+				>
+					<div className="messageItem__message__attachment__info">
+						<span className="messageItem__message__attachment__icon">
+							{attachmentStatus === IS_DECRYPTING ? (
+								<LoadingSpinner />
+							) : (
+								getAttachmentIcon(props.file.type)
+							)}
+						</span>
+						<span className="messageItem__message__attachment__title">
+							<p className="messageItem__message__attachment__filename">
+								{props.attachment.title}
+							</p>
+							<p className="messageItem__message__attachment__meta">
+								{translate(
+									`e2ee.attachment.${attachmentStatus}`
+								)}
+							</p>
+						</span>
+					</div>
+				</div>
 			)}
 		</>
 	);

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -1872,9 +1872,14 @@ export const MessageSubmitInterfaceComponent = ({
 					}
 				} else {
 					// Legacy RocketChat upload path
-					const isAttachmentEncryptionEnabledDevTools = parseInt(
-						getDevToolbarOption(STORAGE_KEY_ATTACHMENT_ENCRYPTION)
-					);
+					const isAttachmentEncryptionEnabledDevTools =
+						process.env.NODE_ENV !== 'production'
+							? parseInt(
+									getDevToolbarOption(
+										STORAGE_KEY_ATTACHMENT_ENCRYPTION
+									)
+								)
+							: 1;
 					let attachmentFile = attachment;
 					let signature = null;
 					let encryptEnabled =

--- a/src/components/twoFactorAuth/TwoFactorAuth.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.tsx
@@ -125,7 +125,9 @@ export const TwoFactorAuth = () => {
 				apiDeleteTwoFactorAuth()
 					.then(reloadUserData)
 					.then(() => setOverlayActive(false))
-					.catch((error) => { /* console.log(error); */ });
+					.catch((error) => {
+						/* console.log(error); */
+					});
 			}
 		},
 		[reloadUserData]
@@ -343,8 +345,10 @@ export const TwoFactorAuth = () => {
 						type: BUTTON_TYPES.PRIMARY
 					},
 					(!isConsultant ||
-						getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY) ===
-							'1') &&
+						(process.env.NODE_ENV !== 'production' &&
+							getDevToolbarOption(
+								STORAGE_KEY_DISABLE_2FA_DUTY
+							) === '1')) &&
 						userData.twoFactorAuth.isActive && {
 							label: translate(
 								'twoFactorAuth.activate.step1.disable'

--- a/src/components/twoFactorAuth/TwoFactorNag.tsx
+++ b/src/components/twoFactorAuth/TwoFactorNag.tsx
@@ -44,7 +44,9 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 		) {
 			setIsShownTwoFactorNag(true);
 			todaysDate >= settings.twofactor.dateTwoFactorObligatory &&
-			getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY) === '0'
+			(process.env.NODE_ENV !== 'production'
+				? getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY)
+				: '0') === '0'
 				? setMessage(settings.twofactor.messages[1])
 				: setMessage(settings.twofactor.messages[0]);
 		} else {
@@ -66,7 +68,9 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 			let todaysDate = new Date(Date.now());
 			if (
 				todaysDate >= settings.twofactor.dateTwoFactorObligatory &&
-				getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY) === '0'
+				(process.env.NODE_ENV !== 'production'
+					? getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY)
+					: '0') === '0'
 			) {
 				setForceHideTwoFactorNag(false);
 				return;


### PR DESCRIPTION
#### [Issue #232](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/232)

## Summary

Fixes FE-M10: two DevToolbar localStorage flags affected production
behavior without any environment guard at their consumption sites.

## Problem

The DevToolbar UI is hidden in production by default (`showDevTools='0'`),
but the flags it manages are still readable from `localStorage` directly
via browser console — no UI needed. Two flags had no `NODE_ENV` check
at their actual read sites:

- `disable 2fa_duty` — setting to `'1'` in production console allowed
  consultants to bypass the client-side 2FA setup obligation overlay
- `attachement_encryption` — setting to `'0'` in production console
  disabled client-side attachment encryption on the legacy RocketChat path

Note: `e2ee_disabled` was also listed as a concern but already has an
explicit production guard in `e2eeSettings.ts` — not affected.

## Changes Made

Added `process.env.NODE_ENV !== 'production'` guards at all 4 consumption
sites:

- **TwoFactorNag.tsx** (2 sites): `disable 2fa_duty` forced to `'0'`
  in production — 2FA duty enforcement always active
- **TwoFactorAuth.tsx** (1 site): `disable 2fa_duty` check short-circuits
  to `false` in production — consultant cannot see disable button via flag
- **MessageAttachment.tsx** (1 site): `attachement_encryption` forced to
  `1` in production — decryption always attempted for `t=e2e` attachments
- **messageSubmitInterfaceComponent.tsx** (1 site): same — encryption
  always enabled on RocketChat upload path if `isE2eeEnabled`

Using `!== 'production'` rather than `=== 'development'` so guards
work correctly when `NODE_ENV` is undefined in local environments
without explicit `.env` config.

## Testing

- TypeScript: 0 errors
- Production behavior: both flags forced to secure defaults
- Non-production (dev/staging): flags still read from localStorage as before