### PR TITLE
test: add unit tests for API, auth, session, and draft modules

### DIFF
--- a/src/api/apiDraftMessages.test.ts
+++ b/src/api/apiDraftMessages.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiGetDraftMessage, apiPostDraftMessage } from './apiDraftMessages';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		draftMessages: 'https://api.oriso-dev.site/service/messages/draft'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: {
+		CATCH_ALL: 'CATCH_ALL',
+		EMPTY: 'EMPTY'
+	},
+	FETCH_METHODS: {
+		GET: 'GET',
+		POST: 'POST'
+	},
+	FETCH_SUCCESS: {
+		CONTENT: 'CONTENT'
+	},
+	fetchData: vi.fn()
+}));
+
+describe('apiDraftMessages', () => {
+	it('posts a draft message with the room/session id header', async () => {
+		vi.mocked(fetchData).mockResolvedValue(undefined);
+
+		await apiPostDraftMessage('room-123', 'Draft body', 'E2EE');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/messages/draft',
+			method: 'POST',
+			headersData: { rcGroupId: 'room-123' },
+			bodyData: JSON.stringify({ message: 'Draft body', t: 'E2EE' }),
+			responseHandling: ['CATCH_ALL']
+		});
+	});
+
+	it('gets a draft message and forwards abort signals', async () => {
+		const controller = new AbortController();
+		vi.mocked(fetchData).mockResolvedValue({
+			message: 'Saved draft',
+			t: 'PLAIN'
+		});
+
+		await expect(
+			apiGetDraftMessage(99, controller.signal)
+		).resolves.toEqual({
+			message: 'Saved draft',
+			t: 'PLAIN'
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/messages/draft',
+			method: 'GET',
+			headersData: { rcGroupId: 99 },
+			responseHandling: ['EMPTY', 'CONTENT'],
+			signal: controller.signal
+		});
+	});
+});

--- a/src/api/apiEventNotifications.test.ts
+++ b/src/api/apiEventNotifications.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiClearEventNotifications,
+	apiGetEventNotifications,
+	apiMarkAllEventNotificationsRead,
+	apiMarkEventNotificationRead
+} from './apiEventNotifications';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		eventNotifications:
+			'https://api.oriso-dev.site/service/users/event-notifications'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: {
+		DELETE: 'DELETE',
+		GET: 'GET',
+		PATCH: 'PATCH'
+	},
+	fetchData: vi.fn()
+}));
+
+describe('apiEventNotifications', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('loads a paginated notification feed', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			items: [],
+			page: 2,
+			perPage: 25,
+			unreadCount: 0
+		});
+
+		await apiGetEventNotifications(2, 25);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/event-notifications?page=2&perPage=25',
+			method: 'GET'
+		});
+	});
+
+	it('marks one, all, and cleared notification states', async () => {
+		vi.mocked(fetchData).mockResolvedValue({});
+
+		await apiMarkEventNotificationRead(123);
+		await apiMarkAllEventNotificationsRead();
+		await apiClearEventNotifications();
+
+		expect(fetchData).toHaveBeenNthCalledWith(1, {
+			url: 'https://api.oriso-dev.site/service/users/event-notifications/123/read',
+			method: 'PATCH'
+		});
+		expect(fetchData).toHaveBeenNthCalledWith(2, {
+			url: 'https://api.oriso-dev.site/service/users/event-notifications/read-all',
+			method: 'PATCH'
+		});
+		expect(fetchData).toHaveBeenNthCalledWith(3, {
+			url: 'https://api.oriso-dev.site/service/users/event-notifications',
+			method: 'DELETE'
+		});
+	});
+});

--- a/src/api/apiGetConsultantSessionList.test.ts
+++ b/src/api/apiGetConsultantSessionList.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	apiGetConsultantSessionList,
+	SESSION_COUNT,
+	TIMEOUT
+} from './apiGetConsultantSessionList';
+import {
+	SESSION_LIST_TAB_ARCHIVE,
+	SESSION_LIST_TYPES
+} from '../components/session/sessionHelpers';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		consultantEnquiriesBase:
+			'https://api.oriso-dev.site/service/conversations/consultants/enquiries/',
+		consultantSessions:
+			'https://api.oriso-dev.site/service/users/sessions/consultants?status=2&',
+		myMessagesBase:
+			'https://api.oriso-dev.site/service/conversations/consultants/mymessages/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { EMPTY: 'EMPTY' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn()
+}));
+
+describe('apiGetConsultantSessionList', () => {
+	it('loads registered enquiries for the enquiry tab', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ sessions: [] });
+
+		await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.ENQUIRY
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: `https://api.oriso-dev.site/service/conversations/consultants/enquiries/registered?count=${SESSION_COUNT}&filter=all&offset=0`,
+			method: 'GET',
+			rcValidation: true,
+			responseHandling: ['EMPTY'],
+			timeout: TIMEOUT
+		});
+	});
+
+	it('loads consultant sessions with pagination', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ sessions: [] });
+
+		await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.MY_SESSION,
+			offset: 30,
+			count: 10
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/sessions/consultants?status=2&count=10&filter=all&offset=30',
+			method: 'GET',
+			rcValidation: true,
+			responseHandling: ['EMPTY'],
+			timeout: TIMEOUT
+		});
+	});
+
+	it('loads archived sessions without sending the filter query param', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ sessions: [] });
+
+		await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.MY_SESSION,
+			sessionListTab: SESSION_LIST_TAB_ARCHIVE,
+			count: 5,
+			offset: 10
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/conversations/consultants/mymessages/archive?count=5&offset=10',
+			method: 'GET',
+			rcValidation: true,
+			responseHandling: ['EMPTY'],
+			timeout: TIMEOUT
+		});
+	});
+});

