### PR TITLE
Document local AgencyService frontend config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,13 +20,13 @@ REACT_APP_DEV_PROXY_SECURE=false
 
 # Service-specific origins for mixed local/dev work.
 # Leave unset/commented to use REACT_APP_API_URL/VITE_API_URL for that service.
-# Example below runs UserService and TenantService locally while the remaining
-# services use the remote API ingress.
+# Example below runs UserService, TenantService, and AgencyService locally while
+# the remaining services use the remote API ingress.
 REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
 REACT_APP_TENANT_SERVICE_ORIGIN=http://localhost:8081
 # Local tenant id used when localhost has no tenant subdomain.
 REACT_APP_LOCAL_TENANT_ID=1
-# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso-dev.site
+REACT_APP_AGENCY_SERVICE_ORIGIN=http://localhost:8084
 # REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso-dev.site
 REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso-dev.site
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -2,7 +2,8 @@
 
 This setup runs the frontend on `localhost:9001`, points UserService calls to a local
 UserService on `localhost:8082`, points TenantService calls to a local TenantService
-on `localhost:8081`, and leaves the remaining APIs on the configured remote API ingress.
+on `localhost:8081`, points AgencyService calls to a local AgencyService on
+`localhost:8084`, and leaves the remaining APIs on the configured remote API ingress.
 
 ## 1. Create `.env`
 
@@ -30,7 +31,7 @@ REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
 # unless those services are local too.
 REACT_APP_TENANT_SERVICE_ORIGIN=http://localhost:8081
 REACT_APP_LOCAL_TENANT_ID=1
-# REACT_APP_AGENCY_SERVICE_ORIGIN=https://api.oriso-dev.site
+REACT_APP_AGENCY_SERVICE_ORIGIN=http://localhost:8084
 # REACT_APP_CONSULTING_TYPE_SERVICE_ORIGIN=https://api.oriso-dev.site
 
 REACT_APP_KEYCLOAK_ORIGIN=https://api.oriso-dev.site
@@ -74,6 +75,8 @@ http://localhost:9001
 - If `REACT_APP_USER_SERVICE_ORIGIN` is absent, those calls fall back to `REACT_APP_API_URL`.
 - `REACT_APP_TENANT_SERVICE_ORIGIN=http://localhost:8081` sends TenantService calls to
   the local TenantService.
+- `REACT_APP_AGENCY_SERVICE_ORIGIN=http://localhost:8084` sends AgencyService calls to
+  the local AgencyService.
 - `REACT_APP_LOCAL_TENANT_ID=1` sets the local `tenantId` cookie for localhost because
   localhost has no tenant subdomain.
 - Keep the other service-specific origins commented unless you are also running those services


### PR DESCRIPTION
## Summary
- enable `REACT_APP_AGENCY_SERVICE_ORIGIN=http://localhost:8084` in the local frontend example
- update local development docs to include AgencyService alongside UserService and TenantService

## Safety
- documentation and sample env only
- service-specific origins still fall back to the main API when unset
- no production runtime config is changed

## Validation
- docs/sample-env only; no runtime tests required
