### PR TITLE
chore(ci): clarify frontend validation workflows

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,4 +1,4 @@
-name: Reusable Docker Build and Publish steps
+name: Reusable Docker build and publish steps
 
 inputs:
   push_to_ghcr:
@@ -22,6 +22,7 @@ runs:
     uses: docker/setup-buildx-action@v4
 
   - name: Login to GitHub Container Registry
+    if: ${{ inputs.push_to_ghcr == 'true' }}
     uses: docker/login-action@v4
     with:
       registry: ${{ env.REGISTRY }}
@@ -38,7 +39,7 @@ runs:
         type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
         type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
-  - name: Build and Push Docker image
+  - name: Build Docker image and publish when enabled
     id: build
     uses: docker/build-push-action@v7
     with:

--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -1,4 +1,4 @@
-name: Reusable Node Build steps
+name: Reusable Node validation and build steps
 
 inputs:
   node_version:
@@ -17,6 +17,10 @@ runs:
   - name: Install dependencies
     shell: bash
     run: npm ci --ignore-scripts --legacy-peer-deps
+
+  - name: Lint scripts and type-check
+    shell: bash
+    run: npm run lint:scripts
 
   - name: Build app
     shell: bash

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -1,24 +1,25 @@
-name: CI - Feature Branch
+name: Frontend Branch Validation
 
 on:
   push:
     branches-ignore:
-    - main
-    - dev
+      - main
+      - dev
 
 jobs:
-  build:
+  validate:
+    name: lint, type-check, build and test frontend
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Build frontend application
-      uses: ./.github/actions/node-build
-      with:
-        node_version: '18'
+      - name: Run frontend validation and build
+        uses: ./.github/actions/node-build
+        with:
+          node_version: '18'
 
-    - name: Run unit tests
-      shell: bash
-      run: npm run test:unit
+      - name: Run unit tests
+        shell: bash
+        run: npm run test:unit

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: CI - Main
+name: Frontend Build and Publish
 
 on:
   push:
@@ -11,7 +11,8 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  publish:
+    name: lint, type-check, build and publish image
     runs-on: ubuntu-latest
 
     permissions:
@@ -19,17 +20,17 @@ jobs:
       packages: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Build frontend application
-      uses: ./.github/actions/node-build
-      with:
-        node_version: '18'
+      - name: Run frontend validation and build
+        uses: ./.github/actions/node-build
+        with:
+          node_version: '18'
 
-    - name: Create and Publish Docker image
-      uses: ./.github/actions/docker-build-push
-      with:
-        push_to_ghcr: true
-        image_name: oriso-frontend
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish frontend Docker image
+        uses: ./.github/actions/docker-build-push
+        with:
+          push_to_ghcr: true
+          image_name: oriso-frontend
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI - Pull Request
+name: Frontend PR Validation
 
 on:
   pull_request:
@@ -8,28 +8,29 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  validate:
+    name: lint, type-check, test, build and Docker validation
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Build frontend application
-      uses: ./.github/actions/node-build
-      with:
-        node_version: '18'
+      - name: Run frontend validation and build
+        uses: ./.github/actions/node-build
+        with:
+          node_version: '18'
 
-    - name: Run unit tests
-      shell: bash
-      run: npm run test:unit
+      - name: Run unit tests
+        shell: bash
+        run: npm run test:unit
 
-    - name: Create Docker image
-      uses: ./.github/actions/docker-build-push
-      with:
-        push_to_ghcr: false
-        image_name: oriso-frontend
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker build validation without publishing
+        uses: ./.github/actions/docker-build-push
+        with:
+          push_to_ghcr: false
+          image_name: oriso-frontend
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
 # NOTE: the Playwright public-route smoke (`npm run test:smoke`) is intentionally
 # NOT a CI job. The app's bootstrap requires a reachable backend to render; CI

