### PR TITLE
feat(timeline): family filter chips + client search (WP-06 Slice 1) [DRAFT]

### DIFF
--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -11,6 +11,11 @@ import {
 import { useActiveListItem } from '../../hooks/useActiveListItem';
 import { pickActiveItemKey } from '../../utils/listItemSelection';
 import {
+	filterTimelineItems,
+	getFamiliesInFeed,
+	TimelineFamilyFilter
+} from './timelineFilter';
+import {
 	NotificationsContext,
 	UserDataContext,
 	AUTHORITIES,
@@ -120,44 +125,77 @@ export const NotificationsCenter = () => {
 	const [selectedNotificationId, setSelectedNotificationId] = useState<
 		string | null
 	>(notificationFeed[0]?.id || null);
+	// WP-06 Slice 1: timeline family filter chip (exactly one active) + search.
+	const [activeFamily, setActiveFamily] =
+		useState<TimelineFamilyFilter>('all');
+	const [searchQuery, setSearchQuery] = useState('');
 
-	useEffect(() => {
-		if (!selectedNotificationId && notificationFeed.length > 0) {
-			setSelectedNotificationId(notificationFeed[0].id);
-			return;
-		}
+	// Families actually present in the feed, in canonical order (drives chips).
+	const familiesInFeed = useMemo(
+		() => getFamiliesInFeed(notificationFeed),
+		[notificationFeed]
+	);
+
+	// WP-06 Slice 1: client-side filter (family chip + search). Search matches
+	// the client-rendered strings only — ADR-AT-01 forbids server full-text.
+	const filteredFeed = useMemo(
+		() =>
+			filterTimelineItems(
+				notificationFeed,
+				{ family: activeFamily, query: searchQuery },
+				(item) => {
+					const { title, text } = describeItem(item, translate);
+					return `${title} ${text}`;
+				}
+			),
+		[notificationFeed, activeFamily, searchQuery, translate]
+	);
+
+	// Keep the master-detail selection inside the visible (filtered) feed.
+	const effectiveSelectedId = useMemo(() => {
 		if (
 			selectedNotificationId &&
-			!notificationFeed.some((item) => item.id === selectedNotificationId)
+			filteredFeed.some((item) => item.id === selectedNotificationId)
 		) {
-			setSelectedNotificationId(notificationFeed[0]?.id || null);
+			return selectedNotificationId;
 		}
-	}, [notificationFeed, selectedNotificationId]);
+		return filteredFeed[0]?.id ?? null;
+	}, [filteredFeed, selectedNotificationId]);
+
+	useEffect(() => {
+		if (selectedNotificationId !== effectiveSelectedId) {
+			setSelectedNotificationId(effectiveSelectedId);
+		}
+	}, [effectiveSelectedId, selectedNotificationId]);
+
+	// Drop back to "All" if the active family is no longer in the feed.
+	useEffect(() => {
+		if (activeFamily !== 'all' && !familiesInFeed.includes(activeFamily)) {
+			setActiveFamily('all');
+		}
+	}, [familiesInFeed, activeFamily]);
 
 	// WP-06 Slice 0b: resolve a SINGLE active card id through the shared
-	// selection primitive. When a conversation is route-active its card wins;
-	// otherwise the in-page master-detail selection (`selectedNotificationId`)
-	// is used. Exactly one card is active by construction. On the standalone
-	// `/notifications` route the route selection is empty, so this is identical
-	// to the previous behaviour (no visual change).
+	// selection primitive over the visible feed. When a conversation is
+	// route-active its card wins; otherwise the in-page master-detail selection
+	// is used. Exactly one card is active by construction.
 	const activeNotificationId = useMemo(
 		() =>
 			pickActiveItemKey(
-				notificationFeed,
+				filteredFeed,
 				activeSelection,
 				(item) => ({ sessionId: resolveSessionId(item) }),
 				(item) => item.id,
-				selectedNotificationId
+				effectiveSelectedId
 			),
-		[notificationFeed, activeSelection, selectedNotificationId]
+		[filteredFeed, activeSelection, effectiveSelectedId]
 	);
 
 	const selectedNotification = useMemo(
 		() =>
-			notificationFeed.find(
-				(item) => item.id === activeNotificationId
-			) || null,
-		[notificationFeed, activeNotificationId]
+			filteredFeed.find((item) => item.id === activeNotificationId) ||
+			null,
+		[filteredFeed, activeNotificationId]
 	);
 	const selectedNotificationCategory = useMemo(
 		() =>
@@ -219,23 +257,23 @@ export const NotificationsCenter = () => {
 		fromId: string | null,
 		unreadOnly: boolean
 	): string | null => {
-		if (notificationFeed.length === 0) {
+		if (filteredFeed.length === 0) {
 			return null;
 		}
 		const startIndex = fromId
-			? notificationFeed.findIndex((item) => item.id === fromId)
+			? filteredFeed.findIndex((item) => item.id === fromId)
 			: -1;
-		const matchesRule = (item: (typeof notificationFeed)[number]) =>
+		const matchesRule = (item: (typeof filteredFeed)[number]) =>
 			!unreadOnly || !item.readAt;
 
-		for (let i = startIndex + 1; i < notificationFeed.length; i++) {
-			if (matchesRule(notificationFeed[i])) {
-				return notificationFeed[i].id;
+		for (let i = startIndex + 1; i < filteredFeed.length; i++) {
+			if (matchesRule(filteredFeed[i])) {
+				return filteredFeed[i].id;
 			}
 		}
 		for (let i = 0; i <= startIndex; i++) {
-			if (i >= 0 && matchesRule(notificationFeed[i])) {
-				return notificationFeed[i].id;
+			if (i >= 0 && matchesRule(filteredFeed[i])) {
+				return filteredFeed[i].id;
 			}
 		}
 		return null;
@@ -279,7 +317,7 @@ export const NotificationsCenter = () => {
 			true
 		);
 		if (nextUnreadId) {
-			const nextItem = notificationFeed.find(
+			const nextItem = filteredFeed.find(
 				(item) => item.id === nextUnreadId
 			);
 			if (nextItem) {
@@ -322,6 +360,60 @@ export const NotificationsCenter = () => {
 			</div>
 			<div className="notificationsCenter__content">
 				<div className="notificationsCenter__list">
+					<div className="notificationsCenter__filters">
+						<div
+							className="notificationsCenter__chips"
+							role="tablist"
+							aria-label={translate(
+								'notifications.center.title',
+								'Notifications'
+							)}
+						>
+							<button
+								type="button"
+								role="tab"
+								aria-selected={activeFamily === 'all'}
+								className={`notificationsCenter__chip ${
+									activeFamily === 'all'
+										? 'notificationsCenter__chip--active'
+										: ''
+								}`}
+								onClick={() => setActiveFamily('all')}
+							>
+								{translate('notifications.families.all', 'All')}
+							</button>
+							{familiesInFeed.map((family) => (
+								<button
+									key={family}
+									type="button"
+									role="tab"
+									aria-selected={activeFamily === family}
+									className={`notificationsCenter__chip ${
+										activeFamily === family
+											? 'notificationsCenter__chip--active'
+											: ''
+									}`}
+									onClick={() => setActiveFamily(family)}
+								>
+									{translate(familyLabelKey(family))}
+								</button>
+							))}
+						</div>
+						<input
+							type="search"
+							className="notificationsCenter__search"
+							placeholder={translate(
+								'notifications.center.searchPlaceholder',
+								'Search activity…'
+							)}
+							value={searchQuery}
+							onChange={(event) => setSearchQuery(event.target.value)}
+							aria-label={translate(
+								'notifications.center.searchPlaceholder',
+								'Search activity…'
+							)}
+						/>
+					</div>
 					{notificationFeed.length === 0 ? (
 						<div className="notificationsCenter__empty">
 							{translate(
@@ -329,8 +421,15 @@ export const NotificationsCenter = () => {
 								'No notifications yet.'
 							)}
 						</div>
+					) : filteredFeed.length === 0 ? (
+						<div className="notificationsCenter__empty">
+							{translate(
+								'notifications.center.noResults',
+								'No activity matches your filters.'
+							)}
+						</div>
 					) : (
-						notificationFeed.map((item) =>
+						filteredFeed.map((item) =>
 							(() => {
 								const category = resolveItemCategory(item);
 								const isMessage = category === 'message';

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -360,60 +360,67 @@ export const NotificationsCenter = () => {
 			</div>
 			<div className="notificationsCenter__content">
 				<div className="notificationsCenter__list">
-					<div className="notificationsCenter__filters">
-						<div
-							className="notificationsCenter__chips"
-							role="tablist"
-							aria-label={translate(
-								'notifications.center.title',
-								'Notifications'
-							)}
-						>
-							<button
-								type="button"
-								role="tab"
-								aria-selected={activeFamily === 'all'}
-								className={`notificationsCenter__chip ${
-									activeFamily === 'all'
-										? 'notificationsCenter__chip--active'
-										: ''
-								}`}
-								onClick={() => setActiveFamily('all')}
+					{notificationFeed.length > 0 && (
+						<div className="notificationsCenter__filters">
+							<div
+								className="notificationsCenter__chips"
+								role="tablist"
+								aria-label={translate(
+									'notifications.center.title',
+									'Notifications'
+								)}
 							>
-								{translate('notifications.families.all', 'All')}
-							</button>
-							{familiesInFeed.map((family) => (
 								<button
-									key={family}
 									type="button"
 									role="tab"
-									aria-selected={activeFamily === family}
+									aria-selected={activeFamily === 'all'}
 									className={`notificationsCenter__chip ${
-										activeFamily === family
+										activeFamily === 'all'
 											? 'notificationsCenter__chip--active'
 											: ''
 									}`}
-									onClick={() => setActiveFamily(family)}
+									onClick={() => setActiveFamily('all')}
 								>
-									{translate(familyLabelKey(family))}
+									{translate(
+										'notifications.families.all',
+										'All'
+									)}
 								</button>
-							))}
+								{familiesInFeed.map((family) => (
+									<button
+										key={family}
+										type="button"
+										role="tab"
+										aria-selected={activeFamily === family}
+										className={`notificationsCenter__chip ${
+											activeFamily === family
+												? 'notificationsCenter__chip--active'
+												: ''
+										}`}
+										onClick={() => setActiveFamily(family)}
+									>
+										{translate(familyLabelKey(family))}
+									</button>
+								))}
+							</div>
+							<input
+								type="search"
+								className="notificationsCenter__search"
+								placeholder={translate(
+									'notifications.center.searchPlaceholder',
+									'Search activity…'
+								)}
+								value={searchQuery}
+								onChange={(event) =>
+									setSearchQuery(event.target.value)
+								}
+								aria-label={translate(
+									'notifications.center.searchPlaceholder',
+									'Search activity…'
+								)}
+							/>
 						</div>
-						<input
-							type="search"
-							className="notificationsCenter__search"
-							placeholder={translate(
-								'notifications.center.searchPlaceholder',
-								'Search activity…'
-							)}
-							value={searchQuery}
-							onChange={(event) => setSearchQuery(event.target.value)}
-							aria-label={translate(
-								'notifications.center.searchPlaceholder',
-								'Search activity…'
-							)}
-						/>
-					</div>
+					)}
 					{notificationFeed.length === 0 ? (
 						<div className="notificationsCenter__empty">
 							{translate(
@@ -455,7 +462,11 @@ export const NotificationsCenter = () => {
 														: 'notificationsCenter__listItemTag--system'
 												}`}
 											>
-												{translate(familyLabelKey(descriptor.family))}
+												{translate(
+													familyLabelKey(
+														descriptor.family
+													)
+												)}
 											</span>
 										</div>
 										<div className="notificationsCenter__listItemBody">

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -78,6 +78,74 @@
 		}
 	}
 
+	// WP-06 Slice 1: timeline filter bar (family chips + search). Sticky so it
+	// stays pinned while the activity list scrolls.
+	&__filters {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px 12px 8px;
+		background: #fff;
+		border-bottom: 1px solid #f2f2f2;
+	}
+
+	&__chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	&__chip {
+		appearance: none;
+		border: 1px solid #e5e7eb;
+		background: #fff;
+		color: #4b515a;
+		border-radius: 999px;
+		padding: 4px 12px;
+		font-size: 12px;
+		font-weight: 600;
+		cursor: pointer;
+		transition:
+			background-color 160ms ease,
+			border-color 160ms ease,
+			color 160ms ease;
+	}
+
+	&__chip:hover {
+		background: #fafafa;
+	}
+
+	// Active chip reuses the shared selection tokens (settings.scss →
+	// _listItemSelection.scss) so the timeline matches the conversation lists.
+	&__chip--active {
+		background: $list-item-selected-bg;
+		border-color: $list-item-accent-ring;
+		color: $list-item-action-color;
+	}
+
+	&__chip:focus-visible {
+		@include list-item-focus-treatment;
+	}
+
+	&__search {
+		appearance: none;
+		width: 100%;
+		box-sizing: border-box;
+		border: 1px solid #e5e7eb;
+		border-radius: 999px;
+		padding: 8px 14px;
+		font-size: 13px;
+		color: #1e1e1e;
+		background: #fff;
+	}
+
+	&__search:focus-visible {
+		@include list-item-focus-treatment;
+	}
+
 	&__listItem {
 		width: 100%;
 		display: flex;

--- a/src/components/notificationsCenter/timelineFilter.test.ts
+++ b/src/components/notificationsCenter/timelineFilter.test.ts
@@ -1,0 +1,161 @@
+/**
+ * WP-06 Activity Timeline — unit coverage for the client-side timeline filter
+ * (Slice 1). Pure-logic vitest spec; runs in CI via `npm run test:unit`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	filterTimelineItems,
+	getFamiliesInFeed,
+	TIMELINE_FAMILY_ORDER
+} from './timelineFilter';
+
+// Minimal feed items: only `eventType` + a `text` used as the search source.
+const feed = [
+	{ id: '1', eventType: 'message.new', text: 'New message from Anna' },
+	{ id: '2', eventType: 'thread.reply.new', text: 'Reply in thread' },
+	{ id: '3', eventType: 'request.new', text: 'New client request' },
+	{ id: '4', eventType: 'handover.requested', text: 'Handover requested' },
+	{ id: '5', eventType: 'call.started', text: 'Call ongoing' },
+	{ id: '6', eventType: 'supervisor.added', text: 'Supervisor added' },
+	{ id: '7', eventType: 'draft.created', text: 'Draft saved' },
+	{ id: '8', eventType: 'some.unknown.type', text: 'Mystery event' }
+];
+
+const searchText = (item: { text: string }) => item.text;
+const ids = (items: ReadonlyArray<{ id: string }>) => items.map((i) => i.id);
+
+describe('WP-06 timeline filter', () => {
+	describe('getFamiliesInFeed', () => {
+		it('returns the present families in canonical order, deduped', () => {
+			const families = getFamiliesInFeed(feed);
+			// messages (2 items) appears once; order follows TIMELINE_FAMILY_ORDER.
+			expect(families).to.deep.equal([
+				'requests',
+				'messages',
+				'drafts',
+				'handover',
+				'calls',
+				'system'
+			]);
+		});
+
+		it('maps unknown event types to the system family', () => {
+			expect(getFamiliesInFeed([{ eventType: 'nope' }])).to.deep.equal([
+				'system'
+			]);
+		});
+
+		it('returns an empty list for an empty feed', () => {
+			expect(getFamiliesInFeed([])).to.deep.equal([]);
+		});
+
+		it('only lists families from the canonical order', () => {
+			getFamiliesInFeed(feed).forEach((family) =>
+				expect(TIMELINE_FAMILY_ORDER).to.include(family)
+			);
+		});
+	});
+
+	describe('filterTimelineItems', () => {
+		it('"all" with no query returns everything (stable order)', () => {
+			expect(
+				ids(filterTimelineItems(feed, { family: 'all', query: '' }, searchText))
+			).to.deep.equal(['1', '2', '3', '4', '5', '6', '7', '8']);
+		});
+
+		it('filters to a single family chip', () => {
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'messages', query: '' },
+						searchText
+					)
+				)
+			).to.deep.equal(['1', '2']);
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'handover', query: '' },
+						searchText
+					)
+				)
+			).to.deep.equal(['4']);
+		});
+
+		it('puts unknown event types under the system chip', () => {
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'system', query: '' },
+						searchText
+					)
+				)
+			).to.include('8');
+		});
+
+		it('search is a case-insensitive substring over getSearchText', () => {
+			expect(
+				ids(filterTimelineItems(feed, { family: 'all', query: 'ANNA' }, searchText))
+			).to.deep.equal(['1']);
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'all', query: 'client request' },
+						searchText
+					)
+				)
+			).to.deep.equal(['3']);
+			// substring match is literal: "requested" also contains "request"
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'all', query: 'request' },
+						searchText
+					)
+				)
+			).to.deep.equal(['3', '4']);
+		});
+
+		it('combines family chip AND search', () => {
+			expect(
+				ids(
+					filterTimelineItems(
+						feed,
+						{ family: 'messages', query: 'reply' },
+						searchText
+					)
+				)
+			).to.deep.equal(['2']);
+			// query matches a different family → excluded by the chip
+			expect(
+				filterTimelineItems(
+					feed,
+					{ family: 'messages', query: 'handover' },
+					searchText
+				)
+			).to.have.length(0);
+		});
+
+		it('ignores a whitespace-only query', () => {
+			expect(
+				filterTimelineItems(feed, { family: 'all', query: '   ' }, searchText)
+			).to.have.length(feed.length);
+		});
+
+		it('returns an empty array when nothing matches', () => {
+			expect(
+				filterTimelineItems(
+					feed,
+					{ family: 'all', query: 'zzz-no-match' },
+					searchText
+				)
+			).to.have.length(0);
+		});
+	});
+});

--- a/src/components/notificationsCenter/timelineFilter.ts
+++ b/src/components/notificationsCenter/timelineFilter.ts
@@ -1,0 +1,85 @@
+/**
+ * WP-06 Activity Timeline — client-side timeline filter (Slice 1).
+ *
+ * Pure helpers backing the timeline's family filter chips and search box. The
+ * family of an event comes from the event-descriptor registry (Slice 0a), so a
+ * single source of truth drives both the card iconography and the chips.
+ *
+ * Search is **client-side only** over already-rendered strings (ADR-AT-01: the
+ * server stores no display text and there is no server full-text search). The
+ * caller supplies `getSearchText` so this module stays free of i18n/React.
+ */
+
+import { EventFamily } from './eventDescriptors/types';
+import { getEventDescriptor } from './eventDescriptors/registry';
+
+/** The active family chip: one real family, or `all`. Exactly one at a time. */
+export type TimelineFamilyFilter = 'all' | EventFamily;
+
+/**
+ * Canonical chip order. Mirrors the registry families; `appointments` is
+ * included for completeness but is deferred (no event types seeded yet), so it
+ * only ever appears if such an event is present.
+ */
+export const TIMELINE_FAMILY_ORDER: ReadonlyArray<EventFamily> = [
+	'requests',
+	'messages',
+	'drafts',
+	'handover',
+	'calls',
+	'system',
+	'appointments'
+];
+
+export interface TimelineFilterState {
+	family: TimelineFamilyFilter;
+	query: string;
+}
+
+/** Minimal shape the filter needs from a feed item. */
+export interface TimelineFilterableItem {
+	eventType?: string | null;
+}
+
+const familyOf = (item: TimelineFilterableItem): EventFamily =>
+	getEventDescriptor(item?.eventType).family;
+
+const normalize = (value: string): string => value.trim().toLowerCase();
+
+const matchesFamily = (
+	item: TimelineFilterableItem,
+	family: TimelineFamilyFilter
+): boolean => family === 'all' || familyOf(item) === family;
+
+/**
+ * The families actually present in the feed, in canonical order. Used to render
+ * only the relevant chips (plus "All") instead of every possible family.
+ */
+export const getFamiliesInFeed = (
+	items: ReadonlyArray<TimelineFilterableItem>
+): EventFamily[] => {
+	const present = new Set(items.map(familyOf));
+	return TIMELINE_FAMILY_ORDER.filter((family) => present.has(family));
+};
+
+/**
+ * Filter the feed by the active family chip and the search query. The query is
+ * a case-insensitive substring match over `getSearchText(item)` (the
+ * client-rendered title/text); an empty/whitespace query matches everything.
+ */
+export const filterTimelineItems = <T extends TimelineFilterableItem>(
+	items: ReadonlyArray<T>,
+	state: TimelineFilterState,
+	getSearchText: (item: T) => string
+): T[] => {
+	const query = normalize(state.query || '');
+	return items.filter((item) => {
+		if (!matchesFamily(item, state.family)) {
+			return false;
+		}
+		if (!query) {
+			return true;
+		}
+		return normalize(getSearchText(item) || '').includes(query);
+	});
+};

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1340,6 +1340,7 @@
 	},
 	"notifications": {
 		"families": {
+			"all": "Alle",
 			"requests": "Anfragen",
 			"messages": "Nachrichten",
 			"drafts": "Entwürfe",
@@ -1433,6 +1434,8 @@
 		"success": "Erfolgreich",
 		"warning": "Warnung",
 		"center": {
+			"searchPlaceholder": "Aktivität durchsuchen…",
+			"noResults": "Keine Aktivität entspricht Ihren Filtern.",
 			"title": "Benachrichtigungen",
 			"subtitle": "Aktuelle Ereignisse und Updates aus Ihren Chats.",
 			"markAllRead": "Alle als gelesen markieren",

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1316,6 +1316,7 @@
 	},
 	"notifications": {
 		"families": {
+			"all": "All",
 			"requests": "Requests",
 			"messages": "Messages",
 			"drafts": "Drafts",
@@ -1409,6 +1410,8 @@
 		"success": "successful",
 		"warning": "warning",
 		"center": {
+			"searchPlaceholder": "Search activity…",
+			"noResults": "No activity matches your filters.",
 			"title": "Notifications",
 			"subtitle": "Recent activities and updates from your chats.",
 			"markAllRead": "Mark all as read",


### PR DESCRIPTION
## WP-06 Activity Timeline — Slice 1 (timeline surface) · DRAFT

Builds the first Activity Timeline surface controls on top of the Slice 0 registry + selection controller: a **family filter chip row** and a **client-side search box**. Opened as a **draft** for review.

### What's in here
- **`timelineFilter.ts`** (pure, vitest-covered): `getFamiliesInFeed` (families actually present, canonical order) + `filterTimelineItems` (family chip + case-insensitive substring search). **Search is client-side only** over the already-rendered strings — ADR-AT-01 forbids server full-text. 11 vitest tests (`timelineFilter.test.ts`).
- **`NotificationsCenter`**: renders an `All` chip + one chip per present family (driven by the event-descriptor families, so a single source of truth feeds both card icons and chips), **exactly one chip active**; a search input; and a distinct **"no results"** state (≠ empty feed). The list, master-detail selection, and "next" navigation all operate on the **filtered** feed; the selection stays inside the visible feed and the chip resets to `All` if its family leaves the feed.
- **Styling** reuses the shared selection tokens/mixin from Slice 0b (active chip + focus rings) so the timeline stays consistent with the conversation/request lists; filter bar is sticky. No card restyle.
- **i18n** (en/de): `notifications.families.all`, `notifications.center.searchPlaceholder`, `notifications.center.noResults`.

### Deferred (later slices, not here)
- Live overlays (drafts/calls) in the time-ordered merge → Slice 3/5.
- The master-detail / inline-reply / responsive surface already exists and is unchanged.

### Verification
- `npx tsc` 0 errors · `eslint` clean · **vitest 45 passing** (11 filter + 16 registry + 18 selection, CI-run) · `stylelint` clean on the additions · `CI=false npm run build` green.

Refs: WP-06 Activity Timeline (Slice 1); ADR-AT-01 (no server full-text); builds on #249/#250 (tracked in #251).

🤖 Generated with [Claude Code](https://claude.com/claude-code)