### PR TITLE
fix: clear enquiry composer draft after send

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -1799,6 +1799,8 @@ export const MessageSubmitInterfaceComponent = ({
 					setEditorState(EditorState.createEmpty());
 					setComposerText('');
 					composerRef.current?.clear();
+					clearDraftMessage();
+					setActiveInfo('');
 				})
 				.then(() => setIsRequestInProgress(false))
 				.catch((error) => {
@@ -1810,6 +1812,7 @@ export const MessageSubmitInterfaceComponent = ({
 			encryptRoom,
 			language,
 			onSendButton,
+			clearDraftMessage,
 			setE2EEState
 		]
 	);

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -1795,11 +1795,11 @@ export const MessageSubmitInterfaceComponent = ({
 						onSendButton && onSendButton(response);
 					})
 				)
-				.then(() => {
+				.then(async () => {
 					setEditorState(EditorState.createEmpty());
 					setComposerText('');
 					composerRef.current?.clear();
-					clearDraftMessage();
+					await clearDraftMessage();
 					setActiveInfo('');
 				})
 				.then(() => setIsRequestInProgress(false))

--- a/src/components/messageSubmitInterface/useDraftMessage.test.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import React, { PropsWithChildren } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { ActiveSessionContext, E2EEContext } from '../../globalState';
+import { useDraftMessage } from './useDraftMessage';
+
+type DraftPayload = {
+	text?: string;
+	[key: string]: unknown;
+};
+
+type DeleteDraftMock = (scopeKey: string) => Promise<void>;
+type GetDraftMock = (
+	scopeKey: string,
+	signal?: AbortSignal
+) => Promise<DraftPayload>;
+type UpsertDraftMock = (
+	scopeKey: string,
+	payload: DraftPayload
+) => Promise<void>;
+
+const mocks = vi.hoisted(() => {
+	const env = process.env as Record<string, string>;
+	env.REACT_APP_API_URL = 'http://localhost:9001';
+	env.REACT_APP_KEYCLOAK_REALM = 'oriso';
+
+	return {
+		apiDeleteUserDraft: vi.fn<DeleteDraftMock>(() => Promise.resolve()),
+		apiGetUserDraft: vi.fn<GetDraftMock>(() =>
+			Promise.reject({ message: 'EMPTY' })
+		),
+		apiUpsertUserDraft: vi.fn<UpsertDraftMock>(() => Promise.resolve())
+	};
+});
+
+vi.mock('../../api', () => ({
+	apiDeleteUserDraft: (scopeKey: string) =>
+		mocks.apiDeleteUserDraft(scopeKey),
+	apiGetUserDraft: (scopeKey: string, signal?: AbortSignal) =>
+		mocks.apiGetUserDraft(scopeKey, signal),
+	apiUpsertUserDraft: (scopeKey: string, payload: DraftPayload) =>
+		mocks.apiUpsertUserDraft(scopeKey, payload),
+	FETCH_ERRORS: { EMPTY: 'EMPTY' }
+}));
+
+vi.mock('../../api/apiPostError', () => ({
+	apiPostError: vi.fn(() => Promise.resolve()),
+	ERROR_LEVEL_WARN: 'warn'
+}));
+
+vi.mock('../../globalState', async () => {
+	const ReactModule = await import('react');
+
+	return {
+		ActiveSessionContext: ReactModule.createContext({
+			activeSession: null,
+			reloadActiveSession: vi.fn(),
+			readActiveSession: vi.fn()
+		}),
+		E2EEContext: ReactModule.createContext({
+			e2EEReady: true,
+			isE2eeEnabled: false,
+			key: null,
+			reloadPrivateKey: vi.fn()
+		})
+	};
+});
+
+vi.mock('../../hooks/useE2EE', () => ({
+	useE2EE: () => ({
+		encrypted: false,
+		key: null,
+		keyID: null,
+		ready: true
+	})
+}));
+
+const wrapper = ({ children }: PropsWithChildren<{}>) => (
+	<E2EEContext.Provider
+		value={{
+			e2EEReady: true,
+			isE2eeEnabled: false,
+			key: null,
+			reloadPrivateKey: vi.fn()
+		}}
+	>
+		<ActiveSessionContext.Provider
+			value={{
+				activeSession: {
+					item: { id: 42 },
+					rid: '!room:matrix.test'
+				} as any,
+				reloadActiveSession: vi.fn(),
+				readActiveSession: vi.fn()
+			}}
+		>
+			{children}
+		</ActiveSessionContext.Provider>
+	</E2EEContext.Provider>
+);
+
+describe('useDraftMessage', () => {
+	beforeEach(() => {
+		mocks.apiDeleteUserDraft.mockClear();
+		mocks.apiGetUserDraft.mockClear();
+		mocks.apiUpsertUserDraft.mockClear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('cancels pending autosave when clearing a sent draft', async () => {
+		const loadDraft = vi.fn();
+
+		const { result, unmount } = renderHook(
+			() =>
+				useDraftMessage(true, loadDraft, {
+					forcedScopeKey: 'scope:session-42|thread:main'
+				}),
+			{ wrapper }
+		);
+
+		await waitFor(() => expect(result.current.loaded).toBe(true));
+
+		vi.useFakeTimers();
+
+		act(() => {
+			result.current.onChange('<p>Sent enquiry text</p>');
+		});
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		act(() => {
+			result.current.clearDraftMessage();
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1600);
+		});
+
+		const staleDraftSave = mocks.apiUpsertUserDraft.mock.calls.find(
+			([scopeKey, payload]) =>
+				scopeKey === 'scope:session-42|thread:main' &&
+				payload?.text === '<p>Sent enquiry text</p>'
+		);
+
+		expect(staleDraftSave).toBeUndefined();
+		expect(mocks.apiDeleteUserDraft).toHaveBeenCalledWith(
+			'scope:session-42|thread:main'
+		);
+
+		unmount();
+	});
+});

--- a/src/components/messageSubmitInterface/useDraftMessage.test.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.test.tsx
@@ -134,12 +134,16 @@ describe('useDraftMessage', () => {
 			await Promise.resolve();
 		});
 
-		act(() => {
-			result.current.clearDraftMessage();
+		await act(async () => {
+			await result.current.clearDraftMessage();
 		});
 
 		await act(async () => {
 			await vi.advanceTimersByTimeAsync(1600);
+		});
+
+		act(() => {
+			unmount();
 		});
 
 		const staleDraftSave = mocks.apiUpsertUserDraft.mock.calls.find(
@@ -152,7 +156,5 @@ describe('useDraftMessage', () => {
 		expect(mocks.apiDeleteUserDraft).toHaveBeenCalledWith(
 			'scope:session-42|thread:main'
 		);
-
-		unmount();
 	});
 });

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -51,7 +51,7 @@ export const useDraftMessage = (
 
 	const [loaded, setLoaded] = useState(false);
 	const [messageRes, setMessageRes] = useState<IUserDraftItem>(null);
-	const [message, setMessage] = useState(null);
+	const [, setMessage] = useState(null);
 	const threadKey = options?.threadRootId || 'main';
 	const roomScopeKey = activeSession?.rid
 		? `scope:${String(activeSession.rid)}|thread:${threadKey}`
@@ -209,6 +209,7 @@ export const useDraftMessage = (
 		if (!isE2eeEnabled || !encrypted) {
 			if (decryptLoadVersion === loadVersionRef.current) {
 				setEditorWithDraftString(messageRes.text);
+				latestMessageRef.current = messageRes.text || '';
 				setMessage(messageRes.text);
 				setLoaded(true);
 			}
@@ -226,6 +227,7 @@ export const useDraftMessage = (
 					return;
 				}
 				setEditorWithDraftString(msg);
+				latestMessageRef.current = msg || '';
 				setMessage(msg);
 				setLoaded(true);
 			});
@@ -325,15 +327,10 @@ export const useDraftMessage = (
 	);
 
 	const saveDraftMessageRef = useRef(saveDraftMessage);
-	const messageRef = useRef(message);
 
 	useEffect(() => {
 		saveDraftMessageRef.current = saveDraftMessage;
 	}, [saveDraftMessage]);
-
-	useEffect(() => {
-		messageRef.current = message;
-	}, [message]);
 
 	const onLogout = useCallback(
 		async (args) => {
@@ -345,10 +342,10 @@ export const useDraftMessage = (
 				skipNextCleanupSaveRef.current = false;
 				return args;
 			}
-			await saveDraftMessage(latestMessageRef.current || message);
+			await saveDraftMessage(latestMessageRef.current);
 			return args;
 		},
-		[message, saveDraftMessage]
+		[saveDraftMessage]
 	);
 
 	useEffect(() => {
@@ -369,13 +366,11 @@ export const useDraftMessage = (
 				skipNextCleanupSaveRef.current = false;
 				return;
 			}
-			saveDraftMessageRef
-				.current(latestMessageRef.current || messageRef.current)
-				.then();
+			saveDraftMessageRef.current(latestMessageRef.current).then();
 		};
 	}, []);
 
-	const clearDraftMessage = useCallback(() => {
+	const clearDraftMessage = useCallback(async () => {
 		if (draftSaveTimeout.current) {
 			clearTimeout(draftSaveTimeout.current);
 			draftSaveTimeout.current = null;
@@ -383,10 +378,12 @@ export const useDraftMessage = (
 		latestMessageRef.current = '';
 		skipNextCleanupSaveRef.current = true;
 		if (canUseRemoteApi) {
-			scopeKeysToTry.forEach((scopeKey) => {
-				void apiDeleteUserDraft(scopeKey);
-			});
-			void updateRemoteDraftIndex('');
+			await Promise.allSettled([
+				...scopeKeysToTry.map((scopeKey) =>
+					apiDeleteUserDraft(scopeKey)
+				),
+				updateRemoteDraftIndex('')
+			]);
 		}
 		setMessage('');
 	}, [canUseRemoteApi, scopeKeysToTry, updateRemoteDraftIndex]);

--- a/src/components/messageSubmitInterface/useDraftMessage.tsx
+++ b/src/components/messageSubmitInterface/useDraftMessage.tsx
@@ -45,6 +45,7 @@ export const useDraftMessage = (
 	const draftSaveTimeout = useRef(null);
 	const loadVersionRef = useRef(0);
 	const latestMessageRef = useRef<string>('');
+	const skipNextCleanupSaveRef = useRef(false);
 
 	const { keyID, key, encrypted, ready } = useE2EE(activeSession.rid);
 
@@ -308,6 +309,7 @@ export const useDraftMessage = (
 				return;
 			}
 
+			skipNextCleanupSaveRef.current = false;
 			latestMessageRef.current = markdownMessage || '';
 			setMessage(markdownMessage);
 
@@ -322,11 +324,26 @@ export const useDraftMessage = (
 		[loaded, saveDraftMessage]
 	);
 
+	const saveDraftMessageRef = useRef(saveDraftMessage);
+	const messageRef = useRef(message);
+
+	useEffect(() => {
+		saveDraftMessageRef.current = saveDraftMessage;
+	}, [saveDraftMessage]);
+
+	useEffect(() => {
+		messageRef.current = message;
+	}, [message]);
+
 	const onLogout = useCallback(
 		async (args) => {
 			if (draftSaveTimeout.current) {
 				clearTimeout(draftSaveTimeout.current);
 				draftSaveTimeout.current = null;
+			}
+			if (skipNextCleanupSaveRef.current) {
+				skipNextCleanupSaveRef.current = false;
+				return args;
 			}
 			await saveDraftMessage(latestMessageRef.current || message);
 			return args;
@@ -348,11 +365,23 @@ export const useDraftMessage = (
 				clearTimeout(draftSaveTimeout.current);
 				draftSaveTimeout.current = null;
 			}
-			saveDraftMessage(latestMessageRef.current || message).then();
+			if (skipNextCleanupSaveRef.current) {
+				skipNextCleanupSaveRef.current = false;
+				return;
+			}
+			saveDraftMessageRef
+				.current(latestMessageRef.current || messageRef.current)
+				.then();
 		};
-	}, [message, saveDraftMessage]);
+	}, []);
 
 	const clearDraftMessage = useCallback(() => {
+		if (draftSaveTimeout.current) {
+			clearTimeout(draftSaveTimeout.current);
+			draftSaveTimeout.current = null;
+		}
+		latestMessageRef.current = '';
+		skipNextCleanupSaveRef.current = true;
 		if (canUseRemoteApi) {
 			scopeKeysToTry.forEach((scopeKey) => {
 				void apiDeleteUserDraft(scopeKey);


### PR DESCRIPTION
## Problem

Pre-Dev E2E validation showed that the first enquiry message is sent successfully, but the composer keeps the sent text in the editor. That leaves the send button enabled and can restore a stale draft after send.

Closes #311

## Solution

- Clear the draft hook state after successful enquiry send.
- Cancel pending draft autosave timers when a draft is deliberately cleared.
- Move cleanup saving to unmount-only refs so normal message changes do not bypass the debounce.
- Guard deliberate clears from stale cleanup/logout saves.
- Add a focused hook regression test for the clear/autosave race.

## Validation

- `npm run test:unit -- useDraftMessage messageSubmitInterface composerMessageSnapshot SendMessageButton`
- `npm run lint:scripts`
- `npm run build`

## Pre-Dev validation plan

After merge and image build, deploy the frontend to Pre-Dev and re-run the registration → enquiry send flow. The composer should be empty, the counter reset, and the send button disabled after the message appears once in the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing a sent draft now prevents it from being saved again during autosave, logout, or unmount.
  * After sending an enquiry, the composer now fully resets its saved draft and status display, reducing leftover content or stale UI state.

* **Tests**
  * Added coverage for draft-clearing behavior to ensure sent text is not restored by pending autosave activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->