### PR TITLE
feat: user-facing department legal texts + configurable registration consulting type

### DIFF
--- a/src/api/apiGetDepartmentLegal.test.ts
+++ b/src/api/apiGetDepartmentLegal.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiGetDepartmentLegal } from './apiGetDepartmentLegal';
+import { fetchData, FETCH_ERRORS } from './fetchData';
+
+vi.mock('./fetchData', async () => {
+	const actual =
+		await vi.importActual<typeof import('./fetchData')>('./fetchData');
+	return {
+		...actual,
+		fetchData: vi.fn()
+	};
+});
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		agencyDepartmentLegal: (agencyId: number, topicId: number) =>
+			`https://api.test.local/service/agencies/${agencyId}/topics/${topicId}/legal`
+	}
+}));
+
+describe('apiGetDepartmentLegal', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('resolves the published legal texts', async () => {
+		const legal = {
+			dpp: { content: '{"de":"<p>Hallo</p>"}' },
+			imprint: { content: null }
+		};
+		vi.mocked(fetchData).mockResolvedValue(legal);
+
+		await expect(apiGetDepartmentLegal(42, 7)).resolves.toEqual(legal);
+	});
+
+	it('degrades gracefully to null when the endpoint 404s (backend without AgencyService #90)', async () => {
+		vi.mocked(fetchData).mockRejectedValue(
+			new Error(FETCH_ERRORS.NO_MATCH)
+		);
+
+		await expect(apiGetDepartmentLegal(42, 7)).resolves.toBeNull();
+	});
+
+	it('degrades gracefully to null on any other error', async () => {
+		vi.mocked(fetchData).mockRejectedValue(
+			new Error(FETCH_ERRORS.CATCH_ALL)
+		);
+
+		await expect(apiGetDepartmentLegal(42, 7)).resolves.toBeNull();
+	});
+
+	it('opts into non-redirecting error handling for 404s', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			dpp: { content: null },
+			imprint: { content: null }
+		});
+
+		await apiGetDepartmentLegal(42, 7);
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.test.local/service/agencies/42/topics/7/legal',
+				skipAuth: true,
+				responseHandling: expect.arrayContaining([
+					FETCH_ERRORS.NO_MATCH,
+					FETCH_ERRORS.CATCH_ALL
+				])
+			})
+		);
+	});
+});

--- a/src/api/apiGetDepartmentLegal.ts
+++ b/src/api/apiGetDepartmentLegal.ts
@@ -1,0 +1,39 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
+
+export interface DepartmentLegalContent {
+	/**
+	 * Published multilingual content as a JSON language->HTML map string.
+	 * Null when the text is a draft or was never authored.
+	 */
+	content: string | null;
+}
+
+export interface DepartmentLegalData {
+	dpp: DepartmentLegalContent;
+	imprint: DepartmentLegalContent;
+}
+
+/**
+ * Loads the published legal texts (data privacy policy + imprint) of a
+ * department (agency x topic). Public endpoint, no auth.
+ *
+ * Degrades gracefully: resolves to null when the endpoint does not exist
+ * yet (backend without AgencyService #90 answers 404), the department is
+ * unknown, or the request fails - callers then fall back to tenant-level
+ * content, i.e. today's behavior.
+ */
+export const apiGetDepartmentLegal = async (
+	agencyId: number,
+	topicId: number,
+	signal?: AbortSignal
+): Promise<DepartmentLegalData | null> =>
+	fetchData({
+		url: endpoints.agencyDepartmentLegal(agencyId, topicId),
+		method: FETCH_METHODS.GET,
+		skipAuth: true,
+		// NO_MATCH + CATCH_ALL keep fetchData from redirecting to the error
+		// page - any non-2xx simply rejects and is mapped to null here.
+		responseHandling: [FETCH_ERRORS.NO_MATCH, FETCH_ERRORS.CATCH_ALL],
+		...(signal ? { signal } : {})
+	}).catch(() => null);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './apiAgencySelection';
+export * from './apiGetDepartmentLegal';
 export * from './apiDeleteAskerAccount';
 export * from './apiDeleteSessionAndUser';
 export * from './apiFinishAnonymousConversation';

--- a/src/components/departmentLegal/DepartmentLegalSection.test.tsx
+++ b/src/components/departmentLegal/DepartmentLegalSection.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DepartmentLegalSection } from './DepartmentLegalSection';
+import { apiGetDepartmentLegal } from '../../api/apiGetDepartmentLegal';
+import {
+	AgencyDataInterface,
+	TopicsDataInterface
+} from '../../globalState/interfaces';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string, fallback?: string) => fallback ?? key,
+		i18n: { language: 'de' }
+	})
+}));
+
+vi.mock('../../api/apiGetDepartmentLegal', () => ({
+	apiGetDepartmentLegal: vi.fn()
+}));
+
+const mockTenant = {
+	content: { privacy: '<p>Träger Datenschutz</p>' }
+};
+
+vi.mock('../../globalState/provider/TenantProvider', () => ({
+	useTenant: () => mockTenant
+}));
+
+vi.mock('../legalContent/legalContent.styles.scss', () => ({}));
+
+const topic = {
+	id: 7,
+	name: 'Suchtberatung'
+} as TopicsDataInterface;
+
+const agencyWithDepartment = {
+	id: 42,
+	name: 'Beratungsstelle',
+	departments: [
+		{ topicId: 7, hasPublishedDpp: true, hasPublishedImprint: false }
+	]
+} as unknown as AgencyDataInterface;
+
+const expandSection = () =>
+	fireEvent.click(
+		screen.getByText('Datenschutzhinweise der Beratungsstelle')
+	);
+
+describe('DepartmentLegalSection', () => {
+	beforeEach(() => {
+		vi.mocked(apiGetDepartmentLegal).mockResolvedValue({
+			dpp: { content: JSON.stringify({ de: '<p>Fachbereich DPP</p>' }) },
+			imprint: { content: null }
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('renders nothing when the backend sends no departments (older backend)', () => {
+		const { container } = render(
+			<DepartmentLegalSection
+				agency={{ id: 42 } as AgencyDataInterface}
+				topic={topic}
+			/>
+		);
+
+		expect(container.innerHTML).toBe('');
+		expect(apiGetDepartmentLegal).not.toHaveBeenCalled();
+	});
+
+	it('renders nothing when the department has no published legal text', () => {
+		const { container } = render(
+			<DepartmentLegalSection
+				agency={
+					{
+						id: 42,
+						departments: [{ topicId: 7 }]
+					} as AgencyDataInterface
+				}
+				topic={topic}
+			/>
+		);
+
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('lazy-loads the legal endpoint only after expanding', async () => {
+		render(
+			<DepartmentLegalSection
+				agency={agencyWithDepartment}
+				topic={topic}
+			/>
+		);
+
+		expect(screen.getByText(/Suchtberatung/)).toBeDefined();
+		expect(apiGetDepartmentLegal).not.toHaveBeenCalled();
+
+		expandSection();
+
+		await waitFor(() =>
+			expect(apiGetDepartmentLegal).toHaveBeenCalledWith(
+				42,
+				7,
+				expect.anything()
+			)
+		);
+		await waitFor(() =>
+			expect(screen.getByText('Fachbereich DPP')).toBeDefined()
+		);
+	});
+
+	it('prefers the department dpp over the tenant content in the consent variant', async () => {
+		render(
+			<DepartmentLegalSection
+				agency={agencyWithDepartment}
+				topic={topic}
+				variant="consent"
+			/>
+		);
+
+		expandSection();
+
+		await waitFor(() =>
+			expect(screen.getByText('Fachbereich DPP')).toBeDefined()
+		);
+		expect(screen.queryByText('Träger Datenschutz')).toBeNull();
+	});
+
+	it('falls back to the tenant content when the endpoint is unavailable (e.g. 404 before AgencyService #90)', async () => {
+		// apiGetDepartmentLegal maps 404/network errors to null
+		vi.mocked(apiGetDepartmentLegal).mockResolvedValue(null);
+
+		render(
+			<DepartmentLegalSection
+				agency={agencyWithDepartment}
+				topic={topic}
+				variant="consent"
+			/>
+		);
+
+		expandSection();
+
+		await waitFor(() =>
+			expect(screen.getByText('Träger Datenschutz')).toBeDefined()
+		);
+	});
+
+	it('shows an unavailable notice when neither department nor tenant content exists', async () => {
+		vi.mocked(apiGetDepartmentLegal).mockResolvedValue(null);
+		mockTenant.content.privacy = '';
+
+		render(
+			<DepartmentLegalSection
+				agency={agencyWithDepartment}
+				topic={topic}
+				variant="consent"
+			/>
+		);
+
+		expandSection();
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(
+					'Die Datenschutzhinweise können derzeit nicht geladen werden.'
+				)
+			).toBeDefined()
+		);
+
+		mockTenant.content.privacy = '<p>Träger Datenschutz</p>';
+	});
+});

--- a/src/components/departmentLegal/DepartmentLegalSection.tsx
+++ b/src/components/departmentLegal/DepartmentLegalSection.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import {
+	Box,
+	Button,
+	CircularProgress,
+	Collapse,
+	Typography
+} from '@mui/material';
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import { useTranslation } from 'react-i18next';
+import {
+	apiGetDepartmentLegal,
+	DepartmentLegalData
+} from '../../api/apiGetDepartmentLegal';
+import {
+	AgencyDataInterface,
+	AgencyDepartmentDataInterface,
+	TopicsDataInterface
+} from '../../globalState/interfaces';
+import { useTenant } from '../../globalState/provider/TenantProvider';
+import { pickConsentPrivacyContent } from '../../utils/legalContent';
+import { LegalContentRenderer } from '../legalContent/LegalContentRenderer';
+
+export const getDepartmentForTopic = (
+	agency?: AgencyDataInterface,
+	topic?: TopicsDataInterface
+): AgencyDepartmentDataInterface | undefined =>
+	topic?.id !== undefined
+		? agency?.departments?.find(
+				(department) => department.topicId === topic.id
+			)
+		: undefined;
+
+export interface DepartmentLegalSectionProps {
+	agency?: AgencyDataInterface;
+	topic?: TopicsDataInterface;
+	/**
+	 * 'details': expandable legal section inside the agency details panel -
+	 * shown when the department has any published legal text.
+	 * 'consent': data privacy display for the registration consent step -
+	 * prefers the department's published DPP and falls back to the tenant
+	 * privacy content when the department text cannot be loaded.
+	 */
+	variant?: 'details' | 'consent';
+}
+
+const topicDisplayName = (topic?: TopicsDataInterface): string =>
+	topic?.titles?.long || topic?.name || '';
+
+/**
+ * Department identity + legal texts for a selected agency/topic pair.
+ * Renders nothing when the backend does not provide `departments` (older
+ * backends without AgencyService #90) or when no published text exists -
+ * that keeps behavior identical to today when the feature is absent.
+ * The legal endpoint is only requested once the user expands the section.
+ */
+export const DepartmentLegalSection = ({
+	agency,
+	topic,
+	variant = 'details'
+}: DepartmentLegalSectionProps) => {
+	const { t } = useTranslation();
+	const tenant = useTenant();
+	const [open, setOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [legal, setLegal] = useState<DepartmentLegalData | null>(null);
+	const [hasLoaded, setHasLoaded] = useState(false);
+
+	const department = getDepartmentForTopic(agency, topic);
+	const hasPublishedDpp = department?.hasPublishedDpp === true;
+	const hasPublishedImprint = department?.hasPublishedImprint === true;
+	const isVisible =
+		variant === 'consent'
+			? hasPublishedDpp
+			: hasPublishedDpp || hasPublishedImprint;
+
+	// Lazy-load the public legal endpoint on first expand only
+	useEffect(() => {
+		if (!open || hasLoaded || !isVisible || !agency?.id || !topic?.id) {
+			return;
+		}
+		const abortController = new AbortController();
+		setIsLoading(true);
+		apiGetDepartmentLegal(agency.id, topic.id, abortController.signal)
+			.then((data) => {
+				setLegal(data);
+				setHasLoaded(true);
+			})
+			.finally(() => setIsLoading(false));
+		return () => abortController.abort();
+	}, [open, hasLoaded, isVisible, agency?.id, topic?.id]);
+
+	if (!isVisible) {
+		return null;
+	}
+
+	const dppContent = legal?.dpp?.content;
+	const imprintContent = legal?.imprint?.content;
+	// Consent display: department DPP wins, tenant content is the fallback
+	// (e.g. when the endpoint 404s on a backend without AgencyService #90).
+	const consentContent =
+		variant === 'consent'
+			? pickConsentPrivacyContent(dppContent, tenant?.content?.privacy)
+			: null;
+
+	const nothingLoaded =
+		hasLoaded &&
+		(variant === 'consent'
+			? !consentContent?.content
+			: !dppContent && !imprintContent);
+
+	return (
+		<Box data-cy={`department-legal-${variant}`} sx={{ width: '100%' }}>
+			<Button
+				type="button"
+				aria-expanded={open}
+				onClick={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					setOpen((current) => !current);
+				}}
+				endIcon={
+					<ExpandMoreRoundedIcon
+						sx={{
+							transform: open ? 'rotate(180deg)' : 'none',
+							transition: 'transform 160ms ease'
+						}}
+					/>
+				}
+				sx={{
+					px: 0,
+					fontWeight: 700,
+					fontSize: 14,
+					textTransform: 'none'
+				}}
+			>
+				{t(
+					'registration.agency.legal.headline',
+					'Datenschutzhinweise der Beratungsstelle'
+				)}
+			</Button>
+			{topicDisplayName(topic) && (
+				<Typography
+					variant="body2"
+					sx={{ color: 'text.secondary', mt: 0.25 }}
+				>
+					{t('registration.agency.legal.department', 'Fachbereich')}
+					{': '}
+					{topicDisplayName(topic)}
+				</Typography>
+			)}
+			<Collapse in={open} timeout="auto" unmountOnExit>
+				<Box
+					onClick={(event) => event.stopPropagation()}
+					sx={{ pt: 1.5, pb: 0.5 }}
+				>
+					{isLoading && (
+						<CircularProgress size={20} aria-label="loading" />
+					)}
+					{nothingLoaded && (
+						<Typography variant="body2">
+							{t(
+								'registration.agency.legal.unavailable',
+								'Die Datenschutzhinweise können derzeit nicht geladen werden.'
+							)}
+						</Typography>
+					)}
+					{variant === 'consent' ? (
+						// Render only once the department fetch settled so the
+						// tenant fallback does not flash before the result.
+						hasLoaded &&
+						consentContent?.content && (
+							<LegalContentRenderer
+								content={consentContent.content}
+							/>
+						)
+					) : (
+						<>
+							{dppContent && (
+								<LegalContentRenderer content={dppContent} />
+							)}
+							{imprintContent && (
+								<>
+									<Typography
+										variant="subtitle2"
+										sx={{ fontWeight: 700, mt: 2, mb: 1 }}
+									>
+										{t(
+											'registration.agency.legal.imprintHeadline',
+											'Impressum der Beratungsstelle'
+										)}
+									</Typography>
+									<LegalContentRenderer
+										content={imprintContent}
+									/>
+								</>
+							)}
+						</>
+					)}
+				</Box>
+			</Collapse>
+		</Box>
+	);
+};

--- a/src/components/legalContent/LegalContentRenderer.test.tsx
+++ b/src/components/legalContent/LegalContentRenderer.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LegalContentRenderer } from './LegalContentRenderer';
+
+let mockLanguage = 'de';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string, fallback?: string) => fallback ?? key,
+		i18n: {
+			get language() {
+				return mockLanguage;
+			}
+		}
+	})
+}));
+
+vi.mock('./legalContent.styles.scss', () => ({}));
+
+const map = (entries: Record<string, unknown>) => JSON.stringify(entries);
+
+describe('LegalContentRenderer', () => {
+	afterEach(() => {
+		cleanup();
+		mockLanguage = 'de';
+	});
+
+	it('renders plain HTML without any notice', () => {
+		render(<LegalContentRenderer content="<p>Datenschutz pur</p>" />);
+
+		expect(screen.getByText('Datenschutz pur')).toBeDefined();
+		expect(screen.queryByRole('note')).toBeNull();
+	});
+
+	it('renders nothing for empty content', () => {
+		const { container } = render(<LegalContentRenderer content="" />);
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('shows the fallback notice when the UI language is missing', () => {
+		mockLanguage = 'fr';
+		render(<LegalContentRenderer content={map({ de: '<p>Hallo</p>' })} />);
+
+		expect(screen.getByText('Hallo')).toBeDefined();
+		expect(
+			screen.getByText(
+				'Dieser Text liegt nicht in Ihrer Sprache vor und wird in seiner Originalsprache angezeigt.'
+			)
+		).toBeDefined();
+	});
+
+	it('shows the machine translation notice and toggles to the original', () => {
+		mockLanguage = 'en';
+		render(
+			<LegalContentRenderer
+				content={map({
+					de: '<p>Hallo Original</p>',
+					en: '<p>Hello translated</p>',
+					en__meta: JSON.stringify({ mt: true, src: 'de' })
+				})}
+			/>
+		);
+
+		expect(screen.getByText('Hello translated')).toBeDefined();
+		expect(
+			screen.getByText(
+				'Maschinell übersetzt — rechtlich verbindlich ist die deutsche Fassung.'
+			)
+		).toBeDefined();
+
+		fireEvent.click(screen.getByText('Original anzeigen'));
+
+		expect(screen.getByText('Hallo Original')).toBeDefined();
+		expect(screen.queryByText('Hello translated')).toBeNull();
+
+		fireEvent.click(screen.getByText('Übersetzung anzeigen'));
+		expect(screen.getByText('Hello translated')).toBeDefined();
+	});
+
+	it('never renders __meta values as content', () => {
+		mockLanguage = 'en';
+		const { container } = render(
+			<LegalContentRenderer
+				content={map({
+					de: '<p>Hallo</p>',
+					en__meta: JSON.stringify({ mt: true, src: 'de' })
+				})}
+			/>
+		);
+
+		expect(container.textContent).not.toContain('mt');
+		expect(container.textContent).not.toContain('src');
+		expect(screen.getByText('Hallo')).toBeDefined();
+	});
+});

--- a/src/components/legalContent/LegalContentRenderer.tsx
+++ b/src/components/legalContent/LegalContentRenderer.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import htmlParser from '../../resources/scripts/util/htmlParser';
+import {
+	normalizeLegalLang,
+	resolveLegalContent
+} from '../../utils/legalContent';
+import './legalContent.styles.scss';
+
+export interface LegalContentRendererProps {
+	/**
+	 * Raw legal content: either plain HTML or a JSON language->HTML map
+	 * (optionally with `<lang>__meta` machine-translation markers).
+	 */
+	content: string | null | undefined;
+	className?: string;
+}
+
+/**
+ * Renders a legal text (imprint / data privacy policy) resolved to the
+ * user's UI language (spec S2):
+ * - missing translation -> original language + "shown in its original
+ *   language" notice
+ * - machine translated -> "machine translated - the German version is
+ *   legally binding" notice with a toggle to the original text
+ * - `__meta` keys are never rendered as content
+ */
+export const LegalContentRenderer = ({
+	content,
+	className
+}: LegalContentRendererProps) => {
+	const { t, i18n } = useTranslation();
+	const [showOriginal, setShowOriginal] = useState(false);
+
+	const uiLang = normalizeLegalLang(i18n?.language);
+	const resolved = useMemo(
+		() => resolveLegalContent(content, uiLang),
+		[content, uiLang]
+	);
+	const displayed = useMemo(
+		() =>
+			showOriginal && resolved
+				? resolveLegalContent(content, resolved.originalLang)
+				: resolved,
+		[showOriginal, resolved, content]
+	);
+
+	if (!displayed) {
+		return null;
+	}
+
+	const showsFallbackLanguage = !showOriginal && displayed.lang !== uiLang;
+
+	return (
+		<div className={clsx('legalContentRenderer', className)}>
+			{showsFallbackLanguage && (
+				<p className="legalContentRenderer__notice" role="note">
+					{t(
+						'legal.notice.fallbackLanguage',
+						'Dieser Text liegt nicht in Ihrer Sprache vor und wird in seiner Originalsprache angezeigt.'
+					)}
+				</p>
+			)}
+			{displayed.isMachineTranslated && (
+				<p
+					className="legalContentRenderer__notice legalContentRenderer__notice--machineTranslated"
+					role="note"
+				>
+					{t(
+						'legal.notice.machineTranslated',
+						'Maschinell übersetzt — rechtlich verbindlich ist die deutsche Fassung.'
+					)}{' '}
+					<button
+						type="button"
+						className="legalContentRenderer__noticeAction"
+						onClick={() => setShowOriginal(true)}
+					>
+						{t('legal.notice.showOriginal', 'Original anzeigen')}
+					</button>
+				</p>
+			)}
+			{showOriginal && (
+				<p className="legalContentRenderer__notice" role="note">
+					{t(
+						'legal.notice.showingOriginal',
+						'Sie sehen die Originalfassung.'
+					)}{' '}
+					<button
+						type="button"
+						className="legalContentRenderer__noticeAction"
+						onClick={() => setShowOriginal(false)}
+					>
+						{t(
+							'legal.notice.showTranslation',
+							'Übersetzung anzeigen'
+						)}
+					</button>
+				</p>
+			)}
+			<div className="legalContentRenderer__content">
+				{htmlParser(displayed.html)}
+			</div>
+		</div>
+	);
+};

--- a/src/components/legalContent/legalContent.styles.scss
+++ b/src/components/legalContent/legalContent.styles.scss
@@ -1,0 +1,27 @@
+.legalContentRenderer {
+	&__notice {
+		background-color: var(--m3-surface-container, #f3f0ef);
+		border-left: 3px solid var(--m3-primary, $primary);
+		border-radius: 4px;
+		color: var(--m3-on-surface-variant, $secondary);
+		font-size: $font-size-secondary;
+		margin: 0 0 $grid-base-two;
+		padding: $grid-base $grid-base-two;
+	}
+
+	&__noticeAction {
+		background: none;
+		border: 0;
+		color: var(--m3-primary, $primary);
+		cursor: pointer;
+		font-size: inherit;
+		font-weight: $font-weight-bold;
+		padding: 0;
+		text-decoration: underline;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: none;
+		}
+	}
+}

--- a/src/components/legalPageWrapper/LegalPageWrapper.tsx
+++ b/src/components/legalPageWrapper/LegalPageWrapper.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Stage } from '../stage/stage';
 import './legalPageWrapper.styles.scss';
-import htmlParser from '../../resources/scripts/util/htmlParser';
+import { LegalContentRenderer } from '../legalContent/LegalContentRenderer';
 
 export interface LegalPageWrapperProps {
 	className?: string;
@@ -18,7 +18,12 @@ export const LegalPageWrapper = ({
 			<Stage className="stageLayout__stage" />
 			<div className={clsx('stageLayout__content', className)}>
 				<section className="template">
-					{typeof content === 'string' && htmlParser(content)}
+					{/* Resolves multilingual legal content (language map with
+					    optional machine-translation markers) to the UI
+					    language; plain HTML passes through unchanged. */}
+					{typeof content === 'string' && (
+						<LegalContentRenderer content={content} />
+					)}
 				</section>
 			</div>
 		</div>

--- a/src/components/registration/accountData/AccountData.tsx
+++ b/src/components/registration/accountData/AccountData.tsx
@@ -55,6 +55,7 @@ import genUserIcon from '../../../resources/img/registration-md3/icons/gen-user.
 import genKeyIcon from '../../../resources/img/registration-md3/icons/gen-key.svg';
 import genAvatarIcon from '../../../resources/img/registration-md3/icons/gen-avatar.svg';
 import genDiceIcon from '../../../resources/img/registration-md3/icons/gen-dice.svg';
+import { DepartmentLegalSection } from '../../departmentLegal/DepartmentLegalSection';
 
 const toRegistrationUsername = (displayName: string) => {
 	const normalized = displayName
@@ -148,7 +149,8 @@ export const AccountData: FC<{
 		useState<boolean>(false);
 	const [usernameAvailabilityFailed, setUsernameAvailabilityFailed] =
 		useState<boolean>(false);
-	const { setDisabledNextButton } = useContext(RegistrationContext);
+	const { setDisabledNextButton, registrationData } =
+		useContext(RegistrationContext);
 
 	const resetUsernameAvailability = useCallback(() => {
 		setUsernameAvailabilityChecked(false);
@@ -610,6 +612,16 @@ export const AccountData: FC<{
 					}
 				/>
 			</FormGroup>
+			{/* Department-specific data privacy policy: shown when the
+			    selected agency has a published DPP for the selected topic;
+			    falls back to the tenant text if it cannot be loaded. */}
+			<Box sx={{ mt: '12px' }}>
+				<DepartmentLegalSection
+					agency={registrationData?.agency}
+					topic={registrationData?.mainTopic}
+					variant="consent"
+				/>
+			</Box>
 		</Box>
 	);
 };

--- a/src/components/registration/agencySelection/AgencyDetailsPanel.tsx
+++ b/src/components/registration/agencySelection/AgencyDetailsPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box, Collapse, Link, Typography } from '@mui/material';
-import { useMemo, type ReactNode } from 'react';
+import { useContext, useMemo, type ReactNode } from 'react';
 import PlaceRoundedIcon from '@mui/icons-material/PlaceRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import CallRoundedIcon from '@mui/icons-material/CallRounded';
@@ -9,10 +9,16 @@ import OpenInNewRoundedIcon from '@mui/icons-material/OpenInNewRounded';
 import NavigationRoundedIcon from '@mui/icons-material/NavigationRounded';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LanguageRoundedIcon from '@mui/icons-material/LanguageRounded';
+import PrivacyTipOutlinedIcon from '@mui/icons-material/PrivacyTipOutlined';
 import { useTranslation } from 'react-i18next';
+import { RegistrationContext } from '../../../globalState';
 import { AgencyDataInterface } from '../../../globalState/interfaces';
 import { registrationMd3 } from '../registrationDesign/registrationDesign';
 import { AgencyLanguages } from './AgencyLanguages';
+import {
+	DepartmentLegalSection,
+	getDepartmentForTopic
+} from '../../departmentLegal/DepartmentLegalSection';
 
 interface AgencyDetailsPanelProps {
 	agency: AgencyDataInterface;
@@ -290,6 +296,12 @@ export const AgencyDetailsPanel = ({
 	open
 }: AgencyDetailsPanelProps) => {
 	const { t } = useTranslation();
+	const { registrationData } = useContext(RegistrationContext);
+	const selectedTopic = registrationData?.mainTopic;
+	const department = getDepartmentForTopic(agency, selectedTopic);
+	const hasDepartmentLegal =
+		department?.hasPublishedDpp === true ||
+		department?.hasPublishedImprint === true;
 	const details = useMemo(() => getAgencyDetails(agency), [agency]);
 	const mapSrc = useMemo(() => osmEmbedSrc(details), [details]);
 	const webMapHref = useMemo(() => osmLink(details), [details]);
@@ -490,6 +502,21 @@ export const AgencyDetailsPanel = ({
 						)}
 					>
 						{details.about}
+					</InfoRow>
+				)}
+
+				{hasDepartmentLegal && (
+					<InfoRow
+						icon={<PrivacyTipOutlinedIcon fontSize="small" />}
+						label={t(
+							'registration.agency.legal.label',
+							'Rechtliches'
+						)}
+					>
+						<DepartmentLegalSection
+							agency={agency}
+							topic={selectedTopic}
+						/>
 					</InfoRow>
 				)}
 			</Box>

--- a/src/containers/registration/hooks/useAgenciesForRegistration.test.tsx
+++ b/src/containers/registration/hooks/useAgenciesForRegistration.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAgenciesForRegistration } from './useAgenciesForRegistration';
+import { apiAgencySelection } from '../../../api';
+import { useAppConfig } from '../../../hooks/useAppConfig';
+import {
+	ConsultingTypeInterface,
+	TopicsDataInterface
+} from '../../../globalState/interfaces';
+
+vi.mock('../../../api', () => ({
+	apiAgencySelection: vi.fn()
+}));
+
+vi.mock('../../../globalState', () => ({
+	useTenant: () => null
+}));
+
+vi.mock('../../../hooks/useAppConfig', () => ({
+	useAppConfig: vi.fn()
+}));
+
+vi.mock('./useConsultantRegistrationData', () => ({
+	useConsultantRegistrationData: () => ({
+		agencies: [],
+		consultingTypes: []
+	})
+}));
+
+vi.mock('../../../globalState/provider/UrlParamsProvider', async () => {
+	const ReactModule = await import('react');
+
+	return {
+		UrlParamsContext: ReactModule.createContext({
+			agency: null,
+			consultingType: null,
+			consultant: null,
+			topic: null,
+			loaded: true,
+			slugFallback: undefined
+		})
+	};
+});
+
+const topic = { id: 7 } as TopicsDataInterface;
+
+const appConfig = (registration: Record<string, unknown>) =>
+	({
+		registration: {
+			consultingTypeDefaults: {
+				// no postcode required so the request fires directly
+				autoSelectPostcode: true,
+				autoSelectAgency: false
+			},
+			...registration
+		}
+	}) as any;
+
+describe('useAgenciesForRegistration consulting type (FE#245)', () => {
+	beforeEach(() => {
+		vi.mocked(apiAgencySelection).mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const lastSearchParams = () =>
+		vi.mocked(apiAgencySelection).mock.calls.at(-1)?.[0];
+
+	it('keeps the historic default 1 when nothing is configured', async () => {
+		vi.mocked(useAppConfig).mockReturnValue(appConfig({}));
+
+		renderHook(() =>
+			useAgenciesForRegistration({ topic, postcode: undefined })
+		);
+
+		await waitFor(() => expect(apiAgencySelection).toHaveBeenCalled());
+		expect(lastSearchParams()).toMatchObject({
+			topicId: 7,
+			consultingType: 1
+		});
+	});
+
+	it('uses the configured default consulting type instead of the hard-coded 1', async () => {
+		vi.mocked(useAppConfig).mockReturnValue(
+			appConfig({ defaultConsultingTypeId: 5 })
+		);
+
+		renderHook(() =>
+			useAgenciesForRegistration({ topic, postcode: undefined })
+		);
+
+		await waitFor(() => expect(apiAgencySelection).toHaveBeenCalled());
+		expect(lastSearchParams()).toMatchObject({ consultingType: 5 });
+	});
+
+	it('lets a selected consulting type win over the configured default', async () => {
+		vi.mocked(useAppConfig).mockReturnValue(
+			appConfig({ defaultConsultingTypeId: 5 })
+		);
+
+		renderHook(() =>
+			useAgenciesForRegistration({
+				topic,
+				postcode: undefined,
+				consultingType: {
+					id: 3,
+					registration: {
+						autoSelectPostcode: true,
+						autoSelectAgency: false
+					}
+				} as unknown as ConsultingTypeInterface
+			})
+		);
+
+		await waitFor(() => expect(apiAgencySelection).toHaveBeenCalled());
+		expect(lastSearchParams()).toMatchObject({ consultingType: 3 });
+	});
+
+	it('respects consulting type id 0 (the old `|| 1` silently replaced it)', async () => {
+		vi.mocked(useAppConfig).mockReturnValue(appConfig({}));
+
+		renderHook(() =>
+			useAgenciesForRegistration({
+				topic,
+				postcode: undefined,
+				consultingType: {
+					id: 0,
+					registration: {
+						autoSelectPostcode: true,
+						autoSelectAgency: false
+					}
+				} as unknown as ConsultingTypeInterface
+			})
+		);
+
+		await waitFor(() => expect(apiAgencySelection).toHaveBeenCalled());
+		expect(lastSearchParams()).toMatchObject({ consultingType: 0 });
+	});
+});

--- a/src/containers/registration/hooks/useAgenciesForRegistration.ts
+++ b/src/containers/registration/hooks/useAgenciesForRegistration.ts
@@ -134,8 +134,17 @@ export const useAgenciesForRegistration = ({
 			{
 				...(autoSelectPostcode ? {} : { postcode }),
 				topicId: topic?.id,
-				// Use consultingType.id if available, otherwise use default consulting type 1
-				consultingType: consultingType?.id || 1,
+				// FE#245: the consulting type is no longer hard-coded to 1.
+				// A selected consulting type always wins (including id 0,
+				// which the old `|| 1` silently overrode). Without a
+				// selection the deployment-configurable default applies
+				// (settings.registration.defaultConsultingTypeId). It
+				// defaults to 1 so existing tenants keep their behavior,
+				// but tenants with other modalities can now override it.
+				consultingType:
+					consultingType?.id ??
+					settings.registration?.defaultConsultingTypeId ??
+					1,
 				fetchConsultingTypeDetails: true
 			},
 			abortController.signal
@@ -160,7 +169,8 @@ export const useAgenciesForRegistration = ({
 		consultingType?.id,
 		topic?.id,
 		postcode,
-		topicsEnabledAndUnSelected
+		topicsEnabledAndUnSelected,
+		settings.registration?.defaultConsultingTypeId
 	]);
 
 	return {

--- a/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
@@ -33,6 +33,15 @@ export interface AppConfigInterface extends AppSettingsInterface {
 	groupChat?: GroupChatConfig;
 	registration: {
 		useConsultingTypeSlug?: boolean;
+		/**
+		 * Consulting type id used for the public agency search during
+		 * registration when the user has not selected a consulting type
+		 * (FE#245). The backend requires the parameter, so it cannot be
+		 * omitted. Defaults to 1 (the historic hard-coded value) so
+		 * existing tenants keep their behavior; deployments whose agencies
+		 * use another modality can override it here.
+		 */
+		defaultConsultingTypeId?: number;
 		consultingTypeDefaults: {
 			autoSelectPostcode: boolean;
 			autoSelectAgency: boolean;

--- a/src/globalState/interfaces/UserDataInterface.ts
+++ b/src/globalState/interfaces/UserDataInterface.ts
@@ -52,6 +52,18 @@ export interface AgencyDataInterface {
 	consultingTypeRel?: ConsultingTypeInterface;
 	topicIds?: number[];
 	agencyLogo?: string | null;
+	/**
+	 * The agency's departments (one per assigned topic) with the publication
+	 * state of their own legal texts. Only present on backends with
+	 * AgencyService #90 - older backends simply never send it.
+	 */
+	departments?: AgencyDepartmentDataInterface[];
+}
+
+export interface AgencyDepartmentDataInterface {
+	topicId: number;
+	hasPublishedDpp?: boolean;
+	hasPublishedImprint?: boolean;
 }
 
 export interface ConsultingTypeDataInterface {

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1107,6 +1107,15 @@
 		"zh": "Chinesisch",
 		"zu": "isiZulu"
 	},
+	"legal": {
+		"notice": {
+			"fallbackLanguage": "Dieser Text liegt nicht in Ihrer Sprache vor und wird in seiner Originalsprache angezeigt.",
+			"machineTranslated": "Maschinell übersetzt — rechtlich verbindlich ist die deutsche Fassung.",
+			"showOriginal": "Original anzeigen",
+			"showingOriginal": "Sie sehen die Originalfassung.",
+			"showTranslation": "Übersetzung anzeigen"
+		}
+	},
 	"login": {
 		"button": {
 			"label": "Anmelden"
@@ -1940,6 +1949,13 @@
 				"openInMaps": "In Karte öffnen",
 				"phoneLabel": "Telefon",
 				"websiteLabel": "Webseite"
+			},
+			"legal": {
+				"department": "Fachbereich",
+				"headline": "Datenschutzhinweise der Beratungsstelle",
+				"imprintHeadline": "Impressum der Beratungsstelle",
+				"label": "Rechtliches",
+				"unavailable": "Die Datenschutzhinweise können derzeit nicht geladen werden."
 			},
 			"search": "Suche nach einer PLZ",
 			"summary": "Ihre Beratungsstelle:"

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -372,6 +372,15 @@
 			}
 		}
 	},
+	"legal": {
+		"notice": {
+			"fallbackLanguage": "Dieser Text liegt nicht in Deiner Sprache vor und wird in seiner Originalsprache angezeigt.",
+			"machineTranslated": "Maschinell übersetzt — rechtlich verbindlich ist die deutsche Fassung.",
+			"showOriginal": "Original anzeigen",
+			"showingOriginal": "Du siehst die Originalfassung.",
+			"showTranslation": "Übersetzung anzeigen"
+		}
+	},
 	"message": {
 		"appointmentCancelled": {
 			"title": "Dein Termin wurde abgesagt"
@@ -653,6 +662,13 @@
 				"openInMaps": "In Karte öffnen",
 				"phoneLabel": "Telefon",
 				"websiteLabel": "Webseite"
+			},
+			"legal": {
+				"department": "Fachbereich",
+				"headline": "Datenschutzhinweise der Beratungsstelle",
+				"imprintHeadline": "Impressum der Beratungsstelle",
+				"label": "Rechtliches",
+				"unavailable": "Die Datenschutzhinweise können derzeit nicht geladen werden."
 			},
 			"summary": "Deine Beratungsstelle"
 		},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1093,6 +1093,15 @@
 		"zh": "Chinese",
 		"zu": "isiZulu"
 	},
+	"legal": {
+		"notice": {
+			"fallbackLanguage": "This text is not available in your language and is shown in its original language.",
+			"machineTranslated": "Machine translated — the German version is legally binding.",
+			"showOriginal": "Show original",
+			"showingOriginal": "You are viewing the original version.",
+			"showTranslation": "Show translation"
+		}
+	},
 	"login": {
 		"button": {
 			"label": "Login"
@@ -1888,6 +1897,13 @@
 				"openInMaps": "Open in maps",
 				"phoneLabel": "Phone",
 				"websiteLabel": "Website"
+			},
+			"legal": {
+				"department": "Department",
+				"headline": "Data privacy notes of the counseling center",
+				"imprintHeadline": "Imprint of the counseling center",
+				"label": "Legal",
+				"unavailable": "The data privacy notes cannot be loaded at the moment."
 			},
 			"search": "Search for a postal code",
 			"summary": "Your counseling center:"

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -125,6 +125,10 @@ export const config: AppConfigInterface = {
 		}
 	},
 	registration: {
+		// FE#245: fallback consulting type for the public agency search when
+		// none is selected. 1 = historic default; override per deployment
+		// when agencies use a different modality.
+		defaultConsultingTypeId: 1,
 		consultingTypeDefaults: {
 			autoSelectPostcode: false,
 			autoSelectAgency: false

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -18,6 +18,9 @@ const keycloakOrigin = getKeycloakOrigin(apiUrl);
 export const endpoints = {
 	agencyConsultants: userServiceOrigin + '/service/users/consultants',
 	agencyServiceBase: agencyServiceOrigin + '/service/agencies',
+	agencyDepartmentLegal: (agencyId: number, topicId: number) =>
+		agencyServiceOrigin +
+		`/service/agencies/${agencyId}/topics/${topicId}/legal`,
 	agencyTopics: agencyServiceOrigin + '/service/agencies/topics',
 	agenciesByTenant: agencyServiceOrigin + '/service/agencies/by-tenant',
 	additionalEnquiry: userServiceOrigin + '/service/users/askers/session/new',

--- a/src/utils/legalContent.test.ts
+++ b/src/utils/legalContent.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeLegalLang,
+	pickConsentPrivacyContent,
+	resolveLegalContent
+} from './legalContent';
+
+const map = (entries: Record<string, unknown>) => JSON.stringify(entries);
+
+describe('normalizeLegalLang', () => {
+	it('reduces i18n tags to the bare language code', () => {
+		expect(normalizeLegalLang('de-DE')).toBe('de');
+		expect(normalizeLegalLang('de@informal')).toBe('de');
+		expect(normalizeLegalLang('EN')).toBe('en');
+	});
+
+	it('defaults to de when nothing is provided', () => {
+		expect(normalizeLegalLang(undefined)).toBe('de');
+		expect(normalizeLegalLang('')).toBe('de');
+	});
+});
+
+describe('resolveLegalContent', () => {
+	it('returns null for empty content', () => {
+		expect(resolveLegalContent(null, 'de')).toBeNull();
+		expect(resolveLegalContent(undefined, 'de')).toBeNull();
+		expect(resolveLegalContent('', 'de')).toBeNull();
+		expect(resolveLegalContent('   ', 'de')).toBeNull();
+	});
+
+	it('passes plain HTML through unchanged without notices', () => {
+		const html = '<p>Datenschutz</p>';
+		expect(resolveLegalContent(html, 'de-DE')).toEqual({
+			html,
+			lang: 'de',
+			isMachineTranslated: false,
+			originalLang: 'de'
+		});
+	});
+
+	it('picks the UI language from a language map', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '<p>Hello</p>'
+		});
+		const resolved = resolveLegalContent(content, 'en');
+		expect(resolved).toEqual({
+			html: '<p>Hello</p>',
+			lang: 'en',
+			isMachineTranslated: false,
+			originalLang: 'de'
+		});
+	});
+
+	it('falls back to the original language when the UI language is missing', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '<p>Hello</p>'
+		});
+		const resolved = resolveLegalContent(content, 'fr');
+		expect(resolved).toEqual({
+			html: '<p>Hallo</p>',
+			lang: 'de',
+			isMachineTranslated: false,
+			originalLang: 'de'
+		});
+	});
+
+	it('flags machine translated content and keeps the original language', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '<p>Hello</p>',
+			en__meta: JSON.stringify({
+				mt: true,
+				src: 'de',
+				at: '2026-07-01T00:00:00Z'
+			})
+		});
+		const resolved = resolveLegalContent(content, 'en');
+		expect(resolved).toEqual({
+			html: '<p>Hello</p>',
+			lang: 'en',
+			isMachineTranslated: true,
+			originalLang: 'de'
+		});
+	});
+
+	it('accepts meta values that are already objects', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '<p>Hello</p>',
+			en__meta: { mt: true, src: 'de' }
+		});
+		expect(resolveLegalContent(content, 'en')?.isMachineTranslated).toBe(
+			true
+		);
+	});
+
+	it('never renders __meta keys as content', () => {
+		const content = map({
+			de__meta: JSON.stringify({ mt: true, src: 'en' }),
+			en__meta: JSON.stringify({ mt: true, src: 'de' })
+		});
+		// map with only meta keys has no renderable content
+		expect(resolveLegalContent(content, 'de')).toBeNull();
+	});
+
+	it('does not leak meta content when the ui language only exists as meta key', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en__meta: JSON.stringify({ mt: true, src: 'de' })
+		});
+		const resolved = resolveLegalContent(content, 'en');
+		expect(resolved?.html).toBe('<p>Hallo</p>');
+		expect(resolved?.lang).toBe('de');
+	});
+
+	it('derives the original language from mt metadata when de is machine translated', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			de__meta: JSON.stringify({ mt: true, src: 'en' }),
+			en: '<p>Hello</p>'
+		});
+		const resolved = resolveLegalContent(content, 'de');
+		expect(resolved).toEqual({
+			html: '<p>Hallo</p>',
+			lang: 'de',
+			isMachineTranslated: true,
+			originalLang: 'en'
+		});
+	});
+
+	it('ignores empty translations when picking content', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '   '
+		});
+		const resolved = resolveLegalContent(content, 'en');
+		expect(resolved?.html).toBe('<p>Hallo</p>');
+		expect(resolved?.lang).toBe('de');
+	});
+
+	it('normalizes regional and informal UI languages', () => {
+		const content = map({
+			de: '<p>Hallo</p>',
+			en: '<p>Hello</p>'
+		});
+		expect(resolveLegalContent(content, 'de@informal')?.html).toBe(
+			'<p>Hallo</p>'
+		);
+		expect(resolveLegalContent(content, 'en-GB')?.html).toBe(
+			'<p>Hello</p>'
+		);
+	});
+
+	it('treats non-object JSON as plain content', () => {
+		const resolved = resolveLegalContent('[1,2,3]', 'de');
+		expect(resolved?.html).toBe('[1,2,3]');
+	});
+});
+
+describe('pickConsentPrivacyContent', () => {
+	const departmentContent = map({ de: '<p>Fachbereich</p>' });
+	const tenantContent = '<p>Träger</p>';
+
+	it('prefers the department dpp over the tenant content', () => {
+		expect(
+			pickConsentPrivacyContent(departmentContent, tenantContent)
+		).toEqual({
+			content: departmentContent,
+			source: 'department'
+		});
+	});
+
+	it('falls back to the tenant content when the department has none', () => {
+		expect(pickConsentPrivacyContent(null, tenantContent)).toEqual({
+			content: tenantContent,
+			source: 'tenant'
+		});
+		expect(pickConsentPrivacyContent(undefined, tenantContent)).toEqual({
+			content: tenantContent,
+			source: 'tenant'
+		});
+	});
+
+	it('treats a department map without renderable content as absent', () => {
+		const emptyDepartment = map({
+			de__meta: JSON.stringify({ mt: true, src: 'en' })
+		});
+		expect(
+			pickConsentPrivacyContent(emptyDepartment, tenantContent)
+		).toEqual({
+			content: tenantContent,
+			source: 'tenant'
+		});
+	});
+
+	it('returns null when neither side has content', () => {
+		expect(pickConsentPrivacyContent(null, '')).toEqual({
+			content: null,
+			source: null
+		});
+	});
+});

--- a/src/utils/legalContent.ts
+++ b/src/utils/legalContent.ts
@@ -1,0 +1,172 @@
+/**
+ * Resolution helpers for multilingual legal content (spec S2).
+ *
+ * Legal texts (department or tenant level) may arrive in two shapes:
+ * 1. A plain HTML string (legacy tenant content) - passed through unchanged.
+ * 2. A JSON string with a language->HTML map, e.g.
+ *    `{"de":"<p>...</p>","en":"<p>...</p>","en__meta":"{\"mt\":true,\"src\":\"de\",\"at\":\"...\"}"}`
+ *    where optional `<lang>__meta` keys carry machine-translation metadata.
+ *    Meta keys are NEVER rendered as content.
+ */
+
+export interface ResolvedLegalContent {
+	html: string;
+	/** Language of the returned html */
+	lang: string;
+	/** True when the returned html is a machine translation */
+	isMachineTranslated: boolean;
+	/** The original (authored, legally binding) language of the text */
+	originalLang: string;
+}
+
+interface LegalContentMeta {
+	mt?: boolean;
+	src?: string;
+	at?: string;
+}
+
+const META_KEY_SUFFIX = '__meta';
+const DEFAULT_ORIGINAL_LANG = 'de';
+
+/**
+ * Normalizes an i18n language tag to the bare language code used as map key,
+ * e.g. `de-DE` -> `de`, `de@informal` -> `de`.
+ */
+export const normalizeLegalLang = (lang: string | null | undefined): string =>
+	(lang || DEFAULT_ORIGINAL_LANG).split(/[-_@]/)[0].toLowerCase();
+
+const parseMeta = (value: unknown): LegalContentMeta | null => {
+	if (value && typeof value === 'object') {
+		return value as LegalContentMeta;
+	}
+	if (typeof value === 'string') {
+		try {
+			const parsed = JSON.parse(value);
+			return parsed && typeof parsed === 'object' ? parsed : null;
+		} catch {
+			return null;
+		}
+	}
+	return null;
+};
+
+const parseLanguageMap = (content: string): Record<string, unknown> | null => {
+	const trimmed = content.trim();
+	// Plain HTML (or anything that is not a JSON object) is passed through.
+	if (!trimmed.startsWith('{')) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(trimmed);
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+			? parsed
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Resolves the content to show for the user's current UI language.
+ *
+ * - Picks the UI language from the map when available.
+ * - Otherwise falls back to the original language (the language without an
+ *   `mt` marker, defaulting to `de`) - the caller should then show a
+ *   "displayed in its original language" notice (`lang !== uiLang`).
+ * - `isMachineTranslated` signals the caller to show the
+ *   "machine translated - the German version is legally binding" notice.
+ *
+ * Returns null when there is no renderable content at all.
+ */
+export const resolveLegalContent = (
+	content: string | null | undefined,
+	uiLang: string
+): ResolvedLegalContent | null => {
+	if (typeof content !== 'string' || content.trim() === '') {
+		return null;
+	}
+
+	const requestedLang = normalizeLegalLang(uiLang);
+	const map = parseLanguageMap(content);
+	if (!map) {
+		// Already-resolved HTML: render as-is, no notices apply.
+		return {
+			html: content,
+			lang: requestedLang,
+			isMachineTranslated: false,
+			originalLang: requestedLang
+		};
+	}
+
+	const metas: Record<string, LegalContentMeta> = {};
+	const htmlByLang: Record<string, string> = {};
+	Object.entries(map).forEach(([key, value]) => {
+		if (key.endsWith(META_KEY_SUFFIX)) {
+			const meta = parseMeta(value);
+			if (meta) {
+				metas[key.slice(0, -META_KEY_SUFFIX.length)] = meta;
+			}
+			return;
+		}
+		if (typeof value === 'string' && value.trim() !== '') {
+			htmlByLang[key] = value;
+		}
+	});
+
+	const contentLangs = Object.keys(htmlByLang);
+	if (contentLangs.length === 0) {
+		return null;
+	}
+
+	// Original language = a language without mt:true meta, preferring `de`.
+	const nonMachineTranslated = contentLangs.filter(
+		(lang) => metas[lang]?.mt !== true
+	);
+	const machineTranslationSource = contentLangs.find(
+		(lang) =>
+			metas[lang]?.mt === true &&
+			metas[lang]?.src &&
+			htmlByLang[metas[lang].src]
+	);
+	const originalLang = nonMachineTranslated.includes(DEFAULT_ORIGINAL_LANG)
+		? DEFAULT_ORIGINAL_LANG
+		: (nonMachineTranslated[0] ??
+			(machineTranslationSource
+				? metas[machineTranslationSource].src
+				: undefined) ??
+			(htmlByLang[DEFAULT_ORIGINAL_LANG]
+				? DEFAULT_ORIGINAL_LANG
+				: contentLangs[0]));
+
+	const lang = htmlByLang[requestedLang] ? requestedLang : originalLang;
+
+	return {
+		html: htmlByLang[lang],
+		lang,
+		isMachineTranslated: metas[lang]?.mt === true,
+		originalLang
+	};
+};
+
+/**
+ * Consent display preference (department -> Träger/tenant): use the
+ * department's own data privacy policy when it has renderable content,
+ * otherwise the tenant content. Returns the winning raw content (still a
+ * map or HTML string - render it through resolveLegalContent) plus its
+ * source for display decisions.
+ */
+export const pickConsentPrivacyContent = (
+	departmentDpp: string | null | undefined,
+	tenantPrivacy: string | null | undefined
+): {
+	content: string | null;
+	source: 'department' | 'tenant' | null;
+} => {
+	if (resolveLegalContent(departmentDpp, DEFAULT_ORIGINAL_LANG)) {
+		return { content: departmentDpp, source: 'department' };
+	}
+	if (resolveLegalContent(tenantPrivacy, DEFAULT_ORIGINAL_LANG)) {
+		return { content: tenantPrivacy, source: 'tenant' };
+	}
+	return { content: null, source: null };
+};


### PR DESCRIPTION
## What users get

- **Agencies of other modalities can show up in registration again.** The agency search no longer has the consulting type hard-coded to 1 (FE#245). A selected consulting type always wins (even id 0, which the old code silently replaced with 1), and deployments can override the fallback via the new app config setting `registration.defaultConsultingTypeId`. The default stays 1, so nothing changes for existing tenants unless they opt in (the backend requires the parameter, so it cannot be dropped entirely).
- **Departments show their own privacy and legal texts.** When the selected agency has a department for the selected topic with published texts, the agency details panel shows the department (topic name) and an expandable "Datenschutzhinweise der Beratungsstelle" section. It loads the text only when the user opens it.
- **The consent step prefers the department text.** On the account step, when the department has a published data privacy policy, that text is shown. If it cannot be loaded, the tenant text is used instead.
- **Translated legal texts are marked.** Machine-translated texts show a note: "Maschinell übersetzt — rechtlich verbindlich ist die deutsche Fassung", with a link to view the original. If a text is missing in the user's language, the original language is shown (with a short note) instead of showing nothing. This applies to the `/impressum` and `/datenschutz` pages and to department texts.

## Backend counterpart

AgencyService PR OpenResilienceInitiative/ORISO-AgencyService#90:

- `departments[]` (`topicId`, `hasPublishedDpp`, `hasPublishedImprint`) on the agency search response
- `GET /agencies/{agencyId}/topics/{topicId}/legal` with published content only (JSON language→HTML map, `<lang>__meta` keys mark machine translations)

**The endpoint is live only after #90 merges.** Until then the feature degrades to today's behavior:

- older backends never send `departments[]`, so no new UI renders at all
- if the flags exist but the legal endpoint answers 404 or fails, the API helper resolves to `null` (no error-page redirect) and the tenant text is used — covered by unit tests

## Changes

- `src/containers/registration/hooks/useAgenciesForRegistration.ts` — de-hardcoded consulting type + config fallback
- `src/utils/legalContent.ts` — pure `resolveLegalContent(map, uiLang)` + consent preference logic
- `src/components/legalContent/LegalContentRenderer.tsx` — reusable renderer with language/MT notices (wired into `/impressum`, `/datenschutz` via `LegalPageWrapper`)
- `src/components/departmentLegal/DepartmentLegalSection.tsx` — lazy-loading department legal section (agency details panel + consent step)
- `src/api/apiGetDepartmentLegal.ts` — public endpoint client with graceful 404 handling
- i18n keys for de, de@informal, en

## Tests

- 37 new vitest cases (resolution util, hook parameter, renderer notices/toggle, department section incl. 404 fallback, API graceful degradation)
- `tsc`, `npm run test:unit` (357 passed), production build: all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
