### PR TITLE
Fix registration shell header and stepper alignment

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -549,9 +549,10 @@ export const Registration = () => {
 										bottom: '0',
 										right: '0',
 										px: {
-											xs: '16px',
+											xs: '20px',
+											sm: '24px',
 											md: '32px',
-											lg: '16px'
+											lg: '32px'
 										},
 										width: { xs: '100vw', lg: '60vw' },
 										backgroundColor:

--- a/src/components/registration/registrationStepper/RegistrationStepper.tsx
+++ b/src/components/registration/registrationStepper/RegistrationStepper.tsx
@@ -84,12 +84,16 @@ export const RegistrationStepper = ({
 			className="registrationStepperSticky"
 			sx={{
 				position: 'sticky',
-				top: { xs: '48px', md: '80px' },
-				zIndex: 62,
-				width: '100%',
-				mx: { xs: -2, md: -3 },
-				px: { xs: 2, md: 3 },
-				pt: { xs: 1, md: 0 },
+				top: { xs: '48px', md: '72px' },
+				zIndex: 68,
+				boxSizing: 'border-box',
+				width: { xs: '100vw', lg: '60vw' },
+				ml: {
+					xs: 'calc((100% - 100vw) / 2)',
+					lg: 'calc((100% - 60vw) / 2)'
+				},
+				px: { xs: 2, sm: 3, lg: 4 },
+				pt: { xs: 1, md: 1.5 },
 				backgroundColor: 'rgba(255, 255, 255, 0.96)',
 				backdropFilter: 'blur(8px)',
 				borderBottom: `1px solid ${registrationMd3.outlineVariant}`,
@@ -104,7 +108,10 @@ export const RegistrationStepper = ({
 					letterSpacing: 1.2,
 					textTransform: 'uppercase',
 					color: registrationMd3.onSurfaceVariant,
-					mb: 1
+					mb: 1,
+					width: '100%',
+					maxWidth: '780px',
+					mx: 'auto'
 				}}
 			>
 				{t('registration.headline')}
@@ -116,6 +123,9 @@ export const RegistrationStepper = ({
 					'overflowX': { xs: 'auto', md: 'visible' },
 					'pb': { xs: 0.5, md: 0 },
 					'scrollbarWidth': 'none',
+					'width': '100%',
+					'maxWidth': '780px',
+					'mx': 'auto',
 					'&::-webkit-scrollbar': { display: 'none' }
 				}}
 			>

--- a/src/components/stageLayout/StageLayout.styles.scss
+++ b/src/components/stageLayout/StageLayout.styles.scss
@@ -8,7 +8,7 @@
 			z-index: 70;
 			background-color: var(--m3-background, $body-bg);
 
-			@include breakpoint($fromLarge) {
+			@include breakpoint($fromXLarge) {
 				background: linear-gradient(
 					90deg,
 					transparent 0 40vw,
@@ -28,7 +28,7 @@
 			z-index: 25;
 			background: var(--m3-background, $body-bg);
 
-			@include breakpoint($fromLarge) {
+			@include breakpoint($fromXLarge) {
 				background: linear-gradient(
 					90deg,
 					transparent 0 40vw,
@@ -65,7 +65,7 @@
 
 			@include breakpoint($fromLarge) {
 				margin-top: 0 !important;
-				padding-top: 104px;
+				padding-top: 0;
 				padding-right: $grid-base-four;
 				padding-left: $grid-base-four;
 
@@ -76,7 +76,7 @@
 			}
 
 			@include breakpoint($fromXLarge) {
-				padding-top: $grid-base-five;
+				padding-top: 0;
 				padding-left: calc(40vw + #{$grid-base-four});
 				padding-right: $grid-base-four;
 

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -138,9 +138,9 @@ export const StageLayout = ({
 							xs: showRegistrationLink ? '48px' : 0,
 							md: 0
 						},
-						height: { xs: 'auto', md: undefined },
-						minHeight: { xs: '48px', md: undefined },
-						py: { xs: 1, md: 0 }
+						height: { xs: 'auto', md: '72px' },
+						minHeight: { xs: '48px', md: '72px' },
+						py: { xs: 1, md: 1.5 }
 					}}
 				>
 					{selectableLocales.length > 1 && (


### PR DESCRIPTION
## Problem
The registration language/login header, stepper, and footer were visually separated on PreDev. On tablet/desktop the login button touched the shell edges, the stepper did not span the active pane consistently, and content could show underneath the sticky top shell.

## Solution
- Give the registration header a stable 72px desktop/tablet shell height with vertical padding.
- Make the registration stepper surface span the active pane/viewport while keeping the step content on the existing 780px rail.
- Remove the registration content top padding that pushed the stepper away from the header.
- Add horizontal padding to the fixed registration footer controls.

Fixes #325

## Validation
- `npm run test:unit -- src/components/stageLayout/stageLayoutRoutes.test.ts`
- `npm run lint:scripts` (passes with existing repository warnings)
- `npx stylelint src/components/stageLayout/StageLayout.styles.scss`
- `git diff --check`
- `npm run build` (passes with existing repository warnings)
- Local Playwright metrics for `/registration/topic-selection`:
  - desktop 1280x941: header 72px, stepper y=72, footer width matches registration pane
  - tablet 1024x768: header 72px, stepper y=72 and full viewport width, footer full viewport width
  - mobile 390x844: stepper and footer remain full viewport width

## Notes
Full `npm run lint:style` still fails on unrelated existing SCSS files outside this diff. The changed SCSS file passes stylelint directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
