### PR TITLE
fix: send matrix messages through context client

### DIFF
--- a/src/api/apiSendMessage.test.ts
+++ b/src/api/apiSendMessage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { apiSendMessage } from './apiSendMessage';
+import { getMatrixClientService } from '../services/matrixClientRegistry';
 
 vi.mock('../resources/scripts/endpoints', () => ({
 	endpoints: {
@@ -49,5 +50,36 @@ describe('apiSendMessage', () => {
 			'Hello Matrix'
 		);
 		expect(response).toEqual({ success: true, event_id: '$event' });
+	});
+
+	it('falls back to the registered Matrix client service when no override is provided', async () => {
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$fallback-event' })
+		);
+		vi.mocked(getMatrixClientService).mockReturnValue({
+			getClient: () => ({}),
+			sendMessage
+		} as any);
+
+		const response = await apiSendMessage(
+			'Hello from registry',
+			'!fallback:example.org',
+			true,
+			false,
+			103024,
+			'!fallback:example.org',
+			null,
+			false,
+			'Counselor'
+		);
+
+		expect(sendMessage).toHaveBeenCalledWith(
+			'!fallback:example.org',
+			'Hello from registry'
+		);
+		expect(response).toEqual({
+			success: true,
+			event_id: '$fallback-event'
+		});
 	});
 });

--- a/src/api/apiSendMessage.test.ts
+++ b/src/api/apiSendMessage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiSendMessage } from './apiSendMessage';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		sendMessage: '/service/messages',
+		eventNotifications: '/service/notifications'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST' },
+	fetchData: vi.fn()
+}));
+
+vi.mock('../services/matrixClientRegistry', () => ({
+	getMatrixClientService: vi.fn(() => null)
+}));
+
+vi.mock('./apiPostMessageEventNotification', () => ({
+	apiPostMessageEventNotification: vi.fn(() => Promise.resolve({}))
+}));
+
+describe('apiSendMessage', () => {
+	it('uses the provided Matrix client service for Matrix-backed sessions', async () => {
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$event' })
+		);
+		const matrixClientService = {
+			getClient: () => ({}),
+			sendMessage
+		};
+
+		const response = await apiSendMessage(
+			'Hello Matrix',
+			'!room:example.org',
+			true,
+			false,
+			103024,
+			'!room:example.org',
+			null,
+			false,
+			'Counselor',
+			matrixClientService as any
+		);
+
+		expect(sendMessage).toHaveBeenCalledWith(
+			'!room:example.org',
+			'Hello Matrix'
+		);
+		expect(response).toEqual({ success: true, event_id: '$event' });
+	});
+});

--- a/src/api/apiSendMessage.ts
+++ b/src/api/apiSendMessage.ts
@@ -2,6 +2,7 @@ import { endpoints } from '../resources/scripts/endpoints';
 import { fetchData, FETCH_METHODS } from './fetchData';
 import { apiPostMessageEventNotification } from './apiPostMessageEventNotification';
 import { getMatrixClientService } from '../services/matrixClientRegistry';
+import type { MatrixClientService } from '../services/matrixClientService';
 
 export const apiSendMessage = (
 	messageData: string,
@@ -12,11 +13,13 @@ export const apiSendMessage = (
 	matrixRoomId?: string, // NEW: Accept Matrix room ID directly
 	threadRootId?: string | null,
 	supervisorMessage?: boolean,
-	senderDisplayName?: string | null
+	senderDisplayName?: string | null,
+	matrixClientServiceOverride?: MatrixClientService | null
 ): Promise<any> => {
 	// MATRIX MIGRATION: Use Matrix SDK directly for INSTANT local echo (like Element!)
 	if (sessionId && matrixRoomId) {
-		const matrixClientService = getMatrixClientService();
+		const matrixClientService =
+			matrixClientServiceOverride || getMatrixClientService();
 		if (!matrixClientService?.getClient()) {
 			return Promise.reject(new Error('Matrix client not initialized'));
 		}

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -2018,7 +2018,8 @@ export const MessageSubmitInterfaceComponent = ({
 					userData?.displayName ||
 						userData?.userName ||
 						`${userData?.firstName || ''} ${userData?.lastName || ''}`.trim() ||
-						'User'
+						'User',
+					matrixClientService
 				)
 					.then(() => encryptRoom(setE2EEState))
 					.then(() => {
@@ -2060,6 +2061,7 @@ export const MessageSubmitInterfaceComponent = ({
 			isSupervisor,
 			key,
 			keyID,
+			matrixClientService,
 			onSendButton,
 			setE2EEState,
 			threadParentPreview,


### PR DESCRIPTION
## Problem
Matrix counselor replies still did not leave the composer after the submit and token persistence fixes. Runtime probes showed the form submit and React handler were reached, but no Matrix `/send/m.room.message` request was emitted.

`MessageSubmitInterfaceComponent` already has the live `matrixClientService` from React context, but `apiSendMessage` only looked up a module-level registry singleton. In lazy chunk/runtime paths this can diverge from the synced context client.

## Solution
- Allow `apiSendMessage` to receive an explicit Matrix client service.
- Pass the context `matrixClientService` from the composer into the Matrix send helper.
- Keep the existing registry fallback for other callers.
- Add unit coverage proving Matrix sends use the provided service.

Relates to #285

## Validation
- `npx vitest run src/api/apiSendMessage.test.ts --passWithNoTests`
- `npm run test:unit`
- `npm run build`

## Remaining risk
Pre-Dev E2E verification is still required after merge and deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix message sending so messages are routed through the active client service more reliably.
  * Local echo sending now stays in sync with the current message service, reducing the chance of failed sends when the service changes.

* **Tests**
  * Added coverage for Matrix-backed message sending to verify successful sends return the expected event ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->