### PR TITLE
fix(api): don't swallow apiGetTopicsData load errors

### DIFF
--- a/src/api/apiGetTopicsData.ts
+++ b/src/api/apiGetTopicsData.ts
@@ -14,6 +14,6 @@ export const apiGetTopicsData = async (): Promise<TopicsDataInterface[]> => {
 		if (error.message === FETCH_ERRORS.EMPTY) {
 			return [];
 		}
-		Promise.reject(error);
+		return Promise.reject(error);
 	});
 };


### PR DESCRIPTION
## Problem
`apiGetTopicsData` swallows real load errors: its catch handler builds `Promise.reject(error)` but never returns it, so any non-`EMPTY` failure resolves the promise to `undefined` instead of rejecting.

## Fix
Add the missing `return` so the rejection propagates.

## Context
Salvaged from #227. The `skipAuth: true` change there is intentionally **not** included — it collides with #238 (merged), whose stale-token self-heal relies on the public topics call surfacing a 401. This is just the orthogonal error-propagation bugfix.