### PR TITLE
feat(timeline): route-derived list-item selection controller (WP-06 Slice 0b)

### DIFF
--- a/cypress/e2e/listItemSelection.cy.ts
+++ b/cypress/e2e/listItemSelection.cy.ts
@@ -1,0 +1,123 @@
+/**
+ * WP-06 Activity Timeline — unit coverage for the route-derived list-item
+ * selection (Slice 0b). Pure-logic spec: imports the selection utility directly
+ * and asserts with chai's `expect`. No app visit / backend required.
+ */
+
+import {
+	deriveActiveSelection,
+	isListItemActive,
+	ListItemIdentity
+} from '../../src/utils/listItemSelection';
+
+describe('WP-06 list-item selection controller', () => {
+	describe('deriveActiveSelection', () => {
+		it('has no active item on bare list views or the timeline', () => {
+			['/sessions/consultant/sessionView', '/sessions/user/view', '/notifications', '/', ''].forEach(
+				(p) => {
+					expect(deriveActiveSelection(p), p).to.deep.equal({
+						groupId: null,
+						sessionId: null
+					});
+				}
+			);
+		});
+
+		it('derives the sessionId from a Matrix session route (groupId null)', () => {
+			expect(
+				deriveActiveSelection('/sessions/consultant/sessionView/session/123')
+			).to.deep.equal({ groupId: null, sessionId: '123' });
+			expect(
+				deriveActiveSelection('/sessions/user/view/session/55')
+			).to.deep.equal({ groupId: null, sessionId: '55' });
+		});
+
+		it('derives groupId + sessionId from a RocketChat route', () => {
+			expect(
+				deriveActiveSelection('/sessions/consultant/sessionView/AbCdGroup/123')
+			).to.deep.equal({ groupId: 'AbCdGroup', sessionId: '123' });
+		});
+
+		it('derives the sessionId from the enquiry write route', () => {
+			expect(
+				deriveActiveSelection('/sessions/user/view/write/77')
+			).to.deep.equal({ groupId: null, sessionId: '77' });
+		});
+
+		it('does not mistake the "session"/"write" literal for a group id', () => {
+			expect(
+				deriveActiveSelection('/sessions/consultant/sessionPreview/session/9').groupId
+			).to.equal(null);
+		});
+
+		it('tolerates a trailing slash', () => {
+			expect(
+				deriveActiveSelection('/sessions/consultant/sessionView/session/123/')
+			).to.deep.equal({ groupId: null, sessionId: '123' });
+		});
+	});
+
+	describe('isListItemActive', () => {
+		it('matches by sessionId, normalising number vs string', () => {
+			const selection = deriveActiveSelection(
+				'/sessions/consultant/sessionView/session/123'
+			);
+			expect(isListItemActive(selection, { sessionId: 123 })).to.equal(true);
+			expect(isListItemActive(selection, { sessionId: '123' })).to.equal(true);
+			expect(isListItemActive(selection, { sessionId: 456 })).to.equal(false);
+		});
+
+		it('matches by groupId or rid', () => {
+			const selection = deriveActiveSelection(
+				'/sessions/consultant/sessionView/AbCdGroup/123'
+			);
+			expect(isListItemActive(selection, { groupId: 'AbCdGroup' })).to.equal(true);
+			expect(isListItemActive(selection, { rid: 'AbCdGroup' })).to.equal(true);
+			expect(isListItemActive(selection, { groupId: 'OtherGroup' })).to.equal(false);
+		});
+
+		it('NEW: entering a Matrix chat room activates that conversation', () => {
+			// Previously `activeSession.rid === groupIdFromParam` compared against
+			// the literal "session" segment and never matched — so the room did
+			// not light up. The route-derived sessionId now matches the item.
+			const selection = deriveActiveSelection(
+				'/sessions/consultant/sessionView/session/55'
+			);
+			const matrixRoomItem: ListItemIdentity = {
+				groupId: null,
+				rid: '!abc:matrix.example',
+				sessionId: 55
+			};
+			expect(isListItemActive(selection, matrixRoomItem)).to.equal(true);
+		});
+
+		it('nothing is active when no conversation is open', () => {
+			const selection = deriveActiveSelection('/sessions/consultant/sessionView');
+			expect(isListItemActive(selection, { sessionId: 1, groupId: 'g' })).to.equal(
+				false
+			);
+		});
+	});
+
+	describe('exactly-one-active invariant', () => {
+		const items: ListItemIdentity[] = [
+			{ sessionId: 1, groupId: 'g1', rid: 'g1' },
+			{ sessionId: 2, groupId: 'g2', rid: 'g2' },
+			{ sessionId: 3, groupId: 'g3', rid: 'g3' }
+		];
+
+		const activeCount = (pathname: string) => {
+			const selection = deriveActiveSelection(pathname);
+			return items.filter((it) => isListItemActive(selection, it)).length;
+		};
+
+		it('marks exactly one item active inside a conversation', () => {
+			expect(activeCount('/sessions/consultant/sessionView/session/2')).to.equal(1);
+			expect(activeCount('/sessions/consultant/sessionView/g3/3')).to.equal(1);
+		});
+
+		it('marks zero items active on the bare list', () => {
+			expect(activeCount('/sessions/consultant/sessionView')).to.equal(0);
+		});
+	});
+});

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -122,8 +122,16 @@
 		background: #fafafa;
 	}
 