--- a/src/api/apiGroupChatSettings.test.ts
+++ b/src/api/apiGroupChatSettings.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiCreateGroupChat, apiUpdateGroupChat } from './apiGroupChatSettings';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		groupChatBase: 'https://api.oriso-dev.site/service/users/chat/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST', PUT: 'PUT' },
+	FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+	fetchData: vi.fn()
+}));
+
+const groupChat = {
+	topic: 'Stress support',
+	startDate: '2026-07-01',
+	startTime: '10:00',
+	duration: 60,
+	agencyId: 17,
+	hintMessage: 'Welcome',
+	repetitive: false
+};
+
+describe('group chat API helpers', () => {
+	it('creates a v1 chat room and returns the backend link data', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-123' });
+
+		await expect(apiCreateGroupChat(groupChat)).resolves.toEqual({
+			groupId: 'group-123'
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/chat/new',
+			method: 'POST',
+			bodyData: JSON.stringify(groupChat),
+			responseHandling: ['CONTENT']
+		});
+	});
+
+	it('creates a v2 chat room when the feature flag is enabled', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-v2' });
+
+		await apiCreateGroupChat({
+			...groupChat,
+			featureGroupChatV2Enabled: true
+		});
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.oriso-dev.site/service/users/chat/v2/new',
+				method: 'POST'
+			})
+		);
+	});
+
+	it('updates an existing chat room', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-123' });
+
+		await apiUpdateGroupChat(123, groupChat);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/chat/123/update',
+			method: 'PUT',
+			bodyData: JSON.stringify(groupChat),
+			responseHandling: ['CONTENT']
+		});
+	});
+});

--- a/src/api/apiMagicLinkLogin.test.ts
+++ b/src/api/apiMagicLinkLogin.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiConsumeMagicLinkLogin } from './apiConsumeMagicLinkLogin';
+import { apiRequestMagicLinkLogin } from './apiRequestMagicLinkLogin';
+
+const fetchDataMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		magicLinkConsume:
+			'https://api.oriso-dev.site/service/users/magic-link/consume',
+		magicLinkRequest:
+			'https://api.oriso-dev.site/service/users/magic-link/request'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: {
+		BAD_REQUEST: 'BAD_REQUEST',
+		FORBIDDEN: 'FORBIDDEN',
+		GATEWAY_TIMEOUT: 'GATEWAY_TIMEOUT',
+		UNAUTHORIZED: 'UNAUTHORIZED'
+	},
+	FETCH_METHODS: { POST: 'POST' },
+	FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+	fetchData: fetchDataMock
+}));
+
+vi.mock('./index', () => ({
+	FETCH_ERRORS: {
+		BAD_REQUEST: 'BAD_REQUEST',
+		UNAUTHORIZED: 'UNAUTHORIZED'
+	},
+	FETCH_METHODS: { POST: 'POST' },
+	FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+	fetchData: fetchDataMock
+}));
+
+describe('magic link login API helpers', () => {
+	it('requests a magic login link for the entered email address', async () => {
+		fetchDataMock.mockResolvedValue(undefined);
+
+		await apiRequestMagicLinkLogin('shanzae@example.com');
+
+		expect(fetchDataMock).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/magic-link/request',
+			method: 'POST',
+			bodyData: JSON.stringify({ username: 'shanzae@example.com' }),
+			skipAuth: true,
+			responseHandling: ['BAD_REQUEST', 'FORBIDDEN', 'GATEWAY_TIMEOUT']
+		});
+	});
+
+	it('consumes a magic login token and returns auth tokens', async () => {
+		const tokenResponse = {
+			access_token: 'access-token',
+			expires_in: 300,
+			refresh_token: 'refresh-token',
+			refresh_expires_in: 600
+		};
+		fetchDataMock.mockResolvedValue(tokenResponse);
+
+		await expect(apiConsumeMagicLinkLogin('magic-token')).resolves.toEqual(
+			tokenResponse
+		);
+
+		expect(fetchDataMock).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/users/magic-link/consume',
+			method: 'POST',
+			bodyData: JSON.stringify({ token: 'magic-token' }),
+			skipAuth: true,
+			responseHandling: ['CONTENT', 'BAD_REQUEST', 'UNAUTHORIZED']
+		});
+	});
+});

--- a/src/api/apiServerSettings.test.ts
+++ b/src/api/apiServerSettings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiServerSettings } from './apiServerSettings';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		serviceSettings: 'https://api.oriso-dev.site/service/settings'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn()
+}));
+
+describe('apiServerSettings', () => {
+	it('loads public server settings without requiring auth', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			multitenancyEnabled: { value: false }
+		});
+
+		await expect(apiServerSettings()).resolves.toEqual({
+			multitenancyEnabled: { value: false }
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.oriso-dev.site/service/settings',
+			method: 'GET',
+			skipAuth: true,
+			responseHandling: []
+		});
+	});
+});

--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { hasActiveAuthSession, isPublicAuthRoute, setTokens } from './auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	handleTokenRefresh,
+	hasActiveAuthSession,
+	isPublicAuthRoute,
+	setTokens
+} from './auth';
 import { setValueInCookie } from '../sessionCookie/accessSessionCookie';
 import {
 	getTokenExpiryFromLocalStorage,
 	setTokenExpiryInLocalStorage
 } from '../sessionCookie/accessSessionLocalStorage';
+import { logout } from '../logout/logout';
+import { refreshKeycloakAccessToken } from '../sessionCookie/refreshKeycloakAccessToken';
 
 vi.mock('../sessionCookie/accessSessionCookie', () => ({
 	setValueInCookie: vi.fn()
@@ -36,6 +43,10 @@ describe('auth helpers', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		window.history.replaceState({}, '', '/login');
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it.each([
@@ -87,6 +98,68 @@ describe('auth helpers', () => {
 		});
 
 		expect(hasActiveAuthSession()).toBe(false);
-		vi.useRealTimers();
+	});
+
+	it('logs out and rejects when access and refresh tokens are expired', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'));
+		vi.mocked(getTokenExpiryFromLocalStorage).mockReturnValue({
+			accessTokenValidUntilTime: Date.now() - 1,
+			refreshTokenValidUntilTime: Date.now() - 1
+		});
+
+		await expect(handleTokenRefresh(false)).rejects.toBeUndefined();
+
+		expect(logout).toHaveBeenCalledWith(false, '/login');
+	});
+
+	it('refreshes tokens when only the access token is expired', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'));
+		vi.mocked(getTokenExpiryFromLocalStorage).mockReturnValue({
+			accessTokenValidUntilTime: Date.now() - 1,
+			refreshTokenValidUntilTime: Date.now() + 60_000
+		});
+		vi.mocked(refreshKeycloakAccessToken).mockResolvedValue({
+			data: {},
+			access_token: 'new-access',
+			expires_in: 300,
+			refresh_token: 'new-refresh',
+			refresh_expires_in: 600
+		});
+
+		await expect(handleTokenRefresh()).resolves.toBeUndefined();
+
+		expect(refreshKeycloakAccessToken).toHaveBeenCalled();
+		expect(setValueInCookie).toHaveBeenCalledWith('keycloak', 'new-access');
+		expect(setValueInCookie).toHaveBeenCalledWith(
+			'refreshToken',
+			'new-refresh'
+		);
+	});
+
+	it('starts refresh and logout timers when tokens are still valid', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'));
+		vi.mocked(getTokenExpiryFromLocalStorage).mockReturnValue({
+			accessTokenValidUntilTime: Date.now() + 20_000,
+			refreshTokenValidUntilTime: Date.now() + 40_000
+		});
+		vi.mocked(refreshKeycloakAccessToken).mockResolvedValue({
+			data: {},
+			access_token: 'timer-access',
+			expires_in: 300,
+			refresh_token: 'timer-refresh',
+			refresh_expires_in: 600
+		});
+
+		await handleTokenRefresh();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(refreshKeycloakAccessToken).toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(30_000);
+
+		expect(logout).toHaveBeenCalledWith(true, '/login');
 	});
 });

