### PR TITLE
fix(registration): restore MD3 fidelity details

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -1,4 +1,4 @@
-import { Link, Button, Box, Chip, Stack, Avatar } from '@mui/material';
+import { Avatar, Box, Button, Chip, Link } from '@mui/material';
 import * as React from 'react';
 import {
 	useState,
@@ -80,6 +80,7 @@ export const Registration = () => {
 	const { addNotification } = useContext(NotificationsContext);
 	const {
 		disabledNextButton,
+		setDisabledNextButton,
 		updateRegistrationData,
 		registrationData,
 		availableSteps
@@ -90,6 +91,8 @@ export const Registration = () => {
 
 	const [stepData, setStepData] = useState<Partial<RegistrationData>>({});
 	const [isRegistering, setIsRegistering] = useState<boolean>(false);
+	const [clearSelectionVersion, setClearSelectionVersion] =
+		useState<number>(0);
 
 	const checkForStepsWithMissingMandatoryFields =
 		useCallback((): number[] => {
@@ -162,6 +165,34 @@ export const Registration = () => {
 			history.push(prevStepUrl);
 		}
 	}, [registrationData, stepData, history, prevStepUrl]);
+
+	const onClearSelection = useCallback(() => {
+		setStepData({});
+		setClearSelectionVersion((version) => version + 1);
+		setDisabledNextButton?.(true);
+		updateRegistrationData({
+			mainTopic: undefined,
+			mainTopicId: undefined,
+			topic: undefined,
+			topicId: undefined,
+			topicGroupId: undefined,
+			agency: undefined,
+			agencyId: undefined
+		});
+		history.push(
+			`${generatePath(path, {
+				topicSlug,
+				step: 'topic-selection'
+			})}${location.search}`
+		);
+	}, [
+		history,
+		location.search,
+		path,
+		setDisabledNextButton,
+		topicSlug,
+		updateRegistrationData
+	]);
 
 	const handleSubmit = useCallback(
 		(e: FormEvent<HTMLFormElement>) => {
@@ -336,6 +367,7 @@ export const Registration = () => {
 														key={name}
 													>
 														<Component
+															key={`${name}-${clearSelectionVersion}`}
 															onChange={
 																setStepData
 															}
@@ -374,156 +406,112 @@ export const Registration = () => {
 										zIndex: 65
 									}}
 								>
-									<Stack
-										direction="row"
-										spacing={{ xs: 1.5, md: 2 }}
-										alignItems="center"
-										justifyContent="space-between"
+									<Box
 										sx={{
 											width: '100%',
 											maxWidth: '780px',
 											minWidth: 0
 										}}
 									>
-										<Link
-											sx={{
-												textDecoration: 'none',
-												color: registrationMd3.onSurfaceVariant,
-												fontWeight: '700',
-												display: 'inline-flex',
-												alignItems: 'center',
-												gap: '8px',
-												whiteSpace: 'nowrap'
-											}}
-											component={RouterLink}
-											onClick={onPrevClick}
-											to={prevStepUrl}
-										>
-											<ArrowBackRoundedIcon fontSize="small" />
-											{t('registration.back')}
-										</Link>
 										<Box
 											sx={{
 												display: {
 													xs: 'none',
-													sm: 'flex'
+													sm: 'grid'
 												},
-												justifyContent: 'center',
-												minWidth: 0,
-												flex: 1
+												gridTemplateColumns:
+													'auto minmax(0, 1fr) auto',
+												alignItems: 'center',
+												gap: 2
 											}}
 										>
-											{selectedLabel ? (
-												<Chip
-													avatar={
-														selectedIcon ? (
-															<Avatar
-																src={
-																	selectedIcon
-																}
-																alt=""
-															/>
-														) : undefined
-													}
-													label={selectedLabel}
-													variant="outlined"
-													sx={{
-														'maxWidth': '100%',
-														'height': '42px',
-														'borderRadius': '999px',
-														'bgcolor': '#fff',
-														'fontWeight': 700,
-														'borderColor':
-															registrationMd3.outlineVariant,
-														'& .MuiChip-label': {
-															overflow: 'hidden',
-															textOverflow:
-																'ellipsis',
-															whiteSpace: 'nowrap'
-														},
-														'& .MuiChip-avatar': {
-															width: 28,
-															height: 28
-														}
-													}}
-												/>
-											) : null}
-										</Box>
-
-										{!nextStepUrl ? (
-											<Button
-												data-cy="button-register"
-												disabled={
-													disabledNextButton ||
-													isRegistering
-												}
-												variant="contained"
-												onClick={onRegisterClick}
-												type={
-													disabledNextButton ||
-													isRegistering
-														? 'button'
-														: 'submit'
-												}
-												sx={{
-													borderRadius: '999px',
-													px: { xs: 3, md: 4 },
-													py: 1.25,
-													fontWeight: 800,
-													minWidth: {
-														xs: 150,
-														md: 176
-													},
-													boxShadow:
-														disabledNextButton ||
-														isRegistering
-															? 'none'
-															: '0 6px 18px rgba(164, 38, 46, 0.30)'
-												}}
-											>
-												{isRegistering
-													? t(
-															'registration.registering',
-															'Registering...'
-														)
-													: t(
-															'registration.register'
-														)}
-											</Button>
-										) : (
-											<Button
-												data-cy="button-next"
-												disabled={disabledNextButton}
-												variant="contained"
-												onClick={onNextClick}
-												endIcon={
-													<ArrowForwardRoundedIcon />
-												}
-												sx={{
-													width: 'unset',
-													borderRadius: '999px',
-													px: { xs: 3, md: 4 },
-													py: 1.25,
-													fontWeight: 800,
-													minWidth: {
-														xs: 150,
-														md: 176
-													},
-													boxShadow:
-														disabledNextButton
-															? 'none'
-															: '0 6px 18px rgba(164, 38, 46, 0.30)'
-												}}
-												type={
+											<RegistrationFooterBackLink
+												to={prevStepUrl}
+												onClick={onPrevClick}
+												label={t('registration.back')}
+											/>
+											<RegistrationFooterChip
+												label={selectedLabel}
+												icon={selectedIcon}
+												onDelete={onClearSelection}
+											/>
+											<RegistrationFooterPrimaryButton
+												nextStepUrl={nextStepUrl}
+												disabledNextButton={
 													disabledNextButton
-														? 'button'
-														: 'submit'
 												}
+												isRegistering={isRegistering}
+												onRegisterClick={
+													onRegisterClick
+												}
+												onNextClick={onNextClick}
+												registerLabel={t(
+													'registration.register'
+												)}
+												registeringLabel={t(
+													'registration.registering',
+													'Registering...'
+												)}
+												nextLabel={t(
+													'registration.next'
+												)}
+											/>
+										</Box>
+										<Box
+											sx={{
+												display: {
+													xs: 'block',
+													sm: 'none'
+												}
+											}}
+										>
+											<RegistrationFooterChip
+												label={selectedLabel}
+												icon={selectedIcon}
+												onDelete={onClearSelection}
+												mobile
+											/>
+											<Box
+												sx={{
+													display: 'flex',
+													alignItems: 'center',
+													gap: 1.5
+												}}
 											>
-												{t('registration.next')}
-											</Button>
-										)}
-									</Stack>
+												<RegistrationFooterBackLink
+													to={prevStepUrl}
+													onClick={onPrevClick}
+													label={t(
+														'registration.back'
+													)}
+												/>
+												<Box sx={{ flex: 1 }} />
+												<RegistrationFooterPrimaryButton
+													nextStepUrl={nextStepUrl}
+													disabledNextButton={
+														disabledNextButton
+													}
+													isRegistering={
+														isRegistering
+													}
+													onRegisterClick={
+														onRegisterClick
+													}
+													onNextClick={onNextClick}
+													registerLabel={t(
+														'registration.register'
+													)}
+													registeringLabel={t(
+														'registration.registering',
+														'Registering...'
+													)}
+													nextLabel={t(
+														'registration.next'
+													)}
+												/>
+											</Box>
+										</Box>
+									</Box>
 								</Box>
 							</form>
 						</Route>
@@ -534,5 +522,156 @@ export const Registration = () => {
 				</Box>
 			</StageLayout>
 		</>
+	);
+};
+
+const RegistrationFooterBackLink = ({
+	to,
+	onClick,
+	label
+}: {
+	to: string;
+	onClick: () => void;
+	label: string;
+}) => (
+	<Link
+		sx={{
+			textDecoration: 'none',
+			color: registrationMd3.onSurfaceVariant,
+			fontWeight: '700',
+			display: 'inline-flex',
+			alignItems: 'center',
+			gap: '8px',
+			whiteSpace: 'nowrap'
+		}}
+		component={RouterLink}
+		onClick={onClick}
+		to={to}
+	>
+		<ArrowBackRoundedIcon fontSize="small" />
+		{label}
+	</Link>
+);
+
+const RegistrationFooterChip = ({
+	label,
+	icon,
+	onDelete,
+	mobile = false
+}: {
+	label?: string | null;
+	icon?: string;
+	onDelete: () => void;
+	mobile?: boolean;
+}) => {
+	if (!label) {
+		return mobile ? null : <Box sx={{ minWidth: 0 }} />;
+	}
+
+	return (
+		<Box
+			sx={{
+				minWidth: 0,
+				overflow: 'hidden',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				mb: mobile ? 1.25 : 0
+			}}
+		>
+			<Chip
+				avatar={
+					icon ? (
+						<Avatar
+							src={icon}
+							alt=""
+							imgProps={{
+								loading: 'lazy',
+								decoding: 'async'
+							}}
+						/>
+					) : undefined
+				}
+				label={label}
+				onDelete={onDelete}
+				variant="outlined"
+				sx={{
+					'maxWidth': '100%',
+					'minWidth': 0,
+					'height': '42px',
+					'borderRadius': '999px',
+					'bgcolor': '#fff',
+					'fontWeight': 700,
+					'borderColor': registrationMd3.outlineVariant,
+					'& .MuiChip-label': {
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap'
+					},
+					'& .MuiChip-avatar': {
+						width: 28,
+						height: 28
+					}
+				}}
+			/>
+		</Box>
+	);
+};
+
+const RegistrationFooterPrimaryButton = ({
+	nextStepUrl,
+	disabledNextButton,
+	isRegistering,
+	onRegisterClick,
+	onNextClick,
+	registerLabel,
+	registeringLabel,
+	nextLabel
+}: {
+	nextStepUrl: string | null;
+	disabledNextButton?: boolean;
+	isRegistering: boolean;
+	onRegisterClick: () => void;
+	onNextClick: () => void;
+	registerLabel: string;
+	registeringLabel: string;
+	nextLabel: string;
+}) => {
+	const disabled = Boolean(disabledNextButton || isRegistering);
+	const buttonSx = {
+		'borderRadius': '999px',
+		'px': { xs: 3, md: 4 },
+		'py': 1.25,
+		'fontWeight': 800,
+		'minWidth': { xs: 150, md: 176 },
+		'boxShadow': disabled ? 'none' : '0 6px 18px rgba(164, 38, 46, 0.30)',
+		'&:hover': {
+			boxShadow: disabled ? 'none' : '0 8px 22px rgba(164, 38, 46, 0.40)'
+		}
+	};
+
+	return nextStepUrl ? (
+		<Button
+			data-cy="button-next"
+			disabled={disabledNextButton}
+			variant="contained"
+			onClick={onNextClick}
+			endIcon={<ArrowForwardRoundedIcon />}
+			sx={{ width: 'unset', ...buttonSx }}
+			type={disabledNextButton ? 'button' : 'submit'}
+		>
+			{nextLabel}
+		</Button>
+	) : (
+		<Button
+			data-cy="button-register"
+			disabled={disabled}
+			variant="contained"
+			onClick={onRegisterClick}
+			type={disabled ? 'button' : 'submit'}
+			sx={buttonSx}
+		>
+			{isRegistering ? registeringLabel : registerLabel}
+		</Button>
 	);
 };

--- a/src/components/registration/topicSelection/TopicSelection.tsx
+++ b/src/components/registration/topicSelection/TopicSelection.tsx
@@ -249,11 +249,15 @@ export const TopicSelection: FC<{
 						{listView
 							? [...(topics || [])]
 									.sort(compareTopicsByDisplayName)
-									.map((topic, index) => (
+									.map((topic, index, sortedTopics) => (
 										<TopicSelect
 											key={`${topic.id}`}
 											topics={topics}
 											index={index}
+											isLast={
+												index ===
+												sortedTopics.length - 1
+											}
 											topic={topic}
 											locale={locale}
 											checked={value === topic?.id}
@@ -298,7 +302,7 @@ export const TopicSelection: FC<{
 											sx={{
 												'boxShadow': 'none',
 												'border': `1px solid ${registrationMd3.outlineVariant}`,
-												'borderRadius': '16px',
+												'borderRadius': '32px',
 												'overflow': 'hidden',
 												'mb': '12px',
 												'backgroundColor':
@@ -382,35 +386,46 @@ export const TopicSelection: FC<{
 													.sort(
 														compareTopicsByDisplayName
 													)
-													.map((topic, index) => (
-														<TopicSelect
-															key={`${topicGroup.id}-${topic.id}`}
-															topics={topics}
-															index={index}
-															topic={topic}
-															locale={locale}
-															checked={
-																value ===
-																	topic.id &&
-																topicGroup.id ===
-																	topicGroupId
-															}
-															onChange={() => {
-																setValue(
-																	topic.id
-																);
-																setTopicGroupId(
-																	topicGroup.id
-																);
-																onChange({
-																	mainTopic:
-																		topic,
-																	topicGroupId:
-																		topicGroup?.id
-																});
-															}}
-														/>
-													))}
+													.map(
+														(
+															topic,
+															index,
+															sortedTopics
+														) => (
+															<TopicSelect
+																key={`${topicGroup.id}-${topic.id}`}
+																topics={topics}
+																index={index}
+																isLast={
+																	index ===
+																	sortedTopics.length -
+																		1
+																}
+																topic={topic}
+																locale={locale}
+																checked={
+																	value ===
+																		topic.id &&
+																	topicGroup.id ===
+																		topicGroupId
+																}
+																onChange={() => {
+																	setValue(
+																		topic.id
+																	);
+																	setTopicGroupId(
+																		topicGroup.id
+																	);
+																	onChange({
+																		mainTopic:
+																			topic,
+																		topicGroupId:
+																			topicGroup?.id
+																	});
+																}}
+															/>
+														)
+													)}
 											</AccordionDetails>
 										</Accordion>
 									)
@@ -422,7 +437,15 @@ export const TopicSelection: FC<{
 	);
 };
 
-const TopicSelect = ({ topics, topic, locale, index, onChange, checked }) => {
+const TopicSelect = ({
+	topics,
+	topic,
+	locale,
+	index,
+	isLast,
+	onChange,
+	checked
+}) => {
 	const display = getRegistrationTopicDisplay(topic, locale);
 
 	return (
@@ -503,7 +526,9 @@ const TopicSelect = ({ topics, topic, locale, index, onChange, checked }) => {
 							sx={{
 								width: 64,
 								height: 64,
-								borderRadius: '12px',
+								borderRadius: isLast
+									? '12px 12px 12px 32px'
+									: '12px',
 								bgcolor: 'transparent',
 								flexShrink: 0
 							}}

--- a/src/components/stage/stage.styles.scss
+++ b/src/components/stage/stage.styles.scss
@@ -38,6 +38,18 @@ $gridSpacing: $grid-base-four;
 	transition-delay: $animation-duration - $animation-duration-width;
 	text-align: center;
 	background-color: var(--m3-primary, $primary);
+	background:
+		radial-gradient(
+			circle at var(--stage-mx, 32%) var(--stage-my, 24%),
+			rgba(255, 255, 255, 0.22),
+			rgba(255, 255, 255, 0) 40%
+		),
+		radial-gradient(
+			560px circle at var(--stage-mx, 32%) var(--stage-my, 24%),
+			rgba(255, 138, 128, 0.34),
+			rgba(255, 138, 128, 0) 60%
+		),
+		linear-gradient(152deg, #da2530 0%, #c0121f 46%, #7c0d15 100%);
 	color: var(--m3-on-primary, $text-invert);
 	flex-direction: column;
 	align-items: center;

--- a/src/components/stage/stage.tsx
+++ b/src/components/stage/stage.tsx
@@ -39,7 +39,10 @@ export const Stage = ({
 
 	const legalLinks = useContext(LegalLinksContext);
 
-	const rootNodeRef = useRef(null);
+	const rootNodeRef = useRef<HTMLDivElement>(null);
+	const glowTargetRef = useRef({ x: 32, y: 24 });
+	const glowPositionRef = useRef({ x: 32, y: 24 });
+	const glowAnimationFrameRef = useRef<number | null>(null);
 
 	const [isOpen, setIsOpen] = useState(!hasAnimation);
 	const [hasAnimationFinished, setHasAnimationFinished] = useState(false);
@@ -54,11 +57,72 @@ export const Stage = ({
 		};
 
 		const rootNode = rootNodeRef.current;
+		if (!rootNode) {
+			return;
+		}
+
 		rootNode.addEventListener('transitionend', onTransitionEnd);
 		return () => {
 			rootNode.removeEventListener('transitionend', onTransitionEnd);
 		};
 	}, [hasAnimation, isReady]);
+
+	const animateStageGlow = useCallback(() => {
+		const rootNode = rootNodeRef.current;
+		if (!rootNode) {
+			glowAnimationFrameRef.current = null;
+			return;
+		}
+
+		const current = glowPositionRef.current;
+		const target = glowTargetRef.current;
+		const deltaX = target.x - current.x;
+		const deltaY = target.y - current.y;
+
+		current.x += deltaX * 0.06;
+		current.y += deltaY * 0.06;
+
+		rootNode.style.setProperty('--stage-mx', `${current.x.toFixed(2)}%`);
+		rootNode.style.setProperty('--stage-my', `${current.y.toFixed(2)}%`);
+
+		if (Math.abs(deltaX) > 0.02 || Math.abs(deltaY) > 0.02) {
+			glowAnimationFrameRef.current =
+				requestAnimationFrame(animateStageGlow);
+			return;
+		}
+
+		glowAnimationFrameRef.current = null;
+	}, []);
+
+	useEffect(
+		() => () => {
+			if (glowAnimationFrameRef.current !== null) {
+				cancelAnimationFrame(glowAnimationFrameRef.current);
+			}
+		},
+		[]
+	);
+
+	const handleStageMouseMove = useCallback(
+		(e: MouseEvent<HTMLDivElement>) => {
+			const rootNode = rootNodeRef.current;
+			if (!rootNode) {
+				return;
+			}
+
+			const rect = rootNode.getBoundingClientRect();
+			glowTargetRef.current = {
+				x: ((e.clientX - rect.left) / rect.width) * 100,
+				y: ((e.clientY - rect.top) / rect.height) * 100
+			};
+
+			if (glowAnimationFrameRef.current === null) {
+				glowAnimationFrameRef.current =
+					requestAnimationFrame(animateStageGlow);
+			}
+		},
+		[animateStageGlow]
+	);
 
 	const [ieBanner, setIeBanner] = useState(true);
 	const closeIeBanner = useCallback((e: MouseEvent<HTMLButtonElement>) => {
@@ -69,6 +133,7 @@ export const Stage = ({
 	return (
 		<div
 			ref={rootNodeRef}
+			onMouseMove={handleStageMouseMove}
 			className={clsx(className, 'stage', {
 				'stage--no-animation': !hasAnimation,
 				'stage--open': isOpen || !hasAnimation,

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -14,6 +14,7 @@ import { MENUPLACEMENT_BOTTOM_LEFT } from '../select/SelectDropdown';
 import {
 	AppBar,
 	Box,
+	Button as MuiButton,
 	Divider,
 	IconButton,
 	Slide,
@@ -21,7 +22,7 @@ import {
 	Typography,
 	useScrollTrigger
 } from '@mui/material';
-import LoginIcon from '@mui/icons-material/Login';
+import LoginRoundedIcon from '@mui/icons-material/LoginRounded';
 import { InfoDrawer } from '../registration/infoDrawer/InfoDrawer';
 
 interface StageLayoutProps {
@@ -51,6 +52,9 @@ export const StageLayout = ({
 	const { selectableLocales } = useContext(LocaleContext);
 	const { specificAgency } = useContext(AgencySpecificContext);
 	const settings = useAppConfig();
+	const loginUrl = `${settings.urls.toLogin}${
+		loginParams ? `?${loginParams}` : ''
+	}`;
 
 	return (
 		<div className={clsx('stageLayout', className)}>
@@ -82,15 +86,13 @@ export const StageLayout = ({
 
 							{showLoginLink && (
 								<IconButton
-									href={`${settings.urls.toLogin}${
-										loginParams ? `?${loginParams}` : ''
-									}`}
+									href={loginUrl}
 									edge="start"
 									color="inherit"
 									aria-label="menu"
 									sx={{ ml: '4px' }}
 								>
-									<LoginIcon color="inherit" />
+									<LoginRoundedIcon color="inherit" />
 								</IconButton>
 							)}
 						</Box>
@@ -138,24 +140,37 @@ export const StageLayout = ({
 							className="stageLayout__toLogin"
 							sx={{ display: { xs: 'none', md: 'block' } }}
 						>
-							<div className="stageLayout__toLogin__button">
-								<a
-									href={`${settings.urls.toLogin}${
-										loginParams ? `?${loginParams}` : ''
-									}`}
-									tabIndex={-1}
-								>
-									<Button
-										item={{
-											label: translate(
-												'registration.login.label'
-											),
-											type: 'TERTIARY'
-										}}
-										isLink
-									/>
-								</a>
-							</div>
+							<MuiButton
+								className="stageLayout__toLogin__button"
+								component="a"
+								href={loginUrl}
+								variant="outlined"
+								startIcon={<LoginRoundedIcon />}
+								sx={{
+									'minHeight': '48px',
+									'minWidth': '148px',
+									'borderRadius': '999px',
+									'px': 2.75,
+									'py': 1,
+									'fontSize': '16px',
+									'fontWeight': 700,
+									'lineHeight': 1.2,
+									'textTransform': 'none',
+									'color': 'var(--m3-on-surface, #1b1b1c)',
+									'borderColor':
+										'var(--m3-outline-variant, #c4c7c8)',
+									'backgroundColor':
+										'rgba(255, 255, 255, 0.92)',
+									'&:hover': {
+										borderColor:
+											'var(--m3-primary, #a4262e)',
+										backgroundColor:
+											'rgba(164, 38, 46, 0.04)'
+									}
+								}}
+							>
+								{translate('registration.login.label')}
+							</MuiButton>
 						</Box>
 					)}
 


### PR DESCRIPTION
## Problem
Production registration had the MD3 structure from #295, but a few prototype details were still missing or weaker than the accepted local design:

- left brand stage glow/gradient
- MD3 outlined login entry
- larger rounded topic group shells and final topic-icon corner treatment
- footer chip grid/truncation behavior, including a working clear X

Closes #296.

## Solution
- Added the layered brand-stage gradient/glow from the prototype, with an event-driven drift animation instead of a permanent animation loop.
- Switched the registration login entry to an MUI outlined icon button.
- Restored the larger rounded accordion shells and last-item icon radius behavior.
- Split the footer into small reusable components with the prototype's `auto minmax(0, 1fr) auto` layout and mobile stacked chip behavior.
- Remount the current step after clearing the footer chip so the radio state, chip state, and disabled Next state stay aligned.

## Validation
- `npx tsc --noEmit --pretty false`
- `npx eslint src/components/stage/stage.tsx src/components/stageLayout/StageLayout.tsx src/components/registration/Registration.tsx src/components/registration/topicSelection/TopicSelection.tsx`
- `npx stylelint src/components/stage/stage.styles.scss src/components/stageLayout/StageLayout.styles.scss` (only existing Browserslist notice)
- `npm run test:unit` (20 files, 179 tests)
- `CI=false npm run build` (successful; existing project warnings only)
- Local in-app Browser visual check at `http://127.0.0.1:9001/registration/topic-selection`: desktop and mobile topic selection, chip truncation/X clear, no horizontal overflow, no relevant console errors.

## Remaining Risk
Final validation still needs the merged `dev` image deployed to Pre-Dev, per the ORISO workflow.
