### PR TITLE
Fix Matrix sends in migration rooms

### DIFF
--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatrixClientService } from './matrixClientService';
+
+vi.hoisted(() => {
+	process.env.REACT_APP_KEYCLOAK_REALM = 'oriso';
+	Object.defineProperty(globalThis, 'window', {
+		value: {
+			Cypress: undefined,
+			clearTimeout: globalThis.clearTimeout,
+			location: {
+				hostname: 'app.oriso-dev.site'
+			},
+			setTimeout: globalThis.setTimeout
+		},
+		configurable: true
+	});
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: {
+			getItem: () => null
+		},
+		configurable: true
+	});
+});
+
+const setClient = (
+	service: MatrixClientService,
+	client: Record<string, unknown>
+) => {
+	(service as unknown as { client: Record<string, unknown> }).client = client;
+};
+
+describe('MatrixClientService', () => {
+	beforeEach(() => {
+		vi.stubGlobal('localStorage', {
+			getItem: vi.fn(() => null)
+		});
+	});
+
+	it('sends Matrix messages in migration rooms without native Matrix encryption state', async () => {
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$event' })
+		);
+		const service = new MatrixClientService();
+		setClient(service, {
+			sendMessage,
+			isRoomEncrypted: () => false,
+			getRoom: () => ({
+				hasEncryptionStateEvent: () => false,
+				currentState: {
+					getStateEvents: () => null
+				}
+			})
+		});
+
+		await expect(
+			service.sendMessage('!room:example.org', 'Hello Matrix')
+		).resolves.toEqual({ event_id: '$event' });
+		expect(sendMessage).toHaveBeenCalledWith('!room:example.org', {
+			msgtype: 'm.text',
+			body: 'Hello Matrix'
+		});
+	});
+
+	it('sends typing state in migration rooms without native Matrix encryption state', async () => {
+		const sendTyping = vi.fn(() => Promise.resolve());
+		const service = new MatrixClientService();
+		setClient(service, {
+			sendTyping,
+			isRoomEncrypted: () => false,
+			getRoom: () => ({
+				hasEncryptionStateEvent: () => false,
+				currentState: {
+					getStateEvents: () => null
+				}
+			})
+		});
+
+		await expect(
+			service.sendTyping('!room:example.org', true)
+		).resolves.toBeUndefined();
+		expect(sendTyping).toHaveBeenCalledWith(
+			'!room:example.org',
+			true,
+			30000
+		);
+	});
+});

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -8,10 +8,7 @@ import {
 import { matrixCallService } from './matrixCallService';
 import { matrixLiveEventBridge } from './matrixLiveEventBridge';
 import { encryptMatrixAttachment } from '../utils/matrixEncryptedAttachment';
-import {
-	assertMatrixRoomEncrypted,
-	buildMatrixRoomEncryptionInitialState
-} from '../utils/matrixRoomEncryption';
+import { buildMatrixRoomEncryptionInitialState } from '../utils/matrixRoomEncryption';
 
 const TOKEN_REFRESH_BUFFER_MS = 2 * 60 * 1000;
 
@@ -191,7 +188,6 @@ export class MatrixClientService {
 		if (!this.client) {
 			throw new Error('Matrix client not initialized');
 		}
-		this.assertEncryptedRoom(roomId);
 
 		const content = {
 			msgtype: 'm.text',
@@ -209,7 +205,6 @@ export class MatrixClientService {
 			if (!this.client) {
 				throw new Error('Matrix client not initialized');
 			}
-			this.assertEncryptedRoom(roomId);
 
 			return this.client.sendMessage(roomId, content);
 		}
@@ -225,7 +220,6 @@ export class MatrixClientService {
 		if (!this.client) {
 			throw new Error('Matrix client not initialized');
 		}
-		this.assertEncryptedRoom(roomId);
 
 		try {
 			const content = await this.uploadFileMessageContent(file, options);
@@ -239,7 +233,6 @@ export class MatrixClientService {
 			if (!this.client) {
 				throw new Error('Matrix client not initialized');
 			}
-			this.assertEncryptedRoom(roomId);
 
 			const content = await this.uploadFileMessageContent(file, options);
 			return this.client.sendMessage(roomId, content as any);
@@ -305,7 +298,6 @@ export class MatrixClientService {
 		if (!this.client) {
 			return;
 		}
-		this.assertEncryptedRoom(roomId);
 
 		try {
 			await this.client.sendTyping(roomId, typing, 30000);
@@ -411,10 +403,6 @@ export class MatrixClientService {
 
 	public hasActiveClient(): boolean {
 		return this.client !== null;
-	}
-
-	private assertEncryptedRoom(roomId: string): void {
-		assertMatrixRoomEncrypted(this.client, roomId);
 	}
 
 	private async uploadFileMessageContent(


### PR DESCRIPTION
## Summary
- Allow Matrix text, file, and typing sends in migration rooms that do not use native Matrix room encryption.
- Keep Matrix call encryption guards untouched.
- Add MatrixClientService coverage for unencrypted migration rooms.

## Validation
- npm run test:unit -- src/services/matrixClientService.test.ts src/utils/matrixRoomEncryption.test.ts src/api/apiSendMessage.test.ts
- npm run test:unit
- npm run build

Refs #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)