### PR TITLE
fix: submit message composer form

### DIFF
--- a/src/components/messageSubmitInterface/SendMessageButton.test.tsx
+++ b/src/components/messageSubmitInterface/SendMessageButton.test.tsx
@@ -36,6 +36,32 @@ describe('SendMessageButton', () => {
 		expect(handleSendButton).toHaveBeenCalledTimes(1);
 	});
 
+	it('can delegate sending to a parent form submit handler', () => {
+		const handleSubmit = vi.fn((event: React.FormEvent) => {
+			event.preventDefault();
+		});
+		const handleSendButton = vi.fn();
+
+		render(
+			<form onSubmit={handleSubmit}>
+				<SendMessageButton
+					type="submit"
+					handleSendButton={handleSendButton}
+				/>
+			</form>
+		);
+
+		const button = screen.getByRole('button', {
+			name: 'enquiry.write.input.button.title'
+		});
+		expect(button.getAttribute('type')).toBe('submit');
+
+		fireEvent.click(button);
+
+		expect(handleSubmit).toHaveBeenCalledTimes(1);
+		expect(handleSendButton).not.toHaveBeenCalled();
+	});
+
 	it('does not send while disabled', () => {
 		const handleSendButton = vi.fn();
 

--- a/src/components/messageSubmitInterface/SendMessageButton.tsx
+++ b/src/components/messageSubmitInterface/SendMessageButton.tsx
@@ -7,17 +7,23 @@ interface SendMessageButtonProps {
 	deactivated?: boolean;
 	isEmpty?: boolean;
 	handleSendButton: Function;
+	type?: 'button' | 'submit';
 }
 
 export const SendMessageButton = (props: SendMessageButtonProps) => {
 	const { t: translate } = useTranslation();
 	const isDisabled = !!props.deactivated;
+	const buttonType = props.type || 'button';
 
 	return (
 		<button
-			type="button"
+			type={buttonType}
 			disabled={isDisabled}
-			onClick={() => props.handleSendButton()}
+			onClick={
+				buttonType === 'button'
+					? () => props.handleSendButton()
+					: undefined
+			}
 			aria-disabled={isDisabled}
 			className={`textarea__iconWrapper ${
 				props.clicked ? 'textarea__iconWrapper--clicked' : ''

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -2241,6 +2241,14 @@ export const MessageSubmitInterfaceComponent = ({
 		userData
 	]);
 
+	const handleFormSubmit = useCallback(
+		(event: React.FormEvent<HTMLFormElement>) => {
+			event.preventDefault();
+			handleButtonClick();
+		},
+		[handleButtonClick]
+	);
+
 	// Key binding function for Draft.js to handle Ctrl+Enter / Cmd+Enter
 	// Only returns a command when modifier keys are pressed, otherwise returns undefined
 	// to let Draft.js handle Enter normally (create new line)
@@ -3830,7 +3838,7 @@ export const MessageSubmitInterfaceComponent = ({
 				</div>
 			)}
 
-			<form className="textarea">
+			<form className="textarea" onSubmit={handleFormSubmit}>
 				<div
 					className={clsx(
 						'textarea__wrapper',
@@ -5222,6 +5230,7 @@ export const MessageSubmitInterfaceComponent = ({
 								<ToolbarScrollRightIcon />
 							</button>
 							<SendMessageButton
+								type="submit"
 								handleSendButton={handleButtonClick}
 								clicked={isRequestInProgress}
 								deactivated={


### PR DESCRIPTION
## Problem
Matrix enquiry replies on Pre-Dev could be typed into the counselor composer, but clicking the send control left the reply as a draft. Logs showed only draft requests and no Matrix `/send/m.room.message` request.

## Solution
- Route the real composer send control through native form submission with `preventDefault()`.
- Keep `SendMessageButton` defaulting to direct button clicks for skeleton and non-form contexts.
- Add unit coverage for the submit-button variant.

Closes #285

## Validation
- `npx vitest run src/components/messageSubmitInterface/SendMessageButton.test.tsx --passWithNoTests`
- `npm run test:unit`
- `npm run build`

## Remaining risk
Pre-Dev E2E verification is still required after this PR is merged and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