+	// WP-06 Slice 0b: keyboard focus is independent of selection (a11y).
+	&__listItem:focus-visible {
+		@include list-item-focus-treatment;
+	}
+
+	// WP-06 Slice 0b: normalise the active row to the shared selection
+	// treatment (lightened background + 2px accent ring) so the timeline
+	// matches the conversation/request lists instead of a one-off colour.
 	&__listItem--active {
-		background: #fff6f7;
+		@include list-item-active-treatment;
 	}
 
 	&__listItemHeader {

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useParams, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+import { useActiveListItem } from '../../hooks/useActiveListItem';
 import { getSessionsListItemIcon, LIST_ICONS } from './sessionsListItemHelpers';
 import {
 	convertISO8601ToMSSinceEpoch,
@@ -93,11 +94,9 @@ export const SessionListItemComponent = ({
 	const [matrixMembers, setMatrixMembers] = useState<RoomMember[]>([]);
 	const { t: translate } = useTranslation(['common']);
 	const settings = useAppConfig();
-	const { sessionId, rcGroupId: groupIdFromParam } = useParams<{
-		rcGroupId: string;
-		sessionId: string;
-	}>();
-	const sessionIdFromParam = sessionId ? parseInt(sessionId) : null;
+	// WP-06 Slice 0b: route-derived single source of truth for the active item
+	// (replaces the per-component rid/sessionId comparison below).
+	const { isActive } = useActiveListItem();
 	const history = useHistory();
 
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
@@ -126,9 +125,11 @@ export const SessionListItemComponent = ({
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
 
 	// Is List Item active
-	const isChatActive =
-		activeSession.rid === groupIdFromParam ||
-		activeSession.item.id === sessionIdFromParam;
+	const isChatActive = isActive({
+		groupId: activeSession.item.groupId,
+		rid: activeSession.rid,
+		sessionId: activeSession.item.id
+	});
 
 	const language = activeSession.item.language || defaultLanguage;
 	const consultingType = useConsultingType(activeSession.item.consultingType);

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -2,11 +2,15 @@ $icon-size: 24px;
 $icon-size-small: 16px;
 $session-card-bg: #eae7e8;
 $session-card-hover-bg: #eadcdc;
-$session-card-selected-bg: #fffafa;
+
+// WP-06 Slice 0b: source the active-state colours from the shared list-item
+// selection tokens (settings.scss → _listItemSelection.scss). Values are
+// unchanged — this only makes them the single canonical source.
+$session-card-selected-bg: $list-item-selected-bg;
 $session-light-border: rgba(255, 255, 255, 0.58);
-$session-selected-border: #ff9d96;
-$session-active-border: #d93025;
-$session-focus-ring: rgba(185, 54, 45, 0.35);
+$session-selected-border: $list-item-accent-ring;
+$session-active-border: $list-item-action-color;
+$session-focus-ring: $list-item-focus-ring;
 $session-topic-chip-bg: #646d78;
 $session-topic-chip-color: #ffffff;
 $session-postcode-border: #646d78;
@@ -143,9 +147,9 @@ $session-postcode-border: #646d78;
 		}
 
 		// Show a single keyboard-navigation ring for the focused item.
+		// WP-06 Slice 0b: shared focus treatment (identical output).
 		&:focus-visible {
-			outline: none;
-			box-shadow: 0 0 0 3px $session-focus-ring;
+			@include list-item-focus-treatment;
 			transition: box-shadow 0.2s ease;
 		}
 

--- a/src/hooks/useActiveListItem.ts
+++ b/src/hooks/useActiveListItem.ts
@@ -1,0 +1,39 @@
+/**
+ * WP-06 Activity Timeline — selection controller hook (Slice 0b).
+ *
+ * Route-derived single source of truth for the active list item. Used by the
+ * conversation list, the request list and the Activity Timeline so the
+ * exactly-one-active invariant holds across all of them, instead of each
+ * component computing (and drifting on) its own flag. See
+ * `utils/listItemSelection` and CONTEXT.md "Active item".
+ */
+
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+	ActiveListSelection,
+	ListItemIdentity,
+	deriveActiveSelection,
+	isListItemActive
+} from '../utils/listItemSelection';
+
+export interface UseActiveListItem {
+	/** The active conversation identity derived from the current route. */
+	selection: ActiveListSelection;
+	/** Whether the given list item is the (single) active one. */
+	isActive: (identity: ListItemIdentity) => boolean;
+}
+
+export const useActiveListItem = (): UseActiveListItem => {
+	const { pathname } = useLocation();
+	const selection = useMemo(
+		() => deriveActiveSelection(pathname),
+		[pathname]
+	);
+	const isActive = useMemo(
+		() => (identity: ListItemIdentity) =>
+			isListItemActive(selection, identity),
+		[selection]
+	);
+	return { selection, isActive };
+};

--- a/src/resources/styles/_listItemSelection.scss
+++ b/src/resources/styles/_listItemSelection.scss
@@ -1,0 +1,33 @@
+// WP-06 Activity Timeline — shared list-item selection primitive (Slice 0b).
+// The single, canonical definition of the active / focus states for any
+// selectable list item (conversation list, request list, Activity Timeline).
+// Tokens mirror the existing conversation-list treatment so nothing is
+// restyled — this only normalises the states so they cannot drift apart per
+// component (CONTEXT.md "Active item"). Imported from settings.scss, which is
+// prepended to every component stylesheet, so the tokens and mixins are
+// globally available without an explicit import.
+
+// --- Tokens ---
+
+$list-item-selected-bg: #fffafa !default; // lightened active background
+$list-item-accent-ring: #ff9d96 !default; // graduated accent ring colour
+$list-item-accent-ring-width: 2px !default; // canonical selection ring width
+$list-item-action-color: #d93025 !default; // red action-target button colour
+$list-item-resting-border: rgba(0, 0, 0, 0.12) !default; // 1px secondary border
+$list-item-focus-ring: rgba(185, 54, 45, 0.35) !default; // a11y focus ring
+
+// --- Mixins ---
+
+// Active selection: lightened background + 2px accent ring. The ring is an
+// inset box-shadow so selecting an item never changes its box size / shifts
+// layout, and it composes onto any existing border.
+@mixin list-item-active-treatment {
+	background-color: $list-item-selected-bg;
+	box-shadow: inset 0 0 0 $list-item-accent-ring-width $list-item-accent-ring;
+}
+
+// Keyboard focus is independent of selection and layers on top.
+@mixin list-item-focus-treatment {
+	outline: none;
+	box-shadow: 0 0 0 3px $list-item-focus-ring;
+}

--- a/src/resources/styles/settings.scss
+++ b/src/resources/styles/settings.scss
@@ -5,6 +5,9 @@
 // BREAKPOINTS
 @import '~breakpoint-sass/stylesheets/breakpoint';
 
+// WP-06 Activity Timeline — shared list-item selection tokens + mixins (Slice 0b)
+@import './listItemSelection';
+
 // FONTS
 $font-family-sans-serif: Roboto, sans-serif;
 $font-family-divider: RobotoSlab, serif;

--- a/src/utils/listItemSelection.ts
+++ b/src/utils/listItemSelection.ts
@@ -1,0 +1,116 @@
+/**
+ * WP-06 Activity Timeline — global list-item selection (Slice 0b).
+ *
+ * Single, route-derived source of truth for "which list item is active". Pure
+ * functions (no React) so they can be unit-tested in isolation; the
+ * `useActiveListItem` hook is a thin wrapper over `deriveActiveSelection`.
+ *
+ * Replaces the per-component active flags that drift apart and let several
+ * items go "red" at once (CONTEXT.md "Active item"): `SessionListItemComponent`
+ * computed `activeSession.rid === groupIdFromParam || activeSession.item.id ===
+ * sessionIdFromParam` itself, which also failed to match Matrix rooms (the
+ * `/session/:sessionId` route) so entering a chat room did not activate it.
+ *
+ * Invariant: exactly one active item. The active identity is derived once from
+ * the URL and every list item compares against it, so two items cannot both be
+ * active unless their identities collide (they don't — sessionId and groupId
+ * are unique per conversation).
+ */
+
+import { matchPath } from 'react-router-dom';
+
+/** The active conversation/request identity derived from the current route. */
+export interface ActiveListSelection {
+	/** RC group id / Matrix room id of the active conversation, if any. */
+	groupId: string | null;
+	/** Numeric session id (as string) of the active conversation, if any. */
+	sessionId: string | null;
+}
+
+/** Identity of a single rendered list item, compared against the selection. */
+export interface ListItemIdentity {
+	/** RC group id (a.k.a. `rid`) or Matrix room id. */
+	groupId?: string | number | null;
+	/** Alias for `groupId` (matches `activeSession.rid`). */
+	rid?: string | number | null;
+	/** Numeric session id. */
+	sessionId?: string | number | null;
+}
+
+/**
+ * Session routes that carry an active conversation, most specific first. The
+ * `write/` and `session/` literals must precede the generic `:rcGroupId`
+ * patterns so those literal segments are never mistaken for a group id.
+ * Covers consultant (`sessionView` / `sessionPreview`) and asker (`view`).
+ */
+const SESSION_ROUTE_PATTERNS: ReadonlyArray<string> = [
+	'/sessions/:userType/:listType/write/:sessionId',
+	'/sessions/:userType/:listType/session/:sessionId',
+	'/sessions/:userType/:listType/:rcGroupId/:sessionId',
+	'/sessions/:userType/:listType/:rcGroupId'
+];
+
+const EMPTY_SELECTION: ActiveListSelection = { groupId: null, sessionId: null };
+
+const norm = (value: string | number | null | undefined): string | null => {
+	const str = value == null ? '' : String(value).trim();
+	return str.length ? str : null;
+};
+
+/**
+ * Derive the active conversation identity from a pathname. Returns
+ * `{ groupId: null, sessionId: null }` when no conversation is open (e.g. on a
+ * bare list view or the timeline).
+ */
+export const deriveActiveSelection = (
+	pathname: string
+): ActiveListSelection => {
+	if (!pathname) {
+		return EMPTY_SELECTION;
+	}
+	for (const path of SESSION_ROUTE_PATTERNS) {
+		const match = matchPath<{ rcGroupId?: string; sessionId?: string }>(
+			pathname,
+			{ path, exact: false }
+		);
+		if (match) {
+			return {
+				groupId: norm(match.params.rcGroupId),
+				sessionId: norm(match.params.sessionId)
+			};
+		}
+	}
+	return EMPTY_SELECTION;
+};
+
+/**
+ * Whether a given list item is the active one. Compares by sessionId first
+ * (unique per conversation), then by groupId/rid. Normalises string vs number
+ * so a numeric `item.id` matches the string route param — the mismatch that
+ * previously left Matrix rooms un-highlighted.
+ */
+export const isListItemActive = (
+	selection: ActiveListSelection | null | undefined,
+	identity: ListItemIdentity
+): boolean => {
+	if (!selection) {
+		return false;
+	}
+	const itemSessionId = norm(identity.sessionId);
+	if (
+		selection.sessionId != null &&
+		itemSessionId != null &&
+		itemSessionId === selection.sessionId
+	) {
+		return true;
+	}
+	const itemGroupId = norm(identity.groupId ?? identity.rid);
+	if (
+		selection.groupId != null &&
+		itemGroupId != null &&
+		itemGroupId === selection.groupId
+	) {
+		return true;
+	}
+	return false;
+};


### PR DESCRIPTION
## WP-06 Activity Timeline — Slice 0b (Global selection controller)

One **route-derived source of truth** for which list item is active, replacing the per-component flags that drift apart and let several items go "red" at once. Robustness fix, **not** a new design.

### What's in here
- **`src/utils/listItemSelection.ts`** — pure `deriveActiveSelection(pathname)` + `isListItemActive(selection, identity)`. Handles every session route (consultant `sessionView`/`sessionPreview`, asker `view`; RC `:rcGroupId/:sessionId`, Matrix `session/:sessionId`, enquiry `write/:sessionId`) and **normalises string vs number** so a numeric `item.id` matches the string route param.
- **`src/hooks/useActiveListItem.ts`** — thin `useLocation`-based hook exposing `{ selection, isActive }`.
- **`SessionListItemComponent`** (conversation list **and** request list) now derives `isChatActive` from the hook instead of `activeSession.rid === groupIdFromParam || activeSession.item.id === sessionIdFromParam`.
- **New behaviour**: entering a chat room now marks that conversation active — the old comparison matched the literal `session` route segment and never lit up Matrix rooms.
- **`src/resources/styles/_listItemSelection.scss`** — shared tokens + mixins (`list-item-active-treatment`, `list-item-focus-treatment`), imported globally via `settings.scss`.

### Visual treatment (normalise, don't restyle)
- **Conversation / request lists**: unchanged. Their existing active/focus values are now **sourced from the shared tokens** (same colours) and the focus ring uses the shared mixin — zero visual change.
- **Activity Timeline**: its one-off `#fff6f7` active row is normalised to the **canonical treatment** (lightened background + **2px accent ring**) and gains an independent `:focus-visible` ring, so it matches the conversation/request lists.
- Active = lightened bg + 2px accent ring + red action button; resting = 1px secondary; `focus-visible` is independent and layers on top.

### Invariant
Active identity is derived **once** from the URL; every item compares against it, so two items can't both be active (sessionId/groupId are unique per conversation). Covered by the unit spec, including the exactly-one-active count and the enter-room-activates case.

### Scope guardrails (explicitly **not** in this slice)
- No event-descriptor registry (that's **Slice 0a**, separate PR — disjoint file set, no overlap).
- No restyle of the conversation/request lists; no Handover/Calls/Drafts/backend work.

### Verification
- `npx tsc` — 0 errors; `eslint` on touched files — 0 errors (only pre-existing warnings).
- `stylelint` — my additions are clean (remaining errors pre-exist on `dev`).
- `CI=false npm run build` — succeeds.
- Selection logic verified green: route derivation, normalisation, enter-room-activates, and exactly-one-active all pass.

Refs: WP-06 Activity Timeline; CONTEXT.md "Active item".

🤖 Generated with [Claude Code](https://claude.com/claude-code)