### PR TITLE
[codex] Block consultant app login

### DIFF
--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -36,6 +36,11 @@ import {
 	persistMatrixLoginData
 } from '../sessionCookie/getMatrixAccessToken';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
+import {
+	clearAuthSession,
+	CONSULTANT_LOGIN_BLOCKED_ERROR,
+	markConsultantLoginBlocked
+} from '../auth/consultantLoginBlock';
 
 interface AuthenticatedAppProps {
 	onAppReady: Function;
@@ -98,6 +103,16 @@ export const AuthenticatedApp = ({
 				.then(() => {
 					Promise.all([reloadUserData(), apiGetConsultingTypes()])
 						.then(([userProfileData, consultingTypes]) => {
+							if (
+								hasUserAuthority(
+									AUTHORITIES.CONSULTANT_DEFAULT,
+									userProfileData
+								)
+							) {
+								clearAuthSession();
+								throw new Error(CONSULTANT_LOGIN_BLOCKED_ERROR);
+							}
+
 							// set informal / formal cookie depending on the given userdata
 							setInformal(!userProfileData.formalLanguage);
 							setConsultingTypes(consultingTypes);
@@ -158,11 +173,16 @@ export const AuthenticatedApp = ({
 
 							setAppReady(true);
 						})
-						.catch((error) => {
-							setLoading(false);
-							// console.log(error);
-						});
-				})
+							.catch((error) => {
+								setLoading(false);
+								if (
+									error?.message ===
+									CONSULTANT_LOGIN_BLOCKED_ERROR
+								) {
+									markConsultantLoginBlocked();
+								}
+							});
+					})
 				.catch(() => {
 					setLoading(false);
 				});

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -172,20 +172,20 @@ export const AuthenticatedApp = ({
 							}
 
 							setAppReady(true);
-						})
+							})
 							.catch((error) => {
 								setLoading(false);
 								if (
 									error?.message ===
 									CONSULTANT_LOGIN_BLOCKED_ERROR
-								) {
+							) {
 									markConsultantLoginBlocked();
 								}
 							});
 					})
-				.catch(() => {
-					setLoading(false);
-				});
+					.catch(() => {
+						setLoading(false);
+					});
 		}
 	}, [
 		locale,

--- a/src/components/auth/consultantLoginBlock.test.ts
+++ b/src/components/auth/consultantLoginBlock.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
 	CONSULTANT_LOGIN_BLOCKED_ERROR,
-	isConsultantAccessToken
+	consumeConsultantLoginBlocked,
+	isConsultantAccessToken,
+	markConsultantLoginBlocked
 } from './consultantLoginBlock';
 
 const createAccessToken = (payload: unknown) => {
@@ -11,6 +13,28 @@ const createAccessToken = (payload: unknown) => {
 };
 
 describe('consultantLoginBlock', () => {
+	beforeEach(() => {
+		const storage = new Map<string, string>();
+		globalThis.sessionStorage = {
+			getItem: (key: string) => storage.get(key) ?? null,
+			setItem: (key: string, value: string) => {
+				storage.set(key, value);
+			},
+			removeItem: (key: string) => {
+				storage.delete(key);
+			},
+			clear: () => {
+				storage.clear();
+			},
+			key: () => null,
+			length: 0
+		};
+	});
+
+	afterEach(() => {
+		delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+	});
+
 	it('uses a stable error code for blocked consultant logins', () => {
 		expect(CONSULTANT_LOGIN_BLOCKED_ERROR).toBe('CONSULTANT_LOGIN_BLOCKED');
 	});
@@ -37,5 +61,13 @@ describe('consultantLoginBlock', () => {
 
 	it('ignores missing access tokens', () => {
 		expect(isConsultantAccessToken()).toBe(false);
+	});
+
+	it('marks and consumes a blocked-login redirect flag', () => {
+		expect(consumeConsultantLoginBlocked()).toBe(false);
+
+		markConsultantLoginBlocked();
+		expect(consumeConsultantLoginBlocked()).toBe(true);
+		expect(consumeConsultantLoginBlocked()).toBe(false);
 	});
 });

--- a/src/components/auth/consultantLoginBlock.test.ts
+++ b/src/components/auth/consultantLoginBlock.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	CONSULTANT_LOGIN_BLOCKED_ERROR,
+	isConsultantAccessToken
+} from './consultantLoginBlock';
+
+const createAccessToken = (payload: unknown) => {
+	const encodedPayload = btoa(JSON.stringify(payload));
+	return `header.${encodedPayload}.signature`;
+};
+
+describe('consultantLoginBlock', () => {
+	it('uses a stable error code for blocked consultant logins', () => {
+		expect(CONSULTANT_LOGIN_BLOCKED_ERROR).toBe('CONSULTANT_LOGIN_BLOCKED');
+	});
+
+	it('detects consultant access tokens', () => {
+		const token = createAccessToken({
+			realm_access: {
+				roles: ['user', 'consultant']
+			}
+		});
+
+		expect(isConsultantAccessToken(token)).toBe(true);
+	});
+
+	it('ignores non-consultant access tokens', () => {
+		const token = createAccessToken({
+			realm_access: {
+				roles: ['user', 'asker']
+			}
+		});
+
+		expect(isConsultantAccessToken(token)).toBe(false);
+	});
+
+	it('ignores missing access tokens', () => {
+		expect(isConsultantAccessToken()).toBe(false);
+	});
+});

--- a/src/components/auth/consultantLoginBlock.ts
+++ b/src/components/auth/consultantLoginBlock.ts
@@ -1,0 +1,23 @@
+import { parseJwt } from '../../utils/parseJWT';
+import {
+	removeRocketChatMasterKeyFromLocalStorage,
+	removeTokenExpiryFromLocalStorage
+} from '../sessionCookie/accessSessionLocalStorage';
+import { removeAllCookies } from '../sessionCookie/accessSessionCookie';
+
+export const CONSULTANT_LOGIN_BLOCKED_ERROR = 'CONSULTANT_LOGIN_BLOCKED';
+
+export const clearAuthSession = () => {
+	removeAllCookies();
+	removeTokenExpiryFromLocalStorage();
+	removeRocketChatMasterKeyFromLocalStorage();
+};
+
+export const isConsultantAccessToken = (accessToken?: string) => {
+	if (!accessToken) {
+		return false;
+	}
+
+	const tokenPayload = parseJwt(accessToken);
+	return tokenPayload?.realm_access?.roles?.includes('consultant') ?? false;
+};

--- a/src/components/auth/consultantLoginBlock.ts
+++ b/src/components/auth/consultantLoginBlock.ts
@@ -6,6 +6,8 @@ import {
 import { removeAllCookies } from '../sessionCookie/accessSessionCookie';
 
 export const CONSULTANT_LOGIN_BLOCKED_ERROR = 'CONSULTANT_LOGIN_BLOCKED';
+export const CONSULTANT_LOGIN_BLOCKED_SESSION_KEY =
+	'oriso.consultantLoginBlocked';
 
 export const clearAuthSession = () => {
 	removeAllCookies();
@@ -20,4 +22,17 @@ export const isConsultantAccessToken = (accessToken?: string) => {
 
 	const tokenPayload = parseJwt(accessToken);
 	return tokenPayload?.realm_access?.roles?.includes('consultant') ?? false;
+};
+
+export const markConsultantLoginBlocked = () => {
+	sessionStorage.setItem(CONSULTANT_LOGIN_BLOCKED_SESSION_KEY, '1');
+};
+
+export const consumeConsultantLoginBlocked = () => {
+	if (sessionStorage.getItem(CONSULTANT_LOGIN_BLOCKED_SESSION_KEY)) {
+		sessionStorage.removeItem(CONSULTANT_LOGIN_BLOCKED_SESSION_KEY);
+		return true;
+	}
+
+	return false;
 };

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -348,7 +348,7 @@ export const Login = () => {
 						setTwoFactorType(error.options.data.otpType);
 						setIsOtpRequired(true);
 					}
-				} else if (error.message === CONSULTANT_LOGIN_BLOCKED_ERROR) {
+				} else if (error?.message === CONSULTANT_LOGIN_BLOCKED_ERROR) {
 					showConsultantLoginBlockedError();
 				}
 

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -11,6 +11,12 @@ import {
 import { endpoints } from '../../resources/scripts/endpoints';
 import { Button, BUTTON_TYPES, ButtonItem } from '../button/Button';
 import { autoLogin, redirectToApp } from '../registration/autoLogin';
+import {
+	clearAuthSession,
+	CONSULTANT_LOGIN_BLOCKED_ERROR,
+	consumeConsultantLoginBlocked,
+	isConsultantAccessToken
+} from '../auth/consultantLoginBlock';
 import { Text } from '../text/Text';
 import { ReactComponent as PersonIcon } from '../../resources/img/icons/person.svg';
 import { ReactComponent as LockIcon } from '../../resources/img/icons/lock.svg';
@@ -47,6 +53,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import {
+	deleteCookieByName,
 	getValueFromCookie,
 	setValueInCookie
 } from '../sessionCookie/accessSessionCookie';
@@ -192,6 +199,21 @@ export const Login = () => {
 		[locale]
 	);
 
+	const showConsultantLoginBlockedError = useCallback(() => {
+		setShowLoginError(translate('login.warning.failed.consultantBlocked'));
+		setLabelState(VALIDITY_INVALID);
+	}, [translate]);
+
+	useEffect(() => {
+		if (consumeConsultantLoginBlocked()) {
+			showConsultantLoginBlockedError();
+		}
+	}, [showConsultantLoginBlockedError]);
+
+	useEffect(() => {
+		deleteCookieByName('tenantId');
+	}, []);
+
 	const postLogin = useCallback(
 		() =>
 			reloadUserData().then(async (userData: UserDataInterface) => {
@@ -207,7 +229,9 @@ export const Login = () => {
 				if (
 					hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData)
 				) {
-					patchedUserData['available'] = false;
+					clearAuthSession();
+					showConsultantLoginBlockedError();
+					throw new Error(CONSULTANT_LOGIN_BLOCKED_ERROR);
 				}
 
 				if (Object.keys(patchedUserData).length > 0) {
@@ -226,7 +250,14 @@ export const Login = () => {
 					return redirectToApp(gcid);
 				}
 			}),
-		[reloadUserData, locale, initLocale, consultant, gcid]
+		[
+			reloadUserData,
+			locale,
+			initLocale,
+			consultant,
+			gcid,
+			showConsultantLoginBlockedError
+		]
 	);
 
 	useEffect(() => {
@@ -249,6 +280,10 @@ export const Login = () => {
 
 		apiConsumeMagicLinkLogin(magicToken)
 			.then((tokenResponse) => {
+				if (isConsultantAccessToken(tokenResponse.access_token)) {
+					throw new Error(CONSULTANT_LOGIN_BLOCKED_ERROR);
+				}
+
 				setTokens(
 					tokenResponse.access_token,
 					tokenResponse.expires_in,
@@ -259,15 +294,26 @@ export const Login = () => {
 				// Continue directly into authenticated app bootstrap.
 				return postLogin();
 			})
-			.catch(() => {
-				setShowLoginError(
-					translate('login.warning.failed.unauthorized.text')
-				);
+			.catch((error) => {
+				if (error?.message === CONSULTANT_LOGIN_BLOCKED_ERROR) {
+					showConsultantLoginBlockedError();
+				} else {
+					setShowLoginError(
+						translate('login.warning.failed.unauthorized.text')
+					);
+				}
 			})
 			.finally(() => {
 				setIsRequestInProgress(false);
 			});
-	}, [magicToken, isMagicTokenLoginAttempted, postLogin, translate, gcid]);
+	}, [
+		magicToken,
+		isMagicTokenLoginAttempted,
+		postLogin,
+		translate,
+		gcid,
+		showConsultantLoginBlockedError
+	]);
 
 	const tryLogin = (otp?: string) => {
 		setIsRequestInProgress(true);
@@ -302,6 +348,8 @@ export const Login = () => {
 						setTwoFactorType(error.options.data.otpType);
 						setIsOtpRequired(true);
 					}
+				} else if (error.message === CONSULTANT_LOGIN_BLOCKED_ERROR) {
+					showConsultantLoginBlockedError();
 				}
 
 				setIsRequestInProgress(false);

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -281,6 +281,7 @@ export const Login = () => {
 		apiConsumeMagicLinkLogin(magicToken)
 			.then((tokenResponse) => {
 				if (isConsultantAccessToken(tokenResponse.access_token)) {
+					clearAuthSession();
 					throw new Error(CONSULTANT_LOGIN_BLOCKED_ERROR);
 				}
 

--- a/src/components/registration/autoLogin.ts
+++ b/src/components/registration/autoLogin.ts
@@ -33,6 +33,11 @@ import {
 import { appConfig } from '../../utils/appConfig';
 import { parseJwt } from '../../utils/parseJWT';
 import { removeRocketChatMasterKeyFromLocalStorage } from '../sessionCookie/accessSessionLocalStorage';
+import {
+	clearAuthSession,
+	CONSULTANT_LOGIN_BLOCKED_ERROR,
+	isConsultantAccessToken
+} from '../auth/consultantLoginBlock';
 
 export interface LoginData {
 	data: {
@@ -139,11 +144,18 @@ export const autoLogin = async ({
 		}
 	}
 
+	const tokenPayload = parseJwt(keycloakRes.access_token);
+
+	if (isConsultantAccessToken(keycloakRes.access_token)) {
+		clearAuthSession();
+		throw new Error(CONSULTANT_LOGIN_BLOCKED_ERROR);
+	}
+
 	if (
 		appConfig.useTenantService &&
 		!appConfig.multitenancyWithSingleDomainEnabled
 	) {
-		const { tenantId } = parseJwt(keycloakRes.access_token);
+		const { tenantId } = tokenPayload;
 		if (tenantId !== autoLoginProps.tenantData.id) {
 			throw new Error(FETCH_ERRORS.UNAUTHORIZED);
 		}

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1202,7 +1202,8 @@
 				"unauthorized": {
 					"otp": "Ihre Zugangsdaten sind nicht korrekt. Bitte versuchen Sie es erneut.",
 					"text": "Benutzername oder Passwort sind nicht korrekt. Bitte versuchen Sie es erneut."
-				}
+				},
+				"consultantBlocked": "Berater-Konten können sich hier nicht anmelden."
 			}
 		}
 	},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1187,7 +1187,8 @@
 				"unauthorized": {
 					"otp": "Your access data is not correct. Please try again.",
 					"text": "Username or password are not correct. Please try again."
-				}
+				},
+				"consultantBlocked": "Consultant accounts cannot sign in here."
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- Block consultant-role users from entering the frontend app after password login, magic-link login, or an already existing authenticated session.
- Clear local auth cookies/token expiry/master-key state when a consultant login is detected.
- Add localized login feedback and unit coverage for consultant access-token detection.

## Bug
Counseling-center admins can create consultant accounts, and the admin UI shows those new consultants as "Invited". That display state is not an email-delivery gate: the admin frontend maps `CREATED` / `IN_PROGRESS` to the displayed `INVITED` state, while the consultant create flow persists the user as `CREATED` in UserService.

The actual bug is that consultant credentials could still authenticate into the app frontend. The old frontend logic only marked consultants as unavailable after login and then continued into the authenticated app bootstrap.

## Fix
- Added a shared `consultantLoginBlock` helper that detects the `consultant` realm role in the Keycloak access token and clears frontend auth session state.
- Blocked consultants directly after Keycloak token acquisition, before Matrix/Budibase setup.
- Blocked consultants again after profile reload in normal login, magic-link login, and authenticated app bootstrap to catch existing sessions.
- Added German and English copy for the blocked-login state.

## Validation
- `python3 -m json.tool src/resources/i18n/de/common.json >/dev/null && python3 -m json.tool src/resources/i18n/en/common.json >/dev/null`
- `npm exec -- eslint src/components/auth/consultantLoginBlock.ts src/components/auth/consultantLoginBlock.test.ts src/components/registration/autoLogin.ts src/components/login/Login.tsx src/components/app/AuthenticatedApp.tsx`
  - Passes with two existing warnings: missing `callContext` hook dependency in `AuthenticatedApp.tsx`, unused `loginRocketChat` in `autoLogin.ts`.
- `npm exec -- tsc --noEmit --pretty false`
- `npm run test:unit` (10 files, 131 tests)
- Local HTTP smoke: configured CRA dev server served `http://127.0.0.1:9003/login` with HTTP 200.

## Browser smoke not completed locally
The credential-based browser smoke could not be completed from localhost because the live ORISO API rejects the local origin during app bootstrap: `https://api.oriso.org/service/settings` fails the preflight from `http://127.0.0.1:9003` with no `Access-Control-Allow-Origin` response. Because that settings call fails before the form renders, a real consultant-login browser flow cannot be verified against the live API from local CRA.

## Smoke test to run on Pre-Dev
1. Deploy this branch/image to Pre-Dev.
2. Open the app login page.
3. Sign in with a consultant account.
4. Confirm the app stays on `/login`, local auth cookies/storage are cleared, and the localized "Consultant accounts cannot sign in here" / "Berater-Konten können sich hier nicht anmelden." error appears.
5. Sign in with a non-consultant account and confirm normal app bootstrap still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