--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hasActiveAuthSession, isPublicAuthRoute, setTokens } from './auth';
+import { setValueInCookie } from '../sessionCookie/accessSessionCookie';
+import {
+	getTokenExpiryFromLocalStorage,
+	setTokenExpiryInLocalStorage
+} from '../sessionCookie/accessSessionLocalStorage';
+
+vi.mock('../sessionCookie/accessSessionCookie', () => ({
+	setValueInCookie: vi.fn()
+}));
+
+vi.mock('../sessionCookie/accessSessionLocalStorage', () => ({
+	getTokenExpiryFromLocalStorage: vi.fn(),
+	setTokenExpiryInLocalStorage: vi.fn()
+}));
+
+vi.mock('../logout/logout', () => ({
+	logout: vi.fn()
+}));
+
+vi.mock('../sessionCookie/refreshKeycloakAccessToken', () => ({
+	refreshKeycloakAccessToken: vi.fn()
+}));
+
+vi.mock('../../utils/appConfig', () => ({
+	appConfig: {
+		urls: {
+			toLogin: '/login'
+		}
+	}
+}));
+
+describe('auth helpers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		window.history.replaceState({}, '', '/login');
+	});
+
+	it.each([
+		['/login', true],
+		['/registration', true],
+		['/tenant-a/registration', true],
+		['/error.401.html', true],
+		['/sessions/consultant/sessionView', false]
+	])('detects public auth route %s', (path, expected) => {
+		window.history.replaceState({}, '', path);
+
+		expect(isPublicAuthRoute()).toBe(expected);
+	});
+
+	it('stores keycloak and refresh tokens with expiry metadata', () => {
+		setTokens('access-token', 300, 'refresh-token', 600);
+
+		expect(setValueInCookie).toHaveBeenCalledWith(
+			'keycloak',
+			'access-token'
+		);
+		expect(setValueInCookie).toHaveBeenCalledWith(
+			'refreshToken',
+			'refresh-token'
+		);
+		expect(setTokenExpiryInLocalStorage).toHaveBeenCalledWith(
+			'auth.access_token_valid_until',
+			300
+		);
+		expect(setTokenExpiryInLocalStorage).toHaveBeenCalledWith(
+			'auth.refresh_token_valid_until',
+			600
+		);
+	});
+
+	it('reports active auth when either access or refresh token is still valid', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'));
+		vi.mocked(getTokenExpiryFromLocalStorage).mockReturnValue({
+			accessTokenValidUntilTime: Date.now() - 1,
+			refreshTokenValidUntilTime: Date.now() + 1_000
+		});
+
+		expect(hasActiveAuthSession()).toBe(true);
+
+		vi.mocked(getTokenExpiryFromLocalStorage).mockReturnValue({
+			accessTokenValidUntilTime: Date.now() - 1,
+			refreshTokenValidUntilTime: Date.now() - 1
+		});
+
+		expect(hasActiveAuthSession()).toBe(false);
+		vi.useRealTimers();
+	});
+});

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -267,7 +267,8 @@ describe('autoLogin', () => {
 		);
 		vi.mocked(apiRocketChatFetchMyKeys).mockResolvedValue({
 			private_key: 'encrypted-private',
-			public_key: JSON.stringify({ n: 'stored-public-key' })
+			public_key: JSON.stringify({ n: 'stored-public-key' }),
+			success: true
 		});
 		const { decryptPrivateKey } = await import(
 			'../../utils/encryptionHelpers'

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { autoLogin } from './autoLogin';
+import { getKeycloakAccessToken } from '../sessionCookie/getKeycloakAccessToken';
+import {
+	getMatrixAccessToken,
+	persistMatrixLoginData
+} from '../sessionCookie/getMatrixAccessToken';
+import { setTokens } from '../auth/auth';
+
+vi.mock('../sessionCookie/getKeycloakAccessToken', () => ({
+	getKeycloakAccessToken: vi.fn()
+}));
+
+vi.mock('../sessionCookie/getMatrixAccessToken', () => ({
+	getMatrixAccessToken: vi.fn(),
+	persistMatrixLoginData: vi.fn()
+}));
+
+vi.mock('../sessionCookie/getRocketchatAccessToken', () => ({
+	getRocketchatAccessToken: vi.fn()
+}));
+
+vi.mock('../sessionCookie/accessSessionCookie', () => ({
+	setValueInCookie: vi.fn()
+}));
+
+vi.mock('../../utils/generateCsrfToken', () => ({
+	generateCsrfToken: vi.fn()
+}));
+
+vi.mock('../../utils/encryptionHelpers', () => ({
+	createAndStoreKeys: vi.fn(),
+	decryptPrivateKey: vi.fn(),
+	deriveMasterKeyFromPassword: vi.fn(),
+	encodeUsername: vi.fn((username: string) => `encoded:${username}`),
+	encryptForParticipant: vi.fn(),
+	encryptPrivateKey: vi.fn(),
+	getTmpMasterKey: vi.fn(),
+	importRawEncryptionKey: vi.fn(),
+	readMasterKeyFromLocalStorage: vi.fn(),
+	storeKeys: vi.fn(),
+	writeMasterKeyToLocalStorage: vi.fn()
+}));
+
+vi.mock('../auth/auth', () => ({
+	setTokens: vi.fn()
+}));
+
+vi.mock('../../api', () => ({
+	FETCH_ERRORS: { UNAUTHORIZED: 'UNAUTHORIZED' },
+	apiUpdateUserE2EKeys: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatFetchMyKeys', () => ({
+	apiRocketChatFetchMyKeys: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatSetUserKeys', () => ({
+	apiRocketChatSetUserKeys: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatSubscriptionsGet', () => ({
+	apiRocketChatSubscriptionsGet: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatRoomsGet', () => ({
+	apiRocketChatRoomsGet: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatUpdateGroupKey', () => ({
+	apiRocketChatUpdateGroupKey: vi.fn()
+}));
+
+vi.mock('../../api/apiRocketChatResetE2EKey', () => ({
+	apiRocketChatResetE2EKey: vi.fn()
+}));
+
+vi.mock('../sessionCookie/getBudibaseAccessToken', () => ({
+	getBudibaseAccessToken: vi.fn()
+}));
+
+vi.mock('../../utils/appConfig', () => ({
+	appConfig: {
+		multitenancyWithSingleDomainEnabled: false,
+		useTenantService: false,
+		urls: {
+			redirectToApp: '/sessions'
+		}
+	}
+}));
+
+vi.mock('../../utils/parseJWT', () => ({
+	parseJwt: vi.fn()
+}));
+
+const keycloakResponse = {
+	access_token: 'keycloak-access',
+	expires_in: 300,
+	refresh_token: 'keycloak-refresh',
+	refresh_expires_in: 600
+};
+
+const matrixResponse = {
+	accessToken: 'matrix-access',
+	deviceId: 'ORISO_WEB_DEVICE',
+	homeserverUrl: 'https://matrix.oriso-dev.site',
+	userId: '@shanzae:matrix.oriso-dev.site'
+};
+
+describe('autoLogin', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getKeycloakAccessToken).mockResolvedValue(keycloakResponse);
+		vi.mocked(getMatrixAccessToken).mockResolvedValue(matrixResponse);
+	});
+
+	it('logs in with Keycloak, stores auth tokens, and persists Matrix login data', async () => {
+		await autoLogin({
+			username: 'shanzae@example.com',
+			password: 'secret!',
+			tenantData: { settings: {} } as any
+		});
+
+		expect(getKeycloakAccessToken).toHaveBeenCalledWith(
+			'encoded:shanzae@example.com',
+			'secret!',
+			null
+		);
+		expect(setTokens).toHaveBeenCalledWith(
+			'keycloak-access',
+			300,
+			'keycloak-refresh',
+			600
+		);
+		expect(getMatrixAccessToken).toHaveBeenCalledWith(
+			'shanzae@example.com',
+			'secret!'
+		);
+		expect(persistMatrixLoginData).toHaveBeenCalledWith(matrixResponse);
+	});
+
+	it('retries with the entered username when encoded username login is unauthorized', async () => {
+		vi.mocked(getKeycloakAccessToken)
+			.mockRejectedValueOnce(new Error('UNAUTHORIZED'))
+			.mockResolvedValueOnce(keycloakResponse);
+
+		await autoLogin({
+			username: 'shanzae@example.com',
+			password: 'secret!',
+			tenantData: { settings: {} } as any
+		});
+
+		expect(getKeycloakAccessToken).toHaveBeenNthCalledWith(
+			1,
+			'encoded:shanzae@example.com',
+			'secret!',
+			null
+		);
+		expect(getKeycloakAccessToken).toHaveBeenNthCalledWith(
+			2,
+			'shanzae%40example.com',
+			'secret!',
+			null
+		);
+	});
+});

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -1,12 +1,33 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { autoLogin } from './autoLogin';
+import { autoLogin, handleE2EESetup } from './autoLogin';
 import { getKeycloakAccessToken } from '../sessionCookie/getKeycloakAccessToken';
 import {
 	getMatrixAccessToken,
 	persistMatrixLoginData
 } from '../sessionCookie/getMatrixAccessToken';
 import { setTokens } from '../auth/auth';
+import { getBudibaseAccessToken } from '../sessionCookie/getBudibaseAccessToken';
+import { parseJwt } from '../../utils/parseJWT';
+import { apiRocketChatFetchMyKeys } from '../../api/apiRocketChatFetchMyKeys';
+import { apiRocketChatSetUserKeys } from '../../api/apiRocketChatSetUserKeys';
+import { apiUpdateUserE2EKeys } from '../../api';
+import {
+	createAndStoreKeys,
+	deriveMasterKeyFromPassword,
+	encryptPrivateKey,
+	readMasterKeyFromLocalStorage,
+	storeKeys,
+	writeMasterKeyToLocalStorage
+} from '../../utils/encryptionHelpers';
+
+const mockAppConfig = vi.hoisted(() => ({
+	multitenancyWithSingleDomainEnabled: false,
+	useTenantService: false,
+	urls: {
+		redirectToApp: '/sessions'
+	}
+}));
 
 vi.mock('../sessionCookie/getKeycloakAccessToken', () => ({
 	getKeycloakAccessToken: vi.fn()
@@ -81,13 +102,7 @@ vi.mock('../sessionCookie/getBudibaseAccessToken', () => ({
 }));
 
 vi.mock('../../utils/appConfig', () => ({
-	appConfig: {
-		multitenancyWithSingleDomainEnabled: false,
-		useTenantService: false,
-		urls: {
-			redirectToApp: '/sessions'
-		}
-	}
+	appConfig: mockAppConfig
 }));
 
 vi.mock('../../utils/parseJWT', () => ({
@@ -112,6 +127,9 @@ const matrixResponse = {
 describe('autoLogin', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockAppConfig.multitenancyWithSingleDomainEnabled = false;
+		mockAppConfig.useTenantService = false;
+		mockAppConfig.urls.redirectToApp = '/sessions';
 		vi.mocked(getKeycloakAccessToken).mockResolvedValue(keycloakResponse);
 		vi.mocked(getMatrixAccessToken).mockResolvedValue(matrixResponse);
 	});
@@ -164,5 +182,108 @@ describe('autoLogin', () => {
 			'secret!',
 			null
 		);
+	});
+
+	it('throws unauthorized when tenant validation fails', async () => {
+		mockAppConfig.useTenantService = true;
+		vi.mocked(parseJwt).mockReturnValue({ tenantId: 'tenant-from-token' });
+
+		await expect(
+			autoLogin({
+				username: 'shanzae@example.com',
+				password: 'secret!',
+				tenantData: { id: 'selected-tenant', settings: {} } as any
+			})
+		).rejects.toThrow('UNAUTHORIZED');
+
+		expect(getMatrixAccessToken).not.toHaveBeenCalled();
+	});
+
+	it('continues login when Matrix login data cannot be loaded', async () => {
+		vi.mocked(getMatrixAccessToken).mockRejectedValue(
+			new Error('matrix unavailable')
+		);
+
+		await autoLogin({
+			username: 'shanzae@example.com',
+			password: 'secret!',
+			tenantData: { settings: {} } as any
+		});
+
+		expect(setTokens).toHaveBeenCalled();
+		expect(persistMatrixLoginData).not.toHaveBeenCalled();
+	});
+
+	it('loads Budibase access token when feature tools are enabled', async () => {
+		await autoLogin({
+			username: 'shanzae@example.com',
+			password: 'secret!',
+			tenantData: {
+				settings: {
+					featureToolsEnabled: true
+				}
+			} as any
+		});
+
+		expect(getBudibaseAccessToken).toHaveBeenCalledWith(
+			'encoded:shanzae@example.com',
+			'secret!',
+			{ featureToolsEnabled: true }
+		);
+	});
+	it('creates and stores new E2EE keys when no Rocket.Chat keys exist', async () => {
+		vi.mocked(deriveMasterKeyFromPassword).mockResolvedValue(
+			'master-key' as any
+		);
+		vi.mocked(apiRocketChatFetchMyKeys).mockResolvedValue({});
+		vi.mocked(createAndStoreKeys).mockResolvedValue({
+			privateKey: 'private-key',
+			publicKey: JSON.stringify({ n: 'public-key-material' })
+		} as any);
+		vi.mocked(encryptPrivateKey).mockResolvedValue(
+			'encrypted-private-key' as any
+		);
+		vi.mocked(apiRocketChatSetUserKeys).mockResolvedValue({});
+		vi.mocked(apiUpdateUserE2EKeys).mockResolvedValue({});
+
+		await handleE2EESetup('secret!', 'rc-user-id');
+
+		expect(createAndStoreKeys).toHaveBeenCalled();
+		expect(apiRocketChatSetUserKeys).toHaveBeenCalledWith(
+			JSON.stringify({ n: 'public-key-material' }),
+			'encrypted-private-key'
+		);
+		expect(apiUpdateUserE2EKeys).toHaveBeenCalledWith(
+			'public-key-material'
+		);
+	});
+
+	it('resets keys and relogs in when encrypted keys cannot be decrypted without a persisted master key', async () => {
+		const reloginCallback = vi.fn().mockResolvedValue('relogged');
+		vi.mocked(deriveMasterKeyFromPassword).mockResolvedValue(
+			'master-key' as any
+		);
+		vi.mocked(apiRocketChatFetchMyKeys).mockResolvedValue({
+			private_key: 'encrypted-private',
+			public_key: JSON.stringify({ n: 'stored-public-key' })
+		});
+		const { decryptPrivateKey } = await import(
+			'../../utils/encryptionHelpers'
+		);
+		const { apiRocketChatResetE2EKey } = await import(
+			'../../api/apiRocketChatResetE2EKey'
+		);
+		vi.mocked(decryptPrivateKey).mockRejectedValue(new Error('bad key'));
+		vi.mocked(readMasterKeyFromLocalStorage).mockReturnValue(null);
+
+		await handleE2EESetup('secret!', 'rc-user-id', reloginCallback);
+
+		expect(apiRocketChatResetE2EKey).toHaveBeenCalled();
+		expect(writeMasterKeyToLocalStorage).toHaveBeenCalledWith(
+			'master-key',
+			'rc-user-id'
+		);
+		expect(reloginCallback).toHaveBeenCalled();
+		expect(storeKeys).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -235,7 +235,9 @@ describe('autoLogin', () => {
 		vi.mocked(deriveMasterKeyFromPassword).mockResolvedValue(
 			'master-key' as any
 		);
-		vi.mocked(apiRocketChatFetchMyKeys).mockResolvedValue({});
+		vi.mocked(apiRocketChatFetchMyKeys).mockResolvedValue({
+			success: true
+		});
 		vi.mocked(createAndStoreKeys).mockResolvedValue({
 			privateKey: 'private-key',
 			publicKey: JSON.stringify({ n: 'public-key-material' })

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -95,6 +95,7 @@ vi.mock('../../utils/parseJWT', () => ({
 }));
 
 const keycloakResponse = {
+	data: {},
 	access_token: 'keycloak-access',
 	expires_in: 300,
 	refresh_token: 'keycloak-refresh',

--- a/src/components/session/sessionHelpers.test.ts
+++ b/src/components/session/sessionHelpers.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	CHAT_TYPE_GROUP_CHAT,
+	CHAT_TYPE_SINGLE_CHAT,
+	getChatItemForSession,
+	getChatTypeForListItem,
+	getSessionType,
+	getViewPathForType,
+	isGroupChat,
+	isMyMessage,
+	isSessionChat,
+	isUserModerator,
+	prepareMessages,
+	SESSION_LIST_TYPES,
+	SESSION_TYPE_ARCHIVED,
+	SESSION_TYPE_ENQUIRY,
+	SESSION_TYPE_GROUP,
+	SESSION_TYPE_SESSION
+} from './sessionHelpers';
+import {
+	STATUS_EMPTY,
+	STATUS_ARCHIVED,
+	STATUS_ENQUIRY
+} from '../../globalState/interfaces';
+import { getValueFromCookie } from '../sessionCookie/accessSessionCookie';
+
+vi.mock('../sessionCookie/accessSessionCookie', () => ({
+	getValueFromCookie: vi.fn()
+}));
+
+vi.mock('../../utils/encryptionHelpers', () => ({
+	decodeUsername: vi.fn((name: string) => `decoded:${name}`)
+}));
+
+describe('sessionHelpers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('classifies enquiry, archived, normal, and group sessions', () => {
+		expect(
+			getSessionType({ session: { status: STATUS_EMPTY } } as any, 'me')
+		).toBe(SESSION_TYPE_ENQUIRY);
+		expect(
+			getSessionType({ session: { status: STATUS_ENQUIRY } } as any, 'me')
+		).toBe(SESSION_TYPE_ENQUIRY);
+		expect(
+			getSessionType(
+				{ session: { status: STATUS_ARCHIVED } } as any,
+				'me'
+			)
+		).toBe(SESSION_TYPE_ARCHIVED);
+		expect(getSessionType({ session: { status: 2 } } as any, 'me')).toBe(
+			SESSION_TYPE_SESSION
+		);
+		expect(
+			getSessionType({ chat: { moderators: ['me'] } } as any, 'me')
+		).toBe(SESSION_TYPE_GROUP);
+	});
+
+	it('resolves chat item and chat type from list items', () => {
+		const sessionItem = { session: { id: 1, askerRcId: 'user-1' } };
+		const groupItem = { chat: { id: 2, moderators: ['mod-1'] } };
+
+		expect(getChatTypeForListItem(sessionItem as any)).toBe(
+			CHAT_TYPE_SINGLE_CHAT
+		);
+		expect(getChatTypeForListItem(groupItem as any)).toBe(
+			CHAT_TYPE_GROUP_CHAT
+		);
+		expect(getChatItemForSession(sessionItem as any)).toBe(
+			sessionItem.session
+		);
+		expect(getChatItemForSession(groupItem as any)).toBe(groupItem.chat);
+		expect(isSessionChat(sessionItem.session as any)).toBe(true);
+		expect(isGroupChat(groupItem.chat as any)).toBe(true);
+	});
+
+	it('maps session list types to their route view names', () => {
+		expect(getViewPathForType(SESSION_LIST_TYPES.ENQUIRY)).toBe(
+			'sessionPreview'
+		);
+		expect(getViewPathForType(SESSION_LIST_TYPES.MY_SESSION)).toBe(
+			'sessionView'
+		);
+	});
+
+	it('marks the logged-in user message and group moderator', () => {
+		vi.mocked(getValueFromCookie).mockReturnValue('rc-user-id');
+
+		expect(isMyMessage('rc-user-id')).toBe(true);
+		expect(isMyMessage('another-user')).toBe(false);
+		expect(
+			isUserModerator({
+				chatItem: { moderators: ['rc-user-id'] },
+				rcUserId: 'rc-user-id'
+			})
+		).toBe(true);
+	});
+
+	it('prepares messages and keeps only one user-left system notification', () => {
+		const messages = [
+			{
+				_id: 'message-1',
+				msg: 'Hello',
+				ts: '2026-06-29T09:00:00.000Z',
+				u: { _id: 'user-1', username: 'user-one', name: 'User One' },
+				unread: true
+			},
+			{
+				_id: 'message-2',
+				msg:
+					'[SYSTEM_NOTIFICATION] ' +
+					JSON.stringify({ type: 'USER_LEFT_CHAT' }),
+				ts: '2026-06-29T09:01:00.000Z',
+				u: { _id: 'system', username: 'system', name: null }
+			},
+			{
+				_id: 'message-3',
+				msg:
+					'[SYSTEM_NOTIFICATION] ' +
+					JSON.stringify({ type: 'USER_LEFT_CHAT' }),
+				ts: '2026-06-29T09:02:00.000Z',
+				u: { _id: 'system', username: 'system', name: null }
+			},
+			{
+				_id: 'message-4',
+				msg: 'Video started',
+				ts: '2026-06-29T09:03:00.000Z',
+				u: { _id: 'user-2', username: 'user-two', name: null },
+				alias: { messageType: 'VIDEOCALL' }
+			}
+		];
+
+		const prepared = prepareMessages(messages);
+
+		expect(prepared.map((message) => message._id)).toEqual([
+			'message-1',
+			'message-2',
+			'message-4'
+		]);
+		expect(prepared[0].displayName).toBe('decoded:User One');
+		expect(prepared[2].isVideoActive).toBe(true);
+	});
+});

--- a/src/components/sessionCookie/getKeycloakAccessToken.test.ts
+++ b/src/components/sessionCookie/getKeycloakAccessToken.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getKeycloakAccessToken } from './getKeycloakAccessToken';
+
+vi.mock('../../resources/scripts/endpoints', () => ({
+	endpoints: {
+		keycloakAccessToken:
+			'https://api.oriso-dev.site/auth/realms/online-beratung/protocol/openid-connect/token'
+	}
+}));
+
+vi.mock('../../api', () => ({
+	FETCH_ERRORS: {
+		BAD_REQUEST: 'BAD_REQUEST',
+		UNAUTHORIZED: 'UNAUTHORIZED'
+	},
+	FetchErrorWithOptions: class FetchErrorWithOptions extends Error {
+		options: Record<string, unknown>;
+
+		constructor(message: string, options: Record<string, unknown>) {
+			super(message);
+			this.options = options;
+		}
+	}
+}));
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	fetchMock.mockReset();
+});
+
+describe('getKeycloakAccessToken', () => {
+	it('posts entered username and password to the configured Keycloak token endpoint', async () => {
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: 'access-token',
+					expires_in: 300,
+					refresh_token: 'refresh-token',
+					refresh_expires_in: 600
+				}),
+				{ status: 200 }
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			getKeycloakAccessToken('shanzae@example.com', 'secret%21')
+		).resolves.toMatchObject({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token'
+		});
+
+		const request = fetchMock.mock.calls[0][0] as Request;
+		expect(request.url).toBe(
+			'https://api.oriso-dev.site/auth/realms/online-beratung/protocol/openid-connect/token'
+		);
+		expect(request.method).toBe('POST');
+		expect(await request.text()).toBe(
+			'username=shanzae@example.com&password=secret%21&client_id=app&grant_type=password'
+		);
+	});
+
+	it('includes an otp code when two-factor authentication is required', async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ access_token: 'token' }), {
+				status: 200
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getKeycloakAccessToken('user', 'password', '123456');
+
+		const request = fetchMock.mock.calls[0][0] as Request;
+		expect(await request.text()).toContain('&otp=123456&');
+	});
+
+	it('rejects invalid credentials as an unauthorized login error', async () => {
+		fetchMock.mockResolvedValue(new Response('', { status: 401 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			getKeycloakAccessToken('wrong@example.com', 'bad-password')
+		).rejects.toThrow('UNAUTHORIZED');
+	});
+
+	it('keeps Keycloak validation details for bad request responses', async () => {
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error_description: 'otp required',
+					otpType: 'EMAIL'
+				}),
+				{ status: 400 }
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			getKeycloakAccessToken('user@example.com', 'password')
+		).rejects.toMatchObject({
+			message: 'BAD_REQUEST',
+			options: {
+				data: {
+					error_description: 'otp required',
+					otpType: 'EMAIL'
+				}
+			}
+		});
+	});
+});

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { persistMatrixLoginData } from './getMatrixAccessToken';
+import {
+	createMatrixClient,
+	getMatrixAccessToken,
+	persistMatrixLoginData
+} from './getMatrixAccessToken';
+import { fetchData } from '../../api/fetchData';
+import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
+import { createClient } from 'matrix-js-sdk';
 
 vi.mock('../../resources/scripts/endpoints', () => ({
 	endpoints: {
@@ -8,8 +15,12 @@ vi.mock('../../resources/scripts/endpoints', () => ({
 	}
 }));
 
+vi.mock('matrix-js-sdk', () => ({
+	createClient: vi.fn((config) => ({ config }))
+}));
+
 vi.mock('../../resources/scripts/runtimeConfig', () => ({
-	getMatrixHomeserverUrl: () => 'https://matrix.example.test'
+	getMatrixHomeserverUrl: vi.fn(() => 'https://matrix.example.test')
 }));
 
 vi.mock('../../api/fetchData', () => ({
@@ -76,5 +87,114 @@ describe('persistMatrixLoginData', () => {
 		expect(localStorage.getItem('matrix_token_expires_at')).toBe(
 			(Date.parse('2026-06-26T00:00:00.000Z') + 3_300_000).toString()
 		);
+	});
+});
+
+describe('getMatrixAccessToken', () => {
+	it('loads Matrix credentials from the API and uses the response device id', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			deviceId: 'RESPONSE_DEVICE',
+			expiresInMs: 120_000,
+			userId: '@user:matrix.example.test'
+		});
+
+		await expect(getMatrixAccessToken()).resolves.toEqual({
+			accessToken: 'matrix-token',
+			deviceId: 'RESPONSE_DEVICE',
+			expiresInMs: 120_000,
+			homeserverUrl: 'https://matrix.example.test',
+			userId: '@user:matrix.example.test'
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example.test/service/matrix/me/token',
+			method: 'GET',
+			responseHandling: ['CATCH_ALL']
+		});
+	});
+
+	it('reuses a stored browser device id when the API omits one', async () => {
+		localStorage.setItem(
+			'matrix_device_id:@user:matrix.example.test',
+			'STORED_DEVICE'
+		);
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			userId: '@user:matrix.example.test'
+		});
+
+		await expect(getMatrixAccessToken()).resolves.toMatchObject({
+			deviceId: 'STORED_DEVICE'
+		});
+	});
+
+	it('creates a browser device id when neither API nor storage has one', async () => {
+		Object.defineProperty(globalThis, 'crypto', {
+			value: { randomUUID: () => '12345678-90ab-cdef-1234-567890abcdef' },
+			configurable: true
+		});
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			userId: '@new-user:matrix.example.test'
+		});
+
+		const result = await getMatrixAccessToken();
+
+		expect(result.deviceId).toBe('ORISO_WEB_1234567890ABCDEF12345678');
+		expect(
+			localStorage.getItem(
+				'matrix_device_id:@new-user:matrix.example.test'
+			)
+		).toBe('ORISO_WEB_1234567890ABCDEF12345678');
+	});
+
+	it('throws when Matrix homeserver URL is missing', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			userId: '@user:matrix.example.test'
+		});
+		vi.mocked(getMatrixHomeserverUrl).mockReturnValue('');
+
+		await expect(getMatrixAccessToken()).rejects.toThrow(
+			'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+		);
+	});
+
+	it('does not write expiry metadata when expiresInMs is absent', () => {
+		persistMatrixLoginData({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
+			homeserverUrl: 'https://matrix.example.test',
+			userId: '@consultant:matrix.example.test'
+		});
+
+		expect(localStorage.getItem('matrix_token_expires_at')).toBeNull();
+	});
+
+	it('creates a Matrix client from stored credentials', () => {
+		const client = createMatrixClient({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
+			homeserverUrl: 'https://matrix.example.test',
+			userId: '@consultant:matrix.example.test'
+		});
+
+		expect(createClient).toHaveBeenCalledWith({
+			baseUrl: 'https://matrix.example.test',
+			accessToken: 'matrix-token',
+			userId: '@consultant:matrix.example.test',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
+			fallbackICEServerAllowed: true
+		});
+		expect(client).toEqual({
+			config: {
+				baseUrl: 'https://matrix.example.test',
+				accessToken: 'matrix-token',
+				userId: '@consultant:matrix.example.test',
+				deviceId: 'ORISO_WEB_TEST_DEVICE',
+				fallbackICEServerAllowed: true
+			}
+		});
 	});
 });

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { persistMatrixLoginData } from './getMatrixAccessToken';
 
 vi.mock('../../resources/scripts/endpoints', () => ({
@@ -17,6 +17,29 @@ vi.mock('../../api/fetchData', () => ({
 	FETCH_METHODS: { GET: 'GET' },
 	fetchData: vi.fn()
 }));
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+	clear: vi.fn(() => storage.clear()),
+	getItem: vi.fn((key: string) => storage.get(key) ?? null),
+	removeItem: vi.fn((key: string) => storage.delete(key)),
+	setItem: vi.fn((key: string, value: string) =>
+		storage.set(key, String(value))
+	)
+};
+
+beforeEach(() => {
+	storage.clear();
+	Object.defineProperty(window, 'localStorage', {
+		value: localStorageMock,
+		configurable: true
+	});
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: localStorageMock,
+		configurable: true
+	});
+	vi.clearAllMocks();
+});
 
 afterEach(() => {
 	vi.useRealTimers();

--- a/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
+++ b/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+	isConversationCircleSession,
+	isInternalGroupChatSession,
+	normalizeSessionToolbarChip
+} from './sessionToolbarFilters';
+
+describe('session toolbar module helpers', () => {
+	it.each([
+		['neu', 'unread'],
+		['unread', 'unread'],
+		['oneToOne', 'nearby'],
+		['chats', 'nearby'],
+		['nearby', 'nearby'],
+		['drafts', 'drafts'],
+		['internal', 'internalGroup'],
+		['circles', 'groups'],
+		['groups', 'groups'],
+		['supervision', 'supervision'],
+		['unknown', null],
+		[null, null]
+	])('normalizes %s to %s', (input, expected) => {
+		expect(normalizeSessionToolbarChip(input as any)).toBe(expected);
+	});
+
+	it('distinguishes conversation circles from internal group chats', () => {
+		expect(
+			isConversationCircleSession({
+				isGroup: true,
+				item: { repetitive: true }
+			})
+		).toBe(true);
+		expect(
+			isInternalGroupChatSession({
+				isGroup: true,
+				item: { repetitive: false }
+			})
+		).toBe(true);
+		expect(
+			isInternalGroupChatSession({
+				isGroup: true,
+				item: { repetitive: true }
+			})
+		).toBe(false);
+		expect(isInternalGroupChatSession({ isGroup: false })).toBe(false);
+	});
+});

--- a/src/services/draftStore.test.ts
+++ b/src/services/draftStore.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	buildDraftKey,
+	DRAFT_STORAGE_KEY,
+	DRAFTS_UPDATED_EVENT,
+	getAllDraftEntries,
+	getDraftEntry,
+	removeDraftEntry,
+	saveDraftEntry
+} from './draftStore';
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+	clear: vi.fn(() => storage.clear()),
+	getItem: vi.fn((key: string) => storage.get(key) ?? null),
+	removeItem: vi.fn((key: string) => storage.delete(key)),
+	setItem: vi.fn((key: string, value: string) =>
+		storage.set(key, String(value))
+	)
+};
+
+describe('draftStore', () => {
+	beforeEach(() => {
+		Object.defineProperty(window, 'localStorage', {
+			value: localStorageMock,
+			configurable: true
+		});
+		Object.defineProperty(globalThis, 'localStorage', {
+			value: localStorageMock,
+			configurable: true
+		});
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('builds stable draft keys for user, scope, and thread', () => {
+		expect(buildDraftKey('user-1', 42)).toBe(
+			'u:user-1|scope:42|thread:main'
+		);
+		expect(buildDraftKey(null, null, 'root-event')).toBe(
+			'u:anonymous|scope:unknown|thread:root-event'
+		);
+	});
+
+	it('saves, reads, sorts, and removes draft entries', () => {
+		const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+		const olderDraft = {
+			key: buildDraftKey('user-1', 'room-1'),
+			userId: 'user-1',
+			text: 'Older draft',
+			updatedAt: 100
+		};
+		const newerDraft = {
+			key: buildDraftKey('user-1', 'room-2'),
+			userId: 'user-1',
+			text: 'Newer draft',
+			updatedAt: 200
+		};
+
+		saveDraftEntry(olderDraft);
+		saveDraftEntry(newerDraft);
+
+		expect(getDraftEntry(olderDraft.key)).toEqual(olderDraft);
+		expect(getAllDraftEntries('user-1')).toEqual([newerDraft, olderDraft]);
+		expect(dispatchSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ type: DRAFTS_UPDATED_EVENT })
+		);
+
+		removeDraftEntry(newerDraft.key);
+
+		expect(getDraftEntry(newerDraft.key)).toBeNull();
+		expect(getAllDraftEntries('user-1')).toEqual([olderDraft]);
+	});
+
+	it('removes a draft when saved text is empty', () => {
+		const draft = {
+			key: buildDraftKey('user-1', 'room-1'),
+			userId: 'user-1',
+			text: 'Text',
+			updatedAt: 100
+		};
+		saveDraftEntry(draft);
+
+		saveDraftEntry({ ...draft, text: '   ' });
+
+		expect(getDraftEntry(draft.key)).toBeNull();
+	});
+
+	it('recovers from malformed draft storage data', () => {
+		localStorage.setItem(DRAFT_STORAGE_KEY, '{not-json');
+
+		expect(getAllDraftEntries()).toEqual([]);
+		expect(getDraftEntry('missing')).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for previously untested frontend modules across the API layer, authentication/session flow, draft persistence, and session list helpers. All tests use **Vitest** with mocked `fetchData`, cookies, and localStorage — no production code changes.

**Scope:** 13 test files · ~1,080 lines · **49 new test cases**

## What's covered

### API modules (`src/api/`)

- **`apiDraftMessages`** — POST/GET draft messages with room headers and abort signals
- **`apiEventNotifications`** — paginated feed loading and mark-one/all/cleared states
- **`apiGetConsultantSessionList`** — enquiry tab, paginated sessions, archived sessions (no filter param)
- **`apiGroupChatSettings`** — v1/v2 chat room creation and room updates
- **`apiMagicLinkLogin`** — magic link request and token consumption
- **`apiServerSettings`** — public server settings without auth

### Auth & session (`src/components/auth/`, `sessionCookie/`, `session/`, `registration/`)

- **`auth`** — public route detection, token storage with expiry metadata, active session checks (access vs refresh token)
- **`getKeycloakAccessToken`** — Keycloak token endpoint, 2FA OTP, unauthorized and bad-request handling
- **`getMatrixAccessToken`** — Matrix credential persistence and expiry metadata
- **`autoLogin`** — Keycloak login + Matrix persistence; username retry on encoded-username 401
- **`sessionHelpers`** — session classification, chat item/type resolution, route mapping, message ownership, system notification deduplication

### Services & UI helpers

- **`draftStore`** — draft key generation, save/read/sort/remove, empty-text cleanup, malformed storage recovery
- **`sessionToolbarFilters`** — chip normalization and conversation-circle vs internal-group-chat distinction

## Testing approach

- Vitest with `vi.mock` for HTTP (`fetchData`), cookies, localStorage, and app config
- `jsdom` environment where DOM APIs are required (auth, draft store, Matrix token persistence)
- Focus on request shape, headers, error paths, and edge cases rather than full integration flows

## Test plan

- [x] `npm run test:unit` — all 274 unit tests pass (42 files)
- [ ] CI passes on PR
- [ ] No production code changes — tests only