--- a/.github/workflows/ci-storybook-feature-branch.yml
+++ b/.github/workflows/ci-storybook-feature-branch.yml
@@ -1,4 +1,4 @@
-name: CI - Storybook Feature Branch
+name: Storybook Branch Validation
 
 on:
   push:
@@ -7,14 +7,15 @@ on:
       - dev
 
 jobs:
-  build:
+  validate:
+    name: lint, type-check and build frontend
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Build frontend application
+      - name: Run frontend validation and build
         uses: ./.github/actions/node-build
         with:
           node_version: '18'

--- a/.github/workflows/ci-storybook-main.yml
+++ b/.github/workflows/ci-storybook-main.yml
@@ -1,4 +1,4 @@
-name: CI - Storybook Main
+name: Storybook Build and Publish
 
 on:
   push:
@@ -11,7 +11,8 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  publish:
+    name: lint, type-check, build and publish Storybook image
     runs-on: ubuntu-latest
 
     permissions:
@@ -22,12 +23,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Build frontend application
+      - name: Run frontend validation and build
         uses: ./.github/actions/node-build
         with:
           node_version: '18'
 
-      - name: Create and Publish Storybook Docker image
+      - name: Publish Storybook Docker image
         uses: ./.github/actions/docker-build-push
         with:
           push_to_ghcr: true

--- a/.github/workflows/ci-storybook-pull-request.yml
+++ b/.github/workflows/ci-storybook-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI - Storybook Pull Request
+name: Storybook PR Validation
 
 on:
   pull_request:
@@ -8,19 +8,20 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  validate:
+    name: lint, type-check, build and Storybook Docker validation
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Build frontend application
+      - name: Run frontend validation and build
         uses: ./.github/actions/node-build
         with:
           node_version: '18'
 
-      - name: Create Storybook Docker image
+      - name: Storybook Docker build validation without publishing
         uses: ./.github/actions/docker-build-push
         with:
           push_to_ghcr: false

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,113 @@
+name: Frontend Release Image
+
+run-name: Publish frontend release image v${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix, for example 2.0.1
+        required: true
+        type: string
+      create_tag:
+        description: Create and push Git tag from this release branch
+        required: true
+        default: true
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  ORG: openresilienceinitiative
+  IMAGE_NAME: oriso-frontend
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: validate, build, tag and publish release image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release input
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          EXPECTED_BRANCH="release/frontend-${VERSION}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must use MAJOR.MINOR.PATCH format, for example 2.0.1"
+            exit 1
+          fi
+
+          if [[ "${GITHUB_REF_NAME}" != "$EXPECTED_BRANCH" ]]; then
+            echo "This workflow must run from ${EXPECTED_BRANCH}"
+            echo "Current ref is ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
+          if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q "refs/tags/v${VERSION}"; then
+            echo "Tag v${VERSION} already exists. Choose a new version or delete the incorrect tag first."
+            exit 1
+          fi
+
+      - name: Run frontend validation and build
+        uses: ./.github/actions/node-build
+        with:
+          node_version: '18'
+
+      - name: Create and push release tag
+        if: ${{ inputs.create_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release frontend v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish versioned frontend Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Release summary
+        shell: bash
+        run: |
+          {
+            echo "### Frontend release image"
+            echo ""
+            echo "- Git tag: \`v${{ inputs.version }}\`"
+            echo "- Image: \`${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}\`"
+            echo "- Source branch: \`${GITHUB_REF_NAME}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- rename frontend and Storybook CI workflows/jobs so PR validation and image publishing are clearer in GitHub checks
- add the existing script lint and TypeScript check before frontend builds via the shared node-build action
- avoid GHCR login for Docker validation builds that do not publish images
- include the frontend release image workflow on dev with clearer release/publish naming

## Verification
- YAML parse passed for changed workflow/action files
- npm run lint:scripts passed locally with warnings
- CI=false npm run build passed locally with warnings

## Notes
- stylelint is not enabled as a blocking CI step yet because the current SCSS baseline still has existing stylelint errors