### PR TITLE
chore(ai-review): automate CodeRabbit and Cursor PR checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+tone_instructions: "Be a strict, practical ORISO reviewer. Keep comments concise, concrete, and focused on correctness, mergeability, privacy, accessibility, tests, and maintainability. Review German UI copy too."
+
+reviews:
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: true
+    base_branches:
+      - "dev"
+      - "main"
+      - "release/.*"
+      - "hotfix/.*"
+
+  path_filters:
+    - "!node_modules/**"
+    - "!build/**"
+    - "!storybook-static/**"
+    - "!coverage/**"
+    - "src/**"
+    - "cypress/**"
+    - "config/**"
+    - "scripts/**"
+    - ".github/**"
+    - "*.md"
+
+  path_instructions:
+    - path: "src/**/*.{ts,tsx,js,jsx}"
+      instructions: |
+        Check behavior against the surrounding ORISO flow, not only types.
+        Flag duplicated route/state logic, missing error/loading handling,
+        privacy regressions around Matrix/chat/drafts, and changes that should
+        be expressed through shared hooks or utilities instead of local flags.
+    - path: "src/**/*.scss"
+      instructions: |
+        Prefer existing design tokens, mixins, and shared component states.
+        Flag hardcoded one-off styling when the same control/state already
+        exists elsewhere. Active/focus/list-item behavior should stay shared.
+    - path: "cypress/**/*"
+      instructions: |
+        Tests should prove the user-visible behavior and relevant edge cases.
+        Flag brittle selectors, over-mocking that hides the bug, and missing
+        assertions for route/state transitions.
+
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: "Use a concise conventional title that names the affected ORISO area."
+    description:
+      mode: warning
+    custom_checks:
+      - name: "Validation evidence"
+        mode: error
+        instructions: |
+          Pass for docs/config-only PRs. For behavior-affecting product code,
+          pass only if the PR includes relevant automated tests or clearly lists
+          the exact validation command and result. Fail if product behavior
+          changed with no test/validation evidence and no explicit rationale.
+      - name: "Shared UI architecture"
+        mode: warning
+        instructions: |
+          Pass when UI changes reuse existing components, tokens, hooks, or
+          shared utilities. Warn when a PR creates a second local implementation
+          of an existing ORISO interaction pattern, especially search fields,
+          list active states, focus treatment, and responsive layout primitives.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CONTEXT.md"
+      - ".understand-anything/README.md"
+      - ".understand-anything/ARCHITECTURE.md"
+      - ".understand-anything/ORISO-ECOSYSTEM.md"
+
+chat:
+  auto_reply: true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,212 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [dev, main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to trigger CodeRabbit for"
+        required: false
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ai-pr-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  coderabbit:
+    name: CodeRabbit trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CodeRabbit reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          trigger_one() {
+            local pr_number="$1"
+            local head_sha="$2"
+            local marker="<!-- ai-pr-review:coderabbit:${head_sha} -->"
+
+            if gh api "repos/${GH_REPO}/issues/${pr_number}/comments?per_page=100" \
+              --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | grep -q .; then
+              echo "CodeRabbit already triggered for PR #${pr_number} at ${head_sha}."
+              return 0
+            fi
+
+            {
+              echo "${marker}"
+              echo "@coderabbitai review"
+            } > /tmp/coderabbit-trigger.md
+
+            gh pr comment "${pr_number}" --repo "${GH_REPO}" --body-file /tmp/coderabbit-trigger.md
+            echo "Triggered CodeRabbit for PR #${pr_number} at ${head_sha}."
+          }
+
+          if [ -n "${EVENT_PR_NUMBER:-}" ]; then
+            trigger_one "${EVENT_PR_NUMBER}" "${EVENT_HEAD_SHA}"
+            exit 0
+          fi
+
+          if [ -n "${INPUT_PR_NUMBER:-}" ]; then
+            head_sha="$(gh pr view "${INPUT_PR_NUMBER}" --repo "${GH_REPO}" --json headRefOid --jq .headRefOid)"
+            trigger_one "${INPUT_PR_NUMBER}" "${head_sha}"
+            exit 0
+          fi
+
+          for base in dev main; do
+            gh pr list --repo "${GH_REPO}" --base "${base}" --state open --limit 100 \
+              --json number,headRefOid --jq '.[] | [.number, .headRefOid] | @tsv' |
+            while IFS=$'\t' read -r pr_number head_sha; do
+              [ -n "${pr_number}" ] || continue
+              trigger_one "${pr_number}" "${head_sha}"
+            done
+          done
+
+  cursor:
+    name: Cursor thermonuclear review
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Check Cursor prerequisites
+        id: guard
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          LAST_COMMIT_MESSAGE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CURSOR_API_KEY:-}" ]; then
+            echo "::notice::CURSOR_API_KEY is not configured; skipping Cursor review."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${HEAD_REPO}" != "${BASE_REPO}" ]; then
+            echo "::notice::Skipping Cursor write-capable review for fork PR ${HEAD_REPO}."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Configure git author
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          git config user.name "oriso-ai-review[bot]"
+          git config user.email "oriso-ai-review[bot]@users.noreply.github.com"
+
+      - name: Install Cursor CLI
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/cursor-agent" --version
+
+      - name: Run Cursor thermonuclear review
+        if: steps.guard.outputs.run == 'true'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+          CURSOR_MODEL: ${{ vars.CURSOR_MODEL }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${BASE_REF}:${BASE_REF}" || true
+
+          model_args=()
+          if [ -n "${CURSOR_MODEL:-}" ]; then
+            model_args=(--model "${CURSOR_MODEL}")
+          fi
+
+          prompt="$(cat <<PROMPT
+          You are Cursor running ORISO's thermonuclear PR review.
+
+          Goal: reduce human review work without creating churn.
+
+          Mandatory context:
+          - Read AGENTS.md first.
+          - Use .understand-anything/README.md, .understand-anything/ARCHITECTURE.md,
+            .understand-anything/ORISO-ECOSYSTEM.md, and .understand-anything/knowledge-graph.json
+            when they help you understand the code quickly.
+          - Compare this PR against origin/${BASE_REF:-dev}.
+
+          Review focus:
+          - correctness, mergeability, broken tests/types/lint
+          - missing validation evidence
+          - privacy/security regressions
+          - duplicated UI/state architecture that should be shared
+          - accessible focus and keyboard behavior
+
+          If you find a clearly safe, scoped improvement:
+          1. Make the smallest change.
+          2. Run the narrowest relevant test/build/lint command.
+          3. Commit it with a concise message beginning "fix(ai-review):".
+          4. Push to this PR branch.
+
+          If the issue is ambiguous, broad, or not safely testable, do not edit.
+          Leave a concise finding in your final summary instead.
+
+          Do not reformat unrelated files. Do not change generated output unless
+          the source change requires it.
+          PROMPT
+          )"
+
+          "$HOME/.local/bin/cursor-agent" \
+            --api-key "${CURSOR_API_KEY}" \
+            --trust \
+            --force \
+            --output-format text \
+            --print \
+            --workspace "$GITHUB_WORKSPACE" \
+            "${model_args[@]}" \
+            "$prompt" | tee /tmp/cursor-review.md
+
+      - name: Comment Cursor summary
+        if: steps.guard.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          marker="<!-- ai-pr-review:cursor:${HEAD_SHA} -->"
+          {
+            echo "${marker}"
+            echo "## Cursor Thermonuclear Review"
+            echo
+            echo '```text'
+            tail -c 60000 /tmp/cursor-review.md
+            echo
+            echo '```'
+          } > /tmp/cursor-comment.md
+
+          gh pr comment "${PR_NUMBER}" --repo "${GH_REPO}" --body-file /tmp/cursor-comment.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Context First
+
+- Treat `dev` as the normal integration branch for ORISO feature PRs unless the task says otherwise.
+- Before non-trivial changes, skim `.understand-anything/README.md`, `.understand-anything/ARCHITECTURE.md`, and `.understand-anything/knowledge-graph.json` for fast repo context.
+- Use `CONTEXT.md` for Activity Timeline and notification vocabulary; avoid inventing parallel terms.
+
+## Frontend Rules
+
+- Keep behavior in shared hooks/utilities when multiple screens need the same state, route, selection, or formatting logic.
+- Reuse existing design tokens, Sass mixins, and component patterns. Avoid one-off hardcoded CSS for controls, active list states, focus rings, and responsive layout.
+- Preserve Matrix/chat/draft privacy boundaries. Do not move plaintext previews or draft contents into server-visible state.
+- UI changes need accessible focus/keyboard behavior and should not rely on color alone.
+
+## Validation
+
+- Prefer red-green TDD for behavior changes: add or update the smallest test that would fail without the fix, then implement.
+- Useful commands:
+    - `npm run test:unit`
+    - `npm run lint:scripts`
+    - `npm run lint:style`
+    - `npm run build`
+- If a full command is too expensive or blocked by existing unrelated failures, run the narrowest relevant command and state the blocker precisely.
+
+## Review Expectations
+
+- CodeRabbit and Cursor should compare PRs against `origin/dev` for normal ORISO feature work.
+- Automated review should flag missing tests, duplicated UI architecture, unsafe privacy changes, and mergeability risks.
+- Only auto-fix issues that are clearly scoped and testable. Leave architectural or ambiguous changes as review comments.


### PR DESCRIPTION
## What

- Add `.coderabbit.yaml` so CodeRabbit auto-reviews PRs targeting `dev`, `main`, release, and hotfix branches instead of skipping non-default target branches.
- Enable assertive reviews, request-changes workflow, validation-evidence checks, and ORISO-specific path instructions.
- Add `AGENTS.md` so Cursor, CodeRabbit, and other agents read the Understand-Anything context and ORISO review rules first.
- Add an `AI PR Review` workflow that triggers CodeRabbit per PR SHA and runs Cursor thermonuclear review in parallel once `CURSOR_API_KEY` is configured.

## Test

- Parsed `.coderabbit.yaml` and `.github/workflows/ai-pr-review.yml` with PyYAML.
- Validated `.coderabbit.yaml` against CodeRabbit schema `https://coderabbit.ai/integrations/schema.v2.json`.
- `git diff --cached --check`.

## Notes

Cursor automation is intentionally a no-op until the repository secret `CURSOR_API_KEY` exists. Local `cursor-agent status` currently reports `Not logged in`, so a Cursor login/API key is still needed for live Cursor execution.

🤖 Generated with Codex