### PR TITLE
fix: allow Matrix enquiry composer submits

### DIFF
--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+	shouldBlockMissingLegacyE2eeKey,
+	shouldUseLegacyE2ee
+} from './messageEncryptionMode';
+
+describe('messageEncryptionMode', () => {
+	it('uses legacy E2EE for non-Matrix conversations when E2EE is enabled', () => {
+		expect(
+			shouldUseLegacyE2ee({
+				isE2eeEnabled: true,
+				isMatrixSession: false,
+				isAskerEnquiry: false
+			})
+		).toBe(true);
+	});
+
+	it('does not use legacy E2EE for Matrix-backed sessions', () => {
+		expect(
+			shouldUseLegacyE2ee({
+				isE2eeEnabled: true,
+				isMatrixSession: true,
+				isAskerEnquiry: false
+			})
+		).toBe(false);
+	});
+
+	it('does not use legacy E2EE for asker enquiries', () => {
+		expect(
+			shouldUseLegacyE2ee({
+				isE2eeEnabled: true,
+				isMatrixSession: false,
+				isAskerEnquiry: true
+			})
+		).toBe(false);
+	});
+
+	it('only blocks missing keys for the legacy E2EE path', () => {
+		expect(
+			shouldBlockMissingLegacyE2eeKey({
+				usesLegacyE2ee: true,
+				encrypted: true,
+				hasKeyId: false
+			})
+		).toBe(true);
+
+		expect(
+			shouldBlockMissingLegacyE2eeKey({
+				usesLegacyE2ee: false,
+				encrypted: true,
+				hasKeyId: false
+			})
+		).toBe(false);
+	});
+});

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -1,0 +1,25 @@
+interface MessageEncryptionModeInput {
+	isE2eeEnabled: boolean;
+	isMatrixSession: boolean;
+	isAskerEnquiry: boolean;
+}
+
+interface MissingLegacyKeyGuardInput {
+	usesLegacyE2ee: boolean;
+	encrypted: boolean;
+	hasKeyId: boolean;
+}
+
+export const shouldUseLegacyE2ee = ({
+	isE2eeEnabled,
+	isMatrixSession,
+	isAskerEnquiry
+}: MessageEncryptionModeInput): boolean =>
+	isE2eeEnabled && !isMatrixSession && !isAskerEnquiry;
+
+export const shouldBlockMissingLegacyE2eeKey = ({
+	usesLegacyE2ee,
+	encrypted,
+	hasKeyId
+}: MissingLegacyKeyGuardInput): boolean =>
+	usesLegacyE2ee && encrypted && !hasKeyId;

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -11,6 +11,10 @@ import { createPortal } from 'react-dom';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { SendMessageButton } from './SendMessageButton';
+import {
+	shouldBlockMissingLegacyE2eeKey,
+	shouldUseLegacyE2ee
+} from './messageEncryptionMode';
 import { matrixClientService } from '../../services/matrixClientService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
@@ -2039,8 +2043,30 @@ export const MessageSubmitInterfaceComponent = ({
 		const attachmentInput: any = attachmentInputRef.current;
 		const selectedFile = attachmentInput && attachmentInput.files[0];
 		const attachment = preselectedFile || selectedFile;
+		const isMatrixSession =
+			Boolean(activeSession.item?.matrixRoomId) ||
+			Boolean(
+				activeSession.rid &&
+					isMatrixRoom(activeSession.rid) &&
+					activeSession.item?.id
+			);
+		const isAskerEnquiry =
+			type === SESSION_LIST_TYPES.ENQUIRY &&
+			hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
+			!isAnonymousLiveChat;
+		const usesLegacyE2ee = shouldUseLegacyE2ee({
+			isE2eeEnabled,
+			isMatrixSession,
+			isAskerEnquiry
+		});
 
-		if (isE2eeEnabled && encrypted && !keyID) {
+		if (
+			shouldBlockMissingLegacyE2eeKey({
+				usesLegacyE2ee,
+				encrypted,
+				hasKeyId: !!keyID
+			})
+		) {
 			// console.error("Can't send message without key");
 			return;
 		}
@@ -2070,8 +2096,8 @@ export const MessageSubmitInterfaceComponent = ({
 		if (prefixParts.length && message.length > 0) {
 			message = `${prefixParts.join(' ')} ${message}`;
 		}
-		let isEncrypted = isE2eeEnabled;
-		if (message.length > 0 && isE2eeEnabled) {
+		let isEncrypted = usesLegacyE2ee;
+		if (message.length > 0 && isEncrypted) {
 			try {
 				message = await encryptText(message, keyID, key);
 			} catch (e: any) {
@@ -2093,11 +2119,7 @@ export const MessageSubmitInterfaceComponent = ({
 			}
 		}
 
-		if (
-			type === SESSION_LIST_TYPES.ENQUIRY &&
-			hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
-			!isAnonymousLiveChat
-		) {
+		if (isAskerEnquiry) {
 			await sendEnquiry(message, isEncrypted);
 			return;
 		}
@@ -2105,6 +2127,9 @@ export const MessageSubmitInterfaceComponent = ({
 		await sendMessage(message, attachment, isEncrypted);
 	}, [
 		encrypted,
+		activeSession.item?.id,
+		activeSession.item?.matrixRoomId,
+		activeSession.rid,
 		encodeAlignmentForTransport,
 		encodeHighlightColorsForTransport,
 		getTypedMarkdownMessage,


### PR DESCRIPTION
## Summary
- skip the legacy Rocket.Chat E2EE key guard for Matrix-backed sessions and asker enquiries
- avoid pre-encrypting Matrix/enquiry messages with the old keyID flow
- add a focused unit test for the encryption-mode decision

## Tests
- npm run test:unit -- src/components/messageSubmitInterface/messageEncryptionMode.test.ts
- npm run lint:scripts (0 errors, existing warnings)
- npm run test:unit (136 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)