### PR TITLE
Hide topics with no agency from the registration topic step

### DIFF
--- a/src/components/registration/topicSelection/TopicSelection.tsx
+++ b/src/components/registration/topicSelection/TopicSelection.tsx
@@ -28,6 +28,8 @@ import {
 } from '../../../globalState';
 import { apiGetTopicGroups } from '../../../api/apiGetTopicGroups';
 import { apiGetTopicsData } from '../../../api/apiGetTopicsData';
+import { apiGetTenantAgenciesTopics } from '../../../api/apiGetTenantAgenciesTopics';
+import { filterTopicsByAgencyCoverage } from './filterTopicsByAgencyCoverage';
 import {
 	TopicsDataInterface,
 	TopicGroup
@@ -120,7 +122,26 @@ export const TopicSelection: FC<{
 			setTopicGroups(undefined);
 
 			const topicsResponse = await apiGetTopicsData();
-			const topics = getFilteredTopics(topicsResponse);
+			let topics = getFilteredTopics(topicsResponse);
+
+			// When the user is browsing topics (no deep-linked topic/agency/consultant),
+			// hide topics that have no agency assigned so registration cannot dead-end on
+			// a topic with zero counselling centres. Fails open on error.
+			if (
+				!preselectedTopic &&
+				!preselectedAgency &&
+				!preselectedConsultant
+			) {
+				try {
+					const agenciesTopics = await apiGetTenantAgenciesTopics();
+					topics = filterTopicsByAgencyCoverage(
+						topics,
+						agenciesTopics
+					);
+				} catch (e) {
+					// keep topics unchanged if agency coverage cannot be determined
+				}
+			}
 			try {
 				const topicIds = topics.map((t) => t.id);
 				const topicGroupsResponse = await apiGetTopicGroups();

--- a/src/components/registration/topicSelection/filterTopicsByAgencyCoverage.ts
+++ b/src/components/registration/topicSelection/filterTopicsByAgencyCoverage.ts
@@ -1,0 +1,29 @@
+import { TopicsDataInterface } from '../../../globalState/interfaces';
+import { TenantAgenciesTopicsInterface } from '../../../api/apiGetTenantAgenciesTopics';
+
+/**
+ * Keep only the topics that have at least one agency assigned, so the registration
+ * topic step cannot dead-end on a topic with zero counselling centres.
+ *
+ * The registration agency query joins `agency_topic`, so a topic without any linked
+ * agency always yields an empty agency list ("Keine Online-Beratungsstelle gefunden").
+ * Offering such topics is a guaranteed dead-end; this filter removes them.
+ *
+ * Fails open: if the agency coverage cannot be determined (request failed or returned
+ * nothing), the topics are returned unchanged so registration stays usable.
+ *
+ * @param topics         the topics fetched for registration
+ * @param agenciesTopics the topics that currently have at least one agency assigned
+ *                       (from `GET /service/agencies/topics`); `null`/empty disables filtering
+ * @return the topics that have agency coverage (or all topics if coverage is unknown)
+ */
+export const filterTopicsByAgencyCoverage = (
+	topics: TopicsDataInterface[],
+	agenciesTopics?: TenantAgenciesTopicsInterface[] | null
+): TopicsDataInterface[] => {
+	if (!Array.isArray(agenciesTopics) || agenciesTopics.length === 0) {
+		return topics;
+	}
+	const coveredTopicIds = new Set(agenciesTopics.map((topic) => topic.id));
+	return topics.filter((topic) => coveredTopicIds.has(topic.id));
+};


### PR DESCRIPTION
## Problem

Registration is topic-first. The backend agency query `INNER JOIN`s `agency_topic`, so a topic with no linked agency always returns an empty list and the user hits "Keine Online-Beratungsstelle gefunden". Today **all** active topics are offered, but on the live system only 4 of 16 topics have any agency — so picking one of the other 12 (e.g. Schwangerschaft, Schulden, Eltern & Familie) is a guaranteed dead-end.

## Fix

Filter the registration topic-selection list to topics that have at least one agency assigned, using the existing `GET /service/agencies/topics` endpoint (`apiGetTenantAgenciesTopics`).

- Applies only when **browsing** (no deep-linked topic/agency/consultant) so deep links are never broken.
- **Fails open:** on request error or empty coverage, topics are left unchanged, so registration can never become unusable due to this filter.
- **Self-correcting:** as agencies get linked to topics, those topics automatically reappear.

Logic extracted into a pure helper `filterTopicsByAgencyCoverage` for clarity and testability.

## Validation

- `tsc --noEmit` clean (0 type errors).
- Behaviour confirmed against live coverage data: `GET /service/agencies/topics` currently returns topics [1, 2, 3, 7], so the 12 empty topics would be hidden until agencies are linked.

> Note: this repo's only test harness is Cypress e2e (no unit runner), so the helper is structured as a pure function for a future unit test / Cypress spec.

## Context

Part of "newly created agencies invisible in registration" — see OpenResilienceInitiative/ORISO-Frontend#245. Complementary backend fix (do not wipe agency-topic links on update): OpenResilienceInitiative/ORISO-AgencyService#39. Next step is to backfill the missing `agency_topic` links so the relevant topics regain coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Topic selection in the registration flow now filters topics based on agency coverage availability. Topics without available agency services are filtered out during the browse flow when no preselected values are active. The system gracefully falls back to showing all topics if coverage data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->