### PR TITLE
fix(registration): keep auth navigation in app shell

### DIFF
--- a/src/components/form/OrisoTextField.tsx
+++ b/src/components/form/OrisoTextField.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { TextField, TextFieldProps } from '@mui/material';
+import { orisoTextFieldSx } from './orisoInputDesign';
+
+const mergeTextFieldSx = (sx?: TextFieldProps['sx']): TextFieldProps['sx'] => {
+	if (!sx) {
+		return orisoTextFieldSx;
+	}
+
+	return [
+		orisoTextFieldSx,
+		...(Array.isArray(sx) ? sx : [sx])
+	] as TextFieldProps['sx'];
+};
+
+export const OrisoTextField = ({ sx, ...props }: TextFieldProps) => (
+	<TextField {...props} sx={mergeTextFieldSx(sx)} />
+);

--- a/src/components/form/orisoInputDesign.ts
+++ b/src/components/form/orisoInputDesign.ts
@@ -1,0 +1,81 @@
+export const orisoInputColors = {
+	onSurface: '#1b1b1c',
+	onSurfaceVariant: '#444748',
+	outline: '#74777b',
+	outlineVariant: '#c4c7c8',
+	surface: '#ffffff',
+	surfaceContainerLowest: '#ffffff',
+	surfaceContainerLow: '#f7f4f4',
+	surfaceContainer: '#f1eeee',
+	surfaceContainerHigh: '#ebe8e8',
+	secondary: '#4c555f',
+	onSecondary: '#ffffff',
+	primary: '#a4262e',
+	onPrimary: '#ffffff',
+	primaryDark: '#7e1d23',
+	error: '#b1005e',
+	focus: '#2d6f7b',
+	focusLayer: 'rgba(45, 111, 123, 0.12)',
+	selectedLayer: 'rgba(164, 38, 46, 0.08)',
+	hoverLayer: 'rgba(27, 27, 28, 0.04)'
+} as const;
+
+const orisoInputAutofill = '#e8f0fe';
+
+export const orisoTextFieldSx = {
+	'& .MuiOutlinedInput-root': {
+		'borderRadius': '12px',
+		'backgroundColor': orisoInputColors.surfaceContainerLowest,
+		'color': orisoInputColors.onSurface,
+		'fontSize': 17,
+		'transition':
+			'border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease',
+		'& fieldset': {
+			borderColor: orisoInputColors.outlineVariant
+		},
+		'&:hover fieldset': {
+			borderColor: orisoInputColors.outline
+		},
+		'&.Mui-focused': {
+			boxShadow: `0 0 0 4px ${orisoInputColors.focusLayer}`
+		},
+		'&.Mui-focused fieldset': {
+			borderColor: orisoInputColors.focus,
+			borderWidth: 2
+		},
+		'&.Mui-error fieldset': {
+			borderColor: orisoInputColors.error,
+			borderWidth: 2
+		},
+		'&:has(input:-webkit-autofill)': {
+			backgroundColor: orisoInputAutofill
+		}
+	},
+	'& .MuiInputBase-input': {
+		'paddingTop': '16px',
+		'paddingBottom': '16px',
+		'&:-webkit-autofill': {
+			WebkitBoxShadow: `0 0 0 100px ${orisoInputAutofill} inset`,
+			WebkitTextFillColor: orisoInputColors.onSurface,
+			caretColor: orisoInputColors.onSurface,
+			transition: 'background-color 9999s ease-out 0s'
+		},
+		'&::placeholder': {
+			color: orisoInputColors.onSurfaceVariant,
+			opacity: 1
+		}
+	},
+	'& .MuiInputAdornment-root': {
+		color: orisoInputColors.onSurfaceVariant
+	},
+	'& .MuiFormHelperText-root': {
+		marginLeft: 0,
+		marginTop: '8px',
+		fontSize: '14px',
+		lineHeight: '20px',
+		color: orisoInputColors.onSurfaceVariant
+	},
+	'& .MuiFormHelperText-root.Mui-error': {
+		color: `${orisoInputColors.error} !important`
+	}
+} as const;

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,6 +1,13 @@
 import '../../polyfill';
 import * as React from 'react';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState
