### PR TITLE
fix(storybook): keep yellow tag text readable

### DIFF
--- a/src/components/tag/tag.styles.scss
+++ b/src/components/tag/tag.styles.scss
@@ -12,6 +12,7 @@
 
 	&--yellow {
 		background-color: $yellow-3;
+		color: var(--m3-on-surface, $secondary);
 	}
 
 	&--green {

--- a/src/components/tag/tag.styles.test.ts
+++ b/src/components/tag/tag.styles.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { compileString } from 'sass';
+
+const tildeImporter = {
+	findFileUrl(url: string) {
+		if (!url.startsWith('~')) {
+			return null;
+		}
+
+		return new URL(
+			`../../../node_modules/${url.slice(1)}`,
+			import.meta.url
+		);
+	}
+};
+
+const compileTagStyles = () =>
+	compileString(
+		[
+			'@import "src/resources/styles/settings.scss";',
+			'@import "src/components/tag/tag.styles.scss";'
+		].join('\n'),
+		{
+			loadPaths: ['.', 'node_modules'],
+			importers: [tildeImporter]
+		}
+	).css;
+
+describe('Tag styles', () => {
+	it('keeps the yellow tag readable when Material 3 on-primary is white', () => {
+		const css = compileTagStyles();
+
+		expect(css).toMatch(
+			/\.tag--yellow\s*\{[^}]*background-color:\s*#ffdca3;[^}]*color:\s*var\(--m3-on-surface,\s*rgba\(0,\s*0,\s*0,\s*0\.9\)\);/s
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Fix the yellow Tag variant so it keeps readable dark text even when Material 3 `--m3-on-primary` is white.
- Add a SCSS regression test for the yellow Tag contrast contract.

## Validation
- `npm run test:unit -- src/components/tag/tag.styles.test.ts src/utils/theme/m3Sweep.test.ts`
- `npx stylelint src/components/tag/tag.styles.scss`
- `npm run build-storybook`
- `npm run build`
- Browser check on local static Storybook: `display-tag--yellow` renders `span.tag--yellow` with `background-color: rgb(255, 220, 163)` and readable dark text via `--m3-on-surface`, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)