### PR TITLE
fix: fall back to composer state for send snapshot

### DIFF
--- a/src/components/messageSubmitInterface/composerMessageSnapshot.test.ts
+++ b/src/components/messageSubmitInterface/composerMessageSnapshot.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resolveComposerMessageSnapshot } from './composerMessageSnapshot';
+
+describe('resolveComposerMessageSnapshot', () => {
+	it('falls back to composer state when the live editor snapshot is empty', () => {
+		expect(
+			resolveComposerMessageSnapshot(
+				'<p></p>',
+				'<p>Queued counselor reply</p>'
+			)
+		).toBe('<p>Queued counselor reply</p>');
+	});
+
+	it('prefers the live editor snapshot when it contains text', () => {
+		expect(
+			resolveComposerMessageSnapshot(
+				'<p>Live counselor reply</p>',
+				'<p>Stale reply</p>'
+			)
+		).toBe('<p>Live counselor reply</p>');
+	});
+
+	it('treats non-breaking spaces as empty content', () => {
+		expect(
+			resolveComposerMessageSnapshot(
+				'<p>&nbsp;</p>',
+				'<p>Reply from state</p>'
+			)
+		).toBe('<p>Reply from state</p>');
+	});
+});

--- a/src/components/messageSubmitInterface/composerMessageSnapshot.ts
+++ b/src/components/messageSubmitInterface/composerMessageSnapshot.ts
@@ -1,0 +1,44 @@
+const stripComposerMarkup = (value?: string | null): string => {
+	const normalizedValue = (value || '')
+		.replace(/<br\s*\/?>/gi, '\n')
+		.replace(/<\/(p|div|li|h[1-6]|blockquote|pre)>/gi, '\n')
+		.replace(/&nbsp;/gi, ' ')
+		.replace(/&#160;/gi, ' ')
+		.replace(/\u00a0/g, ' ')
+		.replace(/\u200b/g, '');
+
+	if (!normalizedValue.trim()) {
+		return '';
+	}
+
+	if (typeof document !== 'undefined' && document.createElement) {
+		const container = document.createElement('div');
+		container.innerHTML = normalizedValue;
+		return (container.textContent || '')
+			.replace(/\u00a0/g, ' ')
+			.replace(/\u200b/g, '');
+	}
+
+	return normalizedValue.replace(/<[^>]+>/g, ' ');
+};
+
+const hasComposerTextContent = (value?: string | null): boolean =>
+	stripComposerMarkup(value).trim().length > 0;
+
+export const resolveComposerMessageSnapshot = (
+	liveEditorHtml?: string | null,
+	composerText?: string | null
+): string => {
+	const liveSnapshot = (liveEditorHtml ?? '').trim();
+	const stateSnapshot = (composerText ?? '').trim();
+
+	if (hasComposerTextContent(liveSnapshot)) {
+		return liveSnapshot;
+	}
+
+	if (hasComposerTextContent(stateSnapshot)) {
+		return stateSnapshot;
+	}
+
+	return liveSnapshot || stateSnapshot;
+};

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -71,6 +71,7 @@ import {
 	normalizeHighlightColor,
 	toolbarCustomClasses
 } from './richtextHelpers';
+import { resolveComposerMessageSnapshot } from './composerMessageSnapshot';
 import { ReactComponent as AudioOnIcon } from '../../resources/img/icons/audio-on.svg';
 import { ReactComponent as RemoveIcon } from '../../resources/img/icons/x.svg';
 import { ReactComponent as CalendarMonthIcon } from '../../resources/img/icons/calendar-month-navigation.svg';
@@ -1285,7 +1286,7 @@ export const MessageSubmitInterfaceComponent = ({
 	const getTypedMarkdownMessage = useCallback(() => {
 		const liveEditorHtml = composerRef.current?.getHTML();
 		// Use latest editor snapshot first to avoid stale last-action/last-char issues.
-		return (liveEditorHtml ?? composerText).trim();
+		return resolveComposerMessageSnapshot(liveEditorHtml, composerText);
 	}, [composerText]);
 
 	const hasMessageContent = useCallback((rawMessage?: string | null) => {


### PR DESCRIPTION
## Summary
- fall back to the synchronized composer state when TipTap returns an empty live HTML snapshot during send
- keep the live editor snapshot as the preferred source when it contains real text
- add regression coverage for empty live snapshots and non-breaking-space snapshots

## Validation
- 
 RUN  v3.2.6 /Users/frankgerhardt/ORISO/ORISO-Frontend

 ✓ src/components/messageSubmitInterface/composerMessageSnapshot.test.ts (3 tests) 1ms
 ✓ src/api/apiSendMessage.test.ts (2 tests) 2ms

 Test Files  2 passed (2)
      Tests  5 passed (5)
   Start at  03:06:42
   Duration  322ms (transform 50ms, setup 0ms, collect 52ms, tests 3ms, environment 0ms, prepare 142ms)
- 
> @onlineberatung/onlineberatung-frontend@2.9.14 test:unit
> vitest run --passWithNoTests


 RUN  v3.2.6 /Users/frankgerhardt/ORISO/ORISO-Frontend

 ✓ src/api/apiSendMessage.test.ts (2 tests) 2ms
 ✓ src/utils/matrixRoomEncryption.test.ts (2 tests) 2ms
 ✓ src/components/emptyState/lottieColorUtils.test.ts (1 test) 2ms
 ✓ src/components/messageSubmitInterface/composerMessageSnapshot.test.ts (3 tests) 2ms
 ✓ src/components/messageSubmitInterface/messageEncryptionMode.test.ts (8 tests) 1ms
 ✓ src/components/notificationsCenter/timelineFilter.test.ts (11 tests) 3ms
 ✓ src/utils/listItemSelection.test.ts (18 tests) 3ms
 ✓ src/components/notificationsCenter/eventDescriptors/registry.test.ts (16 tests) 4ms
 ✓ src/utils/theme/orisoScheme.seeds.test.ts (14 tests) 13ms
 ✓ src/utils/theme/orisoScheme.test.ts (42 tests) 113ms
 ✓ src/utils/theme/m3Sweep.test.ts (9 tests) 148ms
 ✓ src/components/messageSubmitInterface/SendMessageButton.test.tsx (3 tests) 38ms
 ✓ src/components/sessionCookie/getMatrixAccessToken.test.ts (1 test) 2ms
 ✓ src/components/themeDemo/ThemeDemo.test.tsx (3 tests) 23ms
 ✓ src/utils/theme/applyTenantTheme.test.ts (16 tests) 20ms
 ✓ src/components/app/registrationLoader/RegistrationLoader.test.tsx (3 tests) 34ms
 ✓ src/components/registration/topicSelection/TopicSelection.test.tsx (2 tests) 50ms

 Test Files  17 passed (17)
      Tests  154 passed (154)
   Start at  03:06:43
   Duration  1.70s (transform 702ms, setup 0ms, collect 3.79s, tests 461ms, environment 2.08s, prepare 1.45s)
- 
> @onlineberatung/onlineberatung-frontend@2.9.14 build
> node scripts/build.js

Creating an optimized production build...
Compiled with warnings.

(14:3) from "autoprefixer" plugin: start value has mixed support, consider using flex-start instead
Code:
  align-items: start

(15:3) from "autoprefixer" plugin: start value has mixed support, consider using flex-start instead
Code:
  justify-content: start

[eslint] 
src/api/apiPostError.ts
  Line 1:16:  'uuidv4' is defined but never used         @typescript-eslint/no-unused-vars
  Line 2:10:  'endpoints' is defined but never used      @typescript-eslint/no-unused-vars
  Line 3:10:  'fetchData' is defined but never used      @typescript-eslint/no-unused-vars
  Line 3:21:  'FETCH_METHODS' is defined but never used  @typescript-eslint/no-unused-vars
  Line 3:36:  'FETCH_ERRORS' is defined but never used   @typescript-eslint/no-unused-vars
  Line 5:8:   'StackTrace' is defined but never used     @typescript-eslint/no-unused-vars

src/api/fetchRCData.ts
  Line 3:2:  'getErrorCaseForStatus' is defined but never used  @typescript-eslint/no-unused-vars
  Line 4:2:  'redirectToErrorPage' is defined but never used    @typescript-eslint/no-unused-vars

src/components/app/AuthenticatedApp.tsx
  Line 170:5:  React Hook useEffect has missing dependencies: 'callContext' and 'setMatrixClientService'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

src/components/app/NonPlainRoutesWrapper.tsx
  Line 3:10:  'loadKeysFromRocketChat' is defined but never used  @typescript-eslint/no-unused-vars

src/components/app/Routing.tsx
  Line 35:10:  'untilL' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/components/call/FloatingCallWidget.tsx
  Line 303:8:  'toggleMinimized' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 314:8:  'getStatusText' is assigned a value but never used    @typescript-eslint/no-unused-vars

src/components/call/GroupCallWidget.tsx
  Line 90:5:   React Hook useEffect has a missing dependency: 'callData'. Either include it or remove the dependency array                                 react-hooks/exhaustive-deps
  Line 131:5:  React Hook useEffect has a missing dependency: 'setupElementCall'. Either include it or remove the dependency array                         react-hooks/exhaustive-deps
  Line 141:5:  React Hook useEffect has missing dependencies: 'elementCallUrl' and 'setupElementCall'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
  Line 251:8:  'handleWidgetAction' is assigned a value but never used                                                                                     @typescript-eslint/no-unused-vars
  Line 452:5:  React Hook useEffect has missing dependencies: 'handleMouseMove' and 'handleTouchMove'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

src/components/matrixCall/MatrixCallView.tsx
  Line 32:9:   'error' is assigned a value but never used                                                                     @typescript-eslint/no-unused-vars
  Line 115:5:  React Hook useEffect has a missing dependency: 'activeCall'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/components/message/MessageItemComponent.tsx
  Line 77:28:  'ArrowLeftIcon' is defined but never used                                                                                        @typescript-eslint/no-unused-vars
  Line 78:28:  'StackVerticalCircleIcon' is defined but never used                                                                              @typescript-eslint/no-unused-vars
  Line 79:28:  'PenIcon' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
  Line 80:28:  'ArrowForwardIcon' is defined but never used                                                                                     @typescript-eslint/no-unused-vars
  Line 889:5:  React Hook useEffect has a missing dependency: 'parsedMessage.cleanedMessage'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/components/messageSubmitInterface/TipTapComposer.tsx
  Line 55:25:  Unnecessary escape character: \[                                no-useless-escape
  Line 205:7:  'serializeEditorToMarkdown' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
  Line 50:8:    'PluginsEditor' is defined but never used                                                                                                  @typescript-eslint/no-unused-vars
  Line 54:2:    'DraftHandleValue' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
  Line 62:2:    'BoldButton' is defined but never used                                                                                                     @typescript-eslint/no-unused-vars
  Line 63:2:    'ItalicButton' is defined but never used                                                                                                   @typescript-eslint/no-unused-vars
  Line 64:2:    'UnorderedListButton' is defined but never used                                                                                            @typescript-eslint/no-unused-vars
  Line 68:2:    'handleEditorBeforeInput' is defined but never used                                                                                        @typescript-eslint/no-unused-vars
  Line 69:2:    'handleEditorPastedText' is defined but never used                                                                                         @typescript-eslint/no-unused-vars
  Line 120:7:   'linkifyPlugin' is assigned a value but never used                                                                                         @typescript-eslint/no-unused-vars
  Line 138:9:   'Toolbar' is assigned a value but never used                                                                                               @typescript-eslint/no-unused-vars
  Line 968:27:  'setIsRichtextActive' is assigned a value but never used                                                                                   @typescript-eslint/no-unused-vars
  Line 997:9:   'audienceOverlayBounds' is assigned a value but never used                                                                                 @typescript-eslint/no-unused-vars
  Line 1661:9:  'richtextHeight' is assigned a value but never used                                                                                        @typescript-eslint/no-unused-vars
  Line 1737:5:  React Hook useCallback has an unnecessary dependency: 'isRichtextActive'. Either exclude it or remove the dependency array                 react-hooks/exhaustive-deps
  Line 1744:8:  'toggleAbsentMessage' is assigned a value but never used                                                                                   @typescript-eslint/no-unused-vars
  Line 2050:3:  React Hook useCallback has an unnecessary dependency: 'threadParentPreview'. Either exclude it or remove the dependency array              react-hooks/exhaustive-deps
  Line 2258:8:  'keyBindingFn' is assigned a value but never used                                                                                          @typescript-eslint/no-unused-vars
  Line 2268:8:  'enhancedHandleEditorKeyCommand' is assigned a value but never used                                                                        @typescript-eslint/no-unused-vars
  Line 2866:5:  React Hook useEffect has a missing dependency: 'activeSession?.consultant?.displayName'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
  Line 3500:3:  React Hook useCallback has an unnecessary dependency: 'composerText'. Either exclude it or remove the dependency array                     react-hooks/exhaustive-deps
  Line 3769:8:  'handleMobileDownNavigation' is assigned a value but never used                                                                            @typescript-eslint/no-unused-vars

src/components/profile/Profile.tsx
  Line 13:28:  'PersonIcon' is defined but never used  @typescript-eslint/no-unused-vars

src/components/registration/autoLogin.ts
  Line 82:7:  'loginRocketChat' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/components/session/AcceptAssign.tsx
  Line 49:8:  The 'getSessionListTab' function makes the dependencies of useCallback Hook (at line 123) change on every render. To fix this, wrap the definition of 'getSessionListTab' in its own useCallback() Hook  react-hooks/exhaustive-deps

src/components/session/SessionItemComponent.tsx
  Line 44:10:    'RocketChatUsersOfRoomProvider' is defined but never used                                                                     @typescript-eslint/no-unused-vars
  Line 48:28:    'PersonCircleIcon' is defined but never used                                                                                  @typescript-eslint/no-unused-vars
  Line 50:28:    'WelcomeIllustration' is defined but never used                                                                               @typescript-eslint/no-unused-vars
  Line 56:10:    'WaitingRoomContent' is defined but never used                                                                                @typescript-eslint/no-unused-vars
  Line 63:10:    'Text' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
  Line 154:7:    'DEFAULT_BREATH_PHASE_SECONDS' is assigned a value but never used                                                             @typescript-eslint/no-unused-vars
  Line 413:9:    'breathCycles' is assigned a value but never used                                                                             @typescript-eslint/no-unused-vars
  Line 467:9:    'gameStatusTypedText' is assigned a value but never used                                                                      @typescript-eslint/no-unused-vars
  Line 468:9:    'gameStatusTypewriterBusy' is assigned a value but never used                                                                 @typescript-eslint/no-unused-vars
  Line 470:9:    'levelBadgeTypedText' is assigned a value but never used                                                                      @typescript-eslint/no-unused-vars
  Line 471:9:    'levelBadgeTypewriterBusy' is assigned a value but never used                                                                 @typescript-eslint/no-unused-vars
  Line 473:9:    'centerStageTypedText' is assigned a value but never used                                                                     @typescript-eslint/no-unused-vars
  Line 474:9:    'centerStageTypewriterBusy' is assigned a value but never used                                                                @typescript-eslint/no-unused-vars
  Line 754:5:    React Hook useMemo has an unnecessary dependency: 'activeSession.item.id'. Either exclude it or remove the dependency array   react-hooks/exhaustive-deps
  Line 1287:5:   React Hook useCallback has an unnecessary dependency: 'translate'. Either exclude it or remove the dependency array           react-hooks/exhaustive-deps
  Line 1864:5:   React Hook useCallback has a missing dependency: 'activeSession.item.id'. Either include it or remove the dependency array    react-hooks/exhaustive-deps
  Line 2016:5:   React Hook useCallback has a missing dependency: 'setWaitingGateDismissed'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
  Line 2192:5:   React Hook useEffect has a missing dependency: 'translate'. Either include it or remove the dependency array                  react-hooks/exhaustive-deps
  Line 2537:5:   React Hook useEffect has a missing dependency: 'enableInitialScroll'. Either include it or remove the dependency array        react-hooks/exhaustive-deps
  Line 3316:18:  'center' is assigned a value but never used                                                                                   @typescript-eslint/no-unused-vars

src/components/session/SessionStream.tsx
  Line 568:28:  The ref value 'matrixTypingActivityRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'matrixTypingActivityRef.current' to a variable inside the effect, and use that variable in the cleanup function                                                react-hooks/exhaustive-deps
  Line 746:5:   React Hook useEffect has missing dependencies: 'addNewUsersToEncryptedRoom', 'fetchSessionMessages', 'handleChatStopped', 'handleSubscriptionChanged', 'isMatrixSession', 'onDebounceMessage', 'setSessionRead', 'subscribe', 'subscribeTyping', 'unsubscribe', and 'unsubscribeTyping'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

src/components/session/SessionView.tsx
  Line 44:17:  'rcReady' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/components/sessionHeader/GroupChatHeader/index.tsx
  Line 19:10:   'isMobile' is defined but never used                          @typescript-eslint/no-unused-vars
  Line 23:10:   'getGroupChatDate' is defined but never used                  @typescript-eslint/no-unused-vars
  Line 26:10:   'FlyoutMenu' is defined but never used                        @typescript-eslint/no-unused-vars
  Line 27:10:   'BanUser' is defined but never used                           @typescript-eslint/no-unused-vars
  Line 27:19:   'BanUserOverlay' is defined but never used                    @typescript-eslint/no-unused-vars
  Line 28:10:   'Tag' is defined but never used                               @typescript-eslint/no-unused-vars
  Line 49:10:   'releaseToggles' is assigned a value but never used           @typescript-eslint/no-unused-vars
  Line 51:9:    'isUserBanOverlayOpen' is assigned a value but never used     @typescript-eslint/no-unused-vars
  Line 51:31:   'setIsUserBanOverlayOpen' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 181:8:   'sessionView' is assigned a value but never used              @typescript-eslint/no-unused-vars
  Line 183:9:   'flyoutOpenId' is assigned a value but never used             @typescript-eslint/no-unused-vars
  Line 183:23:  'setFlyoutOpenId' is assigned a value but never used          @typescript-eslint/no-unused-vars
  Line 285:8:   'isCurrentUserModerator' is assigned a value but never used   @typescript-eslint/no-unused-vars
  Line 291:8:   'isAskerInfoAvailable' is assigned a value but never used     @typescript-eslint/no-unused-vars
  Line 301:8:   'handleFlyout' is assigned a value but never used             @typescript-eslint/no-unused-vars

src/components/sessionHeader/GroupChatHeader/useJoinVideoCall/index.ts
  Line 7:10:  'generatePath' is defined but never used                                                                                  @typescript-eslint/no-unused-vars
  Line 9:10:  'apiJoinGroupChat' is defined but never used                                                                              @typescript-eslint/no-unused-vars
  Line 42:3:  React Hook useCallback has an unnecessary dependency: 'urls.videoCall'. Either exclude it or remove the dependency array  react-hooks/exhaustive-deps

src/components/sessionHeader/SessionHeaderComponent.tsx
  Line 6:10:   'handleNumericTranslation' is defined but never used                                                                         @typescript-eslint/no-unused-vars
  Line 79:28:  'CloseCircle' is defined but never used                                                                                      @typescript-eslint/no-unused-vars
  Line 245:8:  'preparedUserSessionData' is assigned a value but never used                                                                 @typescript-eslint/no-unused-vars
  Line 250:8:  'translateBase' is assigned a value but never used                                                                           @typescript-eslint/no-unused-vars
  Line 298:5:  React Hook useEffect has a missing dependency: 'loadAvailableConsultants'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/components/sessionMenu/SessionMenu.tsx
  Line 36:2:   'videoCallErrorOverlayItem' is defined but never used       @typescript-eslint/no-unused-vars
  Line 42:2:   'apiStartVideoCall' is defined but never used               @typescript-eslint/no-unused-vars
  Line 57:10:  'supportsE2EEncryptionVideoCall' is defined but never used  @typescript-eslint/no-unused-vars
  Line 93:8:   'settings' is assigned a value but never used               @typescript-eslint/no-unused-vars

src/components/sessionsList/SessionsList.tsx
  Line 1268:5:  React Hook useEffect has a missing dependency: 'dispatch'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

src/components/sessionsList/SessionsListWrapper.tsx
  Line 4:10:   'SESSION_LIST_TYPES' is defined but never used  @typescript-eslint/no-unused-vars
  Line 27:13:  'translate' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 31:10:  'type' is assigned a value but never used       @typescript-eslint/no-unused-vars

src/components/sessionsListItem/SessionListItemComponent.tsx
  Line 48:10:  'getGroupChatDate' is defined but never used            @typescript-eslint/no-unused-vars
  Line 52:10:  'Tag' is defined but never used                         @typescript-eslint/no-unused-vars
  Line 94:9:   'matrixMembers' is assigned a value but never used      @typescript-eslint/no-unused-vars
  Line 118:8:  'dropdownRef' is assigned a value but never used        @typescript-eslint/no-unused-vars
  Line 152:8:  'additionalMembers' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 513:8:  'Icon' is assigned a value but never used               @typescript-eslint/no-unused-vars
  Line 514:8:  'iconTitle' is assigned a value but never used          @typescript-eslint/no-unused-vars

src/components/uiVersionToggle/UIVersionToggle.tsx
  Line 31:19:  'setUseNewUI' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/globalState/provider/NotificationsProvider.tsx
  Line 13:2:  'NOTIFICATION_TYPE_CALL' is defined but never used  @typescript-eslint/no-unused-vars

src/globalState/provider/RocketChatProvider.tsx
  Line 383:3:  Unreachable code  no-unreachable

src/utils/anonymousChatSessionCleanup.ts
  Line 18:5:  'pendingMatrixRoomId' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 19:5:  'pendingUsername' is assigned a value but never used      @typescript-eslint/no-unused-vars

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  901.77 kB  build/static/js/app.7cf37314.js
  502.98 kB  build/static/js/error.5299690a.js
  346.59 kB  build/static/js/258.1e20cad3.chunk.js
  194.01 kB  build/static/js/559.f7f444cb.chunk.js
  147.76 kB  build/static/js/531.79f6515b.chunk.js
  138.64 kB  build/static/js/465.5a591f74.chunk.js
  133.82 kB  build/static/js/782.119d646e.chunk.js
  71.85 kB   build/static/js/224.df274a47.chunk.js
  57.95 kB   build/static/js/508.ec301f1d.chunk.js
  44.51 kB   build/static/js/946.4827fed2.chunk.js
  42.45 kB   build/static/css/app.1c2f7207.css
  39.72 kB   build/static/js/333.52343936.chunk.js
  35.44 kB   build/static/js/851.e0c34fd4.chunk.js
  32.74 kB   build/static/js/590.217c5f12.chunk.js
  29.09 kB   build/static/css/531.607d760d.chunk.css
  18.45 kB   build/static/css/error.0682ba2a.css
  15.87 kB   build/static/js/52.8c811705.chunk.js
  8.65 kB    build/static/css/465.fbf7d6e8.chunk.css
  8.55 kB    build/static/js/202.1d34dc1b.chunk.js
  7.99 kB    build/static/css/202.0e71cf11.chunk.css
  7.19 kB    build/static/js/127.bfb7fcc5.chunk.js
  6.73 kB    build/static/css/487.029c26e6.chunk.css
  6.25 kB    build/static/js/846.3bfc8811.chunk.js
  5.19 kB    build/static/js/399.976b6d29.chunk.js
  5.06 kB    build/static/css/93.d2a8818a.chunk.css
  3.2 kB     build/static/css/846.52ffad7b.chunk.css
  3.05 kB    build/static/js/970.b41180dd.chunk.js
  2.6 kB     build/static/js/33.d9d40c04.chunk.js
  2.52 kB    build/static/js/56.baf35126.chunk.js
  2.1 kB     build/static/js/950.3592cba0.chunk.js
  2.09 kB    build/static/css/627.32b9176b.chunk.css
  1.97 kB    build/static/css/910.8e7c5e59.chunk.css
  1.57 kB    build/static/css/607.4dd90ece.chunk.css
  1.51 kB    build/static/js/109.35eb8792.chunk.js
  1.27 kB    build/static/js/17.89588ebf.chunk.js
  1.2 kB     build/static/js/627.c653daa3.chunk.js
  1.08 kB    build/static/css/950.2aa01c23.chunk.css
  1.06 kB    build/static/css/56.8e7f164d.chunk.css
  882 B      build/static/js/939.ddabc9c9.chunk.js
  717 B      build/static/css/17.a41140ab.chunk.css
  506 B      build/static/css/52.9b83ed1f.chunk.css

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

Fixes #285

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)