### PR TITLE
Fix registration back button footer padding

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -673,7 +673,7 @@ const RegistrationFooterBackLink = ({
 			'whiteSpace': 'nowrap',
 			'px': { xs: 0.5, sm: 1, md: 1.25 },
 			'py': { xs: 0.75, sm: 1 },
-			'mx': { xs: -0.5, sm: -1, md: -1.25 },
+			'mx': { xs: -0.5, sm: 0 },
 			'borderRadius': '999px',
 			'&:hover': {
 				backgroundColor: registrationMd3.hoverLayer


### PR DESCRIPTION
## Summary
- remove the negative desktop margin from the registration footer back link
- keep the mobile touch-target offset intact

## Tests
- npm run lint:scripts
- npm run build

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)