### PR TITLE
Add public DPA signature route

### DIFF
--- a/src/api/apiDpaSignature.test.ts
+++ b/src/api/apiDpaSignature.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiConfirmDpaSignature, DPA_SIGN_ERRORS } from './apiDpaSignature';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		dpaSignatureConfirm: (token: string) =>
+			`https://api.oriso-dev.site/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`
+	}
+}));
+
+describe('apiConfirmDpaSignature', () => {
+	it('posts the public DPA signature payload to the token endpoint', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ status: 'SIGNED' }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			apiConfirmDpaSignature('signed token', {
+				signerName: 'Frank Gerhardt',
+				signerPosition: 'Owner',
+				signerEmail: 'frank@example.com',
+				signerOrganisation: 'ORISO',
+				language: 'de',
+				accepted: true,
+				signerIsMember: false,
+				source: 'PUBLIC_SIGN_LINK'
+			})
+		).resolves.toEqual({ status: 'SIGNED' });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.oriso-dev.site/service/tenant/public/dpa/confirm/signed%20token',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({
+					signerName: 'Frank Gerhardt',
+					signerPosition: 'Owner',
+					signerEmail: 'frank@example.com',
+					signerOrganisation: 'ORISO',
+					language: 'de',
+					accepted: true,
+					signerIsMember: false,
+					source: 'PUBLIC_SIGN_LINK'
+				})
+			}
+		);
+	});
+
+	it('maps expired public sign tokens to a stable error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response(null, { status: 410 }))
+		);
+
+		await expect(
+			apiConfirmDpaSignature('expired', {
+				signerName: 'Frank Gerhardt',
+				signerPosition: 'Owner',
+				signerEmail: 'frank@example.com',
+				signerOrganisation: 'ORISO',
+				language: 'de',
+				accepted: true
+			})
+		).rejects.toThrow(DPA_SIGN_ERRORS.INVALID_OR_EXPIRED_TOKEN);
+	});
+});

--- a/src/api/apiDpaSignature.ts
+++ b/src/api/apiDpaSignature.ts
@@ -1,0 +1,60 @@
+import { endpoints } from '../resources/scripts/endpoints';
+
+export const DPA_SIGN_ERRORS = {
+	INVALID_OR_EXPIRED_TOKEN: 'DPA_SIGN_INVALID_OR_EXPIRED_TOKEN',
+	INVALID_REQUEST: 'DPA_SIGN_INVALID_REQUEST',
+	FAILED: 'DPA_SIGN_FAILED'
+} as const;
+
+export interface DpaSignatureRequest {
+	signerName: string;
+	signerPosition: string;
+	signerEmail: string;
+	signerOrganisation: string;
+	language: string;
+	accepted: boolean;
+	signerIsMember?: boolean;
+	forwardedByUserId?: string;
+	source?: string;
+}
+
+export interface DpaSignatureResponse {
+	tenantId?: number;
+	versionId?: number;
+	status?: string;
+	signerName?: string;
+	signerPosition?: string;
+	signerEmail?: string;
+	signerOrganisation?: string;
+	forwardedByUserId?: string;
+	source?: string;
+	signedAt?: string;
+}
+
+export const apiConfirmDpaSignature = async (
+	token: string,
+	request: DpaSignatureRequest
+): Promise<DpaSignatureResponse> => {
+	const response = await fetch(endpoints.dpaSignatureConfirm(token), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		credentials: 'include',
+		body: JSON.stringify(request)
+	});
+
+	if (!response.ok) {
+		if (response.status === 404 || response.status === 410) {
+			throw new Error(DPA_SIGN_ERRORS.INVALID_OR_EXPIRED_TOKEN);
+		}
+
+		if (response.status === 400) {
+			throw new Error(DPA_SIGN_ERRORS.INVALID_REQUEST);
+		}
+
+		throw new Error(DPA_SIGN_ERRORS.FAILED);
+	}
+
+	const contentType = response.headers.get('content-type');
+
+	return contentType?.includes('application/json') ? response.json() : {};
+};

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,7 +1,12 @@
 import '../../polyfill';
 import * as React from 'react';
 import { ComponentType, useState, lazy, Suspense, useContext } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import {
+	BrowserRouter as Router,
+	Routes,
+	Route,
+	Navigate
+} from 'react-router-dom';
 import { StageProps } from '../stage/stage';
 import '../../resources/styles/styles';
 import { ContextProvider } from '../../globalState/state';
