### PR TITLE
fix(storybook): provide runtime config in dev build

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,5 +2,21 @@
 <link rel="stylesheet" href="compound-design-tokens.css">
 <link rel="stylesheet" href="compound-web.css">
 
+<!--
+  Storybook-only runtime config. The app reads window.__ORISO_RUNTIME_CONFIG__
+  before falling back to build-time env vars; without the app container config,
+  modules that touch Keycloak config at import time crash the Storybook iframe.
+-->
+<script>
+  window.__ORISO_RUNTIME_CONFIG__ = {
+    REACT_APP_KEYCLOAK_REALM: 'online-beratung',
+    REACT_APP_KEYCLOAK_ORIGIN: 'https://auth.storybook.test',
+    REACT_APP_API_URL: 'https://api.storybook.test',
+    REACT_APP_MATRIX_HOMESERVER_URL: 'https://matrix.storybook.test',
+    REACT_APP_ELEMENT_CALL_BASE_URL: 'https://call.storybook.test',
+    REACT_APP_LIVEKIT_WS_URL: 'wss://livekit.storybook.test'
+  };
+</script>
+
 
 <!-- ci trigger storybook -->


### PR DESCRIPTION
## Summary
- inject Storybook-only runtime config before preview modules load
- prevent deployed Storybook docs/canvas from crashing when app modules read Keycloak config at import time

## Validation
- npm ci --legacy-peer-deps --ignore-scripts
- npm run build-storybook
- browser-checked built iframe docs route locally: no REACT_APP_KEYCLOAK_REALM error

## Deploy impact
After merge, the dev Storybook image pipeline should publish a new ghcr.io/openresilienceinitiative/oriso-storybook:dev image. Then run /root/deploy-script/deploy-storybook-dev.sh on the oriso.org server to update storybook.oriso.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)