### PR TITLE
fix: use native message send button

### DIFF
--- a/src/components/messageSubmitInterface/SendMessageButton.test.tsx
+++ b/src/components/messageSubmitInterface/SendMessageButton.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SendMessageButton } from './SendMessageButton';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key
+	})
+}));
+
+vi.mock('../../resources/img/icons/paper-plane.svg', () => ({
+	ReactComponent: 'svg'
+}));
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('SendMessageButton', () => {
+	it('uses a native enabled button for sending messages', () => {
+		const handleSendButton = vi.fn();
+
+		render(<SendMessageButton handleSendButton={handleSendButton} />);
+
+		const button = screen.getByRole('button', {
+			name: 'enquiry.write.input.button.title'
+		});
+		expect(button.tagName).toBe('BUTTON');
+		expect(button.getAttribute('type')).toBe('button');
+		expect((button as HTMLButtonElement).disabled).toBe(false);
+
+		fireEvent.click(button);
+
+		expect(handleSendButton).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not send while disabled', () => {
+		const handleSendButton = vi.fn();
+
+		render(
+			<SendMessageButton
+				deactivated={true}
+				handleSendButton={handleSendButton}
+			/>
+		);
+
+		const button = screen.getByRole('button', {
+			name: 'enquiry.write.input.button.title'
+		});
+		expect((button as HTMLButtonElement).disabled).toBe(true);
+
+		fireEvent.click(button);
+
+		expect(handleSendButton).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/messageSubmitInterface/SendMessageButton.tsx
+++ b/src/components/messageSubmitInterface/SendMessageButton.tsx
@@ -14,22 +14,11 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
 	const isDisabled = !!props.deactivated;
 
 	return (
-		<span
-			onClick={() =>
-				isDisabled ? null : props.handleSendButton()
-			}
-			role="button"
-			tabIndex={isDisabled ? -1 : 0}
+		<button
+			type="button"
+			disabled={isDisabled}
+			onClick={() => props.handleSendButton()}
 			aria-disabled={isDisabled}
-			onKeyDown={(event) => {
-				if (isDisabled) {
-					return;
-				}
-				if (event.key === 'Enter' || event.key === ' ') {
-					event.preventDefault();
-					props.handleSendButton();
-				}
-			}}
 			className={`textarea__iconWrapper ${
 				props.clicked ? 'textarea__iconWrapper--clicked' : ''
 			} ${props.deactivated ? 'textarea__iconWrapper--deactivated' : 'textarea__iconWrapper--active'} ${
@@ -43,6 +32,6 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
 				aria-label={translate('enquiry.write.input.button.title')}
 				title={translate('enquiry.write.input.button.title')}
 			/>
-		</span>
+		</button>
 	);
 };

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -1032,9 +1032,14 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 		&__iconWrapper {
 			width: 48px;
 			height: 48px;
+			border: 0;
 			border-radius: 0 6px 0 24px;
+			padding: 0;
 			cursor: pointer;
 			background-color: #f8ceca;
+			color: inherit;
+			appearance: none;
+			font: inherit;
 			margin: 0;
 			display: inline-flex;
 			align-items: center;
@@ -1053,6 +1058,10 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			}
 			&:hover {
 				background-color: var(--m3-primary-hover, #f3bdb8);
+			}
+			&:focus-visible {
+				outline: 2px solid var(--m3-primary, #cc1e1c);
+				outline-offset: 2px;
 			}
 
 			&--active:not(.textarea__iconWrapper--empty) {


### PR DESCRIPTION
## Problem
The Pre-Dev consultant chat flow can accept a Matrix-backed enquiry, but clicking the visible paper-plane send control leaves the reply in the composer/draft. The browser only sends draft API calls and Synapse never receives `send/m.room.message`.

Fixes #281

## Solution
- Replace the custom `span role="button"` send control with a native `<button type="button">`.
- Preserve existing styling, label, disabled state, and active/clicked classes.
- Add a unit test that verifies the enabled button invokes the send handler and the disabled button does not.

## Validation
- `npm run test:unit -- SendMessageButton.test.tsx`
- `npm run test:unit`
- `npm run build` (success; existing warnings remain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The send message control now behaves like a standard button, improving click and keyboard interaction.
  * Disabled state handling is more reliable, preventing sends when the control is inactive.
  * Added a clear focus indicator for better keyboard accessibility.
* **Tests**
  * Added automated tests covering enabled and disabled button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->