### PR TITLE
fix(login): self-heal stale Keycloak token on public routes to stop white screen

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -34,4 +34,30 @@ describe('Login', () => {
 		cy.visit('/suchtberatung');
 		cy.contains('Login');
 	});
+
+	it('recovers from a stale auth token instead of showing a blank login screen', () => {
+		// Regression test for the production white screen: a returning user whose
+		// Keycloak access token has expired still has the `keycloak` cookie, so
+		// fetchData sends it as a Bearer token and the public topics endpoint
+		// rejects it with 401. Previously the uncaught UNAUTHORIZED rejection left
+		// #appRoot empty forever (and the stale cookie was never cleared, so every
+		// reload repeated it). The app must now self-heal: clear the stale token,
+		// reload anonymously and render the login form.
+		cy.setCookie('keycloak', 'stale.invalid.token');
+
+		// Mirror the backend: 401 while the stale bearer is sent, 200 once it is
+		// gone. Registered after cy.mockApi() so it takes precedence.
+		cy.intercept('GET', /\/service\/topic\/public\/?$/, (req) => {
+			if (req.headers.authorization) {
+				req.reply({ statusCode: 401, body: {} });
+			} else {
+				req.reply({ statusCode: 200, body: [] });
+			}
+		}).as('publicTopicsWithStaleToken');
+
+		cy.visit('/login');
+
+		cy.get('.loginForm').should('exist');
+		cy.getCookie('keycloak').should('not.exist');
+	});
 });

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -57,6 +57,28 @@ const invalidateStaleAuthSession = () => {
 	removeTokenExpiryFromLocalStorage();
 };
 
+// Guards against repeated reloads when several requests 401 on a public auth
+// route within the same page load. At most one self-healing reload is triggered.
+let staleAuthRecoveryTriggered = false;
+
+// A 401 on a public auth route (login / registration / error pages) means any
+// token we presented is stale or expired. Clear it so the next request is
+// anonymous -- the public endpoints then answer 200 instead of 401. If a stale
+// token was actually sent, reload once to re-bootstrap the app cleanly instead
+// of leaving the user stranded on a blank, crashed page (the uncaught
+// UNAUTHORIZED rejection otherwise prevents the login screen from rendering).
+const recoverFromStaleAuthOnPublicRoute = (
+	hadAuthorization: boolean,
+	reject: (reason?: Error) => void
+) => {
+	invalidateStaleAuthSession();
+	reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
+	if (hadAuthorization && !staleAuthRecoveryTriggered) {
+		staleAuthRecoveryTriggered = true;
+		window.location.reload();
+	}
+};
+
 export class FetchErrorWithOptions extends Error {
 	options = {};
 
@@ -263,20 +285,20 @@ export const fetchData = ({
 						reject(new Error(FETCH_ERRORS.GATEWAY_TIMEOUT));
 					} else if (response.status === 401) {
 						if (isPublicAuthRoute()) {
-							if (!authorization) {
-								invalidateStaleAuthSession();
-							}
-							reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
+							recoverFromStaleAuthOnPublicRoute(
+								Boolean(authorization),
+								reject
+							);
 						} else {
 							logout(true, appConfig.urls.toLogin);
 							reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
 						}
 					}
 				} else if (response.status === 401 && isPublicAuthRoute()) {
-					if (!authorization) {
-						invalidateStaleAuthSession();
-					}
-					reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
+					recoverFromStaleAuthOnPublicRoute(
+						Boolean(authorization),
+						reject
+					);
 				} else {
 					const error = getErrorCaseForStatus(response.status);
 					redirectToErrorPage(error);


### PR DESCRIPTION
Closes #237

## Problem
`app.oriso.org/login` (and `/registration`) shows a **blank white screen** for returning users whose Keycloak access token has expired while the `keycloak` cookie is still present. A clean browser is unaffected — so the outage is invisible from outside and only hits returning users.

Console:
```
GET /service/topic/public/  401 (Unauthorized)     fetchData.ts:176
Uncaught (in promise) Error: UNAUTHORIZED          fetchData.ts:269
```

## Root cause
`fetchData` sends the (stale) `keycloak` cookie as a Bearer token. `/service/topic/public/` returns **200 anonymously** but **401 with a stale Bearer**. The public-route 401 handler introduced in `5dda647` cleared the stale session only **`if (!authorization)`** — the inverted condition — so when a stale token *was* sent it never cleared the cookie and just rejected `UNAUTHORIZED`. That rejection is uncaught → the login bootstrap crashes, and the un-cleared cookie makes it repeat on every reload.

## Fix
`src/api/fetchData.ts` — on a public-route 401:
- **always** `invalidateStaleAuthSession()` (clear the stale `keycloak` cookie + token expiry), and
- if a stale token was actually sent, **reload once** (guarded by a module flag → loop-safe) so the app re-bootstraps anonymously and renders the login form.

This keeps the intent of `5dda647` (no disruptive full-logout redirect on login pages) while actually clearing the stale token. One file, minimal blast radius; existing `reject(UNAUTHORIZED)` contract preserved for callers.

## Test
`cypress/e2e/login.cy.ts` — new regression test: with a stale `keycloak` cookie and `/service/topic/public/` returning 401-while-bearer-present / 200-anonymous, the login form must render and the stale cookie must be cleared (previously `#appRoot` stayed empty).

## Verification
- Reproduced the white screen on the live bundle by injecting a stale `keycloak` cookie (`#appRoot` length 0, uncaught `UNAUTHORIZED`, cookie never cleared).
- Confirmed `/service/topic/public/` → 200 anonymous, 401 with bogus Bearer.
- `tsc --noEmit` clean. Cypress regression test added (CI runs it).

## Follow-ups (separate, defense in depth — not in this PR)
- `apiGetTopicsData.ts`: missing `return` before `Promise.reject(error)` (emits an unhandled rejection and resolves `undefined`).
- `TopicsProvider.tsx`: renders `null` indefinitely while `topics === undefined`; consider rendering on failure / an error boundary around the public bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired authentication sessions. When users return with an outdated session token, the app now automatically clears the invalid token and reloads, preventing users from being stuck on a blank login screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->