### PR TITLE
fix(registration): skip welcome screen

### DIFF
--- a/src/components/app/registrationLoader/RegistrationLoader.test.tsx
+++ b/src/components/app/registrationLoader/RegistrationLoader.test.tsx
@@ -36,6 +36,12 @@ describe('RegistrationLoader', () => {
 
 		expect(screen.getAllByText('registration.loader.copy')).toHaveLength(2);
 		expect(screen.queryByText('registration.loader.ready')).toBeNull();
+		expect(
+			screen.getByText('registration.welcomeScreen.info3.title')
+		).toBeDefined();
+		expect(
+			screen.getByText('registration.welcomeScreen.info4.title')
+		).toBeDefined();
 
 		rerender(<RegistrationLoader ready={true} onFinish={onFinish} />);
 

--- a/src/components/app/registrationLoader/RegistrationLoader.tsx
+++ b/src/components/app/registrationLoader/RegistrationLoader.tsx
@@ -5,6 +5,8 @@ import { keyframes } from '@mui/system';
 import { alpha } from '@mui/material/styles';
 import { Box, LinearProgress, Typography, useMediaQuery } from '@mui/material';
 import ChatBubbleRoundedIcon from '@mui/icons-material/ChatBubbleRounded';
+import MailRoundedIcon from '@mui/icons-material/MailRounded';
+import LockRoundedIcon from '@mui/icons-material/LockRounded';
 
 interface RegistrationLoaderProps {
 	/** The real "everything loaded" signal from the app bootstrap (appReady). */
@@ -80,6 +82,19 @@ export const RegistrationLoader = ({
 	const finishedRef = useRef<boolean>(false);
 	const onFinishRef = useRef(onFinish);
 	onFinishRef.current = onFinish;
+
+	const benefitItems = [
+		{
+			icon: MailRoundedIcon,
+			title: t('registration.welcomeScreen.info3.title'),
+			text: t('registration.welcomeScreen.info3.text')
+		},
+		{
+			icon: LockRoundedIcon,
+			title: t('registration.welcomeScreen.info4.title'),
+			text: t('registration.welcomeScreen.info4.text')
+		}
+	];
 
 	const finish = useCallback(() => {
 		if (finishedRef.current) {
@@ -237,6 +252,7 @@ export const RegistrationLoader = ({
 				sx={{
 					color: 'text.secondary',
 					textAlign: 'center',
+					maxWidth: 360,
 					animation:
 						finishing && !prefersReducedMotion
 							? `${contentDrift} ${FINISH_ZOOM_MS}ms ease both`
@@ -247,6 +263,75 @@ export const RegistrationLoader = ({
 					? t('registration.loader.ready')
 					: t('registration.loader.copy')}
 			</Typography>
+			<Box
+				sx={{
+					width: '100%',
+					maxWidth: 560,
+					mt: { xs: 3, sm: 4 },
+					display: 'grid',
+					gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+					gap: 1.5,
+					animation:
+						finishing && !prefersReducedMotion
+							? `${contentDrift} ${FINISH_ZOOM_MS}ms ease both`
+							: 'none'
+				}}
+			>
+				{benefitItems.map(({ icon: Icon, title, text }) => (
+					<Box
+						key={title}
+						sx={{
+							display: 'grid',
+							gridTemplateColumns: '32px 1fr',
+							alignItems: 'start',
+							gap: 1.25,
+							p: 1.5,
+							borderRadius: 3,
+							border: (theme) =>
+								`1px solid ${alpha(theme.palette.primary.main, 0.18)}`,
+							backgroundColor: (theme) =>
+								alpha(theme.palette.primary.main, 0.045)
+						}}
+					>
+						<Box
+							sx={{
+								width: 32,
+								height: 32,
+								borderRadius: '50%',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								color: 'primary.main',
+								backgroundColor: (theme) =>
+									alpha(theme.palette.primary.main, 0.08)
+							}}
+						>
+							<Icon sx={{ fontSize: 18 }} />
+						</Box>
+						<Box>
+							<Typography
+								variant="subtitle2"
+								sx={{
+									fontWeight: 700,
+									lineHeight: 1.25,
+									mb: 0.25
+								}}
+							>
+								{title}
+							</Typography>
+							<Typography
+								variant="body2"
+								sx={{
+									color: 'text.secondary',
+									lineHeight: 1.35
+								}}
+							>
+								{text}
+							</Typography>
+						</Box>
+					</Box>
+				))}
+			</Box>
 			<Box
 				role="status"
 				aria-live="polite"

--- a/src/components/app/registrationLoader/RegistrationLoader.tsx
+++ b/src/components/app/registrationLoader/RegistrationLoader.tsx
@@ -85,11 +85,13 @@ export const RegistrationLoader = ({
 
 	const benefitItems = [
 		{
+			id: 'professional-response',
 			icon: MailRoundedIcon,
 			title: t('registration.welcomeScreen.info3.title'),
 			text: t('registration.welcomeScreen.info3.text')
 		},
 		{
+			id: 'anonymous-free',
 			icon: LockRoundedIcon,
 			title: t('registration.welcomeScreen.info4.title'),
 			text: t('registration.welcomeScreen.info4.text')
@@ -277,9 +279,9 @@ export const RegistrationLoader = ({
 							: 'none'
 				}}
 			>
-				{benefitItems.map(({ icon: Icon, title, text }) => (
+				{benefitItems.map(({ id, icon: Icon, title, text }) => (
 					<Box
-						key={title}
+						key={id}
 						sx={{
 							display: 'grid',
 							gridTemplateColumns: '32px 1fr',

--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import {
 	Route,
+	Redirect,
 	Switch,
 	useHistory,
 	useLocation,
@@ -22,7 +23,6 @@ import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet';
 import { StageLayout } from '../../components/stageLayout/StageLayout';
 import useIsFirstVisit from '../../utils/useIsFirstVisit';
-import { WelcomeScreen } from './welcomeScreen/WelcomeScreen';
 import {
 	RegistrationContext,
 	TenantContext,
@@ -119,14 +119,34 @@ export const Registration = () => {
 		[availableSteps, step]
 	);
 
-	const [prevStepUrl, nextStepUrl] = useMemo(
-		() => [
-			`${generatePath(path, { topicSlug, step: availableSteps[currStepIndex - 1]?.name || 'welcome' })}${location.search}`,
-			availableSteps[currStepIndex + 1]
-				? `${generatePath(path, { topicSlug, step: availableSteps[currStepIndex + 1]?.name || 'welcome' })}${location.search}`
+	const [prevStepUrl, nextStepUrl] = useMemo(() => {
+		const firstStepName = availableSteps[0]?.name || 'topic-selection';
+		const previousStepName =
+			availableSteps[Math.max(currStepIndex - 1, 0)]?.name ||
+			firstStepName;
+		const nextStepName = availableSteps[currStepIndex + 1]?.name;
+
+		return [
+			`${generatePath(path, {
+				topicSlug,
+				step: previousStepName
+			})}${location.search}`,
+			nextStepName
+				? `${generatePath(path, {
+						topicSlug,
+						step: nextStepName
+					})}${location.search}`
 				: null
-		],
-		[availableSteps, currStepIndex, path, topicSlug, location.search]
+		];
+	}, [availableSteps, currStepIndex, path, topicSlug, location.search]);
+
+	const firstStepUrl = useMemo(
+		() =>
+			`${generatePath(path, {
+				topicSlug,
+				step: availableSteps[0]?.name || 'topic-selection'
+			})}${location.search}`,
+		[availableSteps, location.search, path, topicSlug]
 	);
 
 	const mergedRegistrationData = useMemo(
@@ -652,7 +672,7 @@ export const Registration = () => {
 							</form>
 						</Route>
 						<Route>
-							<WelcomeScreen nextStepUrl={nextStepUrl} />
+							<Redirect to={firstStepUrl} />
 						</Route>
 					</Switch>
 				</Box>


### PR DESCRIPTION
## Problem

The public registration welcome page is no longer aligned with the current registration flow. Users who choose registration should land directly on topic selection instead of an intermediate explanation screen.

## Solution

- Redirect unknown/welcome registration entries to the first active registration step.
- Keep the back/next URL calculation inside the available registration steps instead of falling back to `welcome`.
- Move the two remaining advice benefits into the post-registration loader, where they bridge the real app bootstrap before the enquiry view opens.

## Validation

- `npm run test:unit -- src/components/app/registrationLoader/RegistrationLoader.test.tsx`
- `npm run test:unit`
- `npm run lint:scripts` (existing warnings only)
- Production build with PreDev-like env

## Notes

Local rendered QA was blocked by the CRA dev proxy TLS chain and then by the in-app browser URL policy after a localhost failure. Final rendered validation must be performed on PreDev after the image built from `dev` is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
