### PR TITLE
fix(registration): generate safe suggested passwords

### DIFF
--- a/src/utils/anonName/engine.test.ts
+++ b/src/utils/anonName/engine.test.ts
@@ -45,4 +45,13 @@ describe('anonymous name engine', () => {
 		expect(password).toHaveLength(16);
 		expect(allPasswordCriteriaPass(password)).toBe(true);
 	});
+
+	it('generates URI-safe passwords for the registration payload', () => {
+		for (let i = 0; i < 50; i++) {
+			const password = generatePassword();
+
+			expect(encodeURIComponent(password)).toBe(password);
+			expect(allPasswordCriteriaPass(password)).toBe(true);
+		}
+	});
 });

--- a/src/utils/anonName/engine.ts
+++ b/src/utils/anonName/engine.ts
@@ -155,12 +155,15 @@ export function generateAvatar(lang = 'de'): Avatar {
 }
 
 /** A 16-char password guaranteed to contain a digit, an upper- and a lowercase
- *  letter, and a special character. No ambiguous look-alikes. */
+ *  letter, and a special character. No ambiguous look-alikes. Keep special
+ *  characters URI-safe: registration currently sends the password through an
+ *  encoded JSON payload before auto-login reuses the raw value.
+ */
 export function generatePassword(): string {
 	const lower = 'abcdefghijkmnpqrstuvwxyz';
 	const upper = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
 	const digit = '23456789';
-	const special = '!@#$%&*?-_+';
+	const special = '!-_*';
 	const all = lower + upper + digit + special;
 	const chars = [
 		pick([...lower]),


### PR DESCRIPTION
## Summary

- Restrict generated registration password symbols to URI-safe characters.
- Add a regression test that generated passwords stay unchanged through `encodeURIComponent`.
- Keeps suggested passwords compatible with the current encoded registration payload and auto-login flow.

## Validation

- `npm run test:unit -- src/utils/anonName/engine.test.ts src/components/app/registrationLoader/RegistrationLoader.test.tsx`
- `npm run lint:scripts`
- Production build with PreDev environment variables
- PreDev E2E manually confirmed registration works with a URI-safe generated/manual password path; this PR makes the auto-suggested path match that safe set.

Tracked in #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)