### PR TITLE
feat: add case handover access gate

### DIFF
--- a/src/api/apiCaseHandover.ts
+++ b/src/api/apiCaseHandover.ts
@@ -1,0 +1,93 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
+
+export type CaseHandoverStatusValue =
+	| 'NOT_REQUESTED'
+	| 'PENDING'
+	| 'PENDING_CLIENT_CONSENT'
+	| 'GRANTED'
+	| 'DENIED'
+	| 'CLIENT_CONSENT_DECLINED'
+	| string;
+
+export interface CaseHandoverReason {
+	code: string;
+	label: string;
+	clientConsentRequired: boolean;
+	accessAllowed?: boolean;
+	policyAuthority?: string;
+}
+
+export interface CaseHandoverStatus {
+	requestId?: number;
+	sessionId: number;
+	status: CaseHandoverStatusValue;
+	canViewContent: boolean;
+	reasonCode?: string;
+	reasonLabel?: string;
+	clientConsentRequired: boolean;
+	policyAuthority?: string;
+	auditOutcome?: string;
+	createdAt?: string;
+	resolvedAt?: string;
+}
+
+export interface CaseHandoverBatchResult {
+	sessionId: number;
+	success: boolean;
+	status?: CaseHandoverStatus;
+	error?: string;
+}
+
+export const apiGetCaseHandoverReasons = async (): Promise<
+	CaseHandoverReason[]
+> =>
+	fetchData({
+		url: endpoints.caseHandoverReasons,
+		method: FETCH_METHODS.GET
+	});
+
+export const apiGetCaseHandoverStatus = async (
+	sessionId: number
+): Promise<CaseHandoverStatus> =>
+	fetchData({
+		url: `${endpoints.sessionBase}/${sessionId}/case-handover`,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.FORBIDDEN]
+	});
+
+export const apiRequestCaseHandoverAccess = async (
+	sessionId: number,
+	reasonCode: string,
+	explanation: string
+): Promise<CaseHandoverStatus> =>
+	fetchData({
+		url: `${endpoints.sessionBase}/${sessionId}/case-handover`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify({ reasonCode, explanation }),
+		responseHandling: [FETCH_ERRORS.BAD_REQUEST, FETCH_ERRORS.FORBIDDEN]
+	});
+
+export const apiRequestCaseHandoverBatchAccess = async (
+	sessionIds: number[],
+	reasonCode: string,
+	explanation: string
+): Promise<CaseHandoverBatchResult[]> =>
+	fetchData({
+		url: endpoints.caseHandoverBatch,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify({ sessionIds, reasonCode, explanation }),
+		responseHandling: [FETCH_ERRORS.BAD_REQUEST, FETCH_ERRORS.FORBIDDEN]
+	});
+
+export const apiDecideCaseHandoverClientConsent = async (
+	sessionId: number,
+	requestId: number,
+	approved: boolean
+): Promise<CaseHandoverStatus> =>
+	fetchData({
+		url: `${endpoints.sessionBase}/${sessionId}/case-handover/${requestId}/client-consent`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify({ approved }),
+		responseHandling: [FETCH_ERRORS.BAD_REQUEST, FETCH_ERRORS.FORBIDDEN]
+	});

--- a/src/api/apiCaseHandover.ts
+++ b/src/api/apiCaseHandover.ts
@@ -1,4 +1,5 @@
 import { endpoints } from '../resources/scripts/endpoints';
+import { ListItemsResponseInterface } from '../globalState/interfaces';
 import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
 
 export type CaseHandoverStatusValue =
@@ -46,6 +47,34 @@ export const apiGetCaseHandoverReasons = async (): Promise<
 		url: endpoints.caseHandoverReasons,
 		method: FETCH_METHODS.GET
 	});
+
+export const apiGetCaseHandoverCandidates = async ({
+	query,
+	offset = 0,
+	count = 15,
+	archived = false,
+	signal
+}: {
+	query: string;
+	offset?: number;
+	count?: number;
+	archived?: boolean;
+	signal?: AbortSignal;
+}): Promise<ListItemsResponseInterface> => {
+	const params = new URLSearchParams({
+		query,
+		offset: String(offset),
+		count: String(count),
+		archived: String(archived)
+	});
+
+	return fetchData({
+		url: `${endpoints.caseHandoverCandidates}?${params.toString()}`,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.FORBIDDEN],
+		...(signal && { signal })
+	});
+};
 
 export const apiGetCaseHandoverStatus = async (
 	sessionId: number

--- a/src/api/apiCaseHandover.ts
+++ b/src/api/apiCaseHandover.ts
@@ -9,7 +9,7 @@ export type CaseHandoverStatusValue =
 	| 'GRANTED'
 	| 'DENIED'
 	| 'CLIENT_CONSENT_DECLINED'
-	| string;
+	| (string & {});
 
 export interface CaseHandoverReason {
 	code: string;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ export * from './apiUserDrafts';
 export * from './apiGetSessionSupervisors';
 export * from './apiAddSessionSupervisor';
 export * from './apiRemoveSessionSupervisor';
+export * from './apiCaseHandover';
 export * from './apiEnquiryAcceptance';
 export * from './apiGetAgenciesByTenant';
 export * from './apiGetAgencyConsultantList';

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -366,6 +366,9 @@ export const NotificationsCenter = () => {
 				markNotificationAsRead(selectedNotification.id);
 				refreshNotificationFeed();
 			})
+			.catch(() => {
+				// keep notification unread when consent decision fails
+			})
 			.finally(() => setCaseHandoverConsentSubmitting(false));
 	};
 

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../globalState';
 import { useResponsive } from '../../hooks/useResponsive';
 import { useTranslation } from 'react-i18next';
