### PR TITLE
feat(timeline): event-descriptor registry (WP-06 Slice 0a)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# Activity Timeline & Notifications
+
+The consultant- and client-facing history of everything that happens around a case: enquiries, accept/deny, messages, drafts, appointments, handovers, calls. It is **two things in one surface**: an **inbox** (events that happened *to* you) and a **personal action trail** (events *you* performed, e.g. drafts you saved). One central, paginated, navigable surface (Slack-"Activity"-style) plus the transient pop-ups that announce the same events. Spans **ORISO-Frontend** (the surface) and **ORISO-UserService** (the event model + persistence); chat content lives in **Matrix**.
+
+## Language
+
+**Activity Timeline**:
+The single central surface that lists all **activity events** for the signed-in user as a scrollable, clickable history with a detail pane. Canonical name for what the code/Figma variously call Activity Feed / Aktivität / Zeitstrahl / Notifications Center.
+_Avoid_: Activity Feed, Aktivität, Zeitstrahl, Notifications Center, Notifications Page (all aliases for this one surface)
+
+**Activity event**:
+One persistent item in the timeline (e.g. "Request accepted", "Handover requested"). Has an **event type**, an actor/subject, a timestamp, a read-state, and an optional **action target**. Stored in `event_notification` (UserService).
+_Avoid_: Notification (reserve that for the transient pop-up)
+
+**Event type**:
+The string key that identifies what an activity event is (`inquiry.accepted`, `message.new`, `thread.reply.new`, `supervisor.added`, …). Drives the event's icon, label, and action target. Currently string-based, no central enum.
+
+**Toast notification**:
+The transient, auto-dismissing pop-up (`components/notifications`) that announces an event as it arrives. Distinct from an **activity event**: a toast is ephemeral, an activity event is the persisted record of the same thing.
+_Avoid_: Notification (ambiguous), Alert
+
+**Action target**:
+Where an activity event's primary button takes you (`action_path`). **Rule: the target is wherever the event actually originated.** Most events that happen in a case → the **conversation** (chat room); enquiry events that originate in the request area → the **enquiry/request** view (note: "Call appointment requested" originates *in the chat* today, so it targets the conversation, not the request view); a **draft event** → resume the draft where it lives. The button only appears on the focused/active event.
+One target type is special — **Join**: a live-call event ("Call ongoing — N participants") does not navigate but *joins the call* (the same action as the in-room call button). See **Calls** / stateful events.
+
+**Event descriptor**:
+The frontend's per-**event-type** definition that owns everything needed to render that event: its icon, its i18n title/text template, its category, and how to resolve its **action target**. The single registry that turns a typed, text-free server record into a rendered timeline card. Embodies the "every event gets its own icon + button" requirement.
+
+**Handover** (= Reassign):
+Moving an ongoing case to another counsellor. A **two-party** flow: the receiving **counsellor** *and* the **client** must both confirm. States: **Requested** → **Partial** (exactly one party confirmed) → **All Confirmed** (both → handover takes effect). **Auto Confirmed** = a policy skipped a confirmation (e.g. same-agency / supervisor-initiated) or a timeout elapsed. **Denied** = either party refused → handover cancelled. "Partial" and "Auto Confirmed" are precise states, not loose adjectives.
+_Avoid_: "transfer" (ambiguous with file transfer); using "Reassign" in UI copy — UI says "Handover" / "Übergabe"
+
+**Self-event**:
+An **activity event** whose actor is the signed-in user themselves — something *you did*, not something that happened to you. The first one is the **draft event**. Distinguishes the timeline's "personal action trail" half from its "inbox" half. (`recipient_user_id == actor`.)
+
+**Draft event** ("Draft created"):
+A **self-event** representing one of *your* open, unsent message drafts, so you can find a draft you started and abandoned — without remembering whether it was in a request or which conversation. Its **action target** resumes the draft exactly where it lives (reusing the existing `forcedScopeKey` resume nav). Recommended implementation: **a live overlay rendered from the existing client-side draft index** (`scope:__draft-index__`), *not* a persisted `event_notification` row — the index is already deduplicated and self-resolves (an entry vanishes when the draft is sent or discarded), so it sidesteps the append-only limitation. The draft body is *your own* unsent text, hydrated client-side. A dedicated **`DraftsCenter`** / `/drafts` section already exists; the open decision is whether the timeline's Drafts family **replaces** it. *Only the author's own drafts — never "someone else created a draft".*
+
+**Event family**:
+The grouping an **event type** belongs to, used for the filter chips and shared iconography: Requests ("Anfragen"), Messages ("Nachrichten"), Drafts ("Entwürfe"), Appointments ("Termine"), Handover (the Reassign flow), Calls, System. Exactly one family chip can be active to scope the timeline; "Alle" shows everything.
+
+**PrivacyEnvelope**:
+The metadata-only representation of a Matrix message that reaches the backend — `messageId`, `roomId`, `senderId`, `timestamp`, `hasAttachment`, `contentClass`, and **never the plaintext body**. The contract that lets the server know "a message happened" without reading it.
+
+**Active item** (global, not just timeline):
+The single selected item across *any* list — timeline event, conversation, or request. **Invariant: exactly one active item at a time**, derived from the current route (entering a chat room makes that conversation the active item). Strong treatment: lightened background + **2px focus ring in the graduated accent colour** + the red **action target** button. All others rest in the secondary, 1px-ring treatment with no button. Keyboard `focus-visible` is independent (a11y) and layers on top.
+_The visual already exists in many places and must not be restyled._ What's broken is **robustness**: selection state is duplicated per component (`isChatActive`, `activeSession.rid === groupIdFromParam`, NotificationsCenter's own `--active`), so it breaks when touched, lets multiple items go red at once ("focus goes down the drain"), and never activates on entering a chat room. The fix is a **single, route-derived selection source of truth** (a Selection controller/hook), not new CSS.
+_Avoid_: per-component active state, local `isActive` flags duplicated across list components
+
+## Flagged ambiguities
+
+- **"Notification" is overloaded.** Three different things: the **toast** (transient pop-up), the **activity event** (persisted timeline item), and the **email notification** (`EmailNotificationFacade`, transient, server-sent). Always qualify which one.
+- **"Timeline" collision.** Matrix has its own **room timeline** (the message list inside a chat, listened to via `Room.timeline` in `matrixLiveEventBridge`). The **Activity Timeline** is *not* the Matrix room timeline — it is a cross-room, cross-case history. Never conflate.
+- **Source of truth for previews.** The server stores **no rendered display text at all** — only `event_type`, reference IDs, structured params, and read-state. *Every* visible string (even business/system text like "Request accepted: {name}" or "Thema: {topic}") is rendered client-side from i18n templates per **event descriptor**. Chat message previews are additionally E2EE-protected and are hydrated client-side from the Matrix room. (See ADR-AT-01 "Storage & E2EE Boundary" in OrisoPlan WP-06.)
+- **Two kinds of "stateful" — don't conflate (CONFIRMED).** `event_notification` is **append-only** (no correlation/status column, single-INSERT write path, only `markAsRead`; feed has no remove-single-item path). That is *fine* for one kind and a problem for the other:
+  - **Progression-as-history** — a **Handover** going requested → partial → all-confirmed/denied. Each transition is its own immutable fact and shows as its **own timeline card** (exactly the 5 Handover cards in Figma). Append-only handles this with no new mechanism.
+  - **Live-until-resolved** — an open **draft**; an **ongoing, joinable call**. Must vanish/convert when done. Modelled as a **client-side overlay/projection from the authoritative source**, *not* feed rows: drafts ← the draft index (decided); ongoing calls ← a call-liveness signal. The open architecture decision is whether to instead make `event_notification` itself stateful (add correlation_id + status + upsert) — heavier and inconsistent with the drafts decision.
+- **Pre-existing plaintext-draft exposure (CONFIRMED).** `draft_message.text`, the draft **index JSON**, and the `title`/`action_path` columns are all stored server-side in **plaintext** (client encrypts only when RC-era E2EE is on → off for Matrix). Remediation findings (verified): **client-only is a regression** — the local `draftStore` is dead code, drafts+index live server-side only, and the timeline overlay already reads the server index (so it is already cross-device); dropping the server would empty the overlay until a new local path is built. **True zero-knowledge encryption is NOT blocked on Megolm**: a per-user, password-derived master key (`mk_<userId>`, PBKDF2→AES-256, the same key that wraps the RSA private key) already exists and is available at draft-save time — drafts are consultant/auth-scoped, exactly the population that has it. **Decided (2b — see ADR-AT-03 in OrisoPlan WP-06):** client-side encrypt draft text **and** the index JSON under the per-user master key (keep cross-device, server sees only ciphertext); harden PBKDF2 iterations. (Implemented in its own session.)
+- **Live calls have no persistent event today (mapped).** `m.call.invite/answer/hangup` are only *logged* by the backend (persistence is a TODO stub; answer/hangup don't even read `call_id`); `CALL_STARTED/ENDED/IGNORED_CALL` are in-room alias bubbles; participant count is **not tracked** (`m.call.member`/MSC3401 absent). So "call ongoing/ended/missed" timeline events + the "3 people in call" count are **new work**, not just wiring. **Join is feasible** by passing `call_room_id` + `isVideo` to `callManager.startCall` — but ⚠️ **two call stacks exist**: the legacy timeline join (`useJoinVideoCall` → `/videoanruf`) uses native matrix-js-sdk WebRTC; the new affordance must target the **LiveKit/ElementCall** stack (`callManager.startCall`), not the legacy hook.
+  Live **participant count** ("3 in call") is **in scope** (full-calls decision). Recommended source of truth: **Matrix-RTC member state** (`m.call.member`/MSC3401), which ElementCall already maintains via `matrixRTC.getRoomSession()` and the client can subscribe to live; alternative is a backend query of the LiveKit room API. This is the live signal that gates the **Join** overlay.
+- **Rocket.Chat vs Matrix.** Notification delivery is already Matrix-native (`MatrixEventListenerService` `/sync`), but `useE2EE` still implements the *Rocket.Chat* E2EE scheme and skips Matrix rooms. "We do notifications via Rocket.Chat" is no longer true; "client E2EE is still Rocket.Chat-shaped" is.
+
+## Example dialogue
+
+> **Dev:** When the client sends "Voll gut das du das so denkst", what does the server store?
+> **Frank:** Nothing of the text. The server gets a **PrivacyEnvelope** — it knows there was a `message.new` **activity event** from that sender in that room at that time. The "Client replied: Voll gut…" preview is rendered in the client after it decrypts the Matrix message.
+> **Dev:** And "Handover requested — Counsellor + Client must confirm"?
+> **Frank:** That's a server-owned business fact, so the **activity event** carries its full text. It's not chat content.
+> **Dev:** Clicking it?
+> **Frank:** The **action target** of a handover event is the **conversation**; of a new enquiry it's the **request** view. The button only shows on the **active event**.

--- a/cypress/e2e/eventDescriptors.cy.ts
+++ b/cypress/e2e/eventDescriptors.cy.ts
@@ -1,0 +1,253 @@
+/**
+ * WP-06 Activity Timeline — unit coverage for the event-descriptor registry
+ * (Slice 0a).
+ *
+ * Pure-logic spec: imports the registry directly and asserts with chai's
+ * `expect`. It does not visit the app or require a backend, so it runs against
+ * a blank page. Mirrors the existing logic-spec pattern (e.g. tokens.cy.ts).
+ */
+
+import {
+	EVENT_DESCRIPTORS,
+	KNOWN_EVENT_TYPES,
+	FALLBACK_DESCRIPTOR,
+	EVENT_ICONS,
+	getEventDescriptor,
+	isKnownEventType,
+	familyLabelKey,
+	renderEventStrings,
+	getEventIcon,
+	EventFamily
+} from '../../src/components/notificationsCenter/eventDescriptors';
+import enCommon from '../../src/resources/i18n/en/common.json';
+import deCommon from '../../src/resources/i18n/de/common.json';
+
+const EXISTING_EMITTED_TYPES = [
+	'inquiry.accepted',
+	'message.new',
+	'thread.reply.new',
+	'supervisor.added',
+	'supervisor.removed',
+	'supervisor.assigned',
+	'counselor.renamed'
+];
+
+const ALL_FAMILIES: EventFamily[] = [
+	'requests',
+	'messages',
+	'drafts',
+	'handover',
+	'calls',
+	'system',
+	'appointments'
+];
+
+// Expected action-target kind per seeded type (origin rule).
+const EXPECTED_TARGET_KIND: Record<string, string> = {
+	'inquiry.accepted': 'conversation',
+	'message.new': 'conversation',
+	'thread.reply.new': 'conversation',
+	'supervisor.added': 'conversation',
+	'supervisor.removed': 'conversation',
+	'supervisor.assigned': 'conversation',
+	'counselor.renamed': 'conversation',
+	'request.new': 'request',
+	'draft.created': 'draft',
+	'handover.requested': 'conversation',
+	'handover.partial': 'conversation',
+	'handover.all_confirmed': 'conversation',
+	'handover.auto_confirmed': 'conversation',
+	'handover.denied': 'conversation',
+	'call.started': 'join',
+	'call.ended': 'conversation',
+	'call.missed': 'conversation'
+};
+
+// Resolve a dotted i18n key against a loaded common.json object.
+const resolveI18nKey = (obj: any, dottedKey: string): unknown =>
+	dottedKey.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), obj);
+
+describe('WP-06 event-descriptor registry', () => {
+	it('seeds a descriptor for every existing emitted event type', () => {
+		EXISTING_EMITTED_TYPES.forEach((type) => {
+			expect(isKnownEventType(type), `known: ${type}`).to.equal(true);
+			expect(EVENT_DESCRIPTORS[type], `descriptor: ${type}`).to.exist;
+		});
+	});
+
+	it('exposes every seeded type via KNOWN_EVENT_TYPES with no duplicates', () => {
+		const unique = new Set(KNOWN_EVENT_TYPES);
+		expect(unique.size).to.equal(KNOWN_EVENT_TYPES.length);
+		EXISTING_EMITTED_TYPES.forEach((type) =>
+			expect(KNOWN_EVENT_TYPES).to.include(type)
+		);
+	});
+
+	it('gives every descriptor a valid family, category, icon and templates', () => {
+		KNOWN_EVENT_TYPES.forEach((type) => {
+			const d = EVENT_DESCRIPTORS[type];
+			expect(d.eventType, `eventType: ${type}`).to.equal(type);
+			expect(ALL_FAMILIES, `family: ${type}`).to.include(d.family);
+			expect(['system', 'message'], `category: ${type}`).to.include(
+				d.category
+			);
+			// icon id must resolve to a real SVG component
+			expect(EVENT_ICONS[d.icon], `icon component: ${type}`).to.exist;
+			expect(getEventIcon(d.icon), `getEventIcon: ${type}`).to.exist;
+			expect(d.titleTemplate, `title key: ${type}`).to.match(
+				/^notifications\.events\./
+			);
+			expect(d.textTemplate, `text key: ${type}`).to.match(
+				/^notifications\.events\./
+			);
+		});
+	});
+
+	it('covers all designed families across the seeded descriptors', () => {
+		const seededFamilies = new Set(
+			KNOWN_EVENT_TYPES.map((t) => EVENT_DESCRIPTORS[t].family)
+		);
+		// Appointments are deferred (no seeded types); every other family is present.
+		(['requests', 'messages', 'drafts', 'handover', 'calls', 'system'] as EventFamily[]).forEach(
+			(fam) => expect(seededFamilies.has(fam), `family seeded: ${fam}`).to.equal(true)
+		);
+	});
+
+	it('returns the fallback descriptor for unknown / empty types', () => {
+		expect(getEventDescriptor('totally.unknown.type')).to.equal(
+			FALLBACK_DESCRIPTOR
+		);
+		expect(getEventDescriptor(null)).to.equal(FALLBACK_DESCRIPTOR);
+		expect(getEventDescriptor(undefined)).to.equal(FALLBACK_DESCRIPTOR);
+		expect(isKnownEventType('totally.unknown.type')).to.equal(false);
+	});
+
+	describe('resolveActionTarget (origin rule)', () => {
+		it('resolves the expected target kind for every seeded type', () => {
+			KNOWN_EVENT_TYPES.forEach((type) => {
+				const target = EVENT_DESCRIPTORS[type].resolveActionTarget({});
+				expect(target.kind, `kind: ${type}`).to.equal(
+					EXPECTED_TARGET_KIND[type]
+				);
+			});
+		});
+
+		it('chat events target the conversation, honouring actionPath', () => {
+			const target = getEventDescriptor('message.new').resolveActionTarget(
+				{ actionPath: '/sessions/consultant/sessionView/session/42' }
+			);
+			expect(target).to.deep.equal({
+				kind: 'conversation',
+				path: '/sessions/consultant/sessionView/session/42'
+			});
+		});
+
+		it('builds a conversation path from sourceSessionId + base when no actionPath', () => {
+			const target = getEventDescriptor('message.new').resolveActionTarget(
+				{ sourceSessionId: 7, sessionsBasePath: '/sessions/user/view' }
+			);
+			expect(target).to.deep.equal({
+				kind: 'conversation',
+				path: '/sessions/user/view/session/7'
+			});
+		});
+
+		it('request-origin events target the request view', () => {
+			const target = getEventDescriptor('request.new').resolveActionTarget(
+				{ actionPath: '/sessions/consultant/sessionPreview' }
+			);
+			expect(target.kind).to.equal('request');
+			expect((target as any).path).to.equal(
+				'/sessions/consultant/sessionPreview'
+			);
+		});
+
+		it('draft events resume via forcedScopeKey', () => {
+			const target = getEventDescriptor('draft.created').resolveActionTarget(
+				{ forcedScopeKey: 'scope:session:99|thread:main' }
+			);
+			expect(target).to.deep.equal({
+				kind: 'draft',
+				forcedScopeKey: 'scope:session:99|thread:main',
+				path: null
+			});
+		});
+
+		it('live call events resolve to a Join target (no navigation)', () => {
+			const target = getEventDescriptor('call.started').resolveActionTarget(
+				{ callRoomId: '!room:matrix', isVideo: true }
+			);
+			expect(target).to.deep.equal({
+				kind: 'join',
+				callRoomId: '!room:matrix',
+				isVideo: true
+			});
+		});
+	});
+
+	describe('i18n templates', () => {
+		it('has an English + German string for every descriptor template', () => {
+			[...KNOWN_EVENT_TYPES, '__fallback__'].forEach((type) => {
+				const d =
+					type === '__fallback__'
+						? FALLBACK_DESCRIPTOR
+						: EVENT_DESCRIPTORS[type];
+				[d.titleTemplate, d.textTemplate].forEach((key) => {
+					expect(
+						typeof resolveI18nKey(enCommon, key),
+						`en ${key}`
+					).to.equal('string');
+					expect(
+						typeof resolveI18nKey(deCommon, key),
+						`de ${key}`
+					).to.equal('string');
+				});
+			});
+		});
+
+		it('has an English + German label for every family', () => {
+			ALL_FAMILIES.forEach((fam) => {
+				const key = familyLabelKey(fam);
+				expect(resolveI18nKey(enCommon, key), `en ${key}`).to.be.a(
+					'string'
+				).and.not.be.empty;
+				expect(resolveI18nKey(deCommon, key), `de ${key}`).to.be.a(
+					'string'
+				).and.not.be.empty;
+			});
+		});
+	});
+
+	describe('renderEventStrings (client-side rendering, ADR-AT-01)', () => {
+		// Fake translate mimicking i18next: return the en value, else defaultValue.
+		const translate = (key: string, options?: Record<string, unknown>) => {
+			const value = resolveI18nKey(enCommon, key);
+			if (typeof value === 'string' && value.length > 0) {
+				return value;
+			}
+			return (options?.defaultValue as string) ?? '';
+		};
+
+		it('renders a known type from its i18n template', () => {
+			const { title, text } = renderEventStrings(
+				getEventDescriptor('message.new'),
+				translate,
+				{ fallbackTitle: 'server title', fallbackText: 'server text' }
+			);
+			expect(title).to.equal('New message');
+			expect(text).to.equal('You received a new message.');
+		});
+
+		it('falls back to server-provided text for unknown types', () => {
+			const { title, text } = renderEventStrings(
+				getEventDescriptor('totally.unknown.type'),
+				translate,
+				{ fallbackTitle: 'Server-rendered title', fallbackText: 'Server body' }
+			);
+			// fallback descriptor title template exists ("Activity"); text template
+			// is empty, so the server text is used.
+			expect(title).to.equal('Activity');
+			expect(text).to.equal('Server body');
+		});
+	});
+});

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ReactComponent as NotificationBellIcon } from '../../resources/img/icons/notification_bell.svg';
 import { apiUrl } from '../../resources/scripts/endpoints';
+import {
+	getEventDescriptor,
+	getEventIcon,
+	renderEventStrings,
+	familyLabelKey,
+	isKnownEventType
+} from './eventDescriptors';
 import { isMatrixRoom } from '../../utils/matrixRoomUtils';
 import { FETCH_METHODS, fetchData } from '../../api/fetchData';
 import {
@@ -44,6 +50,29 @@ const getNotificationCategory = (item: any): 'system' | 'message' => {
 	if (item?.category === 'message') return 'message';
 	if (item?.actionPath?.includes('threadRootId=')) return 'message';
 	return 'system';
+};
+
+// WP-06 Activity Timeline (Slice 0a): category is registry-driven for known
+// event types; unknown / local-only types keep the legacy heuristic so nothing
+// regresses while the backend is incremental.
+const resolveItemCategory = (item: any): 'system' | 'message' =>
+	isKnownEventType(item?.eventType)
+		? getEventDescriptor(item.eventType).category
+		: getNotificationCategory(item);
+
+// WP-06: render an item's visible strings from its event descriptor's i18n
+// templates (ADR-AT-01 — the server record is text-free), falling back to the
+// server-provided title/text until the strict text-free migration (Slice 2).
+const describeItem = (
+	item: any,
+	translate: (key: string, options?: Record<string, unknown>) => string
+) => {
+	const descriptor = getEventDescriptor(item?.eventType);
+	const { title, text } = renderEventStrings(descriptor, translate, {
+		fallbackTitle: item?.title,
+		fallbackText: item?.text
+	});
+	return { descriptor, title, text };
 };
 
 const getChatKey = (item: any): string => {
@@ -157,9 +186,16 @@ export const NotificationsCenter = () => {
 	const selectedNotificationCategory = useMemo(
 		() =>
 			selectedNotification
-				? getNotificationCategory(selectedNotification)
+				? resolveItemCategory(selectedNotification)
 				: 'system',
 		[selectedNotification]
+	);
+	const selectedDisplay = useMemo(
+		() =>
+			selectedNotification
+				? describeItem(selectedNotification, translate)
+				: null,
+		[selectedNotification, translate]
 	);
 	const selectedSessionId = useMemo(
 		() => resolveSessionId(selectedNotification),
@@ -441,8 +477,11 @@ export const NotificationsCenter = () => {
 					) : (
 						notificationFeed.map((item) =>
 							(() => {
-								const category = getNotificationCategory(item);
+								const category = resolveItemCategory(item);
 								const isMessage = category === 'message';
+								const { descriptor, title, text } =
+									describeItem(item, translate);
+								const Icon = getEventIcon(descriptor.icon);
 								return (
 									<button
 										type="button"
@@ -462,25 +501,17 @@ export const NotificationsCenter = () => {
 														: 'notificationsCenter__listItemTag--system'
 												}`}
 											>
-												{isMessage
-													? translate(
-															'notifications.center.messageTag',
-															'Message notification'
-														)
-													: translate(
-															'notifications.center.systemTag',
-															'System notification'
-														)}
+												{translate(familyLabelKey(descriptor.family))}
 											</span>
 										</div>
 										<div className="notificationsCenter__listItemBody">
 											<div className="notificationsCenter__listItemIconCircle">
-												<NotificationBellIcon />
+												<Icon />
 											</div>
 											<div className="notificationsCenter__listItemContent">
 												<div className="notificationsCenter__listItemHeader">
 													<span className="notificationsCenter__listItemTitle">
-														{item.title}
+														{title}
 													</span>
 													<span className="notificationsCenter__listItemTime">
 														{formatRelativeTime(
@@ -490,7 +521,7 @@ export const NotificationsCenter = () => {
 													</span>
 												</div>
 												<div className="notificationsCenter__listItemText">
-													{item.text}
+													{text}
 												</div>
 											</div>
 										</div>
@@ -513,10 +544,10 @@ export const NotificationsCenter = () => {
 					{selectedNotification ? (
 						<div className="notificationsCenter__detailCard">
 							<h3 className="notificationsCenter__detailTitle">
-								{selectedNotification.title}
+								{selectedDisplay?.title}
 							</h3>
 							<p className="notificationsCenter__detailText">
-								{selectedNotification.text}
+								{selectedDisplay?.text}
 							</p>
 							<div className="notificationsCenter__detailActions">
 								<button

--- a/src/components/notificationsCenter/eventDescriptors/icons.tsx
+++ b/src/components/notificationsCenter/eventDescriptors/icons.tsx
@@ -1,0 +1,43 @@
+/**
+ * WP-06 Activity Timeline — Event-descriptor icons (Slice 0a).
+ *
+ * Resolves an {@link EventIconId} to its SVG React component. Kept separate from
+ * the (pure) registry so `registry.ts` / `types.ts` stay free of SVG/React
+ * imports and remain unit-testable in isolation.
+ */
+
+import * as React from 'react';
+import { ReactComponent as RequestNewIcon } from '../../../resources/img/icons/speech-bubble-plus.svg';
+import { ReactComponent as RequestAcceptedIcon } from '../../../resources/img/icons/checkmark_circle.svg';
+import { ReactComponent as MessageIcon } from '../../../resources/img/icons/speech-bubble.svg';
+import { ReactComponent as ThreadReplyIcon } from '../../../resources/img/icons/corner-up-left.svg';
+import { ReactComponent as DraftIcon } from '../../../resources/img/icons/pen-paper.svg';
+import { ReactComponent as HandoverIcon } from '../../../resources/img/icons/persons-two.svg';
+import { ReactComponent as CallStartedIcon } from '../../../resources/img/icons/call-on.svg';
+import { ReactComponent as CallEndedIcon } from '../../../resources/img/icons/call.svg';
+import { ReactComponent as CallMissedIcon } from '../../../resources/img/icons/call-off.svg';
+import { ReactComponent as SupervisorIcon } from '../../../resources/img/icons/shield.svg';
+import { ReactComponent as RenameIcon } from '../../../resources/img/icons/pen.svg';
+import { ReactComponent as SystemIcon } from '../../../resources/img/icons/notification_bell.svg';
+import { EventIconId } from './types';
+
+type SvgIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+export const EVENT_ICONS: Record<EventIconId, SvgIcon> = {
+	requestNew: RequestNewIcon,
+	requestAccepted: RequestAcceptedIcon,
+	message: MessageIcon,
+	threadReply: ThreadReplyIcon,
+	draft: DraftIcon,
+	handover: HandoverIcon,
+	callStarted: CallStartedIcon,
+	callEnded: CallEndedIcon,
+	callMissed: CallMissedIcon,
+	supervisor: SupervisorIcon,
+	rename: RenameIcon,
+	system: SystemIcon
+};
+
+/** Resolve an icon component by id, falling back to the generic system icon. */
+export const getEventIcon = (iconId: EventIconId): SvgIcon =>
+	EVENT_ICONS[iconId] || EVENT_ICONS.system;

--- a/src/components/notificationsCenter/eventDescriptors/index.ts
+++ b/src/components/notificationsCenter/eventDescriptors/index.ts
@@ -1,0 +1,34 @@
+/**
+ * WP-06 Activity Timeline — Event-descriptor registry (Slice 0a) public API.
+ *
+ * Single import surface for the registry that turns a typed, text-free server
+ * record into a rendered timeline card. See `types.ts` for the shapes and
+ * `registry.ts` for the seeded descriptors.
+ */
+
+export type {
+	EventFamily,
+	EventCategory,
+	EventIconId,
+	EventActionParams,
+	EventActionTarget,
+	EventDescriptor
+} from './types';
+
+export {
+	EVENT_DESCRIPTORS,
+	KNOWN_EVENT_TYPES,
+	FALLBACK_DESCRIPTOR,
+	getEventDescriptor,
+	isKnownEventType,
+	familyLabelKey
+} from './registry';
+
+export { EVENT_ICONS, getEventIcon } from './icons';
+
+export type {
+	TranslateFn,
+	EventStringInput,
+	RenderedEventStrings
+} from './renderEventStrings';
+export { renderEventStrings } from './renderEventStrings';

--- a/src/components/notificationsCenter/eventDescriptors/registry.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.ts
@@ -1,0 +1,272 @@
+/**
+ * WP-06 Activity Timeline — Event-descriptor registry (Slice 0a).
+ *
+ * The single source of truth mapping `event_type` → descriptor. Seeds:
+ *   - the 6 event types emitted today (`inquiry.accepted`, `message.new`,
+ *     `thread.reply.new`, `supervisor.added/removed/assigned`,
+ *     `counselor.renamed`), and
+ *   - descriptors for every designed family that Slices 2–5 will light up
+ *     (Requests, Messages, Drafts, Handover, Calls, System). Appointments are
+ *     deferred (no event types seeded).
+ *
+ * Pure module: no React / SVG imports. Icons are resolved separately by id
+ * (`icons.tsx`); all visible strings are i18n keys rendered client-side
+ * (ADR-AT-01 — the server record is text-free).
+ */
+
+import {
+	EventActionParams,
+	EventActionTarget,
+	EventDescriptor,
+	EventFamily
+} from './types';
+
+/** Default conversation list base when the consumer does not pass one. */
+const DEFAULT_SESSIONS_BASE_PATH = '/sessions/consultant/sessionView';
+
+/** i18n key for a family's filter-chip / tag label. */
+export const familyLabelKey = (family: EventFamily): string =>
+	`notifications.families.${family}`;
+
+// --- Action-target resolvers (origin rule) -------------------------------
+
+const buildConversationPath = (params: EventActionParams): string | null => {
+	if (params.actionPath) {
+		return params.actionPath;
+	}
+	if (params.sourceSessionId != null && params.sourceSessionId !== '') {
+		const base = params.sessionsBasePath || DEFAULT_SESSIONS_BASE_PATH;
+		return `${base}/session/${params.sourceSessionId}`;
+	}
+	return null;
+};
+
+const conversationTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'conversation',
+	path: buildConversationPath(params)
+});
+
+const requestTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'request',
+	path: params.actionPath || params.requestsBasePath || null
+});
+
+const draftTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'draft',
+	forcedScopeKey: params.forcedScopeKey ?? null,
+	path: params.actionPath ?? null
+});
+
+// Slice 5: the consumer wires `join` to `callManager.startCall(callRoomId,
+// isVideo, true)` (LiveKit/ElementCall) — NOT the legacy `useJoinVideoCall`
+// (`/videoanruf`) native-WebRTC path. Here we only produce the pure descriptor.
+const joinTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'join',
+	callRoomId: params.callRoomId ?? params.roomRef ?? null,
+	isVideo: !!params.isVideo
+});
+
+// --- Descriptor factory --------------------------------------------------
+
+interface DescriptorSeed {
+	family: EventDescriptor['family'];
+	category: EventDescriptor['category'];
+	icon: EventDescriptor['icon'];
+	/** camelCase i18n key segment (decoupled from the dotted event_type). */
+	i18nKey: string;
+	resolveActionTarget: EventDescriptor['resolveActionTarget'];
+}
+
+const descriptor = (
+	eventType: string,
+	seed: DescriptorSeed
+): EventDescriptor => ({
+	eventType,
+	family: seed.family,
+	category: seed.category,
+	icon: seed.icon,
+	titleTemplate: `notifications.events.${seed.i18nKey}.title`,
+	textTemplate: `notifications.events.${seed.i18nKey}.text`,
+	resolveActionTarget: seed.resolveActionTarget
+});
+
+/**
+ * Fallback descriptor for unknown / not-yet-described event types. Keeps the
+ * timeline robust: an unseeded type still renders (generic system card) rather
+ * than crashing. The consumer falls back to the server-provided title/text via
+ * `defaultValue` when the template is absent.
+ */
+export const FALLBACK_DESCRIPTOR: EventDescriptor = {
+	eventType: '__fallback__',
+	family: 'system',
+	category: 'system',
+	icon: 'system',
+	titleTemplate: 'notifications.events.fallback.title',
+	textTemplate: 'notifications.events.fallback.text',
+	resolveActionTarget: conversationTarget
+};
+
+// --- The registry --------------------------------------------------------
+
+const seeds: EventDescriptor[] = [
+	// ----- Existing 6 emitted types -----
+	// A request is accepted → the conversation now exists, so it opens the chat.
+	descriptor('inquiry.accepted', {
+		family: 'requests',
+		category: 'system',
+		icon: 'requestAccepted',
+		i18nKey: 'inquiryAccepted',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('message.new', {
+		family: 'messages',
+		category: 'message',
+		icon: 'message',
+		i18nKey: 'messageNew',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('thread.reply.new', {
+		family: 'messages',
+		category: 'message',
+		icon: 'threadReply',
+		i18nKey: 'threadReplyNew',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('supervisor.added', {
+		family: 'system',
+		category: 'system',
+		icon: 'supervisor',
+		i18nKey: 'supervisorAdded',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('supervisor.removed', {
+		family: 'system',
+		category: 'system',
+		icon: 'supervisor',
+		i18nKey: 'supervisorRemoved',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('supervisor.assigned', {
+		family: 'system',
+		category: 'system',
+		icon: 'supervisor',
+		i18nKey: 'supervisorAssigned',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('counselor.renamed', {
+		family: 'system',
+		category: 'system',
+		icon: 'rename',
+		i18nKey: 'counselorRenamed',
+		resolveActionTarget: conversationTarget
+	}),
+
+	// ----- Requests family (Slice 2 will persist "New client request") -----
+	descriptor('request.new', {
+		family: 'requests',
+		category: 'system',
+		icon: 'requestNew',
+		i18nKey: 'requestNew',
+		resolveActionTarget: requestTarget
+	}),
+
+	// ----- Drafts family (self-event; Slice 3 overlay) -----
+	descriptor('draft.created', {
+		family: 'drafts',
+		category: 'system',
+		icon: 'draft',
+		i18nKey: 'draftCreated',
+		resolveActionTarget: draftTarget
+	}),
+
+	// ----- Handover family (append-only progression cards; Slice 4) -----
+	descriptor('handover.requested', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'handoverRequested',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('handover.partial', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'handoverPartial',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('handover.all_confirmed', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'handoverAllConfirmed',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('handover.auto_confirmed', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'handoverAutoConfirmed',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('handover.denied', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'handoverDenied',
+		resolveActionTarget: conversationTarget
+	}),
+
+	// ----- Calls family (Slice 5) -----
+	// Live, joinable call → Join overlay (does not navigate).
+	descriptor('call.started', {
+		family: 'calls',
+		category: 'system',
+		icon: 'callStarted',
+		i18nKey: 'callStarted',
+		resolveActionTarget: joinTarget
+	}),
+	descriptor('call.ended', {
+		family: 'calls',
+		category: 'system',
+		icon: 'callEnded',
+		i18nKey: 'callEnded',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('call.missed', {
+		family: 'calls',
+		category: 'system',
+		icon: 'callMissed',
+		i18nKey: 'callMissed',
+		resolveActionTarget: conversationTarget
+	})
+];
+
+/** event_type → descriptor. */
+export const EVENT_DESCRIPTORS: Readonly<Record<string, EventDescriptor>> =
+	seeds.reduce<Record<string, EventDescriptor>>((acc, entry) => {
+		acc[entry.eventType] = entry;
+		return acc;
+	}, {});
+
+/** All seeded event types (excludes the fallback). */
+export const KNOWN_EVENT_TYPES: ReadonlyArray<string> = seeds.map(
+	(entry) => entry.eventType
+);
+
+/**
+ * Resolve the descriptor for an `event_type`. Never returns null — an unknown
+ * type yields {@link FALLBACK_DESCRIPTOR} so the timeline stays robust.
+ */
+export const getEventDescriptor = (
+	eventType: string | null | undefined
+): EventDescriptor => {
+	if (!eventType) {
+		return FALLBACK_DESCRIPTOR;
+	}
+	return EVENT_DESCRIPTORS[eventType] || FALLBACK_DESCRIPTOR;
+};
+
+/** True if the given event type has a seeded (non-fallback) descriptor. */
+export const isKnownEventType = (
+	eventType: string | null | undefined
+): boolean => !!eventType && eventType in EVENT_DESCRIPTORS;

--- a/src/components/notificationsCenter/eventDescriptors/renderEventStrings.ts
+++ b/src/components/notificationsCenter/eventDescriptors/renderEventStrings.ts
@@ -1,0 +1,54 @@
+/**
+ * WP-06 Activity Timeline — client-side string rendering (Slice 0a).
+ *
+ * Renders an event's visible title/text from its i18n templates (ADR-AT-01: the
+ * server record is text-free; every visible string is produced client-side).
+ *
+ * Migration bridge: until the strict text-free record migration lands (Slice 2)
+ * the backend still sends `title`/`text`. Those are passed as `fallbackTitle` /
+ * `fallbackText` and used only as the i18n `defaultValue`, so:
+ *   - seeded types render from their template, and
+ *   - not-yet-migrated / unknown types still show the server text instead of a
+ *     raw key.
+ * When the server stops sending text, the templates become the sole source and
+ * nothing else here changes — no server-side rendered text is introduced.
+ */
+
+import { EventDescriptor } from './types';
+
+/** Minimal translate signature, satisfied by i18next's `t`. */
+export type TranslateFn = (
+	key: string,
+	options?: Record<string, unknown>
+) => string;
+
+export interface EventStringInput {
+	/** Server-provided title used only as i18n defaultValue (pre-Slice-2). */
+	fallbackTitle?: string | null;
+	/** Server-provided text used only as i18n defaultValue (pre-Slice-2). */
+	fallbackText?: string | null;
+	/** Structured interpolation values for the template (e.g. name, topic). */
+	interpolation?: Record<string, unknown>;
+}
+
+export interface RenderedEventStrings {
+	title: string;
+	text: string;
+}
+
+export const renderEventStrings = (
+	descriptor: EventDescriptor,
+	translate: TranslateFn,
+	input: EventStringInput = {}
+): RenderedEventStrings => {
+	const interpolation = input.interpolation || {};
+	const title = translate(descriptor.titleTemplate, {
+		defaultValue: input.fallbackTitle ?? '',
+		...interpolation
+	});
+	const text = translate(descriptor.textTemplate, {
+		defaultValue: input.fallbackText ?? '',
+		...interpolation
+	});
+	return { title, text };
+};

--- a/src/components/notificationsCenter/eventDescriptors/types.ts
+++ b/src/components/notificationsCenter/eventDescriptors/types.ts
@@ -1,0 +1,126 @@
+/**
+ * WP-06 Activity Timeline — Event-descriptor registry (Slice 0a).
+ *
+ * Types for the single registry that turns a typed, text-free server record
+ * (`event_notification`) into a rendered timeline card. See:
+ *   - ORISO-Frontend/CONTEXT.md  (glossary: "Event descriptor", "Event family",
+ *     "Action target")
+ *   - ADR-AT-01 (Storage & E2EE boundary): the server stores only `event_type`,
+ *     reference IDs and structured params — NO rendered display text. Every
+ *     visible string is rendered client-side from the i18n templates referenced
+ *     here.
+ *
+ * This module is intentionally pure (no React / no SVG imports) so it can be
+ * unit-tested in isolation and so the descriptor data stays serialisable. The
+ * SVG components are resolved separately via `icons.tsx` keyed by `EventIconId`.
+ */
+
+/**
+ * The grouping an event type belongs to — drives the timeline filter chips and
+ * shared iconography. Mirrors the families listed in CONTEXT.md.
+ * `appointments` is reserved (the family exists in the design) but no
+ * appointment event types are seeded yet — Appointment lifecycle events are
+ * deferred (WP-06 "Out of scope / deferred").
+ */
+export type EventFamily =
+	| 'requests'
+	| 'messages'
+	| 'drafts'
+	| 'handover'
+	| 'calls'
+	| 'system'
+	| 'appointments';
+
+/**
+ * Whether the event carries a chat-message preview (`message`) or is a
+ * business/system fact (`system`). Matches the existing
+ * `event_notification.category` contract used by `NotificationsCenter` to
+ * decide whether to hydrate a Matrix chat preview.
+ */
+export type EventCategory = 'system' | 'message';
+
+/**
+ * Stable identifier for the icon of an event type. Resolved to an SVG React
+ * component by `icons.tsx`. Kept as a string id (not the component itself) so
+ * this module stays free of SVG/React imports.
+ */
+export type EventIconId =
+	| 'requestNew'
+	| 'requestAccepted'
+	| 'message'
+	| 'threadReply'
+	| 'draft'
+	| 'handover'
+	| 'callStarted'
+	| 'callEnded'
+	| 'callMissed'
+	| 'supervisor'
+	| 'rename'
+	| 'system';
+
+/**
+ * The structured params a descriptor may use to resolve its action target.
+ * Today only a subset is populated by the backend (`actionPath`,
+ * `sourceSessionId`); the remainder is forward-looking for Slices 2–5 and for
+ * the strict text-free record migration (ADR-AT-01). Everything is optional so
+ * resolution degrades gracefully while the backend is incremental.
+ */
+export interface EventActionParams {
+	/** Pre-built navigation path emitted by the producer today (origin-encoded). */
+	actionPath?: string | null;
+	/** Session id the event belongs to, when known. */
+	sourceSessionId?: string | number | null;
+	/** Matrix room id / RC group id, when known. */
+	roomRef?: string | null;
+	/** Draft resume scope key (`forcedScopeKey`) for draft events. */
+	forcedScopeKey?: string | null;
+	/** Thread root id for thread-scoped message events. */
+	threadRootId?: string | null;
+	/** Live-call room id for `join` targets (Slice 5). */
+	callRoomId?: string | null;
+	/** Whether a live call is video (Slice 5). */
+	isVideo?: boolean | null;
+	/**
+	 * Base path for the signed-in user's conversation list, e.g.
+	 * `/sessions/consultant/sessionView` or `/sessions/user/view`. The consumer
+	 * passes this because it depends on the user's authority.
+	 */
+	sessionsBasePath?: string | null;
+	/** Base path for the request/enquiry list, when different from sessions. */
+	requestsBasePath?: string | null;
+}
+
+/**
+ * Where an event's primary action button takes the user. Rule = ORIGIN
+ * (CONTEXT.md "Action target"): chat events → the conversation;
+ * request-originating events → the request view; a draft → resume where it
+ * lives; a live call → Join (does not navigate — joins the call).
+ *
+ * This is pure data: resolving a target performs no navigation and no side
+ * effect. The consumer decides how to act on each `kind`.
+ */
+export type EventActionTarget =
+	| { kind: 'conversation'; path: string | null }
+	| { kind: 'request'; path: string | null }
+	| { kind: 'draft'; forcedScopeKey: string | null; path: string | null }
+	| { kind: 'join'; callRoomId: string | null; isVideo: boolean }
+	| { kind: 'none' };
+
+/**
+ * The per-event-type definition that owns everything needed to render that
+ * event: its icon, family, category, i18n title/text templates, and how to
+ * resolve its action target.
+ */
+export interface EventDescriptor {
+	/** The canonical `event_type` string this descriptor describes. */
+	eventType: string;
+	family: EventFamily;
+	category: EventCategory;
+	icon: EventIconId;
+	/** i18n key for the card title (rendered client-side, ADR-AT-01). */
+	titleTemplate: string;
+	/** i18n key for the card body text (rendered client-side, ADR-AT-01). */
+	textTemplate: string;
+	/** Origin-based action target. Pure — returns a descriptor, never navigates. */
+	resolveActionTarget: (params: EventActionParams) => EventActionTarget;
+}

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1309,6 +1309,89 @@
 		"tools": "Meine Tools"
 	},
 	"notifications": {
+		"families": {
+			"requests": "Anfragen",
+			"messages": "Nachrichten",
+			"drafts": "Entwürfe",
+			"handover": "Übergabe",
+			"calls": "Anrufe",
+			"system": "System",
+			"appointments": "Termine"
+		},
+		"events": {
+			"fallback": {
+				"title": "Aktivität",
+				"text": ""
+			},
+			"inquiryAccepted": {
+				"title": "Anfrage angenommen",
+				"text": "Die Anfrage wurde angenommen. Sie können das Gespräch beginnen."
+			},
+			"messageNew": {
+				"title": "Neue Nachricht",
+				"text": "Sie haben eine neue Nachricht erhalten."
+			},
+			"threadReplyNew": {
+				"title": "Neue Thread-Antwort",
+				"text": "Es gibt eine neue Antwort in einem Thread."
+			},
+			"supervisorAdded": {
+				"title": "Supervisor hinzugefügt",
+				"text": "Diesem Fall wurde ein Supervisor hinzugefügt."
+			},
+			"supervisorRemoved": {
+				"title": "Supervisor entfernt",
+				"text": "Aus diesem Fall wurde ein Supervisor entfernt."
+			},
+			"supervisorAssigned": {
+				"title": "Supervisor zugewiesen",
+				"text": "Diesem Fall wurde ein Supervisor zugewiesen."
+			},
+			"counselorRenamed": {
+				"title": "Berater:in umbenannt",
+				"text": "Der Anzeigename der Beratung hat sich geändert."
+			},
+			"requestNew": {
+				"title": "Neue Klient:innen-Anfrage",
+				"text": "Eine neue Anfrage wartet auf Bearbeitung."
+			},
+			"draftCreated": {
+				"title": "Entwurf gespeichert",
+				"text": "Sie haben einen ungesendeten Entwurf. Dort fortfahren, wo Sie aufgehört haben."
+			},
+			"handoverRequested": {
+				"title": "Übergabe angefragt",
+				"text": "Eine Fallübergabe wurde angefragt. Beide Seiten müssen bestätigen."
+			},
+			"handoverPartial": {
+				"title": "Übergabe teilweise bestätigt",
+				"text": "Eine Seite hat die Übergabe bestätigt."
+			},
+			"handoverAllConfirmed": {
+				"title": "Übergabe bestätigt",
+				"text": "Beide Seiten haben bestätigt. Die Übergabe ist wirksam."
+			},
+			"handoverAutoConfirmed": {
+				"title": "Übergabe automatisch bestätigt",
+				"text": "Die Übergabe wurde per Richtlinie automatisch bestätigt."
+			},
+			"handoverDenied": {
+				"title": "Übergabe abgelehnt",
+				"text": "Die Übergabe wurde abgelehnt und abgebrochen."
+			},
+			"callStarted": {
+				"title": "Anruf läuft",
+				"text": "Ein Anruf läuft gerade. Treten Sie bei, um teilzunehmen."
+			},
+			"callEnded": {
+				"title": "Anruf beendet",
+				"text": "Der Anruf wurde beendet."
+			},
+			"callMissed": {
+				"title": "Verpasster Anruf",
+				"text": "Sie haben einen Anruf verpasst."
+			}
+		},
 		"error": "Fehlgeschlagen",
 		"info": "Information",
 		"initialRequest": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1285,6 +1285,89 @@
 		"tools": "My tools"
 	},
 	"notifications": {
+		"families": {
+			"requests": "Requests",
+			"messages": "Messages",
+			"drafts": "Drafts",
+			"handover": "Handover",
+			"calls": "Calls",
+			"system": "System",
+			"appointments": "Appointments"
+		},
+		"events": {
+			"fallback": {
+				"title": "Activity",
+				"text": ""
+			},
+			"inquiryAccepted": {
+				"title": "Request accepted",
+				"text": "The request was accepted. You can start the conversation."
+			},
+			"messageNew": {
+				"title": "New message",
+				"text": "You received a new message."
+			},
+			"threadReplyNew": {
+				"title": "New thread reply",
+				"text": "There is a new reply in a thread."
+			},
+			"supervisorAdded": {
+				"title": "Supervisor added",
+				"text": "A supervisor was added to this case."
+			},
+			"supervisorRemoved": {
+				"title": "Supervisor removed",
+				"text": "A supervisor was removed from this case."
+			},
+			"supervisorAssigned": {
+				"title": "Supervisor assigned",
+				"text": "A supervisor was assigned to this case."
+			},
+			"counselorRenamed": {
+				"title": "Counsellor renamed",
+				"text": "The counsellor's display name has changed."
+			},
+			"requestNew": {
+				"title": "New client request",
+				"text": "A new client request is waiting."
+			},
+			"draftCreated": {
+				"title": "Draft saved",
+				"text": "You have an unsent draft. Resume where you left off."
+			},
+			"handoverRequested": {
+				"title": "Handover requested",
+				"text": "A case handover was requested. Both parties must confirm."
+			},
+			"handoverPartial": {
+				"title": "Handover partially confirmed",
+				"text": "One party has confirmed the handover."
+			},
+			"handoverAllConfirmed": {
+				"title": "Handover confirmed",
+				"text": "Both parties confirmed. The handover took effect."
+			},
+			"handoverAutoConfirmed": {
+				"title": "Handover auto-confirmed",
+				"text": "The handover was auto-confirmed by policy."
+			},
+			"handoverDenied": {
+				"title": "Handover denied",
+				"text": "The handover was denied and cancelled."
+			},
+			"callStarted": {
+				"title": "Call ongoing",
+				"text": "A call is ongoing. Join to participate."
+			},
+			"callEnded": {
+				"title": "Call ended",
+				"text": "The call has ended."
+			},
+			"callMissed": {
+				"title": "Missed call",
+				"text": "You missed a call."
+			}
+		},
 		"error": "failed",
 		"info": "info",
 		"initialRequest": {


### PR DESCRIPTION
## WP-06 Activity Timeline — Slice 0a (Event-descriptor registry)

Additive foundation for the Activity Timeline. Introduces a **single registry** that turns a typed, text-free server record into a rendered timeline card, and wires it into `NotificationsCenter` to replace the generic bell + system/message tag with per-type icons and family labels.

### What's in here
- **`src/components/notificationsCenter/eventDescriptors/`** — pure registry mapping `event_type → { icon, family, category, i18n title/text template, resolveActionTarget(params) }`.
  - `types.ts`, `registry.ts`, `renderEventStrings.ts` are pure (no React/SVG imports) and unit-testable in isolation; `icons.tsx` is the only file importing SVGs. `tsc` enforces icon-map completeness (`Record<EventIconId, …>`).
  - **Seeds all listed types**: the 6 emitted today (`inquiry.accepted`, `message.new`, `thread.reply.new`, `supervisor.added/removed/assigned`, `counselor.renamed`) **plus** descriptors for the designed families **Requests, Messages, Drafts, Handover, Calls, System** (Appointments deferred).
  - **Action-target rule = origin** (per `CONTEXT.md`): chat → conversation; request-origin → request view; draft → resume via `forcedScopeKey`; live call → **Join**. Targets are **pure data** — no navigation or call-stack wiring (deferred to Slices 4/5).
- **`NotificationsCenter.tsx`** — now renders each card's icon/family/title/text from the descriptor. Every visible string comes from i18n templates client-side (**ADR-AT-01**: the server record is text-free). While the backend still sends `title`/`text` (pre-Slice-2), those are used only as the i18n `defaultValue`, so nothing regresses and **no server-side rendered text is introduced**.
- **i18n** — `notifications.events.*` + `notifications.families.*` added to `en` and `de`; other locales fall back to `de` (`FALLBACK_LNG`).
- **Tests** — `cypress/e2e/eventDescriptors.cy.ts`: a pure-logic spec covering every seeded type (family/category/icon/templates), the origin action-target kinds, fallback for unknown types, i18n key presence (en+de), and client-side rendering. Runs under the repo's Cypress harness.
- **`CONTEXT.md`** — the Activity Timeline glossary referenced by the registry's code comments and the ADRs.

### Scope guardrails (explicitly **not** in this slice)
- No global selection controller (that's **Slice 0b**, separate PR — this PR leaves `--active` untouched).
- No backend migration of `event_notification` (Slice 2), no Handover internals (Slice 4), no call events/join wiring (Slice 5), no Drafts section removal/encryption.
- **No visual restyle** beyond the additive per-type icon + family label the design requires.

### Verification
- `npx tsc` — 0 errors.
- `eslint` on touched files — 0 errors (only pre-existing warnings).
- `CI=false npm run build` — succeeds (the CI gate).
- Registry logic verified green (all assertions in the spec pass).

Refs: WP-06 Activity Timeline; ADR-AT-01 (Storage & E2EE boundary), ADR-AT-02 (stateful event model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer notifications timeline with standardized event types, categories, icons, and localized titles/texts.
  * Notification items now display more specific labels and icons, with better handling for system and message events.
  * Expanded language support for notification families and event messages in English and German.

* **Bug Fixes**
  * Improved fallback behavior for unknown or missing event types so notifications still render cleanly.
  * Added logic to route notification actions to the most appropriate destination, including chat, requests, drafts, and calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->