### PR TITLE
docs(frontend): add local UserService run guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,12 @@ REACT_APP_API_URL=https://api.oriso.org
 REACT_APP_DEV_REMOTE_API_URL=https://api.oriso.org
 
 # Optional service-specific origins for mixed local/dev work.
-# Leave unset to use REACT_APP_API_URL/VITE_API_URL for that service.
-# Example: run only userservice locally while all other services use dev/prod API ingress.
+# Leave unset/commented to use REACT_APP_API_URL/VITE_API_URL for that service.
+# Example: run only UserService locally while all other services use the remote API ingress.
 REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
-REACT_APP_TENANT_SERVICE_ORIGIN=https://api.oriso.org
-REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso.org
-REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso.org
+# REACT_APP_TENANT_SERVICE_ORIGIN=https://api.oriso.org
+# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso.org
+# REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso.org
 REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso.org
 
 # Disable error boundary handling 0/1 (for dev)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ npm run storybook
 
 Copy `.env.example` to `.env` and provide the environment values required by your local or deployment target.
 
+For the mixed local setup where only UserService runs locally, see
+[Local Development](./docs/local-development.md).
+
 ## Documentation
 
 Use these docs as the canonical references:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,73 @@
+# Local Development
+
+This setup runs the frontend on `localhost:9001`, points UserService calls to a local
+UserService on `localhost:8082`, and leaves all other APIs on the configured remote API ingress.
+
+## 1. Create `.env`
+
+Copy the sample file:
+
+```bash
+cp .env.example .env
+```
+
+For the ORISO dev environment, use these key values:
+
+```env
+PORT=9001
+WDS_SOCKET_PORT=9001
+BROWSER=none
+FAST_REFRESH=true
+
+REACT_APP_API_URL=https://api.oriso-dev.site
+REACT_APP_DEV_REMOTE_API_URL=https://api.oriso-dev.site
+
+# Local UserService. Remove/comment this line to use the broad API instead.
+REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
+
+# Optional service-specific overrides. Keep commented unless that service is local too.
+# REACT_APP_TENANT_SERVICE_ORIGIN=https://api.oriso-dev.site
+# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso-dev.site
+# REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso-dev.site
+
+REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso-dev.site
+REACT_APP_KEYCLOAK_REALM=online-beratung
+
+REACT_APP_MATRIX_HOMESERVER_URL=https://matrix.oriso-dev.site
+REACT_APP_ELEMENT_CALL_BASE_URL=https://call.oriso-dev.site
+REACT_APP_LIVEKIT_WS_URL=wss://livekit.oriso-dev.site
+
+REACT_APP_COOKIE_DOMAIN=
+REACT_APP_HOSTNAMES_WITHOUT_COOKIE_DOMAIN=localhost,127.0.0.1
+REACT_APP_USE_HTTPS=false
+REACT_APP_DISABLE_LIVE_WEBSOCKET=1
+REACT_APP_DISABLE_ERROR_BOUNDARY=1
+REACT_APP_COOKIES_ALLOWEDLIST=devProxy
+CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-WHITELIST-HEADER
+```
+
+## 2. Install dependencies
+
+```bash
+npm ci --legacy-peer-deps
+```
+
+## 3. Run
+
+```bash
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:9001
+```
+
+## Routing Behavior
+
+- `REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082` sends UserService, Matrix token,
+  message, and session calls to the local UserService.
+- If `REACT_APP_USER_SERVICE_ORIGIN` is absent, those calls fall back to `REACT_APP_API_URL`.
+- Keep the other service-specific origins commented unless you are also running those services
+  locally.


### PR DESCRIPTION
## Summary
- add a local development guide for running the frontend with local UserService
- document the minimal `.env` values for `localhost:9001` + `localhost:8082`
- keep optional service-specific origins commented in `.env.example` so other services continue to use the broad API unless explicitly overridden

## Validation
- documentation/config-only change; no runtime code changed