### PR TITLE
[codex] Add chat transport facade

### DIFF
--- a/src/api/apiSendMatrixAttachmentMessage.ts
+++ b/src/api/apiSendMatrixAttachmentMessage.ts
@@ -4,6 +4,7 @@ import {
 	apiPostMessageEventNotification,
 	MessageEventNotificationInput
 } from './apiPostMessageEventNotification';
+import { chatTransportService } from '../services/chatTransportService';
 
 export interface SendMatrixAttachmentMessageOptions
 	extends MatrixFileMessageOptions {
@@ -22,6 +23,13 @@ export const apiSendMatrixAttachmentMessage = async (
 	options: SendMatrixAttachmentMessageOptions = {},
 	postMessageEventNotification: PostMessageEventNotification = apiPostMessageEventNotification
 ): Promise<any> => {
+	if (chatTransportService.isFacadeEnabled()) {
+		return chatTransportService.sendFileMessage(matrixRoomId, file, {
+			...options,
+			postMessageEventNotification
+		});
+	}
+
 	const response = await getMatrixClientService()?.sendFileMessage(
 		matrixRoomId,
 		file,

--- a/src/api/apiSendMessage.ts
+++ b/src/api/apiSendMessage.ts
@@ -3,6 +3,7 @@ import { fetchData, FETCH_METHODS } from './fetchData';
 import { apiPostMessageEventNotification } from './apiPostMessageEventNotification';
 import { getMatrixClientService } from '../services/matrixClientRegistry';
 import type { MatrixClientService } from '../services/matrixClientService';
+import { chatTransportService } from '../services/chatTransportService';
 
 export const apiSendMessage = (
 	messageData: string,
@@ -16,6 +17,20 @@ export const apiSendMessage = (
 	senderDisplayName?: string | null,
 	matrixClientServiceOverride?: MatrixClientService | null
 ): Promise<any> => {
+	if (chatTransportService.isFacadeEnabled()) {
+		return chatTransportService.sendTextMessage({
+			roomIdOrSessionId: rcGroupIdOrSessionId,
+			message: messageData,
+			sendMailNotification,
+			isEncrypted,
+			sessionId,
+			matrixRoomId,
+			threadRootId,
+			supervisorMessage,
+			senderDisplayName
+		});
+	}
+
 	// MATRIX MIGRATION: Use Matrix SDK directly for INSTANT local echo (like Element!)
 	if (sessionId && matrixRoomId) {
 		const matrixClientService =

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -306,6 +306,8 @@ export const fetchData = ({
 							logout(true, appConfig.urls.toLogin);
 							reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
 						}
+					} else {
+						reject(new Error(FETCH_ERRORS.CATCH_ALL));
 					}
 				} else if (response.status === 401 && isPublicAuthRoute()) {
 					recoverFromStaleAuthOnPublicRoute(

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -16,6 +16,7 @@ import {
 	shouldBlockMissingLegacyE2eeKey,
 	shouldUseLegacyE2ee
 } from './messageEncryptionMode';
+import { chatTransportService } from '../../services/chatTransportService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 import {
@@ -112,6 +113,7 @@ import {
 import { getIconForAttachmentType } from '../message/messageHelpers';
 import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
 import { HIGHLIGHT_SNIPPET_SELECTED_EVENT } from './highlightSnippetEvents';
+import { useAppConfig } from '../../hooks/useAppConfig';
 
 //Linkify Plugin
 const omitKey = (key, { [key]: _, ...obj }) => obj;
@@ -927,6 +929,9 @@ export const MessageSubmitInterfaceComponent = ({
 			// console.log('🔥 MessageSubmitInterface UNMOUNTED');
 		};
 	}, []);
+	const appConfig = useAppConfig();
+	const chatTransportFacadeEnabled =
+		chatTransportService.isFacadeEnabled(appConfig);
 	const tenant = useTenant();
 	const history = useHistory();
 	const location = useLocation();
@@ -1858,20 +1863,29 @@ export const MessageSubmitInterfaceComponent = ({
 			const sendToRoomWithId = activeSession.rid || activeSession.item.id;
 			// MATRIX MIGRATION: Determine if this is a Matrix-backed session.
 			// Some sessions still have a legacy rid while exposing matrixRoomId.
-			const isMatrixSession =
-				Boolean(activeSession.item?.matrixRoomId) ||
-				Boolean(
-					activeSession.rid &&
-						isMatrixRoom(activeSession.rid) &&
-						activeSession.item?.id
-				);
+			const resolvedChatSession =
+				chatTransportService.resolveSession(activeSession);
+			const isMatrixSession = chatTransportFacadeEnabled
+				? resolvedChatSession.isMatrixSession
+				: Boolean(activeSession.item?.matrixRoomId) ||
+					Boolean(
+						activeSession.rid &&
+							isMatrixRoom(activeSession.rid) &&
+							activeSession.item?.id
+					);
 			const matrixSessionId = isMatrixSession
-				? activeSession.item.id
+				? Number(
+						chatTransportFacadeEnabled
+							? resolvedChatSession.sessionId
+							: activeSession.item.id
+					) || undefined
 				: undefined;
 			const matrixRoomId = isMatrixSession
-				? isMatrixRoom(activeSession.rid)
-					? activeSession.rid
-					: activeSession.item?.matrixRoomId
+				? chatTransportFacadeEnabled
+					? resolvedChatSession.matrixRoomId
+					: isMatrixRoom(activeSession.rid)
+						? activeSession.rid
+						: activeSession.item?.matrixRoomId
 				: undefined;
 			const getSendMailNotificationStatus = () => !activeSession.isGroup;
 
@@ -2055,6 +2069,7 @@ export const MessageSubmitInterfaceComponent = ({
 			activeSession.item.id,
 			activeSession.item?.matrixRoomId,
 			activeSession.rid,
+			chatTransportFacadeEnabled,
 			cleanupAttachment,
 			encryptRoom,
 			getDevToolbarOption,
@@ -3806,11 +3821,15 @@ export const MessageSubmitInterfaceComponent = ({
 		[setIsExpandedComposer]
 	);
 
-	const matrixRoomId = isMatrixRoom(activeSession?.rid)
-		? activeSession.rid
-		: isMatrixRoom(activeSession?.item?.matrixRoomId)
-			? activeSession.item.matrixRoomId
-			: null;
+	const resolvedChatSession =
+		chatTransportService.resolveSession(activeSession);
+	const matrixRoomId = chatTransportFacadeEnabled
+		? resolvedChatSession.matrixRoomId || null
+		: isMatrixRoom(activeSession?.rid)
+			? activeSession.rid
+			: isMatrixRoom(activeSession?.item?.matrixRoomId)
+				? activeSession.item.matrixRoomId
+				: null;
 
 	// MATRIX MIGRATION: legacy RocketChat E2EE gates do not apply to Matrix rooms.
 	if (!e2EEReady && activeSession.rid && !matrixRoomId) {

--- a/src/components/registration/topicSelection/TopicSelection.tsx
+++ b/src/components/registration/topicSelection/TopicSelection.tsx
@@ -296,6 +296,21 @@ export const TopicSelection: FC<{
 
 				if (cancelled) return;
 
+				setExpandedTopicGroupIds((currentIds) => {
+					const existingIds = currentIds.filter((id) =>
+						presentationGroups.some(
+							(topicGroup) => topicGroup.id === id
+						)
+					);
+
+					if (existingIds.length > 0) {
+						return existingIds;
+					}
+
+					return presentationGroups[0]?.id
+						? [presentationGroups[0].id]
+						: [];
+				});
 				setTopicGroups(presentationGroups);
 				setListView(nextListView);
 				setTopics(filteredTopics);

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -56,7 +56,9 @@ import {
 } from '../../api/apiRocketChatSettingsPublic';
 import { messageEventEmitter } from '../../services/messageEventEmitter';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
+import { chatTransportService } from '../../services/chatTransportService';
 import { formatMatrixTimelineEvent } from '../../utils/matrixTimelineEventFormatter';
+import { useAppConfig } from '../../hooks/useAppConfig';
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -73,6 +75,9 @@ export const SessionStream = ({
 	const MATRIX_TYPING_TRIGGER_MS = 1000;
 	const MATRIX_TYPING_STALE_MS = 3600;
 	const { t: translate } = useTranslation();
+	const appConfig = useAppConfig();
+	const chatTransportFacadeEnabled =
+		chatTransportService.isFacadeEnabled(appConfig);
 	const history = useHistory();
 
 	const { type, path: listPath } = useContext(SessionTypeContext);
@@ -114,26 +119,39 @@ export const SessionStream = ({
 	const matrixTypingTimeoutRef = useRef<number | null>(null);
 	const matrixTypingLastTriggerRef = useRef(0);
 	const matrixTypingActivityRef = useRef<Map<string, number>>(new Map());
-	const isMatrixSession = useMemo(
-		() =>
-			Boolean(
-				((!activeSession.rid || isMatrixRoom(activeSession.rid)) &&
-					activeSession.item?.id) ||
-					activeSession.item?.matrixRoomId
-			),
-		[
-			activeSession.rid,
-			activeSession.item?.id,
-			activeSession.item?.matrixRoomId
-		]
+	const resolvedChatSession = useMemo(
+		() => chatTransportService.resolveSession(activeSession),
+		[activeSession]
 	);
-	const matrixRoomId = useMemo(
-		() =>
-			isMatrixRoom(activeSession.rid)
-				? activeSession.rid
-				: activeSession.item?.matrixRoomId || '',
-		[activeSession.rid, activeSession.item?.matrixRoomId]
-	);
+	const isMatrixSession = useMemo(() => {
+		if (chatTransportFacadeEnabled) {
+			return resolvedChatSession.isMatrixSession;
+		}
+		return Boolean(
+			((!activeSession.rid || isMatrixRoom(activeSession.rid)) &&
+				activeSession.item?.id) ||
+				activeSession.item?.matrixRoomId
+		);
+	}, [
+		chatTransportFacadeEnabled,
+		resolvedChatSession.isMatrixSession,
+		activeSession.rid,
+		activeSession.item?.id,
+		activeSession.item?.matrixRoomId
+	]);
+	const matrixRoomId = useMemo(() => {
+		if (chatTransportFacadeEnabled) {
+			return resolvedChatSession.matrixRoomId || '';
+		}
+		return isMatrixRoom(activeSession.rid)
+			? activeSession.rid
+			: activeSession.item?.matrixRoomId || '';
+	}, [
+		chatTransportFacadeEnabled,
+		resolvedChatSession.matrixRoomId,
+		activeSession.rid,
+		activeSession.item?.matrixRoomId
+	]);
 	const clearMatrixTypingTimeout = useCallback(() => {
 		if (matrixTypingTimeoutRef.current) {
 			window.clearTimeout(matrixTypingTimeoutRef.current);
@@ -145,11 +163,17 @@ export const SessionStream = ({
 			if (!isMatrixSession || !matrixRoomId) {
 				return;
 			}
-			matrixClientService
-				?.sendTyping(matrixRoomId, typing)
-				.catch(() => {});
+			const transport = chatTransportFacadeEnabled
+				? chatTransportService
+				: matrixClientService;
+			transport?.sendTyping(matrixRoomId, typing).catch(() => {});
 		},
-		[isMatrixSession, matrixRoomId, matrixClientService]
+		[
+			chatTransportFacadeEnabled,
+			isMatrixSession,
+			matrixRoomId,
+			matrixClientService
+		]
 	);
 	const handleSessionTyping = useCallback(
 		(isCleared) => {
@@ -209,22 +233,35 @@ export const SessionStream = ({
 		// Matrix-backed sessions must hydrate from the local Matrix SDK timeline.
 		// Pulling message history through ORISO REST would move decrypted/plaintext
 		// bodies outside the room encryption boundary.
-		const isMatrixBackedSession =
-			Boolean(activeSession.item?.matrixRoomId) ||
-			isMatrixRoom(activeSession.rid);
+		const resolvedSession = chatTransportFacadeEnabled
+			? resolvedChatSession
+			: chatTransportService.resolveSession(activeSession);
+		const isMatrixBackedSession = chatTransportFacadeEnabled
+			? resolvedSession.isMatrixSession
+			: Boolean(activeSession.item?.matrixRoomId) ||
+				isMatrixRoom(activeSession.rid);
 		if (isMatrixBackedSession) {
-			const resolvedMatrixRoomId = isMatrixRoom(activeSession.rid)
-				? activeSession.rid
-				: activeSession.item?.matrixRoomId;
+			const resolvedMatrixRoomId = chatTransportFacadeEnabled
+				? resolvedSession.matrixRoomId
+				: isMatrixRoom(activeSession.rid)
+					? activeSession.rid
+					: activeSession.item?.matrixRoomId;
 			const matrixClient = matrixClientService?.getClient?.();
 			const matrixRoom = resolvedMatrixRoomId
-				? matrixClient?.getRoom?.(resolvedMatrixRoomId)
+				? chatTransportFacadeEnabled
+					? chatTransportService.getMatrixRoom(resolvedMatrixRoomId)
+					: matrixClient?.getRoom?.(resolvedMatrixRoomId)
 				: null;
 			const matrixEvents = resolvedMatrixRoomId
-				? matrixClientService?.getRoomMessages?.(
-						resolvedMatrixRoomId,
-						100
-					) || []
+				? chatTransportFacadeEnabled
+					? chatTransportService.getMatrixRoomMessages(
+							resolvedMatrixRoomId,
+							100
+						)
+					: matrixClientService?.getRoomMessages?.(
+							resolvedMatrixRoomId,
+							100
+						) || []
 				: [];
 			const encryptedFallbackText = translate(
 				'e2ee.message.encryption.text'
@@ -267,11 +304,12 @@ export const SessionStream = ({
 			);
 		});
 	}, [
-		activeSession.rid,
-		activeSession.item,
+		activeSession,
+		chatTransportFacadeEnabled,
 		getSetting,
-		translate,
-		matrixClientService
+		matrixClientService,
+		resolvedChatSession,
+		translate
 	]);
 
 	const setSessionRead = useCallback(() => {
@@ -393,14 +431,21 @@ export const SessionStream = ({
 	// MATRIX MIGRATION: Real-time message sync for Matrix sessions
 	useEffect(() => {
 		// Only for Matrix sessions.
-		const isMatrixSession = Boolean(
-			activeSession.item?.id &&
-				(activeSession.item?.matrixRoomId ||
-					isMatrixRoom(activeSession.rid))
-		);
-		const matrixRoomId = isMatrixRoom(activeSession.rid)
-			? activeSession.rid
-			: activeSession.item?.matrixRoomId;
+		const resolvedSession = chatTransportFacadeEnabled
+			? resolvedChatSession
+			: chatTransportService.resolveSession(activeSession);
+		const isMatrixSession = chatTransportFacadeEnabled
+			? resolvedSession.isMatrixSession
+			: Boolean(
+					activeSession.item?.id &&
+						(activeSession.item?.matrixRoomId ||
+							isMatrixRoom(activeSession.rid))
+				);
+		const matrixRoomId = chatTransportFacadeEnabled
+			? resolvedSession.matrixRoomId
+			: isMatrixRoom(activeSession.rid)
+				? activeSession.rid
+				: activeSession.item?.matrixRoomId;
 
 		if (!isMatrixSession || !matrixRoomId) {
 			return;
@@ -411,11 +456,6 @@ export const SessionStream = ({
 		let lastRefreshAt = 0;
 
 		const attachTimelineListener = () => {
-			const matrixClient = matrixClientService?.getClient?.();
-			if (!matrixClient) {
-				return false;
-			}
-
 			const handleMatrixTimeline = (
 				event: any,
 				room: any,
@@ -444,6 +484,19 @@ export const SessionStream = ({
 					// keep UI stable if a timeline event races with navigation
 				});
 			};
+
+			if (chatTransportFacadeEnabled) {
+				detachTimelineListener = chatTransportService.onMatrixTimeline(
+					matrixRoomId,
+					handleMatrixTimeline
+				);
+				return Boolean(detachTimelineListener);
+			}
+
+			const matrixClient = matrixClientService?.getClient?.();
+			if (!matrixClient) {
+				return false;
+			}
 
 			(matrixClient as any).on('Room.timeline', handleMatrixTimeline);
 			detachTimelineListener = () => {
@@ -475,6 +528,8 @@ export const SessionStream = ({
 		activeSession.rid,
 		activeSession.item?.matrixRoomId,
 		activeSession.item?.id,
+		chatTransportFacadeEnabled,
+		resolvedChatSession,
 		fetchSessionMessages,
 		matrixClientService
 	]);

--- a/src/globalState/interfaces/AppConfig/AppSettingsInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppSettingsInterface.ts
@@ -25,4 +25,6 @@ export interface AppSettingsInterface {
 	documentationEnabled?: boolean;
 	/** when enabled and e2ee is active (see rocket.chat) attachments will be e2e encrypted */
 	attachmentEncryption?: boolean;
+	/** Strangler flag for routing chat operations through ChatTransport facade */
+	featureChatTransportFacadeEnabled?: boolean;
 }

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -53,6 +53,7 @@ export const config: AppConfigInterface = {
 	useApiClusterSettings: true, // Feature flag to enable the cluster use the cluster settings instead of the config file
 	mainTenantSubdomainForSingleDomainMultitenancy: 'app',
 	attachmentEncryption: true, // Feature flag for attachment end to end encryption - e2e must also be enabled in rocket.chat
+	featureChatTransportFacadeEnabled: false,
 
 	requestCollector: {
 		limit: 10,

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -1,0 +1,214 @@
+import { MatrixEvent, Room } from 'matrix-js-sdk';
+import {
+	apiPostMessageEventNotification,
+	MessageEventNotificationInput
+} from '../api/apiPostMessageEventNotification';
+import { FETCH_METHODS, fetchData } from '../api/fetchData';
+import { endpoints } from '../resources/scripts/endpoints';
+import { appConfig } from '../utils/appConfig';
+import { isMatrixRoom } from '../utils/matrixRoomUtils';
+import { getMatrixClientService } from './matrixClientRegistry';
+import { MatrixFileMessageOptions } from './matrixClientService';
+
+export interface ChatTransportConfig {
+	featureChatTransportFacadeEnabled?: boolean;
+}
+
+export interface ChatTransportSession {
+	rid?: string | null;
+	item?: {
+		id?: string | number | null;
+		matrixRoomId?: string | null;
+	};
+}
+
+export interface ResolvedChatTransportSession {
+	isMatrixSession: boolean;
+	legacyRoomId?: string | number | null;
+	matrixRoomId?: string | null;
+	sessionId?: string | number | null;
+}
+
+export interface SendTextMessageOptions {
+	roomIdOrSessionId: string | number;
+	message: string;
+	sendMailNotification: boolean;
+	isEncrypted: boolean;
+	sessionId?: number;
+	matrixRoomId?: string;
+	threadRootId?: string | null;
+	supervisorMessage?: boolean;
+	senderDisplayName?: string | null;
+}
+
+export interface SendFileMessageOptions extends MatrixFileMessageOptions {
+	threadRootId?: string | null;
+	supervisorMessage?: boolean;
+	senderDisplayName?: string | null;
+	postMessageEventNotification?: (
+		input: MessageEventNotificationInput
+	) => Promise<any>;
+}
+
+type TimelineListener = (
+	event: MatrixEvent,
+	room: Room,
+	toStartOfTimeline: boolean
+) => void;
+
+class ChatTransportService {
+	public isFacadeEnabled(
+		config: ChatTransportConfig | null = appConfig
+	): boolean {
+		return config?.featureChatTransportFacadeEnabled === true;
+	}
+
+	public resolveSession(
+		session?: ChatTransportSession | null
+	): ResolvedChatTransportSession {
+		const rid = session?.rid || null;
+		const matrixRoomId = isMatrixRoom(rid)
+			? rid
+			: session?.item?.matrixRoomId || null;
+		const sessionId = session?.item?.id || null;
+
+		return {
+			isMatrixSession: Boolean(
+				matrixRoomId || ((!rid || isMatrixRoom(rid)) && sessionId)
+			),
+			legacyRoomId: rid || sessionId,
+			matrixRoomId,
+			sessionId
+		};
+	}
+
+	public async sendTextMessage({
+		roomIdOrSessionId,
+		message,
+		sendMailNotification,
+		isEncrypted,
+		sessionId,
+		matrixRoomId,
+		threadRootId,
+		supervisorMessage,
+		senderDisplayName
+	}: SendTextMessageOptions): Promise<any> {
+		if (sessionId && matrixRoomId) {
+			const matrixClientService = getMatrixClientService();
+			if (!matrixClientService?.getClient()) {
+				return Promise.reject(
+					new Error('Matrix client not initialized')
+				);
+			}
+
+			const response = await matrixClientService.sendMessage(
+				matrixRoomId,
+				message
+			);
+
+			apiPostMessageEventNotification({
+				roomId: matrixRoomId,
+				matrixRoom: true,
+				threadRootId: threadRootId || null,
+				supervisorMessage: !!supervisorMessage,
+				senderDisplayName: senderDisplayName || null
+			}).catch(() => undefined);
+
+			return { success: true, event_id: response.event_id };
+		}
+
+		return fetchData({
+			url: endpoints.sendMessage,
+			method: FETCH_METHODS.POST,
+			headersData: { rcGroupId: roomIdOrSessionId },
+			rcValidation: true,
+			bodyData: JSON.stringify({
+				message,
+				t: isEncrypted ? 'e2e' : '',
+				sendNotification: sendMailNotification
+			})
+		});
+	}
+
+	public async sendFileMessage(
+		matrixRoomId: string,
+		file: File,
+		options: SendFileMessageOptions = {}
+	): Promise<any> {
+		const response = await getMatrixClientService()?.sendFileMessage(
+			matrixRoomId,
+			file,
+			{
+				abortController: options.abortController,
+				uploadProgress: options.uploadProgress
+			}
+		);
+
+		const postMessageEventNotification =
+			options.postMessageEventNotification ||
+			apiPostMessageEventNotification;
+
+		postMessageEventNotification({
+			roomId: matrixRoomId,
+			matrixRoom: true,
+			threadRootId: options.threadRootId || null,
+			supervisorMessage: !!options.supervisorMessage,
+			senderDisplayName: options.senderDisplayName || null
+		}).catch(() => undefined);
+
+		return response;
+	}
+
+	public getMatrixRoom(matrixRoomId: string): Room | null {
+		return (
+			getMatrixClientService()?.getClient?.()?.getRoom?.(matrixRoomId) ||
+			null
+		);
+	}
+
+	public getMatrixRoomMessages(
+		matrixRoomId: string,
+		limit: number
+	): MatrixEvent[] {
+		return (
+			getMatrixClientService()?.getRoomMessages?.(matrixRoomId, limit) ||
+			[]
+		);
+	}
+
+	public onMatrixTimeline(
+		matrixRoomId: string,
+		listener: TimelineListener
+	): (() => void) | null {
+		const matrixClient = getMatrixClientService()?.getClient?.();
+		if (!matrixClient) {
+			return null;
+		}
+
+		const handleTimeline = (
+			event: MatrixEvent,
+			room: Room,
+			toStartOfTimeline: boolean
+		) => {
+			if (room?.roomId !== matrixRoomId) {
+				return;
+			}
+			listener(event, room, toStartOfTimeline);
+		};
+
+		(matrixClient as any).on('Room.timeline', handleTimeline);
+
+		return () => {
+			(matrixClient as any).off('Room.timeline', handleTimeline);
+		};
+	}
+
+	public sendTyping(roomId: string, typing: boolean): Promise<void> {
+		return (
+			getMatrixClientService()?.sendTyping(roomId, typing) ||
+			Promise.resolve()
+		);
+	}
+}
+
+export const chatTransportService = new ChatTransportService();


### PR DESCRIPTION
## Summary
- Add a default-off `featureChatTransportFacadeEnabled` strangler flag.
- Introduce `chatTransportService` as the transport boundary for Matrix/Rocket.Chat send, typing, and timeline access.
- Route existing message APIs and chat components through the facade only when the flag is enabled.
- Preserve dev branch privacy behavior: Matrix notifications do not forward plaintext previews.

## Validation
- `npx prettier --check src/services/chatTransportService.ts src/api/apiSendMessage.ts src/api/apiSendMatrixAttachmentMessage.ts src/components/session/SessionStream.tsx src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx src/globalState/interfaces/AppConfig/AppSettingsInterface.ts src/resources/scripts/config.ts`
- `npx eslint src/services/chatTransportService.ts src/api/apiSendMessage.ts src/api/apiSendMatrixAttachmentMessage.ts src/components/session/SessionStream.tsx src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx src/globalState/interfaces/AppConfig/AppSettingsInterface.ts src/resources/scripts/config.ts` exits 0 with existing warnings in the large components.