+} from 'react';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { Button, BUTTON_TYPES, ButtonItem } from '../button/Button';
 import { autoLogin, redirectToApp } from '../registration/autoLogin';
@@ -86,6 +93,7 @@ export const Login = () => {
 	const [activeLoginMethod] = useState<LoginMethod>('password');
 	const [username, setUsername] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
+	const passwordInputRef = useRef<HTMLInputElement>(null);
 	const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 	const [magicLinkUsername, setMagicLinkUsername] = useState<string>('');
 	const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(
@@ -539,6 +547,7 @@ export const Login = () => {
 										error={labelState === VALIDITY_INVALID}
 										fullWidth
 										autoComplete="current-password"
+										inputRef={passwordInputRef}
 										inputProps={{
 											'aria-label': translate(
 												'login.password.label'
@@ -558,12 +567,19 @@ export const Login = () => {
 												<InputAdornment position="end">
 													<IconButton
 														type="button"
-														onClick={() =>
+														onMouseDown={(event) =>
+															event.preventDefault()
+														}
+														onClick={() => {
 															setIsPasswordVisible(
 																(isVisible) =>
 																	!isVisible
-															)
-														}
+															);
+															window.requestAnimationFrame(
+																() =>
+																	passwordInputRef.current?.focus()
+															);
+														}}
 														edge="end"
 														aria-label={translate(
 															isPasswordVisible

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,11 +1,6 @@
 import '../../polyfill';
 import * as React from 'react';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import {
-	InputField,
-	InputFieldItem,
-	InputFieldLabelState
-} from '../inputField/InputField';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { Button, BUTTON_TYPES, ButtonItem } from '../button/Button';
 import { autoLogin, redirectToApp } from '../registration/autoLogin';
@@ -13,6 +8,8 @@ import { Text } from '../text/Text';
 import { ReactComponent as PersonIcon } from '../../resources/img/icons/person.svg';
 import { ReactComponent as LockIcon } from '../../resources/img/icons/lock.svg';
 import { ReactComponent as VerifiedIcon } from '../../resources/img/icons/verified.svg';
+import { ReactComponent as ShowPasswordIcon } from '../../resources/img/icons/eye.svg';
+import { ReactComponent as HidePasswordIcon } from '../../resources/img/icons/eye-closed.svg';
 import { StageLayout } from '../stageLayout/StageLayout';
 import { apiGetUserData, FETCH_ERRORS } from '../../api';
 import {
@@ -56,8 +53,12 @@ import { budibaseLogout } from '../budibase/budibaseLogout';
 import { GlobalComponentContext } from '../../globalState/provider/GlobalComponentContext';
 import { UrlParamsContext } from '../../globalState/provider/UrlParamsProvider';
 import { setTokens } from '../auth/auth';
+import { IconButton, InputAdornment } from '@mui/material';
+import { OrisoTextField } from '../form/OrisoTextField';
+import { orisoInputColors } from '../form/orisoInputDesign';
 
 const regexAccountDeletedError = /account disabled/i;
+type LoginFieldLabelState = typeof VALIDITY_INVALID | null;
 
 export const Login = () => {
 	type LoginMethod = 'password' | 'magicLink';
@@ -81,10 +82,11 @@ export const Login = () => {
 	const hasTenant = tenant != null;
 
 	const { consultant, loaded: isReady } = useContext(UrlParamsContext);
-	const [labelState, setLabelState] = useState<InputFieldLabelState>(null);
+	const [labelState, setLabelState] = useState<LoginFieldLabelState>(null);
 	const [activeLoginMethod] = useState<LoginMethod>('password');
 	const [username, setUsername] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
+	const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 	const [magicLinkUsername, setMagicLinkUsername] = useState<string>('');
 	const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(
 		username.length > 0 && password.length > 0
@@ -139,52 +141,6 @@ export const Login = () => {
 	const [twoFactorType, setTwoFactorType] = useState<TwoFactorType>(
 		TWO_FACTOR_TYPES.NONE
 	);
-
-	const inputItemUsername: InputFieldItem = {
-		name: 'username',
-		class: 'login',
-		id: 'username',
-		type: 'text',
-		label: translate('login.user.label'),
-		content: username,
-		icon: <PersonIcon />,
-		...(labelState && { labelState })
-	};
-
-	const inputItemMagicLinkUsername: InputFieldItem = {
-		name: 'magicLinkUsername',
-		class: 'login',
-		id: 'magicLinkUsername',
-		type: 'text',
-		label: translate('login.magicLink.usernameLabel'),
-		content: magicLinkUsername,
-		icon: <PersonIcon />
-	};
-
-	const inputItemPassword: InputFieldItem = {
-		name: 'password',
-		id: 'passwordInput',
-		type: 'password',
-		label: translate('login.password.label'),
-		content: password,
-		icon: <LockIcon />,
-		...(labelState && { labelState })
-	};
-
-	const otpInputItem: InputFieldItem = {
-		content: otp,
-		id: 'otp',
-		infoText:
-			twoFactorType === TWO_FACTOR_TYPES.APP
-				? translate(`login.warning.failed.app.otp.missing`)
-				: '',
-		label: translate('twoFactorAuth.activate.otp.input.label.text'),
-		name: 'otp',
-		type: 'text',
-		icon: <VerifiedIcon />,
-		maxLength: OTP_LENGTH,
-		tabIndex: isOtpRequired ? 0 : -1
-	};
 
 	const handleUsernameChange = (event) => {
 		setUsername(event.target.value);
@@ -506,26 +462,138 @@ export const Login = () => {
 									type="infoSmall"
 								/>
 							) : (
-								<InputField
-									item={
+								<OrisoTextField
+									id={
 										activeLoginMethod === 'password'
-											? inputItemUsername
-											: inputItemMagicLinkUsername
+											? 'username'
+											: 'magicLinkUsername'
 									}
-									inputHandle={
+									name={
+										activeLoginMethod === 'password'
+											? 'username'
+											: 'magicLinkUsername'
+									}
+									type="text"
+									value={
+										activeLoginMethod === 'password'
+											? username
+											: magicLinkUsername
+									}
+									onChange={
 										activeLoginMethod === 'password'
 											? handleUsernameChange
 											: handleMagicLinkUsernameChange
 									}
-									keyUpHandle={handleKeyUp}
+									onKeyUp={handleKeyUp}
+									placeholder={
+										activeLoginMethod === 'password'
+											? translate('login.user.label')
+											: translate(
+													'login.magicLink.usernameLabel'
+												)
+									}
+									error={
+										activeLoginMethod === 'password' &&
+										labelState === VALIDITY_INVALID
+									}
+									fullWidth
+									autoComplete="username"
+									inputProps={{
+										'aria-label':
+											activeLoginMethod === 'password'
+												? translate('login.user.label')
+												: translate(
+														'login.magicLink.usernameLabel'
+													)
+									}}
+									InputProps={{
+										startAdornment: (
+											<InputAdornment position="start">
+												<PersonIcon
+													color={
+														orisoInputColors.onSurfaceVariant
+													}
+												/>
+											</InputAdornment>
+										)
+									}}
+									sx={{ mb: '20px' }}
 								/>
 							)}
 							{activeLoginMethod === 'password' && (
 								<>
-									<InputField
-										item={inputItemPassword}
-										inputHandle={handlePasswordChange}
-										keyUpHandle={handleKeyUp}
+									<OrisoTextField
+										id="passwordInput"
+										name="password"
+										type={
+											isPasswordVisible
+												? 'text'
+												: 'password'
+										}
+										value={password}
+										onChange={handlePasswordChange}
+										onKeyUp={handleKeyUp}
+										placeholder={translate(
+											'login.password.label'
+										)}
+										error={labelState === VALIDITY_INVALID}
+										fullWidth
+										autoComplete="current-password"
+										inputProps={{
+											'aria-label': translate(
+												'login.password.label'
+											)
+										}}
+										InputProps={{
+											startAdornment: (
+												<InputAdornment position="start">
+													<LockIcon
+														color={
+															orisoInputColors.onSurfaceVariant
+														}
+													/>
+												</InputAdornment>
+											),
+											endAdornment: (
+												<InputAdornment position="end">
+													<IconButton
+														type="button"
+														onClick={() =>
+															setIsPasswordVisible(
+																(isVisible) =>
+																	!isVisible
+															)
+														}
+														edge="end"
+														aria-label={translate(
+															isPasswordVisible
+																? 'login.password.hide'
+																: 'login.password.show'
+														)}
+														title={translate(
+															isPasswordVisible
+																? 'login.password.hide'
+																: 'login.password.show'
+														)}
+													>
+														{isPasswordVisible ? (
+															<HidePasswordIcon
+																color={
+																	orisoInputColors.onSurfaceVariant
+																}
+															/>
+														) : (
+															<ShowPasswordIcon
+																color={
+																	orisoInputColors.onSurfaceVariant
+																}
+															/>
+														)}
+													</IconButton>
+												</InputAdornment>
+											)
+										}}
+										sx={{ mb: '20px' }}
 									/>
 									<div
 										className={clsx('loginForm__otp', {
@@ -543,10 +611,45 @@ export const Login = () => {
 												type="infoLargeAlternative"
 											/>
 										)}
-										<InputField
-											item={otpInputItem}
-											inputHandle={handleOtpChange}
-											keyUpHandle={handleKeyUp}
+										<OrisoTextField
+											id="otp"
+											name="otp"
+											type="text"
+											value={otp}
+											onChange={handleOtpChange}
+											onKeyUp={handleKeyUp}
+											placeholder={translate(
+												'twoFactorAuth.activate.otp.input.label.text'
+											)}
+											helperText={
+												twoFactorType ===
+												TWO_FACTOR_TYPES.APP
+													? translate(
+															`login.warning.failed.app.otp.missing`
+														)
+													: ''
+											}
+											fullWidth
+											inputProps={{
+												'aria-label': translate(
+													'twoFactorAuth.activate.otp.input.label.text'
+												),
+												'maxLength': OTP_LENGTH,
+												'tabIndex': isOtpRequired
+													? 0
+													: -1
+											}}
+											InputProps={{
+												startAdornment: (
+													<InputAdornment position="start">
+														<VerifiedIcon
+															color={
+																orisoInputColors.onSurfaceVariant
+															}
+														/>
+													</InputAdornment>
+												)
+											}}
 										/>
 										{twoFactorType ===
 											TWO_FACTOR_TYPES.EMAIL && (

--- a/src/components/registration/accountData/AccountData.tsx
+++ b/src/components/registration/accountData/AccountData.tsx
@@ -7,7 +7,6 @@ import {
 	IconButton,
 	InputAdornment,
 	Link,
-	TextField,
 	Typography
 } from '@mui/material';
 import * as React from 'react';
@@ -37,11 +36,11 @@ import { REGISTRATION_DATA_VALIDATION } from '../registrationDataValidation';
 import LegalLinks from '../../../components/legalLinks/LegalLinks';
 import {
 	registrationMd3,
-	registrationMd3TextFieldSx,
 	registrationScreenIntroSx,
 	registrationScreenKickerSx,
 	registrationScreenTitleSx
 } from '../registrationDesign/registrationDesign';
+import { OrisoTextField } from '../../form/OrisoTextField';
 import { AnimalAvatar } from '../../pseudonym/AnimalAvatar';
 import {
 	generateAvatar,
@@ -429,7 +428,7 @@ export const AccountData: FC<{
 				)}
 			</Box>
 
-			<TextField
+			<OrisoTextField
 				value={username}
 				onChange={(event) => {
 					const normalizedVal = event.target.value
@@ -457,9 +456,8 @@ export const AccountData: FC<{
 						</InputAdornment>
 					)
 				}}
-				sx={{ ...registrationMd3TextFieldSx }}
 			/>
-			<TextField
+			<OrisoTextField
 				value={password}
 				onChange={(event) => setPassword(event.target.value)}
 				placeholder={t('registration.account.password.label')}
@@ -505,10 +503,10 @@ export const AccountData: FC<{
 						</InputAdornment>
 					)
 				}}
-				sx={{ mt: '24px', ...registrationMd3TextFieldSx }}
+				sx={{ mt: '24px' }}
 			/>
 			<PasswordRuleChips password={password} />
-			<TextField
+			<OrisoTextField
 				value={repeatPassword}
 				onChange={(event) => setRepeatPassword(event.target.value)}
 				placeholder={t('registration.account.repeatPassword.label')}
@@ -569,7 +567,7 @@ export const AccountData: FC<{
 						</InputAdornment>
 					)
 				}}
-				sx={{ mt: '20px', ...registrationMd3TextFieldSx }}
+				sx={{ mt: '20px' }}
 			/>
 			<FormGroup sx={{ mt: '20px' }}>
 				<FormControlLabel

--- a/src/components/registration/registrationDesign/registrationDesign.ts
+++ b/src/components/registration/registrationDesign/registrationDesign.ts
@@ -1,4 +1,8 @@
 import { TopicsDataInterface } from '../../../globalState/interfaces/TopicsDataInterface';
+import {
+	orisoInputColors,
+	orisoTextFieldSx
+} from '../../form/orisoInputDesign';
 
 import category01 from '../../../resources/img/registration-md3/icons/cat-01.png';
 import category02 from '../../../resources/img/registration-md3/icons/cat-02.png';
@@ -32,88 +36,12 @@ import legalGuardianship05 from '../../../resources/img/registration-md3/icons/t
 import u25Prevention05 from '../../../resources/img/registration-md3/icons/t-05-u25-suizidpra-vention.png';
 
 export const registrationMd3 = {
-	onSurface: '#1b1b1c',
-	onSurfaceVariant: '#444748',
-	outline: '#74777b',
-	outlineVariant: '#c4c7c8',
-	surface: '#ffffff',
-	surfaceContainerLowest: '#ffffff',
-	surfaceContainerLow: '#f7f4f4',
-	surfaceContainer: '#f1eeee',
-	surfaceContainerHigh: '#ebe8e8',
-	secondary: '#4c555f',
-	onSecondary: '#ffffff',
-	primary: '#a4262e',
-	onPrimary: '#ffffff',
-	primaryDark: '#7e1d23',
-	error: '#b1005e',
-	focus: '#2d6f7b',
-	focusLayer: 'rgba(45, 111, 123, 0.12)',
-	selectedLayer: 'rgba(164, 38, 46, 0.08)',
-	hoverLayer: 'rgba(27, 27, 28, 0.04)',
+	...orisoInputColors,
 	heroGradient:
 		'linear-gradient(152deg, #DA2530 0%, #C0121F 46%, #7C0D15 100%)'
 } as const;
 
-const registrationMd3Autofill = '#e8f0fe';
-
-export const registrationMd3TextFieldSx = {
-	'& .MuiOutlinedInput-root': {
-		'borderRadius': '12px',
-		'backgroundColor': registrationMd3.surfaceContainerLowest,
-		'color': registrationMd3.onSurface,
-		'fontSize': 17,
-		'transition':
-			'border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease',
-		'& fieldset': {
-			borderColor: registrationMd3.outlineVariant
-		},
-		'&:hover fieldset': {
-			borderColor: registrationMd3.outline
-		},
-		'&.Mui-focused': {
-			boxShadow: `0 0 0 4px ${registrationMd3.focusLayer}`
-		},
-		'&.Mui-focused fieldset': {
-			borderColor: registrationMd3.focus,
-			borderWidth: 2
-		},
-		'&.Mui-error fieldset': {
-			borderColor: registrationMd3.error,
-			borderWidth: 2
-		},
-		'&:has(input:-webkit-autofill)': {
-			backgroundColor: registrationMd3Autofill
-		}
-	},
-	'& .MuiInputBase-input': {
-		'paddingTop': '16px',
-		'paddingBottom': '16px',
-		'&:-webkit-autofill': {
-			WebkitBoxShadow: `0 0 0 100px ${registrationMd3Autofill} inset`,
-			WebkitTextFillColor: registrationMd3.onSurface,
-			caretColor: registrationMd3.onSurface,
-			transition: 'background-color 9999s ease-out 0s'
-		},
-		'&::placeholder': {
-			color: registrationMd3.onSurfaceVariant,
-			opacity: 1
-		}
-	},
-	'& .MuiInputAdornment-root': {
-		color: registrationMd3.onSurfaceVariant
-	},
-	'& .MuiFormHelperText-root': {
-		marginLeft: 0,
-		marginTop: '8px',
-		fontSize: '14px',
-		lineHeight: '20px',
-		color: registrationMd3.onSurfaceVariant
-	},
-	'& .MuiFormHelperText-root.Mui-error': {
-		color: `${registrationMd3.error} !important`
-	}
-} as const;
+export const registrationMd3TextFieldSx = orisoTextFieldSx;
 
 export const registrationScreenTitleSx = {
 	color: registrationMd3.onSurface,

--- a/src/components/registration/zipcodeInput/ZipcodeInput.tsx
+++ b/src/components/registration/zipcodeInput/ZipcodeInput.tsx
@@ -1,4 +1,4 @@
-import { Box, InputAdornment, TextField, Typography } from '@mui/material';
+import { Box, InputAdornment, Typography } from '@mui/material';
 import * as React from 'react';
 import PlaceRoundedIcon from '@mui/icons-material/PlaceRounded';
 import {
@@ -14,9 +14,9 @@ import { RegistrationContext, RegistrationData } from '../../../globalState';
 import { REGISTRATION_DATA_VALIDATION } from '../registrationDataValidation';
 import {
 	registrationMd3,
-	registrationMd3TextFieldSx,
 	registrationScreenTitleSx
 } from '../registrationDesign/registrationDesign';
+import { OrisoTextField } from '../../form/OrisoTextField';
 
 export const ZipcodeInput: FC<{
 	onChange: Dispatch<SetStateAction<Partial<RegistrationData>>>;
@@ -101,7 +101,7 @@ export const ZipcodeInput: FC<{
 				</Typography>
 			</Box>
 			<Box sx={{ width: '100%', maxWidth: 340 }}>
-				<TextField
+				<OrisoTextField
 					value={value}
 					onChange={(event) => {
 						const nextValue = event.target.value
@@ -129,7 +129,6 @@ export const ZipcodeInput: FC<{
 							</InputAdornment>
 						)
 					}}
-					sx={registrationMd3TextFieldSx}
 				/>
 			</Box>
 		</Box>

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -25,6 +25,8 @@ import {
 } from '@mui/material';
 import { SvgIconProps } from '@mui/material/SvgIcon';
 import { InfoDrawer } from '../registration/infoDrawer/InfoDrawer';
+import { Link as RouterLink, useHistory } from 'react-router-dom';
+import { toSameOriginRoute } from './stageLayoutRoutes';
 
 interface StageLayoutProps {
 	className?: string;
@@ -53,9 +55,20 @@ export const StageLayout = ({
 	const { selectableLocales } = useContext(LocaleContext);
 	const { specificAgency } = useContext(AgencySpecificContext);
 	const settings = useAppConfig();
+	const history = useHistory();
 	const loginUrl = `${settings.urls.toLogin}${
 		loginParams ? `?${loginParams}` : ''
 	}`;
+	const loginRoute = toSameOriginRoute(loginUrl);
+	const registrationRoute = toSameOriginRoute(settings.urls.toRegistration);
+	const handleRegistrationClick = () => {
+		if (registrationRoute) {
+			history.push(registrationRoute);
+			return;
+		}
+
+		window.location.assign(settings.urls.toRegistration);
+	};
 
 	return (
 		<div className={clsx('stageLayout', className)}>
@@ -87,7 +100,12 @@ export const StageLayout = ({
 
 							{showLoginLink && (
 								<IconButton
-									href={loginUrl}
+									{...(loginRoute
+										? {
+												component: RouterLink,
+												to: loginRoute
+											}
+										: { href: loginUrl })}
 									edge="end"
 									color="inherit"
 									aria-label={translate(
@@ -145,8 +163,15 @@ export const StageLayout = ({
 						>
 							<MuiButton
 								className="stageLayout__toLogin__button"
-								component="a"
-								href={loginUrl}
+								{...(loginRoute
+									? {
+											component: RouterLink,
+											to: loginRoute
+										}
+									: {
+											component: 'a',
+											href: loginUrl
+										})}
 								variant="outlined"
 								startIcon={<LoginDoorIcon />}
 								sx={{
@@ -200,22 +225,16 @@ export const StageLayout = ({
 								)}
 								type={'infoSmall'}
 							/>
-							<a
+							<Button
 								className="login__tenantRegistrationLink"
-								href={settings.urls.toRegistration}
-								target="_self"
-								tabIndex={-1}
-							>
-								<Button
-									item={{
-										label: translate(
-											'login.register.linkLabel'
-										),
-										type: 'TERTIARY'
-									}}
-									isLink
-								/>
-							</a>
+								item={{
+									label: translate(
+										'login.register.linkLabel'
+									),
+									type: 'TERTIARY'
+								}}
+								buttonHandle={handleRegistrationClick}
+							/>
 						</div>
 					)}
 				</Box>

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -25,7 +25,8 @@ import {
 } from '@mui/material';
 import { SvgIconProps } from '@mui/material/SvgIcon';
 import { InfoDrawer } from '../registration/infoDrawer/InfoDrawer';
-import { Link as RouterLink, useHistory } from 'react-router-dom';
+import { __RouterContext } from 'react-router';
+import { Link as RouterLink } from 'react-router-dom';
 import { toSameOriginRoute } from './stageLayoutRoutes';
 
 interface StageLayoutProps {
@@ -54,20 +55,21 @@ export const StageLayout = ({
 	const legalLinks = useContext(LegalLinksContext);
 	const { selectableLocales } = useContext(LocaleContext);
 	const { specificAgency } = useContext(AgencySpecificContext);
+	const routerContext = useContext(__RouterContext);
 	const settings = useAppConfig();
-	const history = useHistory();
 	const loginUrl = `${settings.urls.toLogin}${
 		loginParams ? `?${loginParams}` : ''
 	}`;
 	const loginRoute = toSameOriginRoute(loginUrl);
 	const registrationRoute = toSameOriginRoute(settings.urls.toRegistration);
+	const registrationHref = registrationRoute || settings.urls.toRegistration;
 	const handleRegistrationClick = () => {
-		if (registrationRoute) {
-			history.push(registrationRoute);
+		if (registrationRoute && routerContext?.history) {
+			routerContext.history.push(registrationRoute);
 			return;
 		}
 
-		window.location.assign(settings.urls.toRegistration);
+		window.location.assign(registrationHref);
 	};
 
 	return (
@@ -100,12 +102,12 @@ export const StageLayout = ({
 
 							{showLoginLink && (
 								<IconButton
-									{...(loginRoute
+									{...(loginRoute && routerContext
 										? {
 												component: RouterLink,
 												to: loginRoute
 											}
-										: { href: loginUrl })}
+										: { href: loginRoute || loginUrl })}
 									edge="end"
 									color="inherit"
 									aria-label={translate(
@@ -163,14 +165,14 @@ export const StageLayout = ({
 						>
 							<MuiButton
 								className="stageLayout__toLogin__button"
-								{...(loginRoute
+								{...(loginRoute && routerContext
 									? {
 											component: RouterLink,
 											to: loginRoute
 										}
 									: {
 											component: 'a',
-											href: loginUrl
+											href: loginRoute || loginUrl
 										})}
 								variant="outlined"
 								startIcon={<LoginDoorIcon />}

--- a/src/components/stageLayout/stageLayoutRoutes.test.ts
+++ b/src/components/stageLayout/stageLayoutRoutes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { toSameOriginRoute } from './stageLayoutRoutes';
+
+describe('toSameOriginRoute', () => {
+	const origin = 'https://app.oriso-dev.site';
+
+	it('converts same-origin absolute URLs into client routes', () => {
+		expect(
+			toSameOriginRoute(
+				'https://app.oriso-dev.site/login?tenant=oriso#top',
+				origin
+			)
+		).toBe('/login?tenant=oriso#top');
+	});
+
+	it('keeps relative app routes usable by React Router', () => {
+		expect(toSameOriginRoute('/registration', origin)).toBe(
+			'/registration'
+		);
+	});
+
+	it('rejects external origins so links can fall back to document navigation', () => {
+		expect(
+			toSameOriginRoute('https://auth.oriso-dev.site/login', origin)
+		).toBe(null);
+	});
+});

--- a/src/components/stageLayout/stageLayoutRoutes.ts
+++ b/src/components/stageLayout/stageLayoutRoutes.ts
@@ -1,0 +1,16 @@
+export const toSameOriginRoute = (
+	url: string,
+	currentOrigin = window.location.origin
+) => {
+	try {
+		const parsedUrl = new URL(url, currentOrigin);
+
+		if (parsedUrl.origin !== currentOrigin) {
+			return null;
+		}
+
+		return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+	} catch {
+		return url.startsWith('/') ? url : null;
+	}
+};


### PR DESCRIPTION
## Problem
The registration header login action used a same-origin absolute link, so moving from `/registration` to `/login` could trigger a full document navigation and a visible black flash. The login form also still used the older `InputField` styling instead of the newer MUI text-field treatment from the registration postcode field.

## Solution
- Normalize same-origin app URLs to React Router routes in `StageLayout` and keep external origins as real document navigations.
- Replace the login header action with a Router link and use the same in-app routing path for the login registration CTA.
- Add a shared `OrisoTextField` / `orisoInputDesign` primitive and reuse it for login, account data, and postcode inputs.
- Keep the existing registration design export surface by delegating `registrationMd3TextFieldSx` to the shared input style.
- Cover same-origin route normalization with a small Vitest spec.

## Validation
- `npm run test:unit -- src/components/stageLayout/stageLayoutRoutes.test.ts`
- `npm run test:unit`
- `npm run lint:scripts` (passes with existing repo warnings)
- Production build with PreDev-like env values (passes with existing CRA/Browserslist warnings)
- Playwright local smoke with API stubs: `/registration` -> click header Login -> `/login` without a new document navigation entry; login input keeps 12px radius and blue focus glow `rgba(45, 111, 123, 0.12) 0px 0px 0px 4px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
