### PR TITLE
docs(frontend): align env example with dev local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,24 @@
 VITE_PORT=9002
-VITE_API_URL=https://api.oriso.org
+VITE_API_URL=https://api.oriso-dev.site
 VITE_USE_API_URL=true
-VITE_USE_HTTPS=true
+VITE_USE_HTTPS=false
 VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-CSRF-Token
 
 # API Url (production / Docker runtime). For local `npm run dev`, leave empty —
 # the dev-server proxies /service to REACT_APP_DEV_REMOTE_API_URL instead.
-REACT_APP_API_URL=https://api.oriso.org
+REACT_APP_API_URL=https://api.oriso-dev.site
 
 # Remote cluster used by the local dev-server API proxy (see proxy/routes/api.js)
-REACT_APP_DEV_REMOTE_API_URL=https://api.oriso.org
+REACT_APP_DEV_REMOTE_API_URL=https://api.oriso-dev.site
 
 # Optional service-specific origins for mixed local/dev work.
 # Leave unset/commented to use REACT_APP_API_URL/VITE_API_URL for that service.
 # Example: run only UserService locally while all other services use the remote API ingress.
 REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
-# REACT_APP_TENANT_SERVICE_ORIGIN=https://api.oriso.org
-# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso.org
-# REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso.org
-REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso.org
+# REACT_APP_TENANT_SERVICE_ORIGIN=https://api.oriso-dev.site
+# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso-dev.site
+# REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso-dev.site
+REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso-dev.site
 
 # Disable error boundary handling 0/1 (for dev)
 REACT_APP_DISABLE_ERROR_BOUNDARY=1
@@ -30,11 +30,11 @@ REACT_APP_COOKIES_ALLOWEDLIST=devProxy
 CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-WHITELIST-HEADER
 
 # Matrix Synapse / client homeserver (HTTPS in production)
-REACT_APP_MATRIX_HOMESERVER_URL=https://matrix.oriso.site
-VITE_MATRIX_HOMESERVER_URL=https://matrix.oriso.site
+REACT_APP_MATRIX_HOMESERVER_URL=https://matrix.oriso-dev.site
+VITE_MATRIX_HOMESERVER_URL=https://matrix.oriso-dev.site
 
 # Cookie domain for cross-subdomain sharing
-REACT_APP_COOKIE_DOMAIN=.oriso.site
+REACT_APP_COOKIE_DOMAIN=
 
 # Keycloak realm (must match backend / auth gateway configuration)
 REACT_APP_KEYCLOAK_REALM=online-beratung
@@ -43,13 +43,14 @@ REACT_APP_KEYCLOAK_REALM=online-beratung
 REACT_APP_HOSTNAMES_WITHOUT_COOKIE_DOMAIN=localhost,127.0.0.1
 
 # Element Web (classic vs new UI redirect target)
-REACT_APP_ELEMENT_URL=https://element.oriso.site
+REACT_APP_ELEMENT_URL=https://element.oriso-dev.site
 
 # Element Call deployment base URL (no trailing slash)
-REACT_APP_ELEMENT_CALL_BASE_URL=https://call.oriso.site
+REACT_APP_ELEMENT_CALL_BASE_URL=https://call.oriso-dev.site
 
 # LiveKit WebSocket URL (wss:// in production)
-REACT_APP_LIVEKIT_WS_URL=wss://livekit.oriso.site
+REACT_APP_LIVEKIT_WS_URL=wss://livekit.oriso-dev.site
+REACT_APP_DISABLE_LIVE_WEBSOCKET=1
 
 # Public / legal / marketing links (override for white-label)
 REACT_APP_ORGANIZATION_HOME_URL=https://www.caritas.de
@@ -63,7 +64,7 @@ REACT_APP_BROWSER_DOWNLOAD_EDGE_URL=https://www.microsoft.com/edge
 REACT_APP_BROWSER_DOWNLOAD_SAFARI_URL=https://www.apple.com/de/safari/
 
 # HTTPS flag for secure cookies
-REACT_APP_USE_HTTPS=true
+REACT_APP_USE_HTTPS=false
 
 # Node proxy only: LiveKit token service (GET and POST /api/livekit/token)
 # Example for Kubernetes: http://livekit-token-service.caritas.svc.cluster.local:3010


### PR DESCRIPTION
## Summary
- point `.env.example` at the ORISO dev API/auth/Matrix/Call/LiveKit hosts for local development
- keep UserService local override enabled and other service overrides commented
- set local cookie/HTTPS values for localhost and disable LiveService websocket by default for the mixed local setup

## Validation
- documentation/sample-config-only change; no runtime code changed