### PR TITLE
Fix redirected enquiry composer submit

### DIFF
--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+	isAskerEnquirySubmission,
 	shouldBlockMissingLegacyE2eeKey,
 	shouldUseLegacyE2ee
 } from './messageEncryptionMode';
+import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 
 describe('messageEncryptionMode', () => {
 	it('uses legacy E2EE for non-Matrix conversations when E2EE is enabled', () => {
@@ -49,6 +51,50 @@ describe('messageEncryptionMode', () => {
 				usesLegacyE2ee: false,
 				encrypted: true,
 				hasKeyId: false
+			})
+		).toBe(false);
+	});
+
+	it('detects asker enquiry submissions from the enquiry list type', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: true,
+				sessionStatus: undefined,
+				hasAskerAuthority: true,
+				isAnonymousLiveChat: false
+			})
+		).toBe(true);
+	});
+
+	it('detects redirected asker enquiry submissions from the session status', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: false,
+				sessionStatus: STATUS_ENQUIRY,
+				hasAskerAuthority: true,
+				isAnonymousLiveChat: false
+			})
+		).toBe(true);
+	});
+
+	it('does not treat anonymous live chat as an asker enquiry submission', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: true,
+				sessionStatus: STATUS_ENQUIRY,
+				hasAskerAuthority: true,
+				isAnonymousLiveChat: true
+			})
+		).toBe(false);
+	});
+
+	it('requires asker authority for enquiry submissions', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: true,
+				sessionStatus: STATUS_ENQUIRY,
+				hasAskerAuthority: false,
+				isAnonymousLiveChat: false
 			})
 		).toBe(false);
 	});

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -1,7 +1,16 @@
+import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
+
 interface MessageEncryptionModeInput {
 	isE2eeEnabled: boolean;
 	isMatrixSession: boolean;
 	isAskerEnquiry: boolean;
+}
+
+interface AskerEnquirySubmissionInput {
+	isEnquiryListType: boolean;
+	sessionStatus?: number;
+	hasAskerAuthority: boolean;
+	isAnonymousLiveChat: boolean;
 }
 
 interface MissingLegacyKeyGuardInput {
@@ -16,6 +25,16 @@ export const shouldUseLegacyE2ee = ({
 	isAskerEnquiry
 }: MessageEncryptionModeInput): boolean =>
 	isE2eeEnabled && !isMatrixSession && !isAskerEnquiry;
+
+export const isAskerEnquirySubmission = ({
+	isEnquiryListType,
+	sessionStatus,
+	hasAskerAuthority,
+	isAnonymousLiveChat
+}: AskerEnquirySubmissionInput): boolean =>
+	(isEnquiryListType || sessionStatus === STATUS_ENQUIRY) &&
+	hasAskerAuthority &&
+	!isAnonymousLiveChat;
 
 export const shouldBlockMissingLegacyE2eeKey = ({
 	usesLegacyE2ee,

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -12,6 +12,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { SendMessageButton } from './SendMessageButton';
 import {
+	isAskerEnquirySubmission,
 	shouldBlockMissingLegacyE2eeKey,
 	shouldUseLegacyE2ee
 } from './messageEncryptionMode';
@@ -1171,6 +1172,15 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const isAnonymousEnquiryComposer =
 		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
+	const isAskerEnquiry = isAskerEnquirySubmission({
+		isEnquiryListType: type === SESSION_LIST_TYPES.ENQUIRY,
+		sessionStatus: activeSession.item?.status,
+		hasAskerAuthority: hasUserAuthority(
+			AUTHORITIES.ASKER_DEFAULT,
+			userData
+		),
+		isAnonymousLiveChat
+	});
 
 	const {
 		onChange: onDraftMessageChange,
@@ -2050,10 +2060,6 @@ export const MessageSubmitInterfaceComponent = ({
 					isMatrixRoom(activeSession.rid) &&
 					activeSession.item?.id
 			);
-		const isAskerEnquiry =
-			type === SESSION_LIST_TYPES.ENQUIRY &&
-			hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
-			!isAnonymousLiveChat;
 		const usesLegacyE2ee = shouldUseLegacyE2ee({
 			isE2eeEnabled,
 			isMatrixSession,
@@ -2135,17 +2141,16 @@ export const MessageSubmitInterfaceComponent = ({
 		getTypedMarkdownMessage,
 		hasMessageContent,
 		isE2eeEnabled,
+		isAskerEnquiry,
 		key,
 		keyID,
-		isAnonymousLiveChat,
 		preselectedFile,
 		sendEnquiry,
 		sendMessage,
 		selectedAudienceValues,
 		isSupervisor,
 		threadRootId,
-		type,
-		userData
+		translate
 	]);
 
 	const handleButtonClick = useCallback(() => {
@@ -2359,10 +2364,7 @@ export const MessageSubmitInterfaceComponent = ({
 	}, [history]);
 
 	const hasUploadFunctionality =
-		(type !== SESSION_LIST_TYPES.ENQUIRY ||
-			(type === SESSION_LIST_TYPES.ENQUIRY &&
-				!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData))) &&
-		!tenant?.settings?.featureAttachmentUploadDisabled;
+		!isAskerEnquiry && !tenant?.settings?.featureAttachmentUploadDisabled;
 	const currentChatType: 'anonymous' | 'oneOnOne' | 'group' | 'supervision' =
 		isSupervisor
 			? 'supervision'


### PR DESCRIPTION
## Problem
After registration, askers are redirected to the normal session view. The composer can then receive `MY_SESSION` as the list type even though the session is still in enquiry status, so the send action does not route through the enquiry submission path.

## Solution
Add a shared `isAskerEnquirySubmission` predicate for enquiry routing and upload gating. It treats either the enquiry list type or `STATUS_ENQUIRY` as an asker enquiry submission, while keeping anonymous live chat excluded.

## Validation
- `npm run test:unit -- src/components/messageSubmitInterface/messageEncryptionMode.test.ts` - 8 tests passed
- `npm run lint:scripts` - 0 errors, 124 existing warnings
- `npm run test:unit` - 140 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)