### PR TITLE
fix(frontend): allow local dev proxy cert toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ REACT_APP_API_URL=https://api.oriso-dev.site
 
 # Remote cluster used by the local dev-server API proxy (see proxy/routes/api.js)
 REACT_APP_DEV_REMOTE_API_URL=https://api.oriso-dev.site
+# Local dev only: set false if Node cannot verify the dev API certificate chain.
+REACT_APP_DEV_PROXY_SECURE=false
 
 # Optional service-specific origins for mixed local/dev work.
 # Leave unset/commented to use REACT_APP_API_URL/VITE_API_URL for that service.

--- a/proxy/routes/api.js
+++ b/proxy/routes/api.js
@@ -21,11 +21,15 @@ const resolveRemoteApiTarget = () =>
 const resolveRemoteFrontendOrigin = () =>
 	normalizeTarget(process.env.REACT_APP_DEV_REMOTE_FRONTEND_ORIGIN);
 
+const shouldVerifyProxyCertificate = () =>
+	String(process.env.REACT_APP_DEV_PROXY_SECURE || 'true').toLowerCase() !==
+	'false';
+
 const createRemoteProxy = (target) =>
 	createProxyMiddleware({
 		target,
 		changeOrigin: true,
-		secure: true,
+		secure: shouldVerifyProxyCertificate(),
 		logLevel: 'warn',
 		onProxyReq: (proxyReq) => {
 			const remoteFrontendOrigin = resolveRemoteFrontendOrigin();


### PR DESCRIPTION
## Summary\n- add a local dev proxy certificate verification toggle\n- document REACT_APP_DEV_PROXY_SECURE=false in .env.example for dev API certificate-chain issues\n\n## Verification\n- npm run dev\n- curl http://localhost:9001/service/settings returned 200\n- refreshed localhost:9001 in the in-app browser and confirmed the app reached /login without console errors