### PR TITLE
Fix registration footer edge padding

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -523,7 +523,7 @@ export const Registration = () => {
 										px: {
 											xs: '16px',
 											md: '32px',
-											lg: '0'
+											lg: '16px'
 										},
 										width: { xs: '100vw', lg: '60vw' },
 										backgroundColor:


### PR DESCRIPTION
## Summary
- add a small desktop horizontal padding to the sticky registration footer
- keep existing mobile and tablet footer spacing untouched

## Tests
- npm run lint:scripts
- npm run build

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)