### PR TITLE
Feature/storybook resuable components

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,6 +20,20 @@ const absolutizeResolveModule = (dir: string) =>
 			? dir
 			: path.join(projectRoot, dir);
 
+const storybookExcludedWebpackPlugins = new Set([
+	'CopyPlugin',
+	'ESLintWebpackPlugin',
+	'ForkTsCheckerWebpackPlugin',
+	'ForkTsCheckerWarningWebpackPlugin',
+	'HtmlWebpackPlugin',
+	'InterpolateHtmlPlugin',
+	'ReactRefreshPlugin'
+]);
+
+const isStorybookSafeWebpackPlugin = (plugin: {
+	constructor?: { name?: string };
+}) => !storybookExcludedWebpackPlugins.has(plugin?.constructor?.name || '');
+
 /** Storybook 7 only auto-switches this shim for react-dom@18; React 19 needs the createRoot-based shim. */
 const reactDomShimReact18 = requireProject.resolve(
 	'@storybook/react-dom-shim/dist/react-18'
@@ -57,12 +71,15 @@ const config: StorybookConfig = {
 			(p: { constructor?: { name?: string } }) =>
 				p?.constructor?.name !== 'ModuleScopePlugin'
 		);
+		const webpackPlugins = (webpackConfig.plugins || []).filter(
+			isStorybookSafeWebpackPlugin
+		);
 
 		return {
 			...config,
 			output: {
 				...config.output,
-				publicPath: '/'
+				publicPath: ''
 			},
 			resolve: {
 				...config.resolve,
@@ -98,11 +115,15 @@ const config: StorybookConfig = {
 					/^react\/jsx-dev-runtime$/,
 					requireProject.resolve('react/jsx-dev-runtime')
 				),
+				new webpack.NormalModuleReplacementPlugin(
+					/^domhandler\/lib\/node$/,
+					domhandlerLegacyNodeEntry
+				),
 				// Ignore intro.js CSS entirely in Storybook - it's not needed
 				new webpack.IgnorePlugin({
 					resourceRegExp: /intro\.js\/introjs\.css$/
 				}),
-				...webpackConfig.plugins,
+				...webpackPlugins,
 				...config.plugins
 			],
 			module: {
@@ -147,7 +168,9 @@ const config: StorybookConfig = {
 		docsMode: false
 	},
 	typescript: {
-		reactDocgen: 'react-docgen-typescript',
+		// The full app graph is large enough that react-docgen-typescript can
+		// leave the preview stuck at DocGenPlugin during local development.
+		reactDocgen: false,
 		reactDocgenTypescriptOptions: {
 			shouldExtractLiteralValuesFromEnum: true,
 			propFilter: (prop) => {

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+import { Switch, SwitchProps } from './index';
+
+const meta = {
+	title: 'Components/Switch',
+	component: Switch,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'M3 ORISO switch for binary settings. Matches the Design System M3 ORISO switch tokens and supports enabled, disabled, selected, unselected, focus, hover, pressed, and icon states.'
+			}
+		}
+	},
+	argTypes: {
+		checked: {
+			control: 'boolean'
+		},
+		disabled: {
+			control: 'boolean'
+		},
+		showIcon: {
+			control: 'boolean'
+		}
+	}
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const InteractiveSwitch = (args: SwitchProps) => {
+	const [{ checked }, updateArgs] = useArgs();
+
+	return (
+		<Switch
+			{...args}
+			checked={checked}
+			onChange={(nextChecked, event) => {
+				updateArgs({ checked: nextChecked });
+				args.onChange?.(nextChecked, event);
+			}}
+		/>
+	);
+};
+
+export const Checked: Story = {
+	render: InteractiveSwitch,
+	args: {
+		'checked': true,
+		'showIcon': true,
+		'aria-label': 'Enable setting'
+	}
+};
+
+export const Unchecked: Story = {
+	render: InteractiveSwitch,
+	args: {
+		'checked': false,
+		'showIcon': true,
+		'aria-label': 'Disable setting'
+	}
+};
+
+export const DisabledChecked: Story = {
+	args: {
+		'checked': true,
+		'disabled': true,
+		'showIcon': true,
+		'aria-label': 'Disabled enabled setting',
+		'onChange': () => {}
+	}
+};
+
+export const DisabledUnchecked: Story = {
+	args: {
+		'checked': false,
+		'disabled': true,
+		'showIcon': true,
+		'aria-label': 'Disabled setting',
+		'onChange': () => {}
+	}
+};
+
+export const WithoutIcon: Story = {
+	render: InteractiveSwitch,
+	args: {
+		'checked': true,
+		'showIcon': false,
+		'aria-label': 'Enable setting without icon'
+	}
+};
+
+export const WithLabelAndDescription: Story = {
+	render: InteractiveSwitch,
+	args: {
+		checked: true,
+		titleKey: 'profile.browserNotifications.newMessage.title',
+		descriptionKey: 'profile.browserNotifications.newMessage.description',
+		showIcon: true
+	}
+};

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,35 +1,75 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import ReactSwitch from 'react-switch';
-import { ReactSwitchProps } from 'react-switch';
 import { Text } from '../text/Text';
 import styles from './switch.module.scss';
 
-interface SwitchProps extends ReactSwitchProps {
-	titleKey: string;
+export interface SwitchProps
+	extends Omit<
+		React.InputHTMLAttributes<HTMLInputElement>,
+		'type' | 'checked' | 'onChange'
+	> {
+	checked: boolean;
+	onChange: (
+		checked: boolean,
+		event: React.ChangeEvent<HTMLInputElement>
+	) => void;
+	titleKey?: string;
 	descriptionKey?: string;
+	showIcon?: boolean;
 }
 
-export const Switch = ({ titleKey, descriptionKey, ...props }: SwitchProps) => {
+export const Switch = ({
+	titleKey,
+	descriptionKey,
+	showIcon = true,
+	className,
+	checked,
+	onChange,
+	disabled,
+	...props
+}: SwitchProps) => {
 	const { t } = useTranslation();
+	const title = titleKey ? t(titleKey) : undefined;
+
+	const switchClassName = [
+		styles.switch,
+		className,
+		disabled ? styles.disabled : ''
+	]
+		.filter(Boolean)
+		.join(' ');
+
+	const switchControl = (
+		<label className={switchClassName}>
+			<input
+				{...props}
+				aria-label={props['aria-label'] || title}
+				checked={checked}
+				className={styles.input}
+				disabled={disabled}
+				onChange={(event) => onChange(event.target.checked, event)}
+				role="switch"
+				type="checkbox"
+			/>
+			<span className={styles.track} aria-hidden="true">
+				<span className={styles.target}>
+					<span className={styles.handle}>
+						{showIcon && <span className={styles.icon} />}
+					</span>
+				</span>
+			</span>
+		</label>
+	);
+
+	if (!titleKey && !descriptionKey) {
+		return switchControl;
+	}
 
 	return (
 		<div className="mb--2">
 			<div className="flex flex--jc-sb ">
-				<Text text={t(titleKey)} type="standard" />
-				<ReactSwitch
-					className="mr--1"
-					uncheckedIcon={false}
-					checkedIcon={false}
-					width={48}
-					height={26}
-					onColor="#0A882F"
-					offColor="#8C878C"
-					boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-					handleDiameter={27}
-					activeBoxShadow="none"
-					{...props}
-				/>
+				<Text text={title} type="standard" />
+				{switchControl}
 			</div>
 			{descriptionKey && (
 				<Text

--- a/src/components/Switch/switch.module.scss
+++ b/src/components/Switch/switch.module.scss
@@ -1,3 +1,207 @@
 .description {
 	padding-right: 70px;
 }
+
+.switch {
+	--switch-primary: #a5000a;
+	--switch-primary-container: #cc1e1c;
+	--switch-on-primary: #ffffff;
+	--switch-on-primary-container: #ffe2de;
+	--switch-surface: #fcf9f9;
+	--switch-surface-container-highest: #e4e2e2;
+	--switch-on-surface: #1b1b1c;
+	--switch-on-surface-variant: #444748;
+	--switch-outline: #747878;
+	--switch-focus: #4c555f;
+
+	align-items: center;
+	cursor: pointer;
+	display: inline-flex;
+	height: 32px;
+	position: relative;
+	flex: 0 0 auto;
+	vertical-align: middle;
+	width: 52px;
+}
+
+.input {
+	height: 1px;
+	margin: 0;
+	opacity: 0;
+	position: absolute;
+	width: 1px;
+}
+
+.track {
+	background: var(--switch-surface-container-highest);
+	border: 2px solid var(--switch-outline);
+	border-radius: 100px;
+	box-sizing: border-box;
+	display: block;
+	height: 32px;
+	position: relative;
+	transition:
+		background-color 160ms ease,
+		border-color 160ms ease,
+		opacity 160ms ease;
+	width: 52px;
+}
+
+.target {
+	align-items: center;
+	border-radius: 100px;
+	display: flex;
+	height: 40px;
+	justify-content: center;
+	left: -4px;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	transition:
+		background-color 160ms ease,
+		left 160ms ease,
+		right 160ms ease;
+	width: 40px;
+}
+
+.handle {
+	align-items: center;
+	background: var(--switch-outline);
+	border-radius: 24px;
+	color: var(--switch-surface-container-highest);
+	display: flex;
+	height: 24px;
+	justify-content: center;
+	position: relative;
+	transition:
+		background-color 160ms ease,
+		color 160ms ease,
+		height 120ms ease,
+		width 120ms ease;
+	width: 24px;
+}
+
+.icon {
+	display: block;
+	height: 16px;
+	position: relative;
+	width: 16px;
+}
+
+.icon::before,
+.icon::after {
+	background: currentColor;
+	content: '';
+	position: absolute;
+	transform-origin: center;
+}
+
+.icon::before {
+	border-radius: 2px;
+	height: 9px;
+	left: 9px;
+	top: 3px;
+	transform: rotate(45deg);
+	width: 2px;
+}
+
+.icon::after {
+	border-radius: 2px;
+	height: 2px;
+	left: 3px;
+	top: 8px;
+	transform: rotate(45deg);
+	width: 6px;
+}
+
+.input:not(:checked) + .track .icon::before,
+.input:not(:checked) + .track .icon::after {
+	height: 14px;
+	border-radius: 2px;
+	left: 7px;
+	top: 1px;
+	width: 2px;
+}
+
+.input:not(:checked) + .track .icon::before {
+	transform: rotate(45deg);
+}
+
+.input:not(:checked) + .track .icon::after {
+	transform: rotate(-45deg);
+}
+
+.input:checked + .track {
+	background: var(--switch-primary);
+	border-color: var(--switch-primary);
+}
+
+.input:checked + .track .target {
+	left: auto;
+	right: -4px;
+}
+
+.input:checked + .track .handle {
+	background: var(--switch-on-primary);
+	color: var(--switch-primary);
+}
+
+.switch:hover .input:not(:disabled):not(:checked) + .track .target {
+	background: rgba(27, 27, 28, 0.08);
+}
+
+.switch:hover .input:not(:disabled):not(:checked) + .track .handle {
+	background: var(--switch-on-surface-variant);
+}
+
+.switch:hover .input:not(:disabled):checked + .track .target {
+	background: rgba(165, 0, 10, 0.08);
+}
+
+.switch:hover .input:not(:disabled):checked + .track .handle {
+	background: var(--switch-primary-container);
+	color: var(--switch-on-primary-container);
+}
+
+.switch:active .input:not(:disabled) + .track .handle {
+	height: 28px;
+	width: 28px;
+}
+
+.switch:active .input:not(:disabled):not(:checked) + .track .target {
+	background: rgba(27, 27, 28, 0.1);
+}
+
+.switch:active .input:not(:disabled):checked + .track .target {
+	background: rgba(165, 0, 10, 0.1);
+}
+
+.input:focus-visible + .track {
+	outline: 3px solid var(--switch-focus);
+	outline-offset: 2px;
+}
+
+.input:disabled + .track {
+	background: rgba(224, 227, 227, 0.1);
+	border-color: rgba(27, 27, 28, 0.1);
+	cursor: not-allowed;
+}
+
+.input:disabled + .track .handle {
+	background: rgba(27, 27, 28, 0.38);
+	color: rgba(252, 249, 249, 0.75);
+}
+
+.input:disabled:checked + .track {
+	background: rgba(27, 27, 28, 0.1);
+	border-color: transparent;
+}
+
+.input:disabled:checked + .track .handle {
+	background: var(--switch-surface);
+	color: rgba(27, 27, 28, 0.38);
+}
+
+.disabled {
+	cursor: not-allowed;
+}

--- a/src/components/chatMenuDropdown/ChatMenuDropdown.stories.tsx
+++ b/src/components/chatMenuDropdown/ChatMenuDropdown.stories.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ReactComponent as ArchiveIcon } from '../../resources/img/icons/inbox.svg';
+import { ReactComponent as BellOffIcon } from '../../resources/img/icons/bell-off.svg';
+import { ReactComponent as HelpIcon } from '../../resources/img/icons/i.svg';
+import { ReactComponent as PlusIcon } from '../../resources/img/icons/plus.svg';
+import { ReactComponent as PackageIcon } from '../../resources/img/icons/documents.svg';
+import {
+	ChatMenuDropdown,
+	ChatMenuDropdownDivider,
+	ChatMenuDropdownHeader,
+	ChatMenuDropdownItem,
+	ChatMenuDropdownSection
+} from './ChatMenuDropdown';
+
+const meta: Meta<typeof ChatMenuDropdown> = {
+	title: 'Components/Chat/MenuDropdown',
+	component: ChatMenuDropdown,
+	parameters: {
+		layout: 'centered',
+		docs: {
+			description: {
+				component:
+					'Reusable ORISO chat menu matching the App.Oriso Figma menu surface. Used for chat/session action dropdowns.'
+			}
+		},
+		design: {
+			type: 'figma',
+			url: 'https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=7086-57446'
+		}
+	},
+	args: {
+		ariaLabel: 'Chatraum Einstellungen'
+	}
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChatMenuDropdown>;
+
+const FigmaMenuItems = ({ activeFirst = false }: { activeFirst?: boolean }) => (
+	<ChatMenuDropdown ariaLabel="Chatraum Einstellungen">
+		<ChatMenuDropdownHeader
+			subtitle="Jeder Raum individuell anpassbar"
+			title="Chatraum Einstellungen"
+		/>
+		<ChatMenuDropdownDivider />
+		<ChatMenuDropdownSection>
+			<ChatMenuDropdownItem
+				icon={<ArchiveIcon />}
+				title="Lösche Account"
+				description="DerAccount wird in 48h unwiderruflich gelöscht."
+				shortcut="⇧A"
+				active={activeFirst}
+			/>
+			<ChatMenuDropdownItem
+				icon={<BellOffIcon />}
+				title="Stummschalten"
+				description="Deaktiviere Benachrichtigungen für diesen Chat."
+				shortcut="⇧Ö"
+			/>
+			<ChatMenuDropdownItem
+				icon={<HelpIcon />}
+				title="Hilfe Anfragen"
+				description="Eskaliere den Fall intern oder extern ohne den Datenschutz zu vernachlässigen."
+				shortcut="⇧Ä"
+				disabled
+			/>
+		</ChatMenuDropdownSection>
+		<ChatMenuDropdownDivider />
+		<ChatMenuDropdownSection>
+			<ChatMenuDropdownItem
+				icon={<PlusIcon />}
+				title="Weitere Personen einladen"
+				description="Wer eingeladen werden kann, hängt von den Admin-Einstellungen ab."
+				shortcut="⇧I"
+				disabled
+			/>
+			<ChatMenuDropdownItem
+				icon={<PackageIcon />}
+				title="Chat Zusammenfassen"
+				description="Spare Zeit, mit Hilfe unseres vollends Datenschutzkonformen KI Workflows."
+				shortcut="⇧Ü"
+				disabled
+			/>
+		</ChatMenuDropdownSection>
+	</ChatMenuDropdown>
+);
+
+export const FigmaReference: Story = {
+	render: () => <FigmaMenuItems />
+};
+
+export const ActiveState: Story = {
+	render: () => <FigmaMenuItems activeFirst />
+};
+
+export const LegalLinksMenu: Story = {
+	render: () => (
+		<ChatMenuDropdown ariaLabel="Chat legal menu">
+			<ChatMenuDropdownHeader
+				subtitle="Rechtliche Informationen"
+				title="Chat Informationen"
+			/>
+			<ChatMenuDropdownDivider />
+			<ChatMenuDropdownSection>
+				<ChatMenuDropdownItem
+					icon={<HelpIcon />}
+					title="Datenschutzerklärung"
+					description="Lese wie diese Beratungsstelle deine Daten verarbeitet."
+				/>
+				<ChatMenuDropdownItem
+					icon={<ArchiveIcon />}
+					title="Impressum"
+					description="Kontakt- und Anbieterinformationen öffnen."
+				/>
+			</ChatMenuDropdownSection>
+		</ChatMenuDropdown>
+	)
+};

--- a/src/components/chatMenuDropdown/ChatMenuDropdown.tsx
+++ b/src/components/chatMenuDropdown/ChatMenuDropdown.tsx
@@ -74,6 +74,7 @@ export const ChatMenuDropdownItem = ({
 	description,
 	shortcut,
 	disabled = false,
+	active = false,
 	className,
 	children,
 	...rest
@@ -84,6 +85,7 @@ export const ChatMenuDropdownItem = ({
 	description?: React.ReactNode;
 	shortcut?: React.ReactNode;
 	disabled?: boolean;
+	active?: boolean;
 	className?: string;
 	children?: React.ReactNode;
 	[key: string]: any;
@@ -94,6 +96,7 @@ export const ChatMenuDropdownItem = ({
 		className: clsx(
 			'chatMenuDropdown__item',
 			disabled && 'chatMenuDropdown__item--disabled',
+			active && 'chatMenuDropdown__item--active',
 			className
 		),
 		...(Component === 'button'

--- a/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
+++ b/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
@@ -3,14 +3,14 @@
 	background: #ffffff;
 	width: 301px;
 	max-width: calc(100vw - 24px);
-	border: 1px solid var(--m3-primary-container, #cc1e1c);
+	border: 1px solid var(--m3-primary, #a5000a);
 	border-radius: 8px;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 	overflow: auto;
 	z-index: 99999;
 	display: flex;
 	flex-direction: column;
-	padding: 8px;
+	padding: 14px 23px 22px;
 	max-height: min(520px, calc(100vh - 32px));
 	transform-origin: top right;
 
@@ -18,22 +18,22 @@
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
-		padding: 8px 12px 6px;
+		padding: 0 0 12px;
 		width: 100%;
 		box-sizing: border-box;
 	}
 
 	&__subtitle {
 		font-size: 12px;
-		color: $form-secondary;
-		margin: 0 0 4px;
-		line-height: 20px;
+		color: #646d78;
+		margin: 0;
+		line-height: 17px;
 	}
 
 	&__title {
-		font-size: 14px;
+		font-size: 16px;
 		font-weight: 600;
-		color: rgba(0, 0, 0, 0.9);
+		color: #1d1b20;
 		margin: 0;
 		line-height: 22px;
 	}
@@ -41,8 +41,8 @@
 	&__divider {
 		width: 100%;
 		height: 1px;
-		background-color: rgba(204, 30, 28, 0.15);
-		margin: 8px 0;
+		background-color: #d0d0d0;
+		margin: 0 0 8px;
 	}
 
 	&__section {
@@ -55,7 +55,7 @@
 		display: flex;
 		align-items: flex-start;
 		gap: 12px;
-		padding: 12px 16px;
+		padding: 8px 8px 12px;
 		cursor: pointer;
 		transition:
 			background-color 150ms ease,
@@ -67,13 +67,14 @@
 		box-sizing: border-box;
 		border-radius: 8px;
 		margin: 0;
-		color: #4c555f;
+		color: #1d1b20;
 		text-decoration: none;
 		font: inherit;
 
 		&:hover:not(:disabled):not(&--disabled),
-		&:focus-visible:not(:disabled):not(&--disabled) {
-			background-color: #e7effc;
+		&:focus-visible:not(:disabled):not(&--disabled),
+		&--active:not(:disabled):not(&--disabled) {
+			background-color: rgba(165, 0, 10, 0.08);
 			outline: none;
 
 			.chatMenuDropdown__itemTitle,
@@ -100,7 +101,7 @@
 		width: 20px;
 		height: 20px;
 		flex-shrink: 0;
-		color: $form-secondary;
+		color: #1d1b20;
 		margin-top: 2px;
 
 		svg {
@@ -113,7 +114,7 @@
 		}
 
 		&--disabled {
-			color: #9ba4b0;
+			color: #b4b4b4;
 		}
 	}
 
@@ -135,13 +136,13 @@
 
 	&__itemTitle {
 		font-size: 16px;
-		font-weight: 500;
-		color: #4c555f;
-		line-height: 24px;
+		font-weight: 400;
+		color: #1d1b20;
+		line-height: 22px;
 		flex: 1;
 
 		&--disabled {
-			color: #9ba4b0;
+			color: #b4b4b4;
 		}
 	}
 
@@ -151,7 +152,7 @@
 		justify-content: flex-end;
 		font-size: 12px;
 		font-weight: 400;
-		color: #4c555f;
+		color: #1d1b20;
 		background: transparent;
 		border: none;
 		padding: 0;
@@ -162,12 +163,12 @@
 
 	&__itemDescription {
 		font-size: 12px;
-		color: #646d78;
-		line-height: 20px;
+		color: #767676;
+		line-height: 17px;
 		margin: 0;
 
 		&--disabled {
-			color: #9ba4b0;
+			color: #b4b4b4;
 		}
 	}
 }

--- a/src/components/profile/AbsenceFormular.tsx
+++ b/src/components/profile/AbsenceFormular.tsx
@@ -7,7 +7,7 @@ import { UserDataContext } from '../../globalState';
 import { ReactComponent as CheckIcon } from '../../resources/img/illustrations/check.svg';
 import './absenceFormular.styles';
 import { Headline } from '../headline/Headline';
-import Switch from 'react-switch';
+import { Switch } from '../Switch';
 import { Text } from '../text/Text';
 import { Textarea } from '../form/textarea';
 import { isMobile } from 'react-device-detect';
@@ -101,15 +101,7 @@ export const AbsenceFormular = () => {
 						className="mr--1"
 						onChange={() => saveAbsence(!isAbsent)}
 						checked={isAbsent}
-						uncheckedIcon={false}
-						checkedIcon={false}
-						width={48}
-						height={26}
-						onColor="#0A882F"
-						offColor="#8C878C"
-						boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-						handleDiameter={27}
-						activeBoxShadow="none"
+						aria-label={translate('absence.checkbox.label')}
 					/>
 					<Text
 						text={translate('absence.checkbox.label')}

--- a/src/components/profile/ConsultantNotifications.tsx
+++ b/src/components/profile/ConsultantNotifications.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
-import Switch from 'react-switch';
+import { Switch } from '../Switch';
 import { UserDataContext } from '../../globalState';
 import { apiPatchUserData } from '../../api/apiPatchUserData';
 import { useTranslation } from 'react-i18next';
@@ -28,7 +28,9 @@ export const ConsultantNotifications = () => {
 			emailToggles
 		})
 			.then(reloadUserData)
-			.catch((error) => { /* console.log(error); */ });
+			.catch((error) => {
+				/* console.log(error); */
+			});
 	};
 
 	return (
@@ -55,15 +57,7 @@ export const ConsultantNotifications = () => {
 									toggle.name === notification.types[0]
 							)?.state ?? false
 						}
-						uncheckedIcon={false}
-						checkedIcon={false}
-						width={48}
-						height={26}
-						onColor="#0A882F"
-						offColor="#8C878C"
-						boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-						handleDiameter={27}
-						activeBoxShadow="none"
+						aria-label={translate(notification.label)}
 					/>
 					<Text
 						text={translate(notification.label)}

--- a/src/components/profile/EnableWalkthrough.tsx
+++ b/src/components/profile/EnableWalkthrough.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
-import Switch from 'react-switch';
+import { Switch } from '../Switch';
 import { useContext } from 'react';
 import { UserDataContext } from '../../globalState';
 
@@ -25,25 +25,23 @@ export const EnableWalkthrough = () => {
 					className="tertiary"
 				/>
 			</div>
-			<label className="twoFactorAuth__switch">
+			<div className="twoFactorAuth__switch">
 				<Switch
 					onChange={() => {
 						apiPatchConsultantData({
 							walkThroughEnabled: !isWalkThroughEnabled
 						})
 							.then(reloadUserData)
-							.catch((error) => { /* console.log(error); */ });
+							.catch((error) => {
+								/* console.log(error); */
+							});
 					}}
 					checked={userData.isWalkThroughEnabled}
-					uncheckedIcon={false}
-					checkedIcon={false}
-					width={48}
-					height={26}
-					onColor="#0A882F"
-					offColor="#8C878C"
-					boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-					handleDiameter={27}
-					activeBoxShadow="none"
+					aria-label={
+						isWalkThroughEnabled
+							? translate('walkthrough.switch.active.label')
+							: translate('walkthrough.switch.deactive.label')
+					}
 				/>
 				<Text
 					text={
@@ -53,7 +51,7 @@ export const EnableWalkthrough = () => {
 					}
 					type="standard"
 				/>
-			</label>
+			</div>
 		</div>
 	);
 };

--- a/src/components/profile/LiveChatAvailability.tsx
+++ b/src/components/profile/LiveChatAvailability.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useCallback } from 'react';
-import Switch from 'react-switch';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Headline } from '../headline/Headline';
+import { Switch } from '../Switch';
 import { Text } from '../text/Text';
 import { useLiveChatAvailable } from '../../utils/liveChatToggle';
 
@@ -16,9 +16,7 @@ export const LiveChatAvailability = () => {
 		(checked: boolean) => {
 			setLiveChatAvailable(checked);
 			if (checked) {
-				navigate(
-					'/sessions/consultant/sessionPreview?chip=liveChat'
-				);
+				navigate('/sessions/consultant/sessionPreview?chip=liveChat');
 			}
 		},
 		[navigate, setLiveChatAvailable]
@@ -42,15 +40,9 @@ export const LiveChatAvailability = () => {
 						className="mr--1"
 						onChange={handleToggle}
 						checked={liveChatAvailable}
-						uncheckedIcon={false}
-						checkedIcon={false}
-						width={48}
-						height={26}
-						onColor="#0A882F"
-						offColor="#8C878C"
-						boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-						handleDiameter={27}
-						activeBoxShadow="none"
+						aria-label={translate(
+							'profile.functions.liveChat.toggleLabel'
+						)}
 					/>
 					<Text
 						text={translate(

--- a/src/components/profile/MagicLinksLoginFeature.tsx
+++ b/src/components/profile/MagicLinksLoginFeature.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
-import Switch from 'react-switch';
+import { Switch } from '../Switch';
 import { UserDataContext } from '../../globalState';
 import { apiPatchUserData } from '../../api/apiPatchUserData';
 
@@ -64,7 +64,9 @@ export const MagicLinksLoginFeature = () => {
 			</div>
 			{!hasEmail && (
 				<Text
-					text={translate('profile.functions.magicLinks.emailRequired')}
+					text={translate(
+						'profile.functions.magicLinks.emailRequired'
+					)}
 					type="infoSmall"
 					className="tertiary"
 				/>
@@ -76,21 +78,25 @@ export const MagicLinksLoginFeature = () => {
 					onChange={handleToggle}
 					checked={isEnabled}
 					disabled={!hasEmail || isSaving}
-					uncheckedIcon={false}
-					checkedIcon={false}
-					width={48}
-					height={26}
-					onColor="#0A882F"
-					offColor="#8C878C"
-					boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-					handleDiameter={27}
-					activeBoxShadow="none"
+					aria-label={
+						isEnabled
+							? translate(
+									'profile.functions.magicLinks.toggle.enabled'
+								)
+							: translate(
+									'profile.functions.magicLinks.toggle.disabled'
+								)
+					}
 				/>
 				<Text
 					text={
 						isEnabled
-							? translate('profile.functions.magicLinks.toggle.enabled')
-							: translate('profile.functions.magicLinks.toggle.disabled')
+							? translate(
+									'profile.functions.magicLinks.toggle.enabled'
+								)
+							: translate(
+									'profile.functions.magicLinks.toggle.disabled'
+								)
 					}
 					type="standard"
 				/>
@@ -98,5 +104,3 @@ export const MagicLinksLoginFeature = () => {
 		</div>
 	);
 };
-
-

--- a/src/components/twoFactorAuth/TwoFactorAuth.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import Switch from 'react-switch';
 import { apiDeleteTwoFactorAuth } from '../../api';
 import {
 	AUTHORITIES,
@@ -11,6 +10,7 @@ import {
 } from '../../globalState';
 import { Button, BUTTON_TYPES } from '../button/Button';
 import { Headline } from '../headline/Headline';
+import { Switch } from '../Switch';
 import { Text } from '../text/Text';
 import { PenIcon } from '../../resources/img/icons';
 import { useAppConfig } from '../../hooks/useAppConfig';
@@ -139,19 +139,17 @@ export const TwoFactorAuth = () => {
 				/>
 			</div>
 			{!isTwoFactorBinding && (
-				<label className="twoFactorAuth__switch">
+				<div className="twoFactorAuth__switch">
 					<Switch
 						onChange={handleSwitchChange}
 						checked={isSwitchChecked}
-						uncheckedIcon={false}
-						checkedIcon={false}
-						width={48}
-						height={26}
-						onColor="#0A882F"
-						offColor="#8C878C"
-						boxShadow="0px 1px 4px rgba(0, 0, 0, 0.6)"
-						handleDiameter={27}
-						activeBoxShadow="none"
+						aria-label={
+							isSwitchChecked
+								? translate('twoFactorAuth.switch.active.label')
+								: translate(
+										'twoFactorAuth.switch.deactive.label'
+									)
+						}
 					/>
 					<Text
 						text={
@@ -163,7 +161,7 @@ export const TwoFactorAuth = () => {
 						}
 						type="standard"
 					/>
-				</label>
+				</div>
 			)}
 			{(isSwitchChecked || isTwoFactorBinding) &&
 				userData.twoFactorAuth.type && (


### PR DESCRIPTION
## Summary

- Added reusable Storybook components for ORISO UI alignment.
- Created reusable `ChatMenuDropdown` stories based on the Figma dropdown design.
- Updated the shared `Switch` component to match the M3 ORISO Figma switch design.
- Replaced old `react-switch` usages with the shared reusable `Switch` component.
- Fixed Storybook loading issues so the component panel and stories render correctly.

## Changes

- Added Storybook stories for:
  - `Components/Chat/MenuDropdown`
  - `Components/Switch`
- Updated dropdown styles:
  - Figma-aligned border color, radius, spacing, hover, active, and disabled states.
- Updated switch styles:
  - M3 ORISO colors
  - 52x32 switch size
  - Rounded track and handle
  - Checked, unchecked, hover, pressed, focused, and disabled states
  - Optional check/X icon support
- Migrated existing setting toggles to use the shared `Switch` component:
  - Absence toggle
  - Consultant notifications
  - Live chat availability
  - Walkthrough toggle
  - Magic links toggle
  - Two-factor auth toggle
  - Browser/email notification toggles through the shared component

## Storybook Fixes

- Fixed Storybook iframe bundle path issue.
- Patched `domhandler/lib/node` resolution issue.
- Disabled heavy TypeScript docgen for local Storybook preview.
- Removed app-only webpack plugins from Storybook preview config to prevent long loading/freezing.

## Verification

- `npx tsc --noEmit` passes.
- `git diff --check` passes with only Windows CRLF warnings.
- Verified Storybook stories render locally:
  - `Components / Chat / MenuDropdown`
  - `Components / Switch`