### PR TITLE
fix: stabilize password criteria icon rendering

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -96,13 +96,28 @@ export const Input = ({
 	};
 
 	const getMultipleCriteriaDesign = (criteria) => {
+		const iconWrapper = (icon) => (
+			<span
+				aria-hidden="true"
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					width: '16px',
+					height: '16px',
+					marginRight: '3px',
+					flex: '0 0 16px'
+				}}
+			>
+				{icon}
+			</span>
+		);
 		const blurredIcon = wasBlurred ? (
 			<CancelIcon
 				color="error"
 				sx={{
 					width: '16px',
-					height: '16px',
-					mr: '3px'
+					height: '16px'
 				}}
 			/>
 		) : (
@@ -113,8 +128,7 @@ export const Input = ({
 				color="success"
 				sx={{
 					width: '16px',
-					height: '16px',
-					mr: '3px'
+					height: '16px'
 				}}
 			/>
 		) : (
@@ -124,7 +138,7 @@ export const Input = ({
 		const color = criteria.validation(value)
 			? 'success.main'
 			: blurredColor;
-		return { icon, color };
+		return { icon: iconWrapper(icon), color };
 	};
 	const inputRef = useRef<any>(null);
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Keep the password criteria icon container stable while criteria switch between bullet, error, and success states.
- Prevent React DOM removeChild crashes when entering passwords with uppercase or special characters during registration.

## Testing
- npm run lint:scripts (passes with existing warnings)