### PR TITLE
fix(storybook): refresh toolbar story chunk

### DIFF
--- a/src/components/sessionsList/SessionsListToolbar.stories.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.stories.tsx
@@ -119,10 +119,25 @@ export const GroupsFilterActive: Story = {
 };
 
 export const InternalGroupFilterActive: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Shows the toolbar with the internal group chat filter chip selected.'
+			}
+		}
+	},
 	render: () => <SessionsListToolbarPlayground initialChip="internalGroup" />
 };
 
 export const SupervisionFilterActive: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Shows the toolbar with the supervision filter chip selected.'
+			}
+		}
+	},
 	render: () => <SessionsListToolbarPlayground initialChip="supervision" />
 };
 


### PR DESCRIPTION
## Summary
- add docs descriptions to the two SessionsListToolbar filter variants that appeared as stale missing-story pages in an existing browser cache
- force the Storybook build to emit a fresh toolbar story chunk so deployed clients do not keep loading the stale asset

## Validation
- npm run build-storybook
- local static Storybook check: internal group, supervision, and NavigationSidebar iframe routes render without missing-story or Keycloak errors
- fresh browser check against live Storybook confirmed the current server already works without cache; this PR makes existing browser sessions pick up fresh assets after deploy

## Deploy impact
After merge, wait for CI - Storybook Main on dev and run /root/deploy-script/deploy-storybook-dev.sh on the oriso.org server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)