### PR TITLE
docs(frontend): set dev server port in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+PORT=9001
+WDS_SOCKET_PORT=9001
+BROWSER=none
+FAST_REFRESH=true
+
 VITE_PORT=9002
 VITE_API_URL=https://api.oriso-dev.site
 VITE_USE_API_URL=true


### PR DESCRIPTION
## Summary
- add `PORT=9001` to `.env.example` so `npm run dev` starts on the expected localhost port
- include `WDS_SOCKET_PORT`, `BROWSER`, and `FAST_REFRESH` for the documented local setup

## Validation
- sample-config-only change; no runtime code changed