### PR TITLE
fix: detect matrix room encryption state

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -2012,7 +2012,14 @@ export const MessageSubmitInterfaceComponent = ({
 					})
 					.catch((error) => {
 						setIsRequestInProgress(false);
-						// console.log(error);
+						apiPostError({
+							name: error?.name || 'MatrixMessageSendError',
+							message:
+								error?.message ||
+								'Failed to send Matrix chat message',
+							stack: error?.stack,
+							level: ERROR_LEVEL_WARN
+						}).then();
 					});
 			} else {
 				// Matrix file upload already sent the message

--- a/src/utils/matrixRoomEncryption.test.ts
+++ b/src/utils/matrixRoomEncryption.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assertMatrixRoomEncrypted,
+	isMatrixRoomEncrypted
+} from './matrixRoomEncryption';
+
+describe('matrixRoomEncryption', () => {
+	it('detects room encryption from the Matrix room current state event', () => {
+		const client = {
+			isRoomEncrypted: () => false,
+			getRoom: () => ({
+				hasEncryptionStateEvent: () => false,
+				currentState: {
+					getStateEvents: (eventType: string, stateKey: string) =>
+						eventType === 'm.room.encryption' && stateKey === ''
+							? { type: 'm.room.encryption' }
+							: null
+				}
+			})
+		};
+
+		expect(isMatrixRoomEncrypted(client as any, '!room:example.org')).toBe(
+			true
+		);
+		expect(() =>
+			assertMatrixRoomEncrypted(client as any, '!room:example.org')
+		).not.toThrow();
+	});
+
+	it('rejects rooms without any encryption signal', () => {
+		const client = {
+			isRoomEncrypted: () => false,
+			getRoom: () => ({
+				hasEncryptionStateEvent: () => false,
+				currentState: {
+					getStateEvents: () => null
+				}
+			})
+		};
+
+		expect(isMatrixRoomEncrypted(client as any, '!room:example.org')).toBe(
+			false
+		);
+		expect(() =>
+			assertMatrixRoomEncrypted(client as any, '!room:example.org')
+		).toThrow(/encrypted Matrix room/);
+	});
+});

--- a/src/utils/matrixRoomEncryption.ts
+++ b/src/utils/matrixRoomEncryption.ts
@@ -23,11 +23,20 @@ export const isMatrixRoomEncrypted = (
 		isRoomEncrypted?: (roomId: string) => boolean;
 	};
 	const room = clientWithEncryptionState.getRoom?.(roomId);
+	const roomWithState = room as Room & {
+		currentState?: {
+			getStateEvents?: (eventType: string, stateKey?: string) => unknown;
+		};
+	};
+	const roomEncryptionEvent = roomWithState?.currentState?.getStateEvents?.(
+		'm.room.encryption',
+		''
+	);
 
 	return (
-		clientWithEncryptionState.isRoomEncrypted?.(roomId) ??
-		room?.hasEncryptionStateEvent?.() ??
-		false
+		!!clientWithEncryptionState.isRoomEncrypted?.(roomId) ||
+		!!room?.hasEncryptionStateEvent?.() ||
+		!!roomEncryptionEvent
 	);
 };
 


### PR DESCRIPTION
## Summary
- accept Matrix room encryption from room.currentState.getStateEvents('m.room.encryption', '') before SDK sends
- report composer Matrix send failures via the existing error API instead of swallowing them silently
- add regression coverage for the current-state encryption fallback

## Issue
Closes #283

## Validation
- npm run test:unit -- matrixRoomEncryption.test.ts
- npm run test:unit
- npm run build