### PR TITLE
fix: persist refreshed matrix token

### DIFF
--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { persistMatrixLoginData } from './getMatrixAccessToken';
+
+vi.mock('../../resources/scripts/endpoints', () => ({
+	apiUrl: 'https://api.example.test'
+}));
+
+vi.mock('../../resources/scripts/runtimeConfig', () => ({
+	getMatrixHomeserverUrl: () => 'https://matrix.example.test'
+}));
+
+vi.mock('../../api/fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn()
+}));
+
+afterEach(() => {
+	vi.useRealTimers();
+	localStorage.clear();
+});
+
+describe('persistMatrixLoginData', () => {
+	it('persists refreshed Matrix credentials and expiry metadata', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-26T00:00:00.000Z'));
+
+		persistMatrixLoginData({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
+			expiresInMs: 3_300_000,
+			homeserverUrl: 'https://matrix.example.test',
+			userId: '@consultant:matrix.example.test'
+		});
+
+		expect(localStorage.getItem('matrix_access_token')).toBe(
+			'matrix-token'
+		);
+		expect(localStorage.getItem('matrix_user_id')).toBe(
+			'@consultant:matrix.example.test'
+		);
+		expect(localStorage.getItem('matrix_device_id')).toBe(
+			'ORISO_WEB_TEST_DEVICE'
+		);
+		expect(
+			localStorage.getItem(
+				'matrix_device_id:@consultant:matrix.example.test'
+			)
+		).toBe('ORISO_WEB_TEST_DEVICE');
+		expect(localStorage.getItem('matrix_token_expires_at')).toBe(
+			(Date.parse('2026-06-26T00:00:00.000Z') + 3_300_000).toString()
+		);
+	});
+});

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -77,11 +77,19 @@ export const getMatrixAccessToken = (
 };
 
 export const persistMatrixLoginData = (loginData: MatrixLoginData): void => {
+	localStorage.setItem('matrix_access_token', loginData.accessToken);
+	localStorage.setItem('matrix_user_id', loginData.userId);
 	localStorage.setItem(MATRIX_DEVICE_ID_STORAGE_KEY, loginData.deviceId);
 	localStorage.setItem(
 		`${MATRIX_DEVICE_ID_STORAGE_KEY}:${loginData.userId}`,
 		loginData.deviceId
 	);
+	if (loginData.expiresInMs) {
+		localStorage.setItem(
+			'matrix_token_expires_at',
+			(Date.now() + loginData.expiresInMs).toString()
+		);
+	}
 
 	const secure = window.location.protocol === 'https:' ? '; Secure' : '';
 	document.cookie = `rc_uid=${loginData.userId}; path=/; SameSite=Strict${secure}`;


### PR DESCRIPTION
## Problem
Pre-Dev Matrix counselor replies still stayed in the composer after the submit fix. Browser instrumentation showed the native submit path fired and React handled it, but the send path only saved drafts.

The Matrix token metadata in localStorage stayed expired after refresh. Each send attempt refreshed the Matrix client again, replacing the synced client before the room encryption state was available.

## Solution
- Persist refreshed Matrix access token and Matrix user id in localStorage.
- Persist `matrix_token_expires_at` from the token response `expiresInMs` value.
- Add unit coverage for the Matrix login-data persistence contract.

Relates to #285

## Validation
- `npx vitest run src/components/sessionCookie/getMatrixAccessToken.test.ts --passWithNoTests`
- `npm run test:unit`
- `npm run build`

## Remaining risk
Pre-Dev E2E verification is still required after merge and deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