+import { apiDecideCaseHandoverClientConsent } from '../../api';
 import './notificationsCenter.styles';
 
 const formatRelativeTime = (createdAt: string, locale?: string) => {
@@ -96,6 +97,16 @@ const resolveThreadRootId = (item: any): string | null => {
 	return threadRootId ? decodeURIComponent(threadRootId) : null;
 };
 
+const resolveCaseHandoverRequestId = (item: any): string | null => {
+	const path = item?.actionPath;
+	if (!path || !String(path).includes('?')) {
+		return null;
+	}
+	const query = String(path).split('?')[1];
+	const params = new URLSearchParams(query);
+	return params.get('caseHandoverRequestId');
+};
+
 const toNonEmbeddedPath = (path?: string | null): string | null => {
 	if (!path) {
 		return null;
@@ -120,7 +131,8 @@ export const NotificationsCenter = () => {
 	const {
 		notificationFeed,
 		markNotificationAsRead,
-		markAllNotificationsAsRead
+		markAllNotificationsAsRead,
+		refreshNotificationFeed
 	} = useContext(NotificationsContext);
 	const [selectedNotificationId, setSelectedNotificationId] = useState<
 		string | null
@@ -129,6 +141,8 @@ export const NotificationsCenter = () => {
 	const [activeFamily, setActiveFamily] =
 		useState<TimelineFamilyFilter>('all');
 	const [searchQuery, setSearchQuery] = useState('');
+	const [caseHandoverConsentSubmitting, setCaseHandoverConsentSubmitting] =
+		useState(false);
 
 	// Families actually present in the feed, in canonical order (drives chips).
 	const familiesInFeed = useMemo(
@@ -219,7 +233,15 @@ export const NotificationsCenter = () => {
 		() => resolveThreadRootId(selectedNotification),
 		[selectedNotification]
 	);
+	const selectedCaseHandoverRequestId = useMemo(
+		() => resolveCaseHandoverRequestId(selectedNotification),
+		[selectedNotification]
+	);
 	const canShowChatPreview = selectedNotificationCategory === 'message';
+	const canDecideCaseHandoverConsent =
+		selectedNotification?.eventType === 'case.handover.consent.requested' &&
+		Boolean(selectedSessionId) &&
+		Boolean(selectedCaseHandoverRequestId);
 	const getDefaultSessionsPath = useCallback(
 		() =>
 			hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData)
@@ -324,6 +346,27 @@ export const NotificationsCenter = () => {
 				openNotification(nextItem);
 			}
 		}
+	};
+
+	const handleCaseHandoverConsentDecision = (approved: boolean) => {
+		if (
+			!selectedNotification ||
+			!selectedSessionId ||
+			!selectedCaseHandoverRequestId
+		) {
+			return;
+		}
+		setCaseHandoverConsentSubmitting(true);
+		apiDecideCaseHandoverClientConsent(
+			Number(selectedSessionId),
+			Number(selectedCaseHandoverRequestId),
+			approved
+		)
+			.then(() => {
+				markNotificationAsRead(selectedNotification.id);
+				refreshNotificationFeed();
+			})
+			.finally(() => setCaseHandoverConsentSubmitting(false));
 	};
 
 	const nextUnreadId = getNextNotificationId(selectedNotificationId, true);
@@ -514,6 +557,45 @@ export const NotificationsCenter = () => {
 							<p className="notificationsCenter__detailText">
 								{selectedDisplay?.text}
 							</p>
+							{selectedNotification?.eventType ===
+								'case.handover.consent.requested' && (
+								<div className="notificationsCenter__consentActions">
+									<button
+										type="button"
+										className="notificationsCenter__consentButton notificationsCenter__consentButton--approve"
+										onClick={() =>
+											handleCaseHandoverConsentDecision(
+												true
+											)
+										}
+										disabled={
+											!canDecideCaseHandoverConsent ||
+											caseHandoverConsentSubmitting
+										}
+									>
+										{translate(
+											'caseHandover.consent.approve'
+										)}
+									</button>
+									<button
+										type="button"
+										className="notificationsCenter__consentButton"
+										onClick={() =>
+											handleCaseHandoverConsentDecision(
+												false
+											)
+										}
+										disabled={
+											!canDecideCaseHandoverConsent ||
+											caseHandoverConsentSubmitting
+										}
+									>
+										{translate(
+											'caseHandover.consent.decline'
+										)}
+									</button>
+								</div>
+							)}
 							<div className="notificationsCenter__detailActions">
 								<button
 									type="button"

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -143,6 +143,8 @@ export const NotificationsCenter = () => {
 	const [searchQuery, setSearchQuery] = useState('');
 	const [caseHandoverConsentSubmitting, setCaseHandoverConsentSubmitting] =
 		useState(false);
+	const [caseHandoverConsentError, setCaseHandoverConsentError] =
+		useState('');
 
 	// Families actually present in the feed, in canonical order (drives chips).
 	const familiesInFeed = useMemo(
@@ -183,6 +185,10 @@ export const NotificationsCenter = () => {
 	}, [effectiveSelectedId, selectedNotificationId]);
 
 	// Drop back to "All" if the active family is no longer in the feed.
+	useEffect(() => {
+		setCaseHandoverConsentError('');
+	}, [selectedNotificationId]);
+
 	useEffect(() => {
 		if (activeFamily !== 'all' && !familiesInFeed.includes(activeFamily)) {
 			setActiveFamily('all');
@@ -357,6 +363,7 @@ export const NotificationsCenter = () => {
 			return;
 		}
 		setCaseHandoverConsentSubmitting(true);
+		setCaseHandoverConsentError('');
 		apiDecideCaseHandoverClientConsent(
 			Number(selectedSessionId),
 			Number(selectedCaseHandoverRequestId),
@@ -367,7 +374,9 @@ export const NotificationsCenter = () => {
 				refreshNotificationFeed();
 			})
 			.catch(() => {
-				// keep notification unread when consent decision fails
+				setCaseHandoverConsentError(
+					translate('caseHandover.error.failed')
+				);
 			})
 			.finally(() => setCaseHandoverConsentSubmitting(false));
 	};
@@ -597,6 +606,11 @@ export const NotificationsCenter = () => {
 											'caseHandover.consent.decline'
 										)}
 									</button>
+									{caseHandoverConsentError && (
+										<p className="notificationsCenter__detailText">
+											{caseHandoverConsentError}
+										</p>
+									)}
 								</div>
 							)}
 							<div className="notificationsCenter__detailActions">

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -107,6 +107,14 @@ const resolveCaseHandoverRequestId = (item: any): string | null => {
 	return params.get('caseHandoverRequestId');
 };
 
+const parseNumericId = (value?: string | null): number | null => {
+	if (!value || !/^\d+$/.test(value)) {
+		return null;
+	}
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) ? parsed : null;
+};
+
 const toNonEmbeddedPath = (path?: string | null): string | null => {
 	if (!path) {
 		return null;
@@ -243,11 +251,19 @@ export const NotificationsCenter = () => {
 		() => resolveCaseHandoverRequestId(selectedNotification),
 		[selectedNotification]
 	);
+	const selectedSessionNumericId = useMemo(
+		() => parseNumericId(selectedSessionId),
+		[selectedSessionId]
+	);
+	const selectedCaseHandoverRequestNumericId = useMemo(
+		() => parseNumericId(selectedCaseHandoverRequestId),
+		[selectedCaseHandoverRequestId]
+	);
 	const canShowChatPreview = selectedNotificationCategory === 'message';
 	const canDecideCaseHandoverConsent =
 		selectedNotification?.eventType === 'case.handover.consent.requested' &&
-		Boolean(selectedSessionId) &&
-		Boolean(selectedCaseHandoverRequestId);
+		selectedSessionNumericId !== null &&
+		selectedCaseHandoverRequestNumericId !== null;
 	const getDefaultSessionsPath = useCallback(
 		() =>
 			hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData)
@@ -357,16 +373,17 @@ export const NotificationsCenter = () => {
 	const handleCaseHandoverConsentDecision = (approved: boolean) => {
 		if (
 			!selectedNotification ||
-			!selectedSessionId ||
-			!selectedCaseHandoverRequestId
+			selectedSessionNumericId === null ||
+			selectedCaseHandoverRequestNumericId === null
 		) {
+			setCaseHandoverConsentError(translate('caseHandover.error.failed'));
 			return;
 		}
 		setCaseHandoverConsentSubmitting(true);
 		setCaseHandoverConsentError('');
 		apiDecideCaseHandoverClientConsent(
-			Number(selectedSessionId),
-			Number(selectedCaseHandoverRequestId),
+			selectedSessionNumericId,
+			selectedCaseHandoverRequestNumericId,
 			approved
 		)
 			.then(() => {

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -586,7 +586,8 @@ export const NotificationsCenter = () => {
 										}
 									>
 										{translate(
-											'caseHandover.consent.approve'
+											'caseHandover.consent.approve',
+											'Approve'
 										)}
 									</button>
 									<button
@@ -603,11 +604,15 @@ export const NotificationsCenter = () => {
 										}
 									>
 										{translate(
-											'caseHandover.consent.decline'
+											'caseHandover.consent.decline',
+											'Decline'
 										)}
 									</button>
 									{caseHandoverConsentError && (
-										<p className="notificationsCenter__detailText">
+										<p
+											className="notificationsCenter__detailText"
+											role="alert"
+										>
 											{caseHandoverConsentError}
 										</p>
 									)}

--- a/src/components/notificationsCenter/eventDescriptors/registry.test.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.test.ts
@@ -79,6 +79,9 @@ const EXPECTED_TARGET_KIND: Record<string, string> = {
 	'handover.all_confirmed': 'conversation',
 	'handover.auto_confirmed': 'conversation',
 	'handover.denied': 'conversation',
+	'case.handover.consent.requested': 'conversation',
+	'case.handover.granted': 'conversation',
+	'case.handover.consent.declined': 'conversation',
 	'call.started': 'join',
 	'call.ended': 'conversation',
 	'call.missed': 'conversation'
@@ -98,9 +101,9 @@ describe('WP-06 event-descriptor registry', () => {
 		});
 	});
 
-	it('seeds every designed family (Appointments deferred) — 17 types total', () => {
-		// 6 existing + request.new + draft.created + 5 handover + 3 call = 17.
-		expect(KNOWN_EVENT_TYPES.length).toBe(17);
+	it('seeds every designed family (Appointments deferred) — 20 types total', () => {
+		// 7 existing + request.new + draft.created + 8 handover + 3 call = 20.
+		expect(KNOWN_EVENT_TYPES.length).toBe(20);
 		[
 			'request.new',
 			'draft.created',
@@ -109,6 +112,9 @@ describe('WP-06 event-descriptor registry', () => {
 			'handover.all_confirmed',
 			'handover.auto_confirmed',
 			'handover.denied',
+			'case.handover.consent.requested',
+			'case.handover.granted',
+			'case.handover.consent.declined',
 			'call.started',
 			'call.ended',
 			'call.missed'

--- a/src/components/notificationsCenter/eventDescriptors/registry.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.ts
@@ -215,9 +215,30 @@ const seeds: EventDescriptor[] = [
 		i18nKey: 'handoverDenied',
 		resolveActionTarget: conversationTarget
 	}),
+	descriptor('case.handover.consent.requested', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'caseHandoverConsentRequested',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('case.handover.granted', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'caseHandoverGranted',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('case.handover.consent.declined', {
+		family: 'handover',
+		category: 'system',
+		icon: 'handover',
+		i18nKey: 'caseHandoverConsentDeclined',
+		resolveActionTarget: conversationTarget
+	}),
 
 	// ----- Calls family (Slice 5) -----
-	// Live, joinable call → Join overlay (does not navigate).
+	// Live, joinable call -> Join overlay (does not navigate).
 	descriptor('call.started', {
 		family: 'calls',
 		category: 'system',

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -291,6 +291,35 @@
 		max-width: 780px;
 	}
 
+	&__consentActions {
+		display: flex;
+		gap: 10px;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	&__consentButton {
+		min-height: 40px;
+		padding: 0 16px;
+		border: 1px solid #d1d5db;
+		border-radius: 999px;
+		background: #ffffff;
+		color: #374151;
+		font-weight: 700;
+		cursor: pointer;
+
+		&:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+	}
+
+	&__consentButton--approve {
+		border-color: #c4000b;
+		background: #c4000b;
+		color: #ffffff;
+	}
+
 	&__openButton {
 		width: fit-content;
 		padding: 10px 16px;
@@ -500,7 +529,7 @@
 	}
 }
 
-@media (max-width: 1200px) {
+@media (width <= 1200px) {
 	.notificationsCenter {
 		padding: 16px;
 
@@ -713,7 +742,7 @@
 	}
 }
 
-@media (max-width: 900px) {
+@media (width <= 900px) {
 	.notificationsCenter {
 		padding: 16px;
 

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -291,13 +291,6 @@
 		max-width: 780px;
 	}
 
-	&__consentActions {
-		display: flex;
-		gap: 10px;
-		flex-wrap: wrap;
-		justify-content: center;
-	}
-
 	&__consentButton {
 		min-height: 40px;
 		padding: 0 16px;
@@ -315,9 +308,13 @@
 	}
 
 	&__consentButton--approve {
-		border-color: #c4000b;
-		background: #c4000b;
+		border-color: #e63946;
+		background: #e63946;
 		color: #ffffff;
+	}
+
+	&__consentButton:focus-visible {
+		@include list-item-focus-treatment;
 	}
 
 	&__openButton {
@@ -336,6 +333,13 @@
 	}
 
 	&__detailActions {
+		display: flex;
+		gap: 10px;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	&__consentActions {
 		display: flex;
 		gap: 10px;
 		flex-wrap: wrap;
@@ -529,7 +533,8 @@
 	}
 }
 
-@media (width <= 1200px) {
+// stylelint-disable-next-line media-feature-range-notation
+@media (max-width: 1200px) {
 	.notificationsCenter {
 		padding: 16px;
 
@@ -742,7 +747,8 @@
 	}
 }
 
-@media (width <= 900px) {
+// stylelint-disable-next-line media-feature-range-notation
+@media (max-width: 900px) {
 	.notificationsCenter {
 		padding: 16px;
 

--- a/src/components/session/CaseHandoverGate.tsx
+++ b/src/components/session/CaseHandoverGate.tsx
@@ -5,7 +5,8 @@ import {
 	apiGetCaseHandoverReasons,
 	apiRequestCaseHandoverAccess,
 	CaseHandoverReason,
-	CaseHandoverStatus
+	CaseHandoverStatus,
+	FETCH_ERRORS
 } from '../../api';
 import {
 	isCaseHandoverDenied,
@@ -69,7 +70,7 @@ export const CaseHandoverGate = ({
 			})
 			.catch((requestError) => {
 				const message =
-					requestError?.message === 'FORBIDDEN'
+					requestError?.message === FETCH_ERRORS.FORBIDDEN
 						? translate('caseHandover.error.forbidden')
 						: translate('caseHandover.error.failed');
 				setError(message);

--- a/src/components/session/CaseHandoverGate.tsx
+++ b/src/components/session/CaseHandoverGate.tsx
@@ -118,6 +118,7 @@ export const CaseHandoverGate = ({
 						<div
 							className="caseHandoverGate__reasons"
 							role="radiogroup"
+							aria-label={translate('caseHandover.hidden.title')}
 						>
 							{reasons.map((reason) => (
 								<label
@@ -151,6 +152,9 @@ export const CaseHandoverGate = ({
 								setExplanation(event.target.value)
 							}
 							placeholder={translate(
+								'caseHandover.explanation.placeholder'
+							)}
+							aria-label={translate(
 								'caseHandover.explanation.placeholder'
 							)}
 						/>

--- a/src/components/session/CaseHandoverGate.tsx
+++ b/src/components/session/CaseHandoverGate.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	apiGetCaseHandoverReasons,
+	apiRequestCaseHandoverAccess,
+	CaseHandoverReason,
+	CaseHandoverStatus
+} from '../../api';
+import {
+	isCaseHandoverDenied,
+	isCaseHandoverPending
+} from './caseHandoverHelpers';
+import './caseHandoverGate.styles';
+
+interface CaseHandoverGateProps {
+	sessionId: number;
+	status: CaseHandoverStatus | null;
+	onStatusChange: (status: CaseHandoverStatus) => void;
+}
+
+export const CaseHandoverGate = ({
+	sessionId,
+	status,
+	onStatusChange
+}: CaseHandoverGateProps) => {
+	const { t: translate } = useTranslation();
+	const [reasons, setReasons] = useState<CaseHandoverReason[]>([]);
+	const [reasonCode, setReasonCode] = useState('');
+	const [explanation, setExplanation] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState('');
+
+	useEffect(() => {
+		apiGetCaseHandoverReasons()
+			.then((items) => {
+				setReasons(items || []);
+				setReasonCode((current) =>
+					items?.some((item) => item.code === current) ? current : ''
+				);
+			})
+			.catch(() => {
+				setReasons([]);
+				setError(translate('caseHandover.error.failed'));
+			});
+	}, [translate]);
+
+	const selectedReason = useMemo(
+		() => reasons.find((reason) => reason.code === reasonCode),
+		[reasonCode, reasons]
+	);
+
+	const isPending = isCaseHandoverPending(status?.status);
+	const isDenied = isCaseHandoverDenied(status?.status);
+	const canSubmit =
+		Boolean(reasonCode) && explanation.trim().length > 0 && !isSubmitting;
+
+	const handleSubmit = () => {
+		if (!canSubmit) {
+			setError(translate('caseHandover.error.required'));
+			return;
+		}
+
+		setIsSubmitting(true);
+		setError('');
+		apiRequestCaseHandoverAccess(sessionId, reasonCode, explanation)
+			.then((nextStatus) => {
+				onStatusChange(nextStatus);
+			})
+			.catch((requestError) => {
+				const message =
+					requestError?.message === 'FORBIDDEN'
+						? translate('caseHandover.error.forbidden')
+						: translate('caseHandover.error.failed');
+				setError(message);
+			})
+			.finally(() => setIsSubmitting(false));
+	};
+
+	return (
+		<div className="caseHandoverGate" data-cy="case-handover-gate">
+			<div className="caseHandoverGate__shell">
+				<div className="caseHandoverGate__header">
+					<div className="caseHandoverGate__icon" aria-hidden>
+						↕
+					</div>
+					<div>
+						<h2 className="caseHandoverGate__title">
+							{translate('caseHandover.hidden.title')}
+						</h2>
+						<p className="caseHandoverGate__copy">
+							{isPending
+								? translate('caseHandover.pending.copy')
+								: isDenied
+									? translate('caseHandover.denied.copy')
+									: translate('caseHandover.copy')}
+						</p>
+					</div>
+				</div>
+
+				<div className="caseHandoverGate__statusRow">
+					<span className="caseHandoverGate__statusBadge">
+						{isPending
+							? translate('caseHandover.list.awaitingApproval')
+							: isDenied
+								? translate('caseHandover.list.accessDenied')
+								: translate('caseHandover.list.requestAccess')}
+					</span>
+					<span className="caseHandoverGate__policy">
+						{status?.policyAuthority ||
+							selectedReason?.policyAuthority ||
+							translate('caseHandover.policy.defaultAuthority')}
+					</span>
+				</div>
+
+				{!isPending && (
+					<>
+						<div
+							className="caseHandoverGate__reasons"
+							role="radiogroup"
+						>
+							{reasons.map((reason) => (
+								<label
+									key={reason.code}
+									className="caseHandoverGate__reason"
+								>
+									<input
+										type="radio"
+										name="case-handover-reason"
+										value={reason.code}
+										checked={reasonCode === reason.code}
+										onChange={() =>
+											setReasonCode(reason.code)
+										}
+									/>
+									<span>{reason.label}</span>
+									{reason.clientConsentRequired && (
+										<small>
+											{translate(
+												'caseHandover.policy.clientConsentRequired'
+											)}
+										</small>
+									)}
+								</label>
+							))}
+						</div>
+						<textarea
+							className="caseHandoverGate__explanation"
+							value={explanation}
+							onChange={(event) =>
+								setExplanation(event.target.value)
+							}
+							placeholder={translate(
+								'caseHandover.explanation.placeholder'
+							)}
+						/>
+						<button
+							type="button"
+							className="caseHandoverGate__submit"
+							onClick={handleSubmit}
+							disabled={!canSubmit}
+						>
+							{isSubmitting
+								? translate('caseHandover.submitSending')
+								: translate('caseHandover.submit')}
+						</button>
+					</>
+				)}
+
+				{error && <p className="caseHandoverGate__error">{error}</p>}
+			</div>
+		</div>
+	);
+};

--- a/src/components/session/CaseHandoverGate.tsx
+++ b/src/components/session/CaseHandoverGate.tsx
@@ -5,9 +5,9 @@ import {
 	apiGetCaseHandoverReasons,
 	apiRequestCaseHandoverAccess,
 	CaseHandoverReason,
-	CaseHandoverStatus,
-	FETCH_ERRORS
-} from '../../api';
+	CaseHandoverStatus
+} from '../../api/apiCaseHandover';
+import { FETCH_ERRORS } from '../../api/fetchData';
 import {
 	isCaseHandoverDenied,
 	isCaseHandoverPending
@@ -31,6 +31,13 @@ export const CaseHandoverGate = ({
 	const [explanation, setExplanation] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState('');
+
+	useEffect(() => {
+		setReasonCode('');
+		setExplanation('');
+		setError('');
+		setIsSubmitting(false);
+	}, [sessionId]);
 
 	useEffect(() => {
 		apiGetCaseHandoverReasons()

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -242,7 +242,7 @@ export const SessionStream = ({
 	);
 
 	const fetchSessionMessages = useCallback(
-		(forceCaseHandoverAccess = false) => {
+		(forceCaseHandoverAccess = false): Promise<boolean> => {
 			if (abortController.current) {
 				abortController.current.abort();
 			}
@@ -256,7 +256,7 @@ export const SessionStream = ({
 			) {
 				setMessagesItem({ messages: [] });
 				setLoading(false);
-				return Promise.resolve();
+				return Promise.resolve(false);
 			}
 
 			// Matrix-backed sessions must hydrate from the local Matrix SDK timeline.
@@ -311,7 +311,7 @@ export const SessionStream = ({
 					messages: prepareMessages(formattedMessages)
 				});
 				setLoading(false);
-				return Promise.resolve();
+				return Promise.resolve(true);
 			}
 
 			// Legacy RocketChat path
@@ -335,6 +335,7 @@ export const SessionStream = ({
 							)
 						: null
 				);
+				return true;
 			});
 		},
 		[
@@ -447,8 +448,10 @@ export const SessionStream = ({
 
 					if (message.u?.username !== 'rocket-chat-technical-user') {
 						fetchSessionMessages()
-							.then(() => {
-								setSessionRead();
+							.then((loaded) => {
+								if (loaded) {
+									setSessionRead();
+								}
 							})
 							.catch(() => {
 								// prevent error from leaking to console
@@ -823,8 +826,10 @@ export const SessionStream = ({
 			addNewUsersToEncryptedRoom().then();
 
 			fetchSessionMessages()
-				.then(() => {
-					setSessionRead();
+				.then((loaded) => {
+					if (loaded) {
+						setSessionRead();
+					}
 
 					// MATRIX MIGRATION: Skip RocketChat subscriptions for Matrix sessions
 					if (!isMatrixSession && activeSession.rid) {

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -62,7 +62,7 @@ import { chatTransportService } from '../../services/chatTransportService';
 import { formatMatrixTimelineEvent } from '../../utils/matrixTimelineEventFormatter';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import { CaseHandoverGate } from './CaseHandoverGate';
-import { isCaseHandoverCandidate } from './caseHandoverHelpers';
+import { isCaseHandoverAccessControlled } from './caseHandoverHelpers';
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -232,13 +232,12 @@ export const SessionStream = ({
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
 	const caseHandoverGateNeeded = useMemo(
 		() =>
-			isCaseHandoverCandidate({
+			isCaseHandoverAccessControlled({
 				activeSession,
 				userData,
-				type,
-				sessionListTab
+				type
 			}),
-		[activeSession, sessionListTab, type, userData]
+		[activeSession, type, userData]
 	);
 
 	const fetchSessionMessages = useCallback(

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -23,7 +23,9 @@ import {
 } from '../../globalState';
 import {
 	apiGetAgencyConsultantList,
+	apiGetCaseHandoverStatus,
 	apiGetSessionData,
+	CaseHandoverStatus,
 	FETCH_ERRORS
 } from '../../api';
 import {
@@ -59,6 +61,8 @@ import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
 import { chatTransportService } from '../../services/chatTransportService';
 import { formatMatrixTimelineEvent } from '../../utils/matrixTimelineEventFormatter';
 import { useAppConfig } from '../../hooks/useAppConfig';
+import { CaseHandoverGate } from './CaseHandoverGate';
+import { isCaseHandoverCandidate } from './caseHandoverHelpers';
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -103,6 +107,10 @@ export const SessionStream = ({
 
 	const { activeSession, readActiveSession } =
 		useContext(ActiveSessionContext);
+	const [caseHandoverStatus, setCaseHandoverStatus] =
+		useState<CaseHandoverStatus | null>(null);
+	const [caseHandoverStatusLoading, setCaseHandoverStatusLoading] =
+		useState(false);
 
 	const { addNewUsersToEncryptedRoom } = useE2EE(activeSession?.rid);
 	const { isE2eeEnabled } = useContext(E2EEContext);
@@ -222,95 +230,125 @@ export const SessionStream = ({
 	);
 
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
+	const caseHandoverGateNeeded = useMemo(
+		() =>
+			isCaseHandoverCandidate({
+				activeSession,
+				userData,
+				type,
+				sessionListTab
+			}),
+		[activeSession, sessionListTab, type, userData]
+	);
 
-	const fetchSessionMessages = useCallback(() => {
-		if (abortController.current) {
-			abortController.current.abort();
-		}
+	const fetchSessionMessages = useCallback(
+		(forceCaseHandoverAccess = false) => {
+			if (abortController.current) {
+				abortController.current.abort();
+			}
 
-		abortController.current = new AbortController();
+			abortController.current = new AbortController();
 
-		// Matrix-backed sessions must hydrate from the local Matrix SDK timeline.
-		// Pulling message history through ORISO REST would move decrypted/plaintext
-		// bodies outside the room encryption boundary.
-		const resolvedSession = chatTransportFacadeEnabled
-			? resolvedChatSession
-			: chatTransportService.resolveSession(activeSession);
-		const isMatrixBackedSession = chatTransportFacadeEnabled
-			? resolvedSession.isMatrixSession
-			: Boolean(activeSession.item?.matrixRoomId) ||
-				isMatrixRoom(activeSession.rid);
-		if (isMatrixBackedSession) {
-			const resolvedMatrixRoomId = chatTransportFacadeEnabled
-				? resolvedSession.matrixRoomId
-				: isMatrixRoom(activeSession.rid)
-					? activeSession.rid
-					: activeSession.item?.matrixRoomId;
-			const matrixClient = matrixClientService?.getClient?.();
-			const matrixRoom = resolvedMatrixRoomId
-				? chatTransportFacadeEnabled
-					? chatTransportService.getMatrixRoom(resolvedMatrixRoomId)
-					: matrixClient?.getRoom?.(resolvedMatrixRoomId)
-				: null;
-			const matrixEvents = resolvedMatrixRoomId
-				? chatTransportFacadeEnabled
-					? chatTransportService.getMatrixRoomMessages(
-							resolvedMatrixRoomId,
-							100
-						)
-					: matrixClientService?.getRoomMessages?.(
-							resolvedMatrixRoomId,
-							100
-						) || []
-				: [];
-			const encryptedFallbackText = translate(
-				'e2ee.message.encryption.text'
-			);
-			const formattedMessages = matrixEvents
-				.map((event: any) =>
-					formatMatrixTimelineEvent(
-						event,
-						matrixRoom,
-						encryptedFallbackText
-					)
-				)
-				.filter(Boolean);
+			if (
+				caseHandoverGateNeeded &&
+				!forceCaseHandoverAccess &&
+				!caseHandoverStatus?.canViewContent
+			) {
+				setMessagesItem({ messages: [] });
+				setLoading(false);
+				return Promise.resolve();
+			}
 
-			setMessagesItem({ messages: prepareMessages(formattedMessages) });
-			setLoading(false);
-			return Promise.resolve();
-		}
-
-		// Legacy RocketChat path
-		return apiGetSessionData(
-			activeSession.rid,
-			abortController.current.signal
-		).then((messagesData) => {
-			const hiddenSystemMessages = getSetting<IArraySetting>(
-				SETTING_HIDE_SYSTEM_MESSAGES
-			);
-			setMessagesItem(
-				messagesData
-					? prepareMessages(
-							messagesData.messages.filter(
-								(message) =>
-									!hiddenSystemMessages ||
-									!hiddenSystemMessages.value.includes(
-										message.t
-									)
+			// Matrix-backed sessions must hydrate from the local Matrix SDK timeline.
+			// Pulling message history through ORISO REST would move decrypted/plaintext
+			// bodies outside the room encryption boundary.
+			const resolvedSession = chatTransportFacadeEnabled
+				? resolvedChatSession
+				: chatTransportService.resolveSession(activeSession);
+			const isMatrixBackedSession = chatTransportFacadeEnabled
+				? resolvedSession.isMatrixSession
+				: Boolean(activeSession.item?.matrixRoomId) ||
+					isMatrixRoom(activeSession.rid);
+			if (isMatrixBackedSession) {
+				const resolvedMatrixRoomId = chatTransportFacadeEnabled
+					? resolvedSession.matrixRoomId
+					: isMatrixRoom(activeSession.rid)
+						? activeSession.rid
+						: activeSession.item?.matrixRoomId;
+				const matrixClient = matrixClientService?.getClient?.();
+				const matrixRoom = resolvedMatrixRoomId
+					? chatTransportFacadeEnabled
+						? chatTransportService.getMatrixRoom(
+								resolvedMatrixRoomId
 							)
+						: matrixClient?.getRoom?.(resolvedMatrixRoomId)
+					: null;
+				const matrixEvents = resolvedMatrixRoomId
+					? chatTransportFacadeEnabled
+						? chatTransportService.getMatrixRoomMessages(
+								resolvedMatrixRoomId,
+								100
+							)
+						: matrixClientService?.getRoomMessages?.(
+								resolvedMatrixRoomId,
+								100
+							) || []
+					: [];
+				const encryptedFallbackText = translate(
+					'e2ee.message.encryption.text'
+				);
+				const formattedMessages = matrixEvents
+					.map((event: any) =>
+						formatMatrixTimelineEvent(
+							event,
+							matrixRoom,
+							encryptedFallbackText
 						)
-					: null
-			);
-		});
-	}, [
-		activeSession,
-		chatTransportFacadeEnabled,
-		getSetting,
-		matrixClientService,
-		resolvedChatSession,
-		translate
-	]);
+					)
+					.filter(Boolean);
+
+				setMessagesItem({
+					messages: prepareMessages(formattedMessages)
+				});
+				setLoading(false);
+				return Promise.resolve();
+			}
+
+			// Legacy RocketChat path
+			return apiGetSessionData(
+				activeSession.rid,
+				abortController.current.signal
+			).then((messagesData) => {
+				const hiddenSystemMessages = getSetting<IArraySetting>(
+					SETTING_HIDE_SYSTEM_MESSAGES
+				);
+				setMessagesItem(
+					messagesData
+						? prepareMessages(
+								messagesData.messages.filter(
+									(message) =>
+										!hiddenSystemMessages ||
+										!hiddenSystemMessages.value.includes(
+											message.t
+										)
+								)
+							)
+						: null
+				);
+			});
+		},
+		[
+			activeSession,
+			caseHandoverGateNeeded,
+			caseHandoverStatus?.canViewContent,
+			chatTransportFacadeEnabled,
+			getSetting,
+			matrixClientService,
+			resolvedChatSession,
+			translate
+		]
+	);
+	const fetchSessionMessagesRef = useUpdatingRef(fetchSessionMessages);
 
 	const setSessionRead = useCallback(() => {
 		if (readonly) {
@@ -319,6 +357,67 @@ export const SessionStream = ({
 
 		readActiveSession();
 	}, [readActiveSession, readonly]);
+
+	useEffect(() => {
+		let cancelled = false;
+		const sessionId = activeSession.item?.id;
+
+		if (!caseHandoverGateNeeded || !sessionId) {
+			setCaseHandoverStatus(null);
+			setCaseHandoverStatusLoading(false);
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		setCaseHandoverStatusLoading(true);
+		setMessagesItem({ messages: [] });
+
+		apiGetCaseHandoverStatus(sessionId)
+			.then((nextStatus) => {
+				if (cancelled) {
+					return;
+				}
+				setCaseHandoverStatus(nextStatus);
+				if (nextStatus.canViewContent) {
+					setLoading(true);
+					fetchSessionMessagesRef
+						.current(true)
+						.then(() => setSessionRead())
+						.catch(() => setMessagesItem({ messages: [] }))
+						.finally(() => setLoading(false));
+				} else {
+					setLoading(false);
+				}
+			})
+			.catch(() => {
+				if (cancelled) {
+					return;
+				}
+				setCaseHandoverStatus({
+					sessionId,
+					status: 'DENIED',
+					canViewContent: false,
+					clientConsentRequired: false,
+					auditOutcome: 'ACCESS_DENIED'
+				});
+				setLoading(false);
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setCaseHandoverStatusLoading(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		activeSession.item?.id,
+		caseHandoverGateNeeded,
+		fetchSessionMessagesRef,
+		setSessionRead
+	]);
 
 	/**
 	 * ToDo: roomMessageBounce is just a temporary fix because currently
@@ -859,12 +958,39 @@ export const SessionStream = ({
 	// activeSessionId: activeSession?.item?.id
 	// });
 
+	if (caseHandoverGateNeeded && caseHandoverStatusLoading) {
+		return <Loading />;
+	}
+
 	if (loading) {
 		// console.log('🔥 SessionStream: Showing loading spinner');
 		return <Loading />;
 	}
 
 	// console.log('🔥 SessionStream: Rendering session content');
+
+	const handleCaseHandoverStatusChange = (nextStatus: CaseHandoverStatus) => {
+		setCaseHandoverStatus(nextStatus);
+		if (nextStatus.canViewContent) {
+			setLoading(true);
+			fetchSessionMessages(true)
+				.then(() => setSessionRead())
+				.catch(() => setMessagesItem({ messages: [] }))
+				.finally(() => setLoading(false));
+		}
+	};
+
+	if (caseHandoverGateNeeded && !caseHandoverStatus?.canViewContent) {
+		return (
+			<div className="session__wrapper">
+				<CaseHandoverGate
+					session={activeSession}
+					status={caseHandoverStatus}
+					onStatusChange={handleCaseHandoverStatusChange}
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div className="session__wrapper">

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -358,12 +358,23 @@ export const SessionStream = ({
 		readActiveSession();
 	}, [readActiveSession, readonly]);
 
+	const loadAfterCaseHandoverGranted = useCallback(() => {
+		setLoading(true);
+		return fetchSessionMessagesRef
+			.current(true)
+			.then(() => setSessionRead())
+			.catch(() => setMessagesItem({ messages: [] }))
+			.finally(() => setLoading(false));
+	}, [fetchSessionMessagesRef, setSessionRead]);
+
 	useEffect(() => {
 		let cancelled = false;
 		const sessionId = activeSession.item?.id;
 
+		setCaseHandoverStatus(null);
+		setMessagesItem({ messages: [] });
+
 		if (!caseHandoverGateNeeded || !sessionId) {
-			setCaseHandoverStatus(null);
 			setCaseHandoverStatusLoading(false);
 			return () => {
 				cancelled = true;
@@ -371,7 +382,6 @@ export const SessionStream = ({
 		}
 
 		setCaseHandoverStatusLoading(true);
-		setMessagesItem({ messages: [] });
 
 		apiGetCaseHandoverStatus(sessionId)
 			.then((nextStatus) => {
@@ -380,12 +390,7 @@ export const SessionStream = ({
 				}
 				setCaseHandoverStatus(nextStatus);
 				if (nextStatus.canViewContent) {
-					setLoading(true);
-					fetchSessionMessagesRef
-						.current(true)
-						.then(() => setSessionRead())
-						.catch(() => setMessagesItem({ messages: [] }))
-						.finally(() => setLoading(false));
+					loadAfterCaseHandoverGranted();
 				} else {
 					setLoading(false);
 				}
@@ -415,8 +420,7 @@ export const SessionStream = ({
 	}, [
 		activeSession.item?.id,
 		caseHandoverGateNeeded,
-		fetchSessionMessagesRef,
-		setSessionRead
+		loadAfterCaseHandoverGranted
 	]);
 
 	/**
@@ -976,11 +980,7 @@ export const SessionStream = ({
 	const handleCaseHandoverStatusChange = (nextStatus: CaseHandoverStatus) => {
 		setCaseHandoverStatus(nextStatus);
 		if (nextStatus.canViewContent) {
-			setLoading(true);
-			fetchSessionMessages(true)
-				.then(() => setSessionRead())
-				.catch(() => setMessagesItem({ messages: [] }))
-				.finally(() => setLoading(false));
+			loadAfterCaseHandoverGranted();
 		}
 	};
 

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -988,7 +988,7 @@ export const SessionStream = ({
 		return (
 			<div className="session__wrapper">
 				<CaseHandoverGate
-					session={activeSession}
+					sessionId={activeSession.item.id}
 					status={caseHandoverStatus}
 					onStatusChange={handleCaseHandoverStatusChange}
 				/>

--- a/src/components/session/caseHandoverGate.styles.scss
+++ b/src/components/session/caseHandoverGate.styles.scss
@@ -1,0 +1,149 @@
+.caseHandoverGate {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 100%;
+	padding: 32px;
+	background: #ffffff;
+}
+
+.caseHandoverGate__shell {
+	width: min(680px, 100%);
+	border: 1px solid #ffd8d4;
+	border-radius: 24px;
+	padding: 32px;
+	background: #fff;
+	box-shadow: 0 2px 10px rgba(45, 34, 33, 0.08);
+}
+
+.caseHandoverGate__header {
+	display: flex;
+	gap: 18px;
+	align-items: flex-start;
+	margin-bottom: 24px;
+}
+
+.caseHandoverGate__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 56px;
+	width: 56px;
+	height: 56px;
+	border-radius: 18px;
+	background: #5c6672;
+	color: #ffffff;
+	font-size: 32px;
+	line-height: 1;
+}
+
+.caseHandoverGate__title {
+	margin: 0 0 8px;
+	font-size: 28px;
+	line-height: 34px;
+	font-weight: 600;
+	color: #202124;
+}
+
+.caseHandoverGate__copy {
+	margin: 0;
+	color: #4b515a;
+	font-size: 16px;
+	line-height: 24px;
+}
+
+.caseHandoverGate__statusRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 20px;
+	padding-bottom: 18px;
+	border-bottom: 1px solid #f3d6d2;
+}
+
+.caseHandoverGate__statusBadge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 32px;
+	padding: 0 14px;
+	border-radius: 999px;
+	background: #eef1f4;
+	color: #4b515a;
+	font-weight: 600;
+}
+
+.caseHandoverGate__policy {
+	color: #6d747d;
+	font-size: 13px;
+	text-align: right;
+}
+
+.caseHandoverGate__reasons {
+	display: grid;
+	gap: 10px;
+	margin-bottom: 18px;
+}
+
+.caseHandoverGate__reason {
+	display: grid;
+	grid-template-columns: 24px 1fr auto;
+	align-items: center;
+	gap: 12px;
+	min-height: 52px;
+	padding: 12px 14px;
+	border-radius: 14px;
+	background: #f5f3f4;
+	color: #242527;
+	cursor: pointer;
+
+	input {
+		width: 18px;
+		height: 18px;
+		accent-color: #c4000b;
+	}
+
+	small {
+		color: #a5000a;
+		font-size: 12px;
+	}
+}
+
+.caseHandoverGate__explanation {
+	display: block;
+	width: 100%;
+	min-height: 140px;
+	margin-bottom: 16px;
+	padding: 16px;
+	border: 1px solid #ffb4ab;
+	border-radius: 16px;
+	resize: vertical;
+	font: inherit;
+	color: #202124;
+}
+
+.caseHandoverGate__submit {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 48px;
+	padding: 0 24px;
+	border: 0;
+	border-radius: 24px;
+	background: #c4000b;
+	color: #ffffff;
+	font-weight: 700;
+	cursor: pointer;
+
+	&:disabled {
+		background: #c5ccd5;
+		cursor: not-allowed;
+	}
+}
+
+.caseHandoverGate__error {
+	margin: 14px 0 0;
+	color: #a5000a;
+	font-weight: 600;
+}

--- a/src/components/session/caseHandoverHelpers.test.ts
+++ b/src/components/session/caseHandoverHelpers.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	STATUS_ENQUIRY,
+	STATUS_ACTIVE
+} from '../../globalState/interfaces';
+import {
+	isCaseHandoverCandidate,
+	isCaseHandoverDenied,
+	isCaseHandoverPending
+} from './caseHandoverHelpers';
+import type { SESSION_LIST_TYPES as SessionListType } from './sessionHelpers';
+
+vi.mock('../../globalState', () => ({
+	AUTHORITIES: {
+		ASKER_DEFAULT: 'AUTHORIZATION_USER_DEFAULT',
+		CONSULTANT_DEFAULT: 'AUTHORIZATION_CONSULTANT_DEFAULT'
+	},
+	hasUserAuthority: (authority: string, userData: any) =>
+		userData?.grantedAuthorities?.includes(authority)
+}));
+
+vi.mock('./sessionHelpers', () => ({
+	SESSION_LIST_TAB_ARCHIVE: 'archive',
+	SESSION_LIST_TYPES: {
+		ENQUIRY: 'ENQUIRY',
+		MY_SESSION: 'MY_SESSION'
+	}
+}));
+
+const AUTHORITIES = {
+	ASKER_DEFAULT: 'AUTHORIZATION_USER_DEFAULT',
+	CONSULTANT_DEFAULT: 'AUTHORIZATION_CONSULTANT_DEFAULT'
+};
+
+const SESSION_LIST_TAB_ARCHIVE = 'archive';
+const SESSION_LIST_TYPES = {
+	MY_SESSION: 'MY_SESSION'
+};
+const MY_SESSION_TYPE = SESSION_LIST_TYPES.MY_SESSION as SessionListType;
+
+const baseSession = {
+	item: { id: 123, status: STATUS_ACTIVE },
+	consultant: { id: 'original-counsellor' },
+	isEmptyEnquiry: false,
+	isGroup: false,
+	isSession: true
+};
+
+const consultantUser = {
+	userId: 'receiving-counsellor',
+	grantedAuthorities: [AUTHORITIES.CONSULTANT_DEFAULT]
+};
+
+describe('caseHandoverHelpers', () => {
+	it('marks another counsellor owned my-session as handover candidate', () => {
+		expect(
+			isCaseHandoverCandidate({
+				activeSession: baseSession,
+				userData: consultantUser,
+				type: MY_SESSION_TYPE
+			})
+		).toBe(true);
+	});
+
+	it('keeps asker, archive, enquiry, group, and own sessions out of handover candidates', () => {
+		const commonInput = {
+			activeSession: baseSession,
+			userData: consultantUser,
+			type: MY_SESSION_TYPE
+		};
+
+		expect(
+			isCaseHandoverCandidate({
+				...commonInput,
+				userData: {
+					userId: 'asker',
+					grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT]
+				}
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverCandidate({
+				...commonInput,
+				sessionListTab: SESSION_LIST_TAB_ARCHIVE
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverCandidate({
+				...commonInput,
+				activeSession: {
+					...baseSession,
+					item: { ...baseSession.item, status: STATUS_ENQUIRY }
+				}
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverCandidate({
+				...commonInput,
+				activeSession: { ...baseSession, isGroup: true }
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverCandidate({
+				...commonInput,
+				activeSession: {
+					...baseSession,
+					consultant: { id: consultantUser.userId }
+				}
+			})
+		).toBe(false);
+	});
+
+	it('groups pending and denied statuses for list and gate display', () => {
+		expect(isCaseHandoverPending('PENDING')).toBe(true);
+		expect(isCaseHandoverPending('PENDING_CLIENT_CONSENT')).toBe(true);
+		expect(isCaseHandoverPending('GRANTED')).toBe(false);
+
+		expect(isCaseHandoverDenied('DENIED')).toBe(true);
+		expect(isCaseHandoverDenied('CLIENT_CONSENT_DECLINED')).toBe(true);
+		expect(isCaseHandoverDenied('NOT_REQUESTED')).toBe(false);
+	});
+});

--- a/src/components/session/caseHandoverHelpers.test.ts
+++ b/src/components/session/caseHandoverHelpers.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { STATUS_ENQUIRY, STATUS_ACTIVE } from '../../globalState/interfaces';
 import {
-	STATUS_ENQUIRY,
-	STATUS_ACTIVE
-} from '../../globalState/interfaces';
-import {
+	isCaseHandoverAccessControlled,
 	isCaseHandoverCandidate,
 	isCaseHandoverDenied,
 	isCaseHandoverPending
@@ -60,6 +58,24 @@ describe('caseHandoverHelpers', () => {
 				type: MY_SESSION_TYPE
 			})
 		).toBe(true);
+	});
+
+	it('keeps archive sessions access-controlled even when batch selection is disabled', () => {
+		expect(
+			isCaseHandoverAccessControlled({
+				activeSession: baseSession,
+				userData: consultantUser,
+				type: MY_SESSION_TYPE
+			})
+		).toBe(true);
+		expect(
+			isCaseHandoverCandidate({
+				activeSession: baseSession,
+				userData: consultantUser,
+				type: MY_SESSION_TYPE,
+				sessionListTab: SESSION_LIST_TAB_ARCHIVE
+			})
+		).toBe(false);
 	});
 
 	it('keeps asker, archive, enquiry, group, and own sessions out of handover candidates', () => {

--- a/src/components/session/caseHandoverHelpers.test.ts
+++ b/src/components/session/caseHandoverHelpers.test.ts
@@ -126,6 +126,66 @@ describe('caseHandoverHelpers', () => {
 		).toBe(false);
 	});
 
+	it('keeps missing, asker, non-my-session, enquiry, group, and own sessions out of access control', () => {
+		const commonInput = {
+			activeSession: baseSession,
+			userData: consultantUser,
+			type: MY_SESSION_TYPE
+		};
+
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				activeSession: null
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				userData: null
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				userData: {
+					userId: 'asker',
+					grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT]
+				}
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				type: 'ENQUIRY' as SessionListType
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				activeSession: {
+					...baseSession,
+					item: { ...baseSession.item, status: STATUS_ENQUIRY }
+				}
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				activeSession: { ...baseSession, isGroup: true }
+			})
+		).toBe(false);
+		expect(
+			isCaseHandoverAccessControlled({
+				...commonInput,
+				activeSession: {
+					...baseSession,
+					consultant: { id: consultantUser.userId }
+				}
+			})
+		).toBe(false);
+	});
+
 	it('groups pending and denied statuses for list and gate display', () => {
 		expect(isCaseHandoverPending('PENDING')).toBe(true);
 		expect(isCaseHandoverPending('PENDING_CLIENT_CONSENT')).toBe(true);

--- a/src/components/session/caseHandoverHelpers.ts
+++ b/src/components/session/caseHandoverHelpers.ts
@@ -1,0 +1,63 @@
+import { AUTHORITIES, hasUserAuthority } from '../../globalState';
+import { STATUS_ENQUIRY } from '../../globalState/interfaces';
+import {
+	SESSION_LIST_TAB,
+	SESSION_LIST_TAB_ARCHIVE,
+	SESSION_LIST_TYPES
+} from './sessionHelpers';
+
+export const CASE_HANDOVER_PENDING_STATUSES = [
+	'PENDING',
+	'PENDING_CLIENT_CONSENT'
+];
+
+export const CASE_HANDOVER_DENIED_STATUSES = [
+	'DENIED',
+	'CLIENT_CONSENT_DECLINED'
+];
+
+interface CaseHandoverCandidateInput {
+	activeSession: any;
+	userData: any;
+	type: SESSION_LIST_TYPES;
+	sessionListTab?: SESSION_LIST_TAB | string | null;
+}
+
+export const isCaseHandoverCandidate = ({
+	activeSession,
+	userData,
+	type,
+	sessionListTab
+}: CaseHandoverCandidateInput): boolean => {
+	if (!activeSession || !activeSession.item || !userData) {
+		return false;
+	}
+	if (hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData)) {
+		return false;
+	}
+	if (type !== SESSION_LIST_TYPES.MY_SESSION) {
+		return false;
+	}
+	if (sessionListTab === SESSION_LIST_TAB_ARCHIVE) {
+		return false;
+	}
+	if (activeSession.isGroup || !activeSession.isSession) {
+		return false;
+	}
+	if (
+		activeSession.isEmptyEnquiry ||
+		activeSession.item.status === STATUS_ENQUIRY
+	) {
+		return false;
+	}
+	const ownerId = activeSession.consultant?.id;
+	return (
+		Boolean(ownerId) && String(ownerId) !== String(userData.userId || '')
+	);
+};
+
+export const isCaseHandoverPending = (status?: string | null): boolean =>
+	Boolean(status && CASE_HANDOVER_PENDING_STATUSES.includes(status));
+
+export const isCaseHandoverDenied = (status?: string | null): boolean =>
+	Boolean(status && CASE_HANDOVER_DENIED_STATUSES.includes(status));

--- a/src/components/session/caseHandoverHelpers.ts
+++ b/src/components/session/caseHandoverHelpers.ts
@@ -23,12 +23,11 @@ interface CaseHandoverCandidateInput {
 	sessionListTab?: SESSION_LIST_TAB | string | null;
 }
 
-export const isCaseHandoverCandidate = ({
+export const isCaseHandoverAccessControlled = ({
 	activeSession,
 	userData,
-	type,
-	sessionListTab
-}: CaseHandoverCandidateInput): boolean => {
+	type
+}: Omit<CaseHandoverCandidateInput, 'sessionListTab'>): boolean => {
 	if (!activeSession || !activeSession.item || !userData) {
 		return false;
 	}
@@ -36,9 +35,6 @@ export const isCaseHandoverCandidate = ({
 		return false;
 	}
 	if (type !== SESSION_LIST_TYPES.MY_SESSION) {
-		return false;
-	}
-	if (sessionListTab === SESSION_LIST_TAB_ARCHIVE) {
 		return false;
 	}
 	if (activeSession.isGroup || !activeSession.isSession) {
@@ -54,6 +50,18 @@ export const isCaseHandoverCandidate = ({
 	return (
 		Boolean(ownerId) && String(ownerId) !== String(userData.userId || '')
 	);
+};
+
+export const isCaseHandoverCandidate = ({
+	activeSession,
+	userData,
+	type,
+	sessionListTab
+}: CaseHandoverCandidateInput): boolean => {
+	if (sessionListTab === SESSION_LIST_TAB_ARCHIVE) {
+		return false;
+	}
+	return isCaseHandoverAccessControlled({ activeSession, userData, type });
 };
 
 export const isCaseHandoverPending = (status?: string | null): boolean =>

--- a/src/components/session/caseHandoverHelpers.ts
+++ b/src/components/session/caseHandoverHelpers.ts
@@ -1,5 +1,8 @@
 import { AUTHORITIES, hasUserAuthority } from '../../globalState';
-import { STATUS_ENQUIRY } from '../../globalState/interfaces';
+import {
+	STATUS_ENQUIRY,
+	UserDataInterface
+} from '../../globalState/interfaces';
 import {
 	SESSION_LIST_TAB,
 	SESSION_LIST_TAB_ARCHIVE,
@@ -16,9 +19,26 @@ export const CASE_HANDOVER_DENIED_STATUSES = [
 	'CLIENT_CONSENT_DECLINED'
 ];
 
+interface CaseHandoverSessionInput {
+	item?: {
+		status?: number | string;
+	};
+	consultant?: {
+		id?: string | number;
+	};
+	isEmptyEnquiry?: boolean;
+	isGroup?: boolean;
+	isSession?: boolean;
+}
+
+interface CaseHandoverUserInput {
+	userId?: string | number;
+	grantedAuthorities?: readonly string[];
+}
+
 interface CaseHandoverCandidateInput {
-	activeSession: any;
-	userData: any;
+	activeSession: CaseHandoverSessionInput | null;
+	userData: CaseHandoverUserInput | null;
 	type: SESSION_LIST_TYPES;
 	sessionListTab?: SESSION_LIST_TAB | string | null;
 }
@@ -31,7 +51,12 @@ export const isCaseHandoverAccessControlled = ({
 	if (!activeSession || !activeSession.item || !userData) {
 		return false;
 	}
-	if (hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData)) {
+	if (
+		hasUserAuthority(
+			AUTHORITIES.ASKER_DEFAULT,
+			userData as UserDataInterface
+		)
+	) {
 		return false;
 	}
 	if (type !== SESSION_LIST_TYPES.MY_SESSION) {

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -35,6 +35,7 @@ import { SessionsListSkeleton } from '../sessionsListItem/SessionsListItemSkelet
 import { isAnonymousAskerCandidate } from './sessionClassification';
 import {
 	apiGetAskerSessionList,
+	apiGetCaseHandoverCandidates,
 	apiGetCaseHandoverReasons,
 	apiGetConsultantSessionList,
 	apiRequestCaseHandoverBatchAccess,
@@ -413,6 +414,8 @@ export const SessionsList = ({
 	const [sessionToolbarSearch, setSessionToolbarSearch] = useState('');
 	const [sessionToolbarSelectedPeople, setSessionToolbarSelectedPeople] =
 		useState<string[]>([]);
+	const [caseHandoverCandidateSessions, setCaseHandoverCandidateSessions] =
+		useState<ListItemInterface[]>([]);
 	const [userDrafts, setUserDrafts] = useState<IUserDraftItem[]>([]);
 	const [caseHandoverBatchMode, setCaseHandoverBatchMode] = useState(false);
 	const [caseHandoverSelectedIds, setCaseHandoverSelectedIds] = useState<
@@ -1361,6 +1364,51 @@ export const SessionsList = ({
 			),
 		[userDrafts]
 	);
+	useEffect(() => {
+		const query = sessionToolbarSearch.trim();
+
+		if (!showConsultantToolbarActions) {
+			setCaseHandoverCandidateSessions([]);
+			return;
+		}
+
+		if (!query) {
+			if (sessionToolbarSelectedPeople.length === 0) {
+				setCaseHandoverCandidateSessions([]);
+			}
+			return;
+		}
+
+		const controller = new AbortController();
+		const timeoutId = window.setTimeout(() => {
+			apiGetCaseHandoverCandidates({
+				query,
+				count: 50,
+				archived: sessionListTab === SESSION_LIST_TAB_ARCHIVE,
+				signal: controller.signal
+			})
+				.then(({ sessions: candidateSessions }) => {
+					setCaseHandoverCandidateSessions(
+						candidateSessions || []
+					);
+				})
+				.catch((error) => {
+					if (error?.message !== FETCH_ERRORS.ABORT) {
+						setCaseHandoverCandidateSessions([]);
+					}
+				});
+		}, 250);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+			controller.abort();
+		};
+	}, [
+		sessionListTab,
+		sessionToolbarSearch,
+		sessionToolbarSelectedPeople.length,
+		showConsultantToolbarActions
+	]);
 	const loadUserDrafts = useCallback(async () => {
 		if (!showMySessionToolbar) {
 			setUserDrafts([]);
@@ -1664,8 +1712,28 @@ export const SessionsList = ({
 		}
 	};
 	const finalSessionsList = React.useMemo(
-		() => (sessions || []).filter(filterSessions),
-		[filterSessions, sessions]
+		() => {
+			const baseSessions = (sessions || []).filter(filterSessions);
+			if (caseHandoverCandidateSessions.length === 0) {
+				return baseSessions;
+			}
+
+			const baseSessionIds = new Set(
+				baseSessions
+					.map((session) => session.session?.id || session.chat?.id)
+					.filter(Boolean)
+					.map(String)
+			);
+			const candidates = caseHandoverCandidateSessions
+				.filter(filterSessions)
+				.filter((session) => {
+					const id = session.session?.id || session.chat?.id;
+					return id !== undefined && !baseSessionIds.has(String(id));
+				});
+
+			return [...candidates, ...baseSessions];
+		},
+		[caseHandoverCandidateSessions, filterSessions, sessions]
 	);
 	const sessionToolbarPairs = React.useMemo(
 		() =>

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -1373,9 +1373,7 @@ export const SessionsList = ({
 		}
 
 		if (!query) {
-			if (sessionToolbarSelectedPeople.length === 0) {
-				setCaseHandoverCandidateSessions([]);
-			}
+			setCaseHandoverCandidateSessions([]);
 			return;
 		}
 
@@ -1388,9 +1386,7 @@ export const SessionsList = ({
 				signal: controller.signal
 			})
 				.then(({ sessions: candidateSessions }) => {
-					setCaseHandoverCandidateSessions(
-						candidateSessions || []
-					);
+					setCaseHandoverCandidateSessions(candidateSessions || []);
 				})
 				.catch((error) => {
 					if (error?.message !== FETCH_ERRORS.ABORT) {
@@ -1403,12 +1399,7 @@ export const SessionsList = ({
 			window.clearTimeout(timeoutId);
 			controller.abort();
 		};
-	}, [
-		sessionListTab,
-		sessionToolbarSearch,
-		sessionToolbarSelectedPeople.length,
-		showConsultantToolbarActions
-	]);
+	}, [sessionListTab, sessionToolbarSearch, showConsultantToolbarActions]);
 	const loadUserDrafts = useCallback(async () => {
 		if (!showMySessionToolbar) {
 			setUserDrafts([]);
@@ -1711,30 +1702,27 @@ export const SessionsList = ({
 			}
 		}
 	};
-	const finalSessionsList = React.useMemo(
-		() => {
-			const baseSessions = (sessions || []).filter(filterSessions);
-			if (caseHandoverCandidateSessions.length === 0) {
-				return baseSessions;
-			}
+	const finalSessionsList = React.useMemo(() => {
+		const baseSessions = (sessions || []).filter(filterSessions);
+		if (caseHandoverCandidateSessions.length === 0) {
+			return baseSessions;
+		}
 
-			const baseSessionIds = new Set(
-				baseSessions
-					.map((session) => session.session?.id || session.chat?.id)
-					.filter(Boolean)
-					.map(String)
-			);
-			const candidates = caseHandoverCandidateSessions
-				.filter(filterSessions)
-				.filter((session) => {
-					const id = session.session?.id || session.chat?.id;
-					return id !== undefined && !baseSessionIds.has(String(id));
-				});
+		const baseSessionIds = new Set(
+			baseSessions
+				.map((session) => session.session?.id || session.chat?.id)
+				.filter(Boolean)
+				.map(String)
+		);
+		const candidates = caseHandoverCandidateSessions
+			.filter(filterSessions)
+			.filter((session) => {
+				const id = session.session?.id || session.chat?.id;
+				return id !== undefined && !baseSessionIds.has(String(id));
+			});
 
-			return [...candidates, ...baseSessions];
-		},
-		[caseHandoverCandidateSessions, filterSessions, sessions]
-	);
+		return [...candidates, ...baseSessions];
+	}, [caseHandoverCandidateSessions, filterSessions, sessions]);
 	const sessionToolbarPairs = React.useMemo(
 		() =>
 			finalSessionsList.map((raw) => ({

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -35,7 +35,10 @@ import { SessionsListSkeleton } from '../sessionsListItem/SessionsListItemSkelet
 import { isAnonymousAskerCandidate } from './sessionClassification';
 import {
 	apiGetAskerSessionList,
+	apiGetCaseHandoverReasons,
 	apiGetConsultantSessionList,
+	apiRequestCaseHandoverBatchAccess,
+	CaseHandoverReason,
 	FETCH_ERRORS,
 	SESSION_COUNT
 } from '../../api';
@@ -82,6 +85,7 @@ import {
 	DRAFTS_UPDATED_EVENT,
 	REMOTE_DRAFT_INDEX_SCOPE
 } from '../../services/draftStore';
+import { isCaseHandoverCandidate } from '../session/caseHandoverHelpers';
 
 function buildSessionSearchHaystack(
 	raw: ListItemInterface,
@@ -410,6 +414,19 @@ export const SessionsList = ({
 	const [sessionToolbarSelectedPeople, setSessionToolbarSelectedPeople] =
 		useState<string[]>([]);
 	const [userDrafts, setUserDrafts] = useState<IUserDraftItem[]>([]);
+	const [caseHandoverBatchMode, setCaseHandoverBatchMode] = useState(false);
+	const [caseHandoverSelectedIds, setCaseHandoverSelectedIds] = useState<
+		number[]
+	>([]);
+	const [caseHandoverReasons, setCaseHandoverReasons] = useState<
+		CaseHandoverReason[]
+	>([]);
+	const [caseHandoverReasonCode, setCaseHandoverReasonCode] = useState('');
+	const [caseHandoverExplanation, setCaseHandoverExplanation] = useState('');
+	const [caseHandoverBatchSubmitting, setCaseHandoverBatchSubmitting] =
+		useState(false);
+	const [caseHandoverBatchSummary, setCaseHandoverBatchSummary] =
+		useState('');
 	/**
 	 * Initial chip selection:
 	 *   - enquiry list: honour ?chip=liveChat in the URL (sidebar toggle
@@ -1382,6 +1399,22 @@ export const SessionsList = ({
 		};
 	}, [loadUserDrafts, showMySessionToolbar]);
 
+	useEffect(() => {
+		if (!caseHandoverBatchMode) {
+			return;
+		}
+		apiGetCaseHandoverReasons()
+			.then((items) => {
+				setCaseHandoverReasons(items || []);
+				setCaseHandoverReasonCode((current) =>
+					items?.some((item) => item.code === current) ? current : ''
+				);
+			})
+			.catch(() => {
+				setCaseHandoverReasons([]);
+			});
+	}, [caseHandoverBatchMode]);
+
 	const handleOpenDraft = useCallback(
 		(draft: IUserDraftItem) => {
 			if (!draft.actionPath) {
@@ -1657,6 +1690,83 @@ export const SessionsList = ({
 	const sortedSessions = sessionToolbarFilteredPairs
 		.map(({ extended }) => extended)
 		.sort(sortSessions);
+	const caseHandoverSelectableIds = React.useMemo(
+		() =>
+			sortedSessions
+				.filter((session) =>
+					isCaseHandoverCandidate({
+						activeSession: session,
+						userData,
+						type,
+						sessionListTab
+					})
+				)
+				.map((session) => session.item.id)
+				.filter(
+					(sessionId): sessionId is number =>
+						typeof sessionId === 'number'
+				),
+		[sessionListTab, sortedSessions, type, userData]
+	);
+	const handleCaseHandoverSelect = useCallback((sessionId: number) => {
+		setCaseHandoverBatchSummary('');
+		setCaseHandoverSelectedIds((current) =>
+			current.includes(sessionId)
+				? current.filter((id) => id !== sessionId)
+				: [...current, sessionId]
+		);
+	}, []);
+	const handleCloseCaseHandoverBatch = useCallback(() => {
+		setCaseHandoverBatchMode(false);
+		setCaseHandoverSelectedIds([]);
+		setCaseHandoverExplanation('');
+		setCaseHandoverBatchSummary('');
+	}, []);
+	const handleSubmitCaseHandoverBatch = useCallback(() => {
+		if (
+			caseHandoverSelectedIds.length === 0 ||
+			!caseHandoverReasonCode ||
+			!caseHandoverExplanation.trim()
+		) {
+			setCaseHandoverBatchSummary(
+				translate('caseHandover.batch.required')
+			);
+			return;
+		}
+		setCaseHandoverBatchSubmitting(true);
+		setCaseHandoverBatchSummary('');
+		apiRequestCaseHandoverBatchAccess(
+			caseHandoverSelectedIds,
+			caseHandoverReasonCode,
+			caseHandoverExplanation
+		)
+			.then((results) => {
+				const successful = (results || []).filter(
+					(result) => result.success
+				).length;
+				const failed = (results || []).length - successful;
+				setCaseHandoverBatchSummary(
+					translate('caseHandover.batch.result', {
+						successful,
+						failed
+					})
+				);
+				setCaseHandoverSelectedIds([]);
+				void refetchSessionList();
+			})
+			.catch(() => {
+				setCaseHandoverBatchSummary(
+					translate('caseHandover.error.failed')
+				);
+			})
+			.finally(() => setCaseHandoverBatchSubmitting(false));
+	}, [
+		caseHandoverExplanation,
+		caseHandoverReasonCode,
+		caseHandoverSelectedIds,
+		refetchSessionList,
+		translate
+	]);
 	const unmatchedDrafts = React.useMemo(() => {
 		if (sessionToolbarChip !== 'drafts') {
 			return [];
@@ -1784,6 +1894,103 @@ export const SessionsList = ({
 					chipCounts={toolbarChipCounts}
 				/>
 			)}
+			{showConsultantToolbarActions && (
+				<div className="sessionsList__caseHandoverBatch">
+					{!caseHandoverBatchMode ? (
+						<button
+							type="button"
+							className="sessionsList__caseHandoverBatchToggle"
+							onClick={() => {
+								setCaseHandoverBatchMode(true);
+								setCaseHandoverBatchSummary('');
+							}}
+							disabled={caseHandoverSelectableIds.length === 0}
+						>
+							{translate('caseHandover.batch.start')}
+						</button>
+					) : (
+						<div className="sessionsList__caseHandoverBatchPanel">
+							<div className="sessionsList__caseHandoverBatchHeader">
+								<strong>
+									{translate('caseHandover.batch.title')}
+								</strong>
+								<span>
+									{translate(
+										'caseHandover.batch.selectedCount',
+										{
+											count: caseHandoverSelectedIds.length
+										}
+									)}
+								</span>
+							</div>
+							<div className="sessionsList__caseHandoverBatchReasons">
+								{caseHandoverReasons.map((reason) => (
+									<label key={reason.code}>
+										<input
+											type="radio"
+											name="case-handover-batch-reason"
+											checked={
+												caseHandoverReasonCode ===
+												reason.code
+											}
+											onChange={() =>
+												setCaseHandoverReasonCode(
+													reason.code
+												)
+											}
+										/>
+										<span>{reason.label}</span>
+									</label>
+								))}
+							</div>
+							<textarea
+								className="sessionsList__caseHandoverBatchExplanation"
+								value={caseHandoverExplanation}
+								onChange={(event) =>
+									setCaseHandoverExplanation(
+										event.target.value
+									)
+								}
+								placeholder={translate(
+									'caseHandover.explanation.placeholder'
+								)}
+							/>
+							<div className="sessionsList__caseHandoverBatchActions">
+								<button
+									type="button"
+									onClick={handleCloseCaseHandoverBatch}
+								>
+									{translate('caseHandover.batch.cancel')}
+								</button>
+								<button
+									type="button"
+									className="sessionsList__caseHandoverBatchSubmit"
+									onClick={handleSubmitCaseHandoverBatch}
+									disabled={
+										caseHandoverBatchSubmitting ||
+										caseHandoverSelectedIds.length === 0 ||
+										!caseHandoverReasonCode ||
+										!caseHandoverExplanation.trim()
+									}
+								>
+									{caseHandoverBatchSubmitting
+										? translate(
+												'caseHandover.submitSending'
+											)
+										: translate(
+												'caseHandover.batch.confirm'
+											)}
+								</button>
+							</div>
+							{caseHandoverBatchSummary && (
+								<div className="sessionsList__caseHandoverBatchSummary">
+									{caseHandoverBatchSummary}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+			)}
 			<div className="sessionsList__scrollArea">
 				<div
 					className={clsx('sessionsList__scrollContainer', {
@@ -1826,6 +2033,15 @@ export const SessionsList = ({
 											isSessionListItemActive(
 												sortedSessions[index - 1]
 											)
+										}
+										caseHandoverBatchMode={
+											caseHandoverBatchMode
+										}
+										caseHandoverSelected={caseHandoverSelectedIds.includes(
+											activeSession.item.id
+										)}
+										onCaseHandoverSelect={
+											handleCaseHandoverSelect
 										}
 									/>
 								</ActiveSessionProvider>

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -1353,6 +1353,9 @@ export const SessionsList = ({
 	const showConsultantToolbarActions =
 		type === SESSION_LIST_TYPES.MY_SESSION &&
 		!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
+	const showCaseHandoverBatchUi =
+		showConsultantToolbarActions &&
+		sessionListTab !== SESSION_LIST_TAB_ARCHIVE;
 
 	const showMySessionToolbar =
 		type === SESSION_LIST_TYPES.MY_SESSION ||
@@ -1778,6 +1781,14 @@ export const SessionsList = ({
 		setCaseHandoverExplanation('');
 		setCaseHandoverBatchSummary('');
 	}, []);
+	useEffect(() => {
+		if (
+			sessionListTab === SESSION_LIST_TAB_ARCHIVE &&
+			caseHandoverBatchMode
+		) {
+			handleCloseCaseHandoverBatch();
+		}
+	}, [caseHandoverBatchMode, handleCloseCaseHandoverBatch, sessionListTab]);
 	const handleSubmitCaseHandoverBatch = useCallback(() => {
 		if (
 			caseHandoverSelectedIds.length === 0 ||
@@ -1950,7 +1961,7 @@ export const SessionsList = ({
 					chipCounts={toolbarChipCounts}
 				/>
 			)}
-			{showConsultantToolbarActions && (
+			{showCaseHandoverBatchUi && (
 				<div className="sessionsList__caseHandoverBatch">
 					{!caseHandoverBatchMode ? (
 						<button

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -2048,7 +2048,11 @@ export const SessionsList = ({
 								</button>
 							</div>
 							{caseHandoverBatchSummary && (
-								<div className="sessionsList__caseHandoverBatchSummary">
+								<div
+									className="sessionsList__caseHandoverBatchSummary"
+									role="status"
+									aria-live="polite"
+								>
 									{caseHandoverBatchSummary}
 								</div>
 							)}

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -1979,7 +1979,13 @@ export const SessionsList = ({
 									)}
 								</span>
 							</div>
-							<div className="sessionsList__caseHandoverBatchReasons">
+							<div
+								className="sessionsList__caseHandoverBatchReasons"
+								role="radiogroup"
+								aria-label={translate(
+									'caseHandover.batch.title'
+								)}
+							>
 								{caseHandoverReasons.map((reason) => (
 									<label key={reason.code}>
 										<input
@@ -2008,6 +2014,9 @@ export const SessionsList = ({
 									)
 								}
 								placeholder={translate(
+									'caseHandover.explanation.placeholder'
+								)}
+								aria-label={translate(
 									'caseHandover.explanation.placeholder'
 								)}
 							/>

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -98,6 +98,120 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 		flex-direction: column;
 	}
 
+	&__caseHandoverBatch {
+		padding: 0 24px 12px;
+		background: $sessionShellSurface;
+	}
+
+	&__caseHandoverBatchToggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 40px;
+		padding: 0 18px;
+		border: 0;
+		border-radius: 20px;
+		background: #c4000b;
+		color: #ffffff;
+		font-weight: 700;
+		cursor: pointer;
+
+		&:disabled {
+			background: #d8dde3;
+			color: #6d747d;
+			cursor: not-allowed;
+		}
+	}
+
+	&__caseHandoverBatchPanel {
+		padding: 14px;
+		border-radius: 18px;
+		background: #ffffff;
+		border: 1px solid #ffd8d4;
+		box-shadow: 0 1px 3px rgba(45, 34, 33, 0.08);
+	}
+
+	&__caseHandoverBatchHeader {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin-bottom: 12px;
+		color: #30343a;
+		font-size: 14px;
+	}
+
+	&__caseHandoverBatchReasons {
+		display: grid;
+		gap: 8px;
+		margin-bottom: 10px;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			min-height: 34px;
+			padding: 6px 10px;
+			border-radius: 12px;
+			background: #f5f3f4;
+			font-size: 13px;
+			color: #30343a;
+		}
+
+		input {
+			accent-color: #c4000b;
+		}
+	}
+
+	&__caseHandoverBatchExplanation {
+		display: block;
+		width: 100%;
+		min-height: 84px;
+		padding: 12px;
+		border: 1px solid #ffb4ab;
+		border-radius: 14px;
+		resize: vertical;
+		font: inherit;
+		font-size: 13px;
+		color: #202124;
+	}
+
+	&__caseHandoverBatchActions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 12px;
+
+		button {
+			min-height: 36px;
+			padding: 0 14px;
+			border: 0;
+			border-radius: 18px;
+			background: #eef1f4;
+			color: #4b515a;
+			font-weight: 700;
+			cursor: pointer;
+		}
+
+		.sessionsList__caseHandoverBatchSubmit {
+			background: #c4000b;
+			color: #ffffff;
+
+			&:disabled {
+				background: #d8dde3;
+				color: #6d747d;
+				cursor: not-allowed;
+			}
+		}
+	}
+
+	&__caseHandoverBatchSummary {
+		margin-top: 10px;
+		color: #4b515a;
+		font-size: 13px;
+		font-weight: 600;
+	}
+
 	&__selectWrapper {
 		width: 100%;
 		background-color: $sessionShellSurface;

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -8,6 +8,13 @@ $mobileNavigationHeight: 76px;
 $tabBarHeightMobile: 77px;
 $tabBarHeightDesktop: 53px;
 $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
+$caseHandoverAction: var(--m3-primary, $primary);
+$caseHandoverActionDisabled: var(--m3-surface-variant, #d8dde3);
+$caseHandoverTextMuted: var(--m3-on-surface-variant, #6d747d);
+$caseHandoverPanelBorder: var(--m3-primary-fixed-dim, #ffb4aa);
+$caseHandoverPanelSurface: var(--m3-surface, #ffffff);
+$caseHandoverFieldSurface: var(--m3-surface-container-low, #f5f3f4);
+$caseHandoverBodyText: var(--m3-on-surface, #30343a);
 
 .sessionsList,
 .session {
@@ -111,14 +118,14 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 		padding: 0 18px;
 		border: 0;
 		border-radius: 20px;
-		background: #c4000b;
+		background: $caseHandoverAction;
 		color: #ffffff;
 		font-weight: 700;
 		cursor: pointer;
 
 		&:disabled {
-			background: #d8dde3;
-			color: #6d747d;
+			background: $caseHandoverActionDisabled;
+			color: $caseHandoverTextMuted;
 			cursor: not-allowed;
 		}
 	}
@@ -126,8 +133,8 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 	&__caseHandoverBatchPanel {
 		padding: 14px;
 		border-radius: 18px;
-		background: #ffffff;
-		border: 1px solid #ffd8d4;
+		background: $caseHandoverPanelSurface;
+		border: 1px solid $caseHandoverPanelBorder;
 		box-shadow: 0 1px 3px rgba(45, 34, 33, 0.08);
 	}
 
@@ -137,7 +144,7 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 		justify-content: space-between;
 		gap: 8px;
 		margin-bottom: 12px;
-		color: #30343a;
+		color: $caseHandoverBodyText;
 		font-size: 14px;
 	}
 
@@ -153,13 +160,13 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 			min-height: 34px;
 			padding: 6px 10px;
 			border-radius: 12px;
-			background: #f5f3f4;
+			background: $caseHandoverFieldSurface;
 			font-size: 13px;
-			color: #30343a;
+			color: $caseHandoverBodyText;
 		}
 
 		input {
-			accent-color: #c4000b;
+			accent-color: $caseHandoverAction;
 		}
 	}
 
@@ -168,12 +175,12 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 		width: 100%;
 		min-height: 84px;
 		padding: 12px;
-		border: 1px solid #ffb4ab;
+		border: 1px solid $caseHandoverPanelBorder;
 		border-radius: 14px;
 		resize: vertical;
 		font: inherit;
 		font-size: 13px;
-		color: #202124;
+		color: $caseHandoverBodyText;
 	}
 
 	&__caseHandoverBatchActions {
@@ -187,19 +194,19 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 			padding: 0 14px;
 			border: 0;
 			border-radius: 18px;
-			background: #eef1f4;
-			color: #4b515a;
+			background: $caseHandoverFieldSurface;
+			color: $caseHandoverTextMuted;
 			font-weight: 700;
 			cursor: pointer;
 		}
 
 		.sessionsList__caseHandoverBatchSubmit {
-			background: #c4000b;
+			background: $caseHandoverAction;
 			color: #ffffff;
 
 			&:disabled {
-				background: #d8dde3;
-				color: #6d747d;
+				background: $caseHandoverActionDisabled;
+				color: $caseHandoverTextMuted;
 				cursor: not-allowed;
 			}
 		}
@@ -207,7 +214,7 @@ $sessionShellSurface: var(--m3-surface-container-high, #eae7e8);
 
 	&__caseHandoverBatchSummary {
 		margin-top: 10px;
-		color: #4b515a;
+		color: $caseHandoverTextMuted;
 		font-size: 13px;
 		font-weight: 600;
 	}

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -1468,6 +1468,11 @@ export const SessionListItemComponent = ({
 								caseHandoverBatchMode &&
 								!canBatchSelectCaseHandover
 							}
+							aria-pressed={
+								caseHandoverBatchMode
+									? caseHandoverSelected
+									: undefined
+							}
 						>
 							{caseHandoverBatchMode && (
 								<span

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -1409,8 +1409,16 @@ export const SessionListItemComponent = ({
 				</div>
 				<div className="sessionsListItem__row">
 					<SessionListItemLastMessage
-						lastMessage={displayLastMessage}
-						lastMessageType={activeSession.item.lastMessageType}
+						lastMessage={
+							caseHandoverContentLocked
+								? translate('caseHandover.list.hiddenPreview')
+								: displayLastMessage
+						}
+						lastMessageType={
+							caseHandoverContentLocked
+								? null
+								: activeSession.item.lastMessageType
+						}
 						language={language}
 						showLanguage={
 							language &&
@@ -1419,23 +1427,25 @@ export const SessionListItemComponent = ({
 						}
 						showSpan={activeSession.isEmptyEnquiry}
 					/>
-					{activeSession.item.attachment && (
-						<SessionListItemAttachment
-							attachment={activeSession.item.attachment}
-						/>
-					)}
-					{activeSession.item.videoCallMessageDTO && (
-						<SessionListItemVideoCall
-							videoCallMessage={
-								activeSession.item.videoCallMessageDTO
-							}
-							listItemUsername={
-								activeSession.user?.username ||
-								activeSession.consultant?.username
-							}
-							listItemAskerRcId={activeSession.item.askerRcId}
-						/>
-					)}
+					{!caseHandoverContentLocked &&
+						activeSession.item.attachment && (
+							<SessionListItemAttachment
+								attachment={activeSession.item.attachment}
+							/>
+						)}
+					{!caseHandoverContentLocked &&
+						activeSession.item.videoCallMessageDTO && (
+							<SessionListItemVideoCall
+								videoCallMessage={
+									activeSession.item.videoCallMessageDTO
+								}
+								listItemUsername={
+									activeSession.user?.username ||
+									activeSession.consultant?.username
+								}
+								listItemAskerRcId={activeSession.item.askerRcId}
+							/>
+						)}
 					{caseHandoverCandidate &&
 					!caseHandoverStatus?.canViewContent ? (
 						<button

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -64,13 +64,23 @@ import { useSearchParam } from '../../hooks/useSearchParams';
 import { SessionListItemLastMessage } from './SessionListItemLastMessage';
 import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
 import { useTranslation } from 'react-i18next';
-import { apiPutArchive, apiPutDearchive } from '../../api';
+import {
+	apiGetCaseHandoverStatus,
+	apiPutArchive,
+	apiPutDearchive,
+	CaseHandoverStatus
+} from '../../api';
 import { Overlay, OVERLAY_FUNCTIONS } from '../overlay/Overlay';
 import { archiveSessionSuccessOverlayItem } from '../sessionMenu/sessionMenuHelpers';
 import { mobileListView } from '../app/navigationHandler';
 import LegalLinks from '../legalLinks/LegalLinks';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { getSessionDropdownPosition } from './sessionDropdownPosition';
+import {
+	isCaseHandoverCandidate,
+	isCaseHandoverDenied,
+	isCaseHandoverPending
+} from '../session/caseHandoverHelpers';
 interface SessionListItemProps {
 	defaultLanguage: string;
 	itemRef?: any;
@@ -78,6 +88,9 @@ interface SessionListItemProps {
 	index: number;
 	isBeforeActive?: boolean;
 	isAfterActive?: boolean;
+	caseHandoverBatchMode?: boolean;
+	caseHandoverSelected?: boolean;
+	onCaseHandoverSelect?: (sessionId: number) => void;
 }
 
 export const SessionListItemComponent = ({
@@ -86,7 +99,10 @@ export const SessionListItemComponent = ({
 	handleKeyDownLisItemContent,
 	index,
 	isBeforeActive = false,
-	isAfterActive = false
+	isAfterActive = false,
+	caseHandoverBatchMode = false,
+	caseHandoverSelected = false,
+	onCaseHandoverSelect
 }: SessionListItemProps) => {
 	const { t: translate } = useTranslation(['common']);
 	const location = useLocation();
@@ -121,6 +137,8 @@ export const SessionListItemComponent = ({
 	const [overlayItem, setOverlayItem] = useState(null);
 	const [overlayActive, setOverlayActive] = useState(false);
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
+	const [caseHandoverStatus, setCaseHandoverStatus] =
+		useState<CaseHandoverStatus | null>(null);
 
 	useEffect(() => {
 		setFlyoutOpen(false);
@@ -151,8 +169,23 @@ export const SessionListItemComponent = ({
 		isMatrixRoomIdHeuristic(sessionItem?.groupId) ||
 		isMatrixRoomIdHeuristic(sessionItem?.matrixRoomId);
 	const [plainTextLastMessage, setPlainTextLastMessage] = useState(null);
+	const caseHandoverCandidate = isCaseHandoverCandidate({
+		activeSession,
+		userData,
+		type,
+		sessionListTab
+	});
+	const caseHandoverContentLocked =
+		caseHandoverCandidate && !caseHandoverStatus?.canViewContent;
 
 	useEffect(() => {
+		if (caseHandoverContentLocked) {
+			setPlainTextLastMessage(
+				translate('caseHandover.list.hiddenPreview')
+			);
+			return;
+		}
+
 		if (isMatrixBackedSession) {
 			setPlainTextLastMessage(translate('e2ee.message.encryption.text'));
 			return;
@@ -212,15 +245,65 @@ export const SessionListItemComponent = ({
 		encrypted,
 		sessionItem,
 		isMatrixBackedSession,
+		caseHandoverContentLocked,
 		translate,
 		ready
 	]);
+
+	useEffect(() => {
+		let cancelled = false;
+		if (!caseHandoverCandidate || !activeSession?.item?.id) {
+			setCaseHandoverStatus(null);
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		apiGetCaseHandoverStatus(activeSession.item.id)
+			.then((status) => {
+				if (!cancelled) {
+					setCaseHandoverStatus(status);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setCaseHandoverStatus({
+						sessionId: activeSession.item.id,
+						status: 'DENIED',
+						canViewContent: false,
+						clientConsentRequired: false,
+						auditOutcome: 'ACCESS_DENIED'
+					});
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [activeSession?.item?.id, caseHandoverCandidate]);
 
 	const isAsker = hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
 	const isSupervisorView =
 		!isAsker &&
 		!!activeSession?.consultant?.id &&
 		activeSession.consultant.id !== userData.userId;
+	const caseHandoverListLabel = (() => {
+		if (caseHandoverStatus?.canViewContent) {
+			return translate('caseHandover.list.accessGranted');
+		}
+		if (isCaseHandoverPending(caseHandoverStatus?.status)) {
+			return translate('caseHandover.list.awaitingApproval');
+		}
+		if (isCaseHandoverDenied(caseHandoverStatus?.status)) {
+			return translate('caseHandover.list.accessDenied');
+		}
+		return translate('caseHandover.list.requestAccess');
+	})();
+	const canBatchSelectCaseHandover =
+		caseHandoverBatchMode &&
+		caseHandoverCandidate &&
+		!caseHandoverStatus?.canViewContent &&
+		!isCaseHandoverPending(caseHandoverStatus?.status);
 
 	const displayLastMessage = useMemo(() => {
 		if (!plainTextLastMessage) return plainTextLastMessage;
@@ -426,6 +509,17 @@ export const SessionListItemComponent = ({
 				navigate(targetPath);
 			}
 		}
+	};
+
+	const handleCaseHandoverActionClick = (
+		event: React.MouseEvent<HTMLButtonElement>
+	) => {
+		event.stopPropagation();
+		if (canBatchSelectCaseHandover && onCaseHandoverSelect) {
+			onCaseHandoverSelect(activeSession.item.id);
+			return;
+		}
+		handleOnClick();
 	};
 
 	const isMenuInteractionTarget = (target: EventTarget | null) =>
@@ -801,6 +895,8 @@ export const SessionListItemComponent = ({
 				!isChatActive &&
 					activeSession.item.messagesRead &&
 					'sessionsListItem--read',
+				caseHandoverContentLocked &&
+					'sessionsListItem--caseHandoverLocked',
 				isBeforeActive && 'sessionsListItem--beforeActive',
 				isAfterActive && 'sessionsListItem--afterActive'
 			)}
@@ -1340,61 +1436,100 @@ export const SessionListItemComponent = ({
 							listItemAskerRcId={activeSession.item.askerRcId}
 						/>
 					)}
-					{(() => {
-						if (isAnonymousChat) {
+					{caseHandoverCandidate &&
+					!caseHandoverStatus?.canViewContent ? (
+						<button
+							type="button"
+							className={clsx(
+								'sessionsListItem__caseHandoverButton',
+								isCaseHandoverPending(
+									caseHandoverStatus?.status
+								) &&
+									'sessionsListItem__caseHandoverButton--pending',
+								isCaseHandoverDenied(
+									caseHandoverStatus?.status
+								) &&
+									'sessionsListItem__caseHandoverButton--denied',
+								caseHandoverSelected &&
+									'sessionsListItem__caseHandoverButton--selected'
+							)}
+							onClick={handleCaseHandoverActionClick}
+							disabled={
+								caseHandoverBatchMode &&
+								!canBatchSelectCaseHandover
+							}
+						>
+							{caseHandoverBatchMode && (
+								<span
+									className={clsx(
+										'sessionsListItem__caseHandoverCheckbox',
+										caseHandoverSelected &&
+											'sessionsListItem__caseHandoverCheckbox--selected'
+									)}
+									aria-hidden
+								/>
+							)}
+							{caseHandoverBatchMode
+								? translate('caseHandover.batch.selectCase')
+								: caseHandoverListLabel}
+						</button>
+					) : (
+						(() => {
+							if (isAnonymousChat) {
+								return (
+									<div
+										className={clsx(
+											'sessionsListItem__consultingTypeIcon',
+											'sessionsListItem__consultingTypeIcon--liveChat'
+										)}
+									>
+										<svg
+											width="22"
+											height="19"
+											viewBox="0 0 22 19"
+											fill="none"
+											xmlns="http://www.w3.org/2000/svg"
+											aria-hidden="true"
+										>
+											<path
+												d="M0 18V6L8 0L14.95 5.19175C14.55 5.20842 14.1639 5.25008 13.7917 5.31675C13.4194 5.38342 13.0527 5.47783 12.6917 5.6L8 2.08325L1.66675 6.83325V16.3333H8.11675C8.25558 16.6444 8.41525 16.9361 8.59575 17.2083C8.77642 17.4806 8.97225 17.7445 9.18325 18H0ZM10.8333 17.5833C10.2056 16.9832 9.71533 16.2847 9.3625 15.4875C9.00967 14.6903 8.83325 13.8612 8.83325 13C8.83325 11.2278 9.44992 9.72925 10.6832 8.50425C11.9166 7.27925 13.4111 6.66675 15.1667 6.66675C16.9389 6.66675 18.4375 7.27925 19.6625 8.50425C20.8875 9.72925 21.5 11.2278 21.5 13C21.5 13.8612 21.3306 14.6876 20.9918 15.4792C20.6528 16.2709 20.1638 16.9639 19.525 17.5583L18.7 16.7332C19.2388 16.2499 19.6458 15.6861 19.9207 15.0418C20.1957 14.3973 20.3333 13.7167 20.3333 13C20.3333 11.5555 19.8333 10.3332 18.8333 9.33325C17.8333 8.33325 16.6111 7.83325 15.1667 7.83325C13.7389 7.83325 12.5208 8.33325 11.5125 9.33325C10.5042 10.3332 10 11.5555 10 13C10 13.7167 10.1431 14.3986 10.4292 15.0457C10.7153 15.6931 11.1249 16.2584 11.6582 16.7417L10.8333 17.5833ZM12.6083 15.7917C12.2083 15.4306 11.8958 15.0083 11.6708 14.525C11.4458 14.0417 11.3333 13.5333 11.3333 13C11.3333 11.9278 11.7083 11.0209 12.4583 10.2793C13.2083 9.53758 14.1111 9.16675 15.1667 9.16675C16.2389 9.16675 17.1458 9.53758 17.8875 10.2793C18.6292 11.0209 19 11.9278 19 13C19 13.5278 18.8958 14.0362 18.6875 14.525C18.4792 15.0138 18.1722 15.4388 17.7667 15.8L16.925 14.9832C17.2138 14.7277 17.4374 14.4277 17.5958 14.0832C17.7541 13.7389 17.8333 13.3778 17.8333 13C17.8333 12.2555 17.5749 11.6249 17.0583 11.1082C16.5416 10.5916 15.9111 10.3333 15.1667 10.3333C14.4334 10.3333 13.8056 10.5916 13.2833 11.1082C12.7611 11.6249 12.5 12.2555 12.5 13C12.5 13.3778 12.5833 13.7362 12.75 14.075C12.9167 14.4138 13.1389 14.7111 13.4167 14.9668L12.6083 15.7917ZM14.5833 19V13.9168C14.4332 13.8056 14.3124 13.6708 14.2208 13.5125C14.1291 13.3542 14.0833 13.1833 14.0833 13C14.0833 12.6945 14.1888 12.4376 14.4 12.2292C14.6112 12.0209 14.8667 11.9167 15.1667 11.9167C15.4722 11.9167 15.7292 12.0209 15.9375 12.2292C16.1458 12.4376 16.25 12.6945 16.25 13C16.25 13.1833 16.2097 13.3556 16.1292 13.5168C16.0486 13.6778 15.9222 13.8111 15.75 13.9168V19H14.5833Z"
+												fill="#4B515A"
+											/>
+										</svg>
+										<span className="sessionsListItem__consultingTypeIcon--liveChatLabel">
+											{translate(
+												'sessionList.item.sessionType.liveChat',
+												'Live Chat'
+											)}
+										</span>
+									</div>
+								);
+							}
 							return (
 								<div
 									className={clsx(
 										'sessionsListItem__consultingTypeIcon',
-										'sessionsListItem__consultingTypeIcon--liveChat'
+										'sessionsListItem__consultingTypeIcon--nearby'
 									)}
 								>
-									<svg
-										width="22"
-										height="19"
-										viewBox="0 0 22 19"
-										fill="none"
-										xmlns="http://www.w3.org/2000/svg"
-										aria-hidden="true"
-									>
-										<path
-											d="M0 18V6L8 0L14.95 5.19175C14.55 5.20842 14.1639 5.25008 13.7917 5.31675C13.4194 5.38342 13.0527 5.47783 12.6917 5.6L8 2.08325L1.66675 6.83325V16.3333H8.11675C8.25558 16.6444 8.41525 16.9361 8.59575 17.2083C8.77642 17.4806 8.97225 17.7445 9.18325 18H0ZM10.8333 17.5833C10.2056 16.9832 9.71533 16.2847 9.3625 15.4875C9.00967 14.6903 8.83325 13.8612 8.83325 13C8.83325 11.2278 9.44992 9.72925 10.6832 8.50425C11.9166 7.27925 13.4111 6.66675 15.1667 6.66675C16.9389 6.66675 18.4375 7.27925 19.6625 8.50425C20.8875 9.72925 21.5 11.2278 21.5 13C21.5 13.8612 21.3306 14.6876 20.9918 15.4792C20.6528 16.2709 20.1638 16.9639 19.525 17.5583L18.7 16.7332C19.2388 16.2499 19.6458 15.6861 19.9207 15.0418C20.1957 14.3973 20.3333 13.7167 20.3333 13C20.3333 11.5555 19.8333 10.3332 18.8333 9.33325C17.8333 8.33325 16.6111 7.83325 15.1667 7.83325C13.7389 7.83325 12.5208 8.33325 11.5125 9.33325C10.5042 10.3332 10 11.5555 10 13C10 13.7167 10.1431 14.3986 10.4292 15.0457C10.7153 15.6931 11.1249 16.2584 11.6582 16.7417L10.8333 17.5833ZM12.6083 15.7917C12.2083 15.4306 11.8958 15.0083 11.6708 14.525C11.4458 14.0417 11.3333 13.5333 11.3333 13C11.3333 11.9278 11.7083 11.0209 12.4583 10.2793C13.2083 9.53758 14.1111 9.16675 15.1667 9.16675C16.2389 9.16675 17.1458 9.53758 17.8875 10.2793C18.6292 11.0209 19 11.9278 19 13C19 13.5278 18.8958 14.0362 18.6875 14.525C18.4792 15.0138 18.1722 15.4388 17.7667 15.8L16.925 14.9832C17.2138 14.7277 17.4374 14.4277 17.5958 14.0832C17.7541 13.7389 17.8333 13.3778 17.8333 13C17.8333 12.2555 17.5749 11.6249 17.0583 11.1082C16.5416 10.5916 15.9111 10.3333 15.1667 10.3333C14.4334 10.3333 13.8056 10.5916 13.2833 11.1082C12.7611 11.6249 12.5 12.2555 12.5 13C12.5 13.3778 12.5833 13.7362 12.75 14.075C12.9167 14.4138 13.1389 14.7111 13.4167 14.9668L12.6083 15.7917ZM14.5833 19V13.9168C14.4332 13.8056 14.3124 13.6708 14.2208 13.5125C14.1291 13.3542 14.0833 13.1833 14.0833 13C14.0833 12.6945 14.1888 12.4376 14.4 12.2292C14.6112 12.0209 14.8667 11.9167 15.1667 11.9167C15.4722 11.9167 15.7292 12.0209 15.9375 12.2292C16.1458 12.4376 16.25 12.6945 16.25 13C16.25 13.1833 16.2097 13.3556 16.1292 13.5168C16.0486 13.6778 15.9222 13.8111 15.75 13.9168V19H14.5833Z"
-											fill="#4B515A"
-										/>
-									</svg>
-									<span className="sessionsListItem__consultingTypeIcon--liveChatLabel">
+									<img
+										src={nearbyConversationIcon}
+										alt={translate(
+											'sessionList.toolbar.chips.nearby',
+											'Nähe'
+										)}
+										className="sessionsListItem__consultingTypeIcon--nearbyIcon"
+									/>
+									<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
 										{translate(
-											'sessionList.item.sessionType.liveChat',
-											'Live Chat'
+											'sessionList.toolbar.chips.nearby',
+											'Nähe'
 										)}
 									</span>
 								</div>
 							);
-						}
-						return (
-							<div
-								className={clsx(
-									'sessionsListItem__consultingTypeIcon',
-									'sessionsListItem__consultingTypeIcon--nearby'
-								)}
-							>
-								<img
-									src={nearbyConversationIcon}
-									alt={translate(
-										'sessionList.toolbar.chips.nearby',
-										'Nähe'
-									)}
-									className="sessionsListItem__consultingTypeIcon--nearbyIcon"
-								/>
-								<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
-									{translate(
-										'sessionList.toolbar.chips.nearby',
-										'Nähe'
-									)}
-								</span>
-							</div>
-						);
-					})()}
+						})()
+					)}
 				</div>
 			</div>
 			{overlayActive && overlayItem && (

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -140,6 +140,8 @@ export const SessionListItemComponent = ({
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
 	const [caseHandoverStatus, setCaseHandoverStatus] =
 		useState<CaseHandoverStatus | null>(null);
+	const [caseHandoverStatusLoading, setCaseHandoverStatusLoading] =
+		useState(false);
 
 	useEffect(() => {
 		setFlyoutOpen(false);
@@ -260,11 +262,13 @@ export const SessionListItemComponent = ({
 		let cancelled = false;
 		if (!caseHandoverAccessControlled || !activeSession?.item?.id) {
 			setCaseHandoverStatus(null);
+			setCaseHandoverStatusLoading(false);
 			return () => {
 				cancelled = true;
 			};
 		}
 
+		setCaseHandoverStatusLoading(true);
 		apiGetCaseHandoverStatus(activeSession.item.id)
 			.then((status) => {
 				if (!cancelled) {
@@ -280,6 +284,11 @@ export const SessionListItemComponent = ({
 						clientConsentRequired: false,
 						auditOutcome: 'ACCESS_DENIED'
 					});
+				}
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setCaseHandoverStatusLoading(false);
 				}
 			});
 
@@ -308,8 +317,13 @@ export const SessionListItemComponent = ({
 	const canBatchSelectCaseHandover =
 		caseHandoverBatchMode &&
 		caseHandoverCandidate &&
+		!caseHandoverStatusLoading &&
 		!caseHandoverStatus?.canViewContent &&
 		!isCaseHandoverPending(caseHandoverStatus?.status);
+	const canShowCaseHandoverAction =
+		caseHandoverCandidate &&
+		!caseHandoverStatusLoading &&
+		!caseHandoverStatus?.canViewContent;
 
 	const displayLastMessage = useMemo(() => {
 		if (!plainTextLastMessage) return plainTextLastMessage;
@@ -1452,8 +1466,7 @@ export const SessionListItemComponent = ({
 								listItemAskerRcId={activeSession.item.askerRcId}
 							/>
 						)}
-					{caseHandoverCandidate &&
-					!caseHandoverStatus?.canViewContent ? (
+					{canShowCaseHandoverAction ? (
 						<button
 							type="button"
 							className={clsx(

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -68,7 +68,8 @@ import {
 	apiGetCaseHandoverStatus,
 	apiPutArchive,
 	apiPutDearchive,
-	CaseHandoverStatus
+	CaseHandoverStatus,
+	FETCH_ERRORS
 } from '../../api';
 import { Overlay, OVERLAY_FUNCTIONS } from '../overlay/Overlay';
 import { archiveSessionSuccessOverlayItem } from '../sessionMenu/sessionMenuHelpers';
@@ -275,8 +276,12 @@ export const SessionListItemComponent = ({
 					setCaseHandoverStatus(status);
 				}
 			})
-			.catch(() => {
-				if (!cancelled) {
+			.catch((error) => {
+				if (cancelled) {
+					return;
+				}
+
+				if (error?.message === FETCH_ERRORS.FORBIDDEN) {
 					setCaseHandoverStatus({
 						sessionId: activeSession.item.id,
 						status: 'DENIED',
@@ -284,7 +289,10 @@ export const SessionListItemComponent = ({
 						clientConsentRequired: false,
 						auditOutcome: 'ACCESS_DENIED'
 					});
+					return;
 				}
+
+				setCaseHandoverStatus(null);
 			})
 			.finally(() => {
 				if (!cancelled) {

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -77,6 +77,7 @@ import LegalLinks from '../legalLinks/LegalLinks';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { getSessionDropdownPosition } from './sessionDropdownPosition';
 import {
+	isCaseHandoverAccessControlled,
 	isCaseHandoverCandidate,
 	isCaseHandoverDenied,
 	isCaseHandoverPending
@@ -169,6 +170,11 @@ export const SessionListItemComponent = ({
 		isMatrixRoomIdHeuristic(sessionItem?.groupId) ||
 		isMatrixRoomIdHeuristic(sessionItem?.matrixRoomId);
 	const [plainTextLastMessage, setPlainTextLastMessage] = useState(null);
+	const caseHandoverAccessControlled = isCaseHandoverAccessControlled({
+		activeSession,
+		userData,
+		type
+	});
 	const caseHandoverCandidate = isCaseHandoverCandidate({
 		activeSession,
 		userData,
@@ -176,7 +182,7 @@ export const SessionListItemComponent = ({
 		sessionListTab
 	});
 	const caseHandoverContentLocked =
-		caseHandoverCandidate && !caseHandoverStatus?.canViewContent;
+		caseHandoverAccessControlled && !caseHandoverStatus?.canViewContent;
 
 	useEffect(() => {
 		if (caseHandoverContentLocked) {
@@ -252,7 +258,7 @@ export const SessionListItemComponent = ({
 
 	useEffect(() => {
 		let cancelled = false;
-		if (!caseHandoverCandidate || !activeSession?.item?.id) {
+		if (!caseHandoverAccessControlled || !activeSession?.item?.id) {
 			setCaseHandoverStatus(null);
 			return () => {
 				cancelled = true;
@@ -280,7 +286,7 @@ export const SessionListItemComponent = ({
 		return () => {
 			cancelled = true;
 		};
-	}, [activeSession?.item?.id, caseHandoverCandidate]);
+	}, [activeSession?.item?.id, caseHandoverAccessControlled]);
 
 	const isAsker = hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
 	const isSupervisorView =
@@ -1464,6 +1470,14 @@ export const SessionListItemComponent = ({
 									'sessionsListItem__caseHandoverButton--selected'
 							)}
 							onClick={handleCaseHandoverActionClick}
+							onKeyDown={(event) => {
+								if (
+									event.key === 'Enter' ||
+									event.key === ' '
+								) {
+									event.stopPropagation();
+								}
+							}}
 							disabled={
 								caseHandoverBatchMode &&
 								!canBatchSelectCaseHandover

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -145,6 +145,13 @@ $session-postcode-color: #410001;
 		}
 	}
 
+	&--caseHandoverLocked {
+		.sessionsListItem__content {
+			background: #ffffff;
+			border-color: #ffd8d4;
+		}
+	}
+
 	&__content {
 		width: calc(100% - 18px);
 		max-width: calc(100% - 18px);
@@ -790,6 +797,59 @@ $session-postcode-color: #410001;
 
 			* {
 				fill: var(--m3-secondary, $secondary);
+			}
+		}
+
+		&__caseHandoverButton {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			gap: 8px;
+			min-width: 142px;
+			min-height: 38px;
+			margin: 8px 16px 8px 8px;
+			padding: 0 14px;
+			border: 0;
+			border-radius: 18px;
+			background: #c4000b;
+			color: #ffffff;
+			font-family: $font-family-sans-serif;
+			font-size: 13px;
+			font-weight: 700;
+			line-height: 1;
+			cursor: pointer;
+			flex-shrink: 0;
+
+			&:disabled {
+				background: #d8dde3;
+				color: #79818c;
+				cursor: not-allowed;
+			}
+
+			&--pending {
+				background: #667280;
+			}
+
+			&--denied {
+				background: #f7d7d7;
+				color: #a5000a;
+			}
+
+			&--selected {
+				background: #a5000a;
+			}
+		}
+
+		&__caseHandoverCheckbox {
+			width: 14px;
+			height: 14px;
+			border: 2px solid currentColor;
+			border-radius: 3px;
+			background: transparent;
+
+			&--selected {
+				background: currentColor;
+				box-shadow: inset 0 0 0 3px #a5000a;
 			}
 		}
 

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -800,59 +800,6 @@ $session-postcode-color: #410001;
 			}
 		}
 
-		&__caseHandoverButton {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			gap: 8px;
-			min-width: 142px;
-			min-height: 38px;
-			margin: 8px 16px 8px 8px;
-			padding: 0 14px;
-			border: 0;
-			border-radius: 18px;
-			background: #c4000b;
-			color: #ffffff;
-			font-family: $font-family-sans-serif;
-			font-size: 13px;
-			font-weight: 700;
-			line-height: 1;
-			cursor: pointer;
-			flex-shrink: 0;
-
-			&:disabled {
-				background: #d8dde3;
-				color: #79818c;
-				cursor: not-allowed;
-			}
-
-			&--pending {
-				background: #667280;
-			}
-
-			&--denied {
-				background: #f7d7d7;
-				color: #a5000a;
-			}
-
-			&--selected {
-				background: #a5000a;
-			}
-		}
-
-		&__caseHandoverCheckbox {
-			width: 14px;
-			height: 14px;
-			border: 2px solid currentColor;
-			border-radius: 3px;
-			background: transparent;
-
-			&--selected {
-				background: currentColor;
-				box-shadow: inset 0 0 0 3px #a5000a;
-			}
-		}
-
 		&--team,
 		&--oneOnOne {
 			// Additional styling if needed
@@ -919,6 +866,59 @@ $session-postcode-color: #410001;
 
 	.tag {
 		margin-left: $grid-base;
+	}
+
+	&__caseHandoverButton {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		min-width: 142px;
+		min-height: 38px;
+		margin: 8px 16px 8px 8px;
+		padding: 0 14px;
+		border: 0;
+		border-radius: 18px;
+		background: #c4000b;
+		color: #ffffff;
+		font-family: $font-family-sans-serif;
+		font-size: 13px;
+		font-weight: 700;
+		line-height: 1;
+		cursor: pointer;
+		flex-shrink: 0;
+
+		&:disabled {
+			background: #d8dde3;
+			color: #79818c;
+			cursor: not-allowed;
+		}
+
+		&--pending {
+			background: #667280;
+		}
+
+		&--denied {
+			background: #f7d7d7;
+			color: #a5000a;
+		}
+
+		&--selected {
+			background: #a5000a;
+		}
+	}
+
+	&__caseHandoverCheckbox {
+		width: 14px;
+		height: 14px;
+		border: 2px solid currentcolor;
+		border-radius: 3px;
+		background: transparent;
+
+		&--selected {
+			background: currentcolor;
+			box-shadow: inset 0 0 0 3px #a5000a;
+		}
 	}
 }
 

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -145,13 +145,6 @@ $session-postcode-color: #410001;
 		}
 	}
 
-	&--caseHandoverLocked {
-		.sessionsListItem__content {
-			background: #ffffff;
-			border-color: #ffd8d4;
-		}
-	}
-
 	&__content {
 		width: calc(100% - 18px);
 		max-width: calc(100% - 18px);
@@ -216,6 +209,12 @@ $session-postcode-color: #410001;
 
 	&:not(.sessionsListItem--active) .sessionsListItem__content {
 		border-color: $session-light-border;
+	}
+
+	&--caseHandoverLocked:not(.sessionsListItem--active)
+		.sessionsListItem__content {
+		background: #ffffff;
+		border-color: #ffd8d4;
 	}
 
 	&:first-child:not(.sessionsListItem--active) .sessionsListItem__content {

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -17,6 +17,12 @@ $session-chip-hover-bg: #646d78;
 $session-chip-hover-color: #ffffff;
 $session-postcode-border: #ffb4aa;
 $session-postcode-color: #410001;
+$case-handover-action: var(--m3-primary, $primary);
+$case-handover-action-hover: var(--m3-primary-hover, $hover-primary);
+$case-handover-action-disabled: var(--m3-surface-variant, #d8dde3);
+$case-handover-status-muted: var(--m3-on-surface-variant, #667280);
+$case-handover-denied-bg: var(--m3-error-container, #f7d7d7);
+$case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 .sessionsListItem {
 	display: flex;
@@ -878,7 +884,7 @@ $session-postcode-color: #410001;
 		padding: 0 14px;
 		border: 0;
 		border-radius: 18px;
-		background: #c4000b;
+		background: $case-handover-action;
 		color: #ffffff;
 		font-family: $font-family-sans-serif;
 		font-size: 13px;
@@ -888,22 +894,22 @@ $session-postcode-color: #410001;
 		flex-shrink: 0;
 
 		&:disabled {
-			background: #d8dde3;
-			color: #79818c;
+			background: $case-handover-action-disabled;
+			color: $case-handover-status-muted;
 			cursor: not-allowed;
 		}
 
 		&--pending {
-			background: #667280;
+			background: $case-handover-status-muted;
 		}
 
 		&--denied {
-			background: #f7d7d7;
-			color: #a5000a;
+			background: $case-handover-denied-bg;
+			color: $case-handover-denied-text;
 		}
 
 		&--selected {
-			background: #a5000a;
+			background: $case-handover-action-hover;
 		}
 	}
 
@@ -916,7 +922,7 @@ $session-postcode-color: #410001;
 
 		&--selected {
 			background: currentcolor;
-			box-shadow: inset 0 0 0 3px #a5000a;
+			box-shadow: inset 0 0 0 3px $case-handover-action-hover;
 		}
 	}
 }

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -56,7 +56,7 @@ export const useSession = (
 
 	const loadSession = useCallback(() => {
 		// console.log('🔍 useSession.loadSession CALLED:', { rid, sessionId, chatId });
-		
+
 		if (abortController.current) {
 			// console.log('🔍 useSession: Aborting previous request');
 			abortController.current.abort();
@@ -93,13 +93,16 @@ export const useSession = (
 
 		return promise
 			.then(async ({ sessions: [activeSession] }) => {
-				// console.log('✅ useSession: API response received:', { 
+				// console.log('✅ useSession: API response received:', {
 				// hasSession: !!activeSession,
-				// sessionData: activeSession 
+				// sessionData: activeSession
 				// });
-				
+
 				if (activeSession) {
-					const extendedSession = buildExtendedSession(activeSession, rid);
+					const extendedSession = buildExtendedSession(
+						activeSession,
+						rid
+					);
 					// console.log('✅ useSession: Extended session built:', extendedSession);
 					setSession(extendedSession);
 				} else {
@@ -107,7 +110,7 @@ export const useSession = (
 						sessionId &&
 						(await loadCaseHandoverCandidateSession(
 							abortController.current?.signal
-						))
+						).catch(() => false))
 					) {
 						return;
 					}
@@ -122,7 +125,7 @@ export const useSession = (
 				// isAbort: e.message === FETCH_ERRORS.ABORT,
 				// repetitiveId: repetitiveId.current
 				// });
-				
+
 				if (e.message === FETCH_ERRORS.ABORT) {
 					return;
 				}

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -6,6 +6,7 @@ import {
 import { buildExtendedSession, ExtendedSessionInterface } from '../globalState';
 import { apiSetSessionRead, FETCH_ERRORS } from '../api';
 import { apiGetChatRoomById } from '../api/apiGetChatRoomById';
+import { apiGetCaseHandoverCandidates } from '../api/apiCaseHandover';
 
 export const useSession = (
 	rid: string | null,
@@ -21,6 +22,31 @@ export const useSession = (
 	const [session, setSession] = useState<ExtendedSessionInterface>(null);
 	const repetitiveId = useRef(null);
 	const abortController = useRef<AbortController>(null);
+
+	const loadCaseHandoverCandidateSession = useCallback(
+		async (signal?: AbortSignal): Promise<boolean> => {
+			if (!sessionId) {
+				return false;
+			}
+
+			const { sessions } = await apiGetCaseHandoverCandidates({
+				query: String(sessionId),
+				count: 1,
+				signal
+			});
+			const candidate = (sessions || []).find(
+				(item) => item?.session?.id === sessionId
+			);
+			if (!candidate) {
+				return false;
+			}
+
+			setSession(buildExtendedSession(candidate, rid));
+			setReady(true);
+			return true;
+		},
+		[rid, sessionId]
+	);
 
 	useEffect(() => {
 		repetitiveId.current = session?.item?.repetitive
@@ -66,7 +92,7 @@ export const useSession = (
 		}
 
 		return promise
-			.then(({ sessions: [activeSession] }) => {
+			.then(async ({ sessions: [activeSession] }) => {
 				// console.log('✅ useSession: API response received:', { 
 				// hasSession: !!activeSession,
 				// sessionData: activeSession 
@@ -77,11 +103,19 @@ export const useSession = (
 					// console.log('✅ useSession: Extended session built:', extendedSession);
 					setSession(extendedSession);
 				} else {
+					if (
+						sessionId &&
+						(await loadCaseHandoverCandidateSession(
+							abortController.current?.signal
+						))
+					) {
+						return;
+					}
 					// console.log('⚠️ useSession: No session in response');
 				}
 				setReady(true);
 			})
-			.catch((e) => {
+			.catch(async (e) => {
 				// console.log('❌ useSession: Error loading session:', {
 				// error: e,
 				// message: e.message,
@@ -103,11 +137,19 @@ export const useSession = (
 						}
 					);
 				}
+				if (
+					sessionId &&
+					(await loadCaseHandoverCandidateSession(
+						abortController.current?.signal
+					).catch(() => false))
+				) {
+					return;
+				}
 				// console.log('❌ useSession: Setting session to null');
 				setSession(null);
 				setReady(true);
 			});
-	}, [rid, sessionId, chatId]);
+	}, [rid, sessionId, chatId, loadCaseHandoverCandidateSession]);
 
 	const readSession = useCallback(() => {
 		if (!session) {

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -31,7 +31,7 @@ export const useSession = (
 
 			const { sessions } = await apiGetCaseHandoverCandidates({
 				query: String(sessionId),
-				count: 1,
+				count: 15,
 				signal
 			});
 			const candidate = (sessions || []).find(

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -84,7 +84,6 @@ export const useSession = (
 				abortController.current.signal
 			);
 		} else {
-			// console.log('🔍 useSession: Loading by rid (groupId):', rid);
 			promise = apiGetSessionRoomsByGroupIds(
 				[rid],
 				abortController.current.signal
@@ -93,17 +92,11 @@ export const useSession = (
 
 		return promise
 			.then(async ({ sessions: [activeSession] }) => {
-				// console.log('✅ useSession: API response received:', {
-				// hasSession: !!activeSession,
-				// sessionData: activeSession
-				// });
-
 				if (activeSession) {
 					const extendedSession = buildExtendedSession(
 						activeSession,
 						rid
 					);
-					// console.log('✅ useSession: Extended session built:', extendedSession);
 					setSession(extendedSession);
 				} else {
 					if (
@@ -114,24 +107,15 @@ export const useSession = (
 					) {
 						return;
 					}
-					// console.log('⚠️ useSession: No session in response');
 				}
 				setReady(true);
 			})
 			.catch(async (e) => {
-				// console.log('❌ useSession: Error loading session:', {
-				// error: e,
-				// message: e.message,
-				// isAbort: e.message === FETCH_ERRORS.ABORT,
-				// repetitiveId: repetitiveId.current
-				// });
-
 				if (e.message === FETCH_ERRORS.ABORT) {
 					return;
 				}
 
 				if (repetitiveId.current) {
-					// console.log('🔄 useSession: Retrying with repetitiveId:', repetitiveId.current);
 					return apiGetChatRoomById(repetitiveId.current).then(
 						({ sessions: [session] }) => {
 							// console.log('✅ useSession: Repetitive session loaded:', session);

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1410,6 +1410,18 @@
 				"title": "Übergabe abgelehnt",
 				"text": "Die Übergabe wurde abgelehnt und abgebrochen."
 			},
+			"caseHandoverConsentRequested": {
+				"title": "Zugriffsanfrage einer Beratungsperson",
+				"text": "Eine Beratungsperson hat Zugriff auf diesen Fall angefragt. Ihre Zustimmung ist laut Richtlinie erforderlich."
+			},
+			"caseHandoverGranted": {
+				"title": "Neue Beratungsperson hat den Fall übernommen",
+				"text": "Die berechtigte Fallübergabe wurde protokolliert."
+			},
+			"caseHandoverConsentDeclined": {
+				"title": "Fallübergabe abgelehnt",
+				"text": "Die Klient:innen-Zustimmung wurde abgelehnt. Inhalte bleiben gesperrt."
+			},
 			"callStarted": {
 				"title": "Anruf läuft",
 				"text": "Ein Anruf läuft gerade. Treten Sie bei, um teilzunehmen."
@@ -2214,6 +2226,20 @@
 	},
 	"caseHandover": {
 		"copy": "Dieser Fall ist nur als Metadaten sichtbar. Wählen Sie einen Übergabegrund und erklären Sie, warum Sie Zugriff benötigen.",
+		"batch": {
+			"cancel": "Auswahl schließen",
+			"confirm": "Auswahl anfragen",
+			"required": "Wählen Sie mindestens einen Fall, einen Grund und eine Begründung.",
+			"result": "{{successful}} Anfrage(n) gesendet, {{failed}} fehlgeschlagen.",
+			"selectCase": "Fall auswählen",
+			"selectedCount": "{{count}} ausgewählt",
+			"start": "Mehrere Fälle auswählen",
+			"title": "Mehrfach-Zugriffsanfrage"
+		},
+		"consent": {
+			"approve": "Zugriff freigeben",
+			"decline": "Zugriff ablehnen"
+		},
 		"denied": {
 			"copy": "Die vorherige Anfrage hat keine Inhaltsansicht freigeschaltet.",
 			"title": "Zugriff abgelehnt"
@@ -2227,12 +2253,23 @@
 			"placeholder": "Begründung beschreiben"
 		},
 		"eyebrow": "Informationen bleiben verborgen, bis die Anfrage freigegeben ist",
+		"hidden": {
+			"title": "Informationen bleiben verborgen, bis die Anfrage freigegeben ist"
+		},
+		"list": {
+			"accessDenied": "Zugriff abgelehnt",
+			"accessGranted": "Zugriff freigegeben",
+			"awaitingApproval": "Warten auf Freigabe",
+			"hiddenPreview": "Informationen bleiben verborgen, bis die Anfrage freigegeben ist",
+			"requestAccess": "Zugriff anfragen"
+		},
 		"pending": {
 			"copy": "Ihre Anfrage wurde protokolliert und wartet auf die konfigurierte Richtlinienentscheidung.",
 			"title": "Warten auf Freigabe"
 		},
 		"policy": {
-			"clientConsentRequired": "Klient:innen-Zustimmung ist erforderlich, bevor der Zugriff aktiviert wird."
+			"clientConsentRequired": "Klient:innen-Zustimmung ist erforderlich, bevor der Zugriff aktiviert wird.",
+			"defaultAuthority": "Plattform-Richtlinie für Fallübergaben"
 		},
 		"reasons": {
 			"loading": "Gründe werden geladen"

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1386,6 +1386,18 @@
 				"title": "Handover denied",
 				"text": "The handover was denied and cancelled."
 			},
+			"caseHandoverConsentRequested": {
+				"title": "Counsellor access request",
+				"text": "A counsellor requested access to this case. Your consent is required by policy."
+			},
+			"caseHandoverGranted": {
+				"title": "New counsellor took over your case",
+				"text": "The authorised case handover was logged."
+			},
+			"caseHandoverConsentDeclined": {
+				"title": "Case handover declined",
+				"text": "Client consent was declined. Content visibility remains locked."
+			},
 			"callStarted": {
 				"title": "Call ongoing",
 				"text": "A call is ongoing. Join to participate."
@@ -2150,6 +2162,20 @@
 	},
 	"caseHandover": {
 		"copy": "This case is visible as metadata only. Select a handover reason and explain why you need access.",
+		"batch": {
+			"cancel": "Close selection",
+			"confirm": "Request selected",
+			"required": "Select at least one case, one reason, and an explanation.",
+			"result": "{{successful}} request(s) sent, {{failed}} failed.",
+			"selectCase": "Select case",
+			"selectedCount": "{{count}} selected",
+			"start": "Select multiple cases",
+			"title": "Batch access request"
+		},
+		"consent": {
+			"approve": "Approve access",
+			"decline": "Decline access"
+		},
 		"denied": {
 			"copy": "The previous request did not grant content visibility.",
 			"title": "Access denied"
@@ -2163,12 +2189,23 @@
 			"placeholder": "Describe the reason"
 		},
 		"eyebrow": "Information hidden until request is approved",
+		"hidden": {
+			"title": "Information hidden until request is approved"
+		},
+		"list": {
+			"accessDenied": "Access denied",
+			"accessGranted": "Access granted",
+			"awaitingApproval": "Awaiting approval",
+			"hiddenPreview": "Information hidden until request is approved",
+			"requestAccess": "Request access"
+		},
 		"pending": {
 			"copy": "Your request was recorded and is waiting for the configured policy decision.",
 			"title": "Awaiting approval"
 		},
 		"policy": {
-			"clientConsentRequired": "Client consent is required before access can be activated."
+			"clientConsentRequired": "Client consent is required before access can be activated.",
+			"defaultAuthority": "Platform handover policy"
 		},
 		"reasons": {
 			"loading": "Loading reasons"

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -67,6 +67,9 @@ export const endpoints = {
 	consultantStatistics: apiUrl + '/service/statistics/consultant',
 	consultantsLanguages:
 		userServiceOrigin + '/service/users/consultants/languages',
+	caseHandoverBatch: userServiceOrigin + '/service/users/case-handover/batch',
+	caseHandoverReasons:
+		userServiceOrigin + '/service/users/case-handover/reasons',
 	consultingTypeServiceBase:
 		consultingTypeServiceOrigin + '/service/consultingtypes',
 	deleteAskerAccount: userServiceOrigin + '/service/users/account',

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -68,6 +68,8 @@ export const endpoints = {
 	consultantsLanguages:
 		userServiceOrigin + '/service/users/consultants/languages',
 	caseHandoverBatch: userServiceOrigin + '/service/users/case-handover/batch',
+	caseHandoverCandidates:
+		userServiceOrigin + '/service/users/case-handover/candidates',
 	caseHandoverReasons:
 		userServiceOrigin + '/service/users/case-handover/reasons',
 	consultingTypeServiceBase:


### PR DESCRIPTION
## Summary
- Add the case handover access gate so locked cases show metadata and request controls without rendering chat history.
- Add reason selection, required explanation, access states, batch selection flow, and handover notification descriptors.
- Add tests for handover candidate/status helpers and preserve existing notification registry coverage.

## Validation
- `npm run lint:scripts`
- `npx vitest run src/components/session/caseHandoverHelpers.test.ts src/components/notificationsCenter/eventDescriptors/registry.test.ts`
- `npm run build`
- `git diff --check`

## Notes
This is a draft because Pre-Dev currently deploys fixed `:dev` images. End-to-end Pre-Dev validation can run after merge/dev-image build or after an explicit temporary custom-image rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a case-handover access workflow across sessions, including single requests, eligible consultant batch requests, and client consent approve/decline decisions.
  * Introduced a case-handover gate UI with reason selection, explanation input, and clear pending/denied states.
  * Updated the notifications center to support new handover consent events with inline approve/decline actions.
* **Bug Fixes**
  * Improved session loading to wait for handover status before revealing or locking content.
* **Tests**
  * Expanded coverage for new handover notification event types and helper logic.
* **Style / Localization**
  * Added consent/batch/gate UI styles and new English/German handover copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->