@@ -43,6 +48,11 @@ const AuthenticatedApp = lazy(() =>
 const InviteLink = lazy(() =>
 	import('../invite/InviteLink').then((m) => ({
 		default: m.InviteLink
+	}))
+);
+const DpaSign = lazy(() =>
+	import('../dpaSign/DpaSign').then((m) => ({
+		default: m.DpaSign
 	}))
 );
 
@@ -177,6 +187,10 @@ const RouterWrapper = ({ extraRoutes }: RouterWrapperProps) => {
 								<Route
 									path="/invite/:token/:topicSlug"
 									element={<InviteLink />}
+								/>
+								<Route
+									path="/dpa-sign/:token"
+									element={<DpaSign />}
 								/>
 								<Route
 									path="/login"

--- a/src/components/dpaSign/DpaSign.tsx
+++ b/src/components/dpaSign/DpaSign.tsx
@@ -1,0 +1,280 @@
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
+import {
+	Alert,
+	Box,
+	Button,
+	Checkbox,
+	FormControlLabel,
+	MenuItem,
+	Paper,
+	TextField,
+	Typography
+} from '@mui/material';
+import * as React from 'react';
+import { FormEvent, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+	apiConfirmDpaSignature,
+	DPA_SIGN_ERRORS
+} from '../../api/apiDpaSignature';
+
+type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
+
+interface FormState {
+	signerName: string;
+	signerPosition: string;
+	signerEmail: string;
+	signerOrganisation: string;
+	language: string;
+	accepted: boolean;
+}
+
+const INITIAL_FORM_STATE: FormState = {
+	signerName: '',
+	signerPosition: '',
+	signerEmail: '',
+	signerOrganisation: '',
+	language: 'de',
+	accepted: false
+};
+
+export const DpaSign = () => {
+	const { token } = useParams<{ token: string }>();
+	const { t } = useTranslation();
+	const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
+	const [submitState, setSubmitState] = useState<SubmitState>('idle');
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	const decodedToken = useMemo(
+		() => (token ? decodeURIComponent(token) : ''),
+		[token]
+	);
+
+	const updateField = <K extends keyof FormState>(
+		field: K,
+		value: FormState[K]
+	) => {
+		setFormState((current) => ({
+			...current,
+			[field]: value
+		}));
+	};
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		setErrorMessage(null);
+
+		if (!decodedToken) {
+			setSubmitState('error');
+			setErrorMessage(
+				t(
+					'dpaSign.error.missingToken',
+					'Der Signaturlink ist unvollständig.'
+				)
+			);
+			return;
+		}
+
+		if (!formState.accepted) {
+			setSubmitState('error');
+			setErrorMessage(
+				t(
+					'dpaSign.error.acceptRequired',
+					'Bitte bestätigen Sie die Vereinbarung.'
+				)
+			);
+			return;
+		}
+
+		setSubmitState('submitting');
+
+		try {
+			await apiConfirmDpaSignature(decodedToken, {
+				...formState,
+				signerIsMember: false,
+				source: 'PUBLIC_SIGN_LINK'
+			});
+			setSubmitState('success');
+		} catch (error) {
+			setSubmitState('error');
+			setErrorMessage(resolveErrorMessage(error, t));
+		}
+	};
+
+	return (
+		<Box
+			component="main"
+			sx={{
+				minHeight: '100vh',
+				background: 'var(--m3-surface, #f8faf9)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				px: 2,
+				py: 4
+			}}
+		>
+			<Paper
+				component="form"
+				elevation={0}
+				onSubmit={handleSubmit}
+				sx={{
+					width: '100%',
+					maxWidth: 560,
+					border: '1px solid var(--m3-outline-variant, #dce5df)',
+					borderRadius: 2,
+					p: { xs: 3, sm: 4 },
+					display: 'grid',
+					gap: 2
+				}}
+			>
+				<Box>
+					<Typography variant="h4" component="h1" gutterBottom>
+						{t('dpaSign.title', 'AVV unterzeichnen')}
+					</Typography>
+					<Typography color="text.secondary">
+						{t(
+							'dpaSign.subtitle',
+							'Bitte prüfen und bestätigen Sie die Angaben zur unterzeichnenden Person.'
+						)}
+					</Typography>
+				</Box>
+
+				{submitState === 'success' ? (
+					<Alert severity="success">
+						{t(
+							'dpaSign.success',
+							'Die AVV-Signatur wurde gespeichert.'
+						)}
+					</Alert>
+				) : (
+					<>
+						<TextField
+							label={t('dpaSign.signerName', 'Name')}
+							value={formState.signerName}
+							onChange={(event) =>
+								updateField('signerName', event.target.value)
+							}
+							required
+							fullWidth
+						/>
+						<TextField
+							label={t('dpaSign.signerPosition', 'Position')}
+							value={formState.signerPosition}
+							onChange={(event) =>
+								updateField(
+									'signerPosition',
+									event.target.value
+								)
+							}
+							required
+							fullWidth
+						/>
+						<TextField
+							label={t('dpaSign.signerEmail', 'E-Mail')}
+							type="email"
+							value={formState.signerEmail}
+							onChange={(event) =>
+								updateField('signerEmail', event.target.value)
+							}
+							required
+							fullWidth
+						/>
+						<TextField
+							label={t(
+								'dpaSign.signerOrganisation',
+								'Organisation'
+							)}
+							value={formState.signerOrganisation}
+							onChange={(event) =>
+								updateField(
+									'signerOrganisation',
+									event.target.value
+								)
+							}
+							required
+							fullWidth
+						/>
+						<TextField
+							label={t('dpaSign.language', 'Sprache')}
+							value={formState.language}
+							onChange={(event) =>
+								updateField('language', event.target.value)
+							}
+							required
+							fullWidth
+							select
+						>
+							<MenuItem value="de">Deutsch</MenuItem>
+							<MenuItem value="en">English</MenuItem>
+						</TextField>
+						<FormControlLabel
+							control={
+								<Checkbox
+									checked={formState.accepted}
+									onChange={(event) =>
+										updateField(
+											'accepted',
+											event.target.checked
+										)
+									}
+									required
+								/>
+							}
+							label={t(
+								'dpaSign.accept',
+								'Ich bestätige die Vereinbarung verbindlich.'
+							)}
+						/>
+						{errorMessage && (
+							<Alert severity="error">{errorMessage}</Alert>
+						)}
+						<Button
+							type="submit"
+							variant="contained"
+							size="large"
+							startIcon={<CheckRoundedIcon />}
+							disabled={submitState === 'submitting'}
+							sx={{ justifySelf: 'start' }}
+						>
+							{submitState === 'submitting'
+								? t('dpaSign.submitting', 'Speichern...')
+								: t('dpaSign.submit', 'Unterzeichnen')}
+						</Button>
+					</>
+				)}
+			</Paper>
+		</Box>
+	);
+};
+
+const resolveErrorMessage = (
+	error: unknown,
+	t: ReturnType<typeof useTranslation>['t']
+) => {
+	if (
+		error instanceof Error &&
+		error.message === DPA_SIGN_ERRORS.INVALID_OR_EXPIRED_TOKEN
+	) {
+		return t(
+			'dpaSign.error.invalidToken',
+			'Dieser Signaturlink ist ungültig, abgelaufen oder wurde bereits verwendet.'
+		);
+	}
+
+	if (
+		error instanceof Error &&
+		error.message === DPA_SIGN_ERRORS.INVALID_REQUEST
+	) {
+		return t(
+			'dpaSign.error.invalidRequest',
+			'Die Angaben konnten nicht gespeichert werden. Bitte prüfen Sie das Formular.'
+		);
+	}
+
+	return t(
+		'dpaSign.error.generic',
+		'Die Signatur konnte gerade nicht gespeichert werden.'
+	);
+};

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -149,6 +149,9 @@ export const endpoints = {
 	setAbsence: userServiceOrigin + '/service/users/consultants/absences',
 	startVideoCall: apiUrl + '/service/videocalls/new',
 	tenantServiceBase: tenantServiceOrigin + '/service/tenant',
+	dpaSignatureConfirm: (token: string) =>
+		tenantServiceOrigin +
+		`/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`,
 	topicGroups: consultingTypeServiceOrigin + '/service/topic-groups',
 	topicsData: consultingTypeServiceOrigin + '/service/topic/public/',
 	twoFactorAuth: userServiceOrigin + '/service/users/2fa',


### PR DESCRIPTION
## Problem
External DPA signers need a public route that can confirm a single-use DPA token without requiring a platform account.

## Solution
- Add `/dpa-sign/:token` before the authenticated app catch-all.
- Add a public DPA signature API helper.
- Render required signer fields and acceptance checkbox.
- Show a stable error for expired or already-used tokens.

## Validation
- `npm run test:unit -- src/api/apiDpaSignature.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm run build`
- Local browser smoke against the built app: valid token success and expired token error.

## Coordination
Depends on the TenantService DPA signature fields PR. Merge before deploying Frontend dev image to Pre-Dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)