### PR TITLE
feat(modality): getModality() selector — single source of truth (ADR-006 Step 1)

### DIFF
--- a/src/components/session/getModality.test.ts
+++ b/src/components/session/getModality.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { ListItemInterface } from '../../globalState/interfaces/SessionsDataInterface';
+import { getModality, Modality } from './getModality';
+
+const asItem = (partial: unknown): ListItemInterface =>
+	partial as ListItemInterface;
+
+describe('getModality', () => {
+	it('classifies an anonymous session as LIVE_CHAT', () => {
+		const item = asItem({ session: { registrationType: 'ANONYMOUS' } });
+		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('classifies a registered session as AGENCY_COUNSELLING', () => {
+		const item = asItem({ session: { registrationType: 'REGISTERED' } });
+		expect(getModality(item)).toBe(Modality.AGENCY_COUNSELLING);
+	});
+
+	it('classifies a team session as INTERNAL_GROUP even when registered', () => {
+		const item = asItem({
+			session: { registrationType: 'REGISTERED', teamSession: true }
+		});
+		expect(getModality(item)).toBe(Modality.INTERNAL_GROUP);
+	});
+
+	it('classifies a non-repetitive group chat as INTERNAL_GROUP', () => {
+		const item = asItem({ chat: { repetitive: false } });
+		expect(getModality(item)).toBe(Modality.INTERNAL_GROUP);
+	});
+
+	it('classifies a repetitive group chat as SELF_HELP', () => {
+		const item = asItem({ chat: { repetitive: true } });
+		expect(getModality(item)).toBe(Modality.SELF_HELP);
+	});
+
+	it('prefers an explicit backend conversationType over the heuristic', () => {
+		// looks like AGENCY_COUNSELLING by heuristic, but the backend says LIVE_CHAT
+		const item = asItem({
+			session: { registrationType: 'REGISTERED', conversationType: 'LIVE_CHAT' }
+		});
+		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('ignores an unknown explicit conversationType and falls back to the heuristic', () => {
+		const item = asItem({
+			session: { registrationType: 'ANONYMOUS', conversationType: 'NONSENSE' }
+		});
+		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('defaults to AGENCY_COUNSELLING for an empty/unknown item', () => {
+		expect(getModality(asItem({}))).toBe(Modality.AGENCY_COUNSELLING);
+	});
+});

--- a/src/components/session/getModality.ts
+++ b/src/components/session/getModality.ts
@@ -1,0 +1,71 @@
+import {
+	GroupChatItemInterface,
+	ListItemInterface,
+	SessionItemInterface
+} from '../../globalState/interfaces/SessionsDataInterface';
+
+/**
+ * The four conversation modalities (ADR-006 / CONTEXT-conversation-types).
+ *
+ * Modality answers "what kind of conversation is this" and is orthogonal to the lifecycle status
+ * (Enquiry → Active → Finished → Archived). The two must never be merged into one "type" again.
+ */
+export enum Modality {
+	AGENCY_COUNSELLING = 'AGENCY_COUNSELLING',
+	LIVE_CHAT = 'LIVE_CHAT',
+	INTERNAL_GROUP = 'INTERNAL_GROUP',
+	SELF_HELP = 'SELF_HELP'
+}
+
+const REGISTRATION_TYPE_ANONYMOUS = 'ANONYMOUS';
+
+const isModality = (value: unknown): value is Modality =>
+	typeof value === 'string' &&
+	(Object.values(Modality) as string[]).includes(value);
+
+/**
+ * The single source of truth for a conversation's modality on the frontend.
+ *
+ * ADR-006 Step 1: every modality decision must go through this one pure selector instead of
+ * re-deriving the kind from scattered booleans (registrationType, teamSession, repetitive, …) at
+ * the ~90 call sites that are the documented root cause of the recurring "touching the live chat
+ * makes the chat go fuzzy" regressions.
+ *
+ * It prefers an explicit backend `conversationType` once that field is populated (ADR-006 target
+ * state) and falls back to the existing heuristic while it is rolled out. The fallback order is
+ * significant: a group `chat` is checked before `teamSession`, which is checked before the
+ * anonymous (live-chat) signal, so an internal group is never mislabelled as agency counselling.
+ */
+export const getModality = (item?: ListItemInterface): Modality => {
+	const session = item?.session as
+		| (SessionItemInterface & {
+				teamSession?: boolean;
+				conversationType?: string;
+		  })
+		| undefined;
+	const chat = item?.chat as
+		| (GroupChatItemInterface & { conversationType?: string })
+		| undefined;
+
+	// 1. An explicit backend modality wins once it is populated (ADR-006 target state).
+	const explicit = session?.conversationType ?? chat?.conversationType;
+	if (isModality(explicit)) {
+		return explicit;
+	}
+
+	// 2. Fallback heuristic (centralised here, deleted once the column is populated everywhere).
+	if (chat) {
+		return chat.repetitive ? Modality.SELF_HELP : Modality.INTERNAL_GROUP;
+	}
+	if (session) {
+		if (session.teamSession === true) {
+			return Modality.INTERNAL_GROUP;
+		}
+		if ((session.registrationType as string) === REGISTRATION_TYPE_ANONYMOUS) {
+			return Modality.LIVE_CHAT;
+		}
+		return Modality.AGENCY_COUNSELLING;
+	}
+
+	return Modality.AGENCY_COUNSELLING;
+};


### PR DESCRIPTION
## Why
A conversation's modality (Live Chat / Agency Counselling / Internal Group / Self-Help) is re-derived from scattered booleans (`registrationType`, `teamSession`, `repetitive`, …) at ~90 call sites — the documented root cause of the recurring "touching the live chat makes other chats go fuzzy" regressions. ADR-006 Step 1 centralises this into one pure selector.

## What
Adds `getModality(item): Modality` + a `Modality` enum in `src/components/session/getModality.ts`. It prefers an explicit backend `conversationType` once that field is populated (ADR-006 target state) and falls back to the verified heuristic while it is rolled out. **Additive only** — new file + 8 vitest cases (test-first, red → green), `tsc --noEmit` clean. **No call sites migrated yet** (the ~90-site sweep is deferred to avoid colliding with #126 / #275).

## Acceptance
- Correct modality for: anonymous → `LIVE_CHAT`; registered → `AGENCY_COUNSELLING`; `teamSession` → `INTERNAL_GROUP`; group `chat` + `repetitive` → `SELF_HELP`; explicit `conversationType` wins; empty/unknown → `AGENCY_COUNSELLING` default.
- 8/8 vitest green; `tsc --noEmit` clean.

## Affected repos
`ORISO-Frontend` only.

Refs **ADR-006** (conversation_type as persisted modality), Step 1 (frontend read-contract first).

🤖 Built test-first in an isolated worktree off `origin/dev`.
