### PR TITLE
Route supervisor asides to the side room, render for members (ADR-008 FE)

### DIFF
--- a/src/components/messageSubmitInterface/asideRouting.test.ts
+++ b/src/components/messageSubmitInterface/asideRouting.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAsideTargetRoomId } from './asideRouting';
+
+const CLIENT_ROOM = '!client:matrix.example.org';
+const SIDE_ROOM = '!supervision:matrix.example.org';
+
+describe('resolveAsideTargetRoomId (ADR-008 aside send routing)', () => {
+	it('routes a supervisor aside to the supervision side room, not the client room', () => {
+		const result = resolveAsideTargetRoomId({
+			isAside: true,
+			clientRoomId: CLIENT_ROOM,
+			supervisionRoomId: SIDE_ROOM
+		});
+
+		// Composer with isSupervisor=true + supervisionRoomId set must target
+		// the side room, never the client-facing room.
+		expect(result.abort).toBe(false);
+		expect(result.targetRoomId).toBe(SIDE_ROOM);
+		expect(result.targetRoomId).not.toBe(CLIENT_ROOM);
+	});
+
+	it('routes an explicit VISIBLE_TO aside to the supervision side room', () => {
+		const result = resolveAsideTargetRoomId({
+			isAside: true,
+			clientRoomId: CLIENT_ROOM,
+			supervisionRoomId: SIDE_ROOM
+		});
+
+		expect(result.abort).toBe(false);
+		expect(result.targetRoomId).toBe(SIDE_ROOM);
+	});
+
+	it('aborts (never falls back to the client room) when an aside has no side room', () => {
+		const result = resolveAsideTargetRoomId({
+			isAside: true,
+			clientRoomId: CLIENT_ROOM,
+			supervisionRoomId: undefined
+		});
+
+		// SAFETY: an aside with a missing side room must abort — leaking it into
+		// the client room would expose the aside to the client.
+		expect(result.abort).toBe(true);
+		expect(result.targetRoomId).toBeNull();
+		expect(result.targetRoomId).not.toBe(CLIENT_ROOM);
+	});
+
+	it('also aborts when the side room id is an empty string', () => {
+		const result = resolveAsideTargetRoomId({
+			isAside: true,
+			clientRoomId: CLIENT_ROOM,
+			supervisionRoomId: ''
+		});
+
+		expect(result.abort).toBe(true);
+		expect(result.targetRoomId).toBeNull();
+	});
+
+	it('routes a normal (non-aside) message to the client room', () => {
+		const result = resolveAsideTargetRoomId({
+			isAside: false,
+			clientRoomId: CLIENT_ROOM,
+			supervisionRoomId: SIDE_ROOM
+		});
+
+		expect(result.abort).toBe(false);
+		expect(result.targetRoomId).toBe(CLIENT_ROOM);
+	});
+});

--- a/src/components/messageSubmitInterface/asideRouting.ts
+++ b/src/components/messageSubmitInterface/asideRouting.ts
@@ -1,0 +1,52 @@
+/**
+ * ADR-008 supervisor/aside side-channel — outgoing send routing.
+ *
+ * An "aside" is any message the client must never receive: supervisor
+ * feedback (SUPERVISOR_FEEDBACK_PREFIX) or an explicit VISIBLE_TO audience
+ * selection. Those messages are sent to a per-session supervision side room
+ * the client is never invited to, NOT to the client-facing room.
+ *
+ * SAFETY: if a message is an aside but no supervision room id is available,
+ * the send MUST be aborted — never fall back to the client room, or the aside
+ * would leak to the client.
+ */
+
+interface AsideRoutingInput {
+	/** True when the outgoing message carries an aside (supervisor feedback or explicit VISIBLE_TO audience). */
+	isAside: boolean;
+	/** The client-facing Matrix room id for this session. */
+	clientRoomId?: string | null;
+	/** The per-session supervision side room id (from SessionSupervisor.matrixRoomId). */
+	supervisionRoomId?: string | null;
+}
+
+export interface AsideRoutingResult {
+	/** The Matrix room id the message should be sent to, or null when the send must be aborted. */
+	targetRoomId: string | null;
+	/** True when the send must be aborted to avoid leaking an aside into the client room. */
+	abort: boolean;
+}
+
+/**
+ * Decide which room an outgoing message goes to.
+ *
+ * - Non-aside messages always target the client room.
+ * - Aside messages target the supervision side room; if it is missing the
+ *   send is aborted (never leaked into the client room).
+ */
+export const resolveAsideTargetRoomId = ({
+	isAside,
+	clientRoomId,
+	supervisionRoomId
+}: AsideRoutingInput): AsideRoutingResult => {
+	if (!isAside) {
+		return { targetRoomId: clientRoomId || null, abort: false };
+	}
+
+	if (supervisionRoomId) {
+		return { targetRoomId: supervisionRoomId, abort: false };
+	}
+
+	// Aside with no side room: abort rather than leak into the client room.
+	return { targetRoomId: null, abort: true };
+};

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 
 import { SendMessageButton } from './SendMessageButton';
 import { isAskerEnquirySubmission } from './messageEncryptionMode';
+import { resolveAsideTargetRoomId } from './asideRouting';
 import { chatTransportService } from '../../services/chatTransportService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
@@ -174,6 +175,8 @@ export interface MessageSubmitInterfaceComponentProps {
 	/** Anonymous enquiry after "Jetzt Chat starten" — use live chat send, not enquiry API. */
 	isAnonymousLiveChat?: boolean;
 	isSupervisor?: boolean;
+	/** ADR-008: per-session supervision side room id; aside sends go here, never the client room. */
+	supervisionRoomId?: string;
 	threadRootId?: string | null;
 	threadParentPreview?: string | null;
 	mobileUnreadCount?: number;
@@ -194,6 +197,7 @@ export const MessageSubmitInterfaceComponent = ({
 	handleMessageSendSuccess: onMessageSendSuccess,
 	isAnonymousLiveChat = false,
 	isSupervisor,
+	supervisionRoomId,
 	threadRootId,
 	threadParentPreview,
 	mobileUnreadCount = 0,
@@ -1847,7 +1851,7 @@ export const MessageSubmitInterfaceComponent = ({
 	]);
 
 	const sendMessage = useCallback(
-		async (message, attachment: File, isEncrypted) => {
+		async (message, attachment: File, isEncrypted, isAside = false) => {
 			const sendToRoomWithId = activeSession.rid || activeSession.item.id;
 			// Determine if this is a Matrix-backed session.
 			// Some sessions still have a legacy rid while exposing matrixRoomId.
@@ -1857,9 +1861,30 @@ export const MessageSubmitInterfaceComponent = ({
 			const matrixSessionId = isMatrixSession
 				? Number(resolvedChatSession.sessionId) || undefined
 				: undefined;
-			const matrixRoomId = isMatrixSession
+			const clientRoomId = isMatrixSession
 				? resolvedChatSession.matrixRoomId
 				: undefined;
+			// ADR-008: aside messages (supervisor feedback / explicit VISIBLE_TO)
+			// go to the supervision side room, never the client-facing room.
+			const asideRouting = resolveAsideTargetRoomId({
+				isAside,
+				clientRoomId,
+				supervisionRoomId
+			});
+			if (asideRouting.abort) {
+				// An aside with no side room must never leak into the client
+				// room — abort the send and surface an error instead.
+				setIsRequestInProgress(false);
+				handleAttachmentUploadError(INFO_TYPES.ATTACHMENT_OTHER_ERROR);
+				apiPostError({
+					name: 'SupervisionAsideRoutingError',
+					message:
+						'Aside message has no supervision side room id; send aborted to avoid leaking into the client room',
+					level: ERROR_LEVEL_WARN
+				}).then();
+				return;
+			}
+			const matrixRoomId = asideRouting.targetRoomId ?? undefined;
 			const getSendMailNotificationStatus = () => !activeSession.isGroup;
 
 			if (attachment) {
@@ -1983,6 +2008,7 @@ export const MessageSubmitInterfaceComponent = ({
 			matrixClientService,
 			onSendButton,
 			setE2EEState,
+			supervisionRoomId,
 			threadParentPreview,
 			threadRootId,
 			userData?.displayName,
@@ -2029,12 +2055,18 @@ export const MessageSubmitInterfaceComponent = ({
 		const explicitAudience = selectedAudienceValues.filter(
 			(value) => value !== '__all__'
 		);
-		if (humanTargetCount > 1 && explicitAudience.length > 0) {
+		const hasExplicitAudience =
+			humanTargetCount > 1 && explicitAudience.length > 0;
+		if (hasExplicitAudience) {
 			prefixParts.push(buildVisibleToPrefix(explicitAudience));
 		}
 		if (isSupervisor) {
 			prefixParts.push(SUPERVISOR_FEEDBACK_PREFIX);
 		}
+		// ADR-008: any message carrying an aside (supervisor feedback OR an
+		// explicit VISIBLE_TO audience) must be routed to the supervision side
+		// room, never the client-facing room.
+		const isAside = Boolean(isSupervisor) || hasExplicitAudience;
 		if (prefixParts.length && message.length > 0) {
 			message = `${prefixParts.join(' ')} ${message}`;
 		}
@@ -2047,7 +2079,7 @@ export const MessageSubmitInterfaceComponent = ({
 			return;
 		}
 
-		await sendMessage(message, attachment, isEncrypted);
+		await sendMessage(message, attachment, isEncrypted, isAside);
 	}, [
 		encodeAlignmentForTransport,
 		encodeHighlightColorsForTransport,

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -407,6 +407,11 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		new URLSearchParams(location.search).get('embeddedNotifications') ===
 		'1';
 	const [isSupervisor, setIsSupervisor] = useState(false);
+	// ADR-008: per-session supervision side room id (shared by all supervisor
+	// entries). Aside sends are routed here so the client never receives them.
+	const [supervisionRoomId, setSupervisionRoomId] = useState<
+		string | undefined
+	>(undefined);
 	const [showWaitingMiniGame, setShowWaitingMiniGame] = useState(false);
 	const [breathPhase, setBreathPhase] = useState<BreathPhase>('inhale');
 	const [phaseTotalMs, setPhaseTotalMs] = useState(0);
@@ -1712,6 +1717,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		if (!isSupervisionEnabledForCurrentChat) {
 			setIsSupervisor(false);
 			setSupervisionReason(null);
+			setSupervisionRoomId(undefined);
 			return;
 		}
 		if (
@@ -1728,15 +1734,23 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 						(s) => s.supervisorConsultantId === userData.userId
 					);
 					setSupervisionReason(currentSupervisor?.notes || null);
+					// ADR-008: all supervisor entries share the one per-session
+					// supervision side room id — take it from any entry.
+					const sideRoomId = supervisors.find(
+						(s) => s.matrixRoomId
+					)?.matrixRoomId;
+					setSupervisionRoomId(sideRoomId || undefined);
 				})
 				.catch((error) => {
 					// console.error('Failed to check supervisor status:', error);
 					setIsSupervisor(false);
 					setSupervisionReason(null);
+					setSupervisionRoomId(undefined);
 				});
 		} else {
 			setIsSupervisor(false);
 			setSupervisionReason(null);
+			setSupervisionRoomId(undefined);
 		}
 	}, [activeSession.item.id, userData, isSupervisionEnabledForCurrentChat]);
 
@@ -4558,6 +4572,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 							typingUsers={props.typingUsers}
 							handleMessageSendSuccess={handleMessageSendSuccess}
 							isSupervisor={isSupervisor}
+							supervisionRoomId={supervisionRoomId}
 							threadRootId={activeThreadRootId}
 							threadParentPreview={
 								activeThreadRootMessage
@@ -4678,6 +4693,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 										handleMessageSendSuccess
 									}
 									isSupervisor={isSupervisor}
+									supervisionRoomId={supervisionRoomId}
 									mobileUnreadCount={newMessages}
 									mobileIsScrolledToBottom={
 										isScrolledToBottom

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -20,10 +20,12 @@ import {
 import {
 	apiGetAgencyConsultantList,
 	apiGetCaseHandoverStatus,
+	apiGetSessionSupervisors,
 	CaseHandoverStatus,
 	FETCH_ERRORS
 } from '../../api';
 import {
+	mergeMatrixMessages,
 	prepareMessages,
 	SESSION_LIST_TAB,
 	SESSION_LIST_TYPES
@@ -97,6 +99,12 @@ export const SessionStream = ({
 	const abortController = useRef<AbortController>(null);
 	const hasUserInitiatedStopOrLeaveRequest = useRef<boolean>(false);
 
+	// ADR-008: per-session supervision side room id, resolved for authorized
+	// supervisors/consultants. When present we also load & merge its messages
+	// so asides render for members — the client is never a member of this room.
+	const [supervisionRoomId, setSupervisionRoomId] = useState<
+		string | undefined
+	>(undefined);
 	const [matrixTypingUsers, setMatrixTypingUsers] = useState<string[]>([]);
 	const matrixTypingTimeoutRef = useRef<number | null>(null);
 	const matrixTypingLastTriggerRef = useRef(0);
@@ -178,6 +186,46 @@ export const SessionStream = ({
 		[activeSession, type, userData]
 	);
 
+	// ADR-008: resolve the per-session supervision side room id for members.
+	// The backend only returns supervisor entries (with the side room id) to
+	// authorized callers, so non-members never receive one and asides stay
+	// invisible to them. The security boundary is Matrix room membership.
+	useEffect(() => {
+		let cancelled = false;
+		const sessionId = activeSession.item?.id;
+
+		setSupervisionRoomId(undefined);
+
+		if (
+			!hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) ||
+			!sessionId
+		) {
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		apiGetSessionSupervisors(sessionId)
+			.then((supervisors) => {
+				if (cancelled) {
+					return;
+				}
+				const sideRoomId = supervisors.find(
+					(s) => s.matrixRoomId
+				)?.matrixRoomId;
+				setSupervisionRoomId(sideRoomId || undefined);
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setSupervisionRoomId(undefined);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [activeSession.item?.id, userData]);
+
 	const fetchSessionMessages = useCallback(
 		(forceCaseHandoverAccess = false): Promise<boolean> => {
 			if (abortController.current) {
@@ -201,27 +249,39 @@ export const SessionStream = ({
 			// bodies outside the room encryption boundary.
 			if (resolvedChatSession.isMatrixSession) {
 				const resolvedMatrixRoomId = resolvedChatSession.matrixRoomId;
-				const matrixRoom = resolvedMatrixRoomId
-					? chatTransportService.getMatrixRoom(resolvedMatrixRoomId)
-					: null;
-				const matrixEvents = resolvedMatrixRoomId
-					? chatTransportService.getMatrixRoomMessages(
-							resolvedMatrixRoomId,
-							100
-						)
-					: [];
 				const encryptedFallbackText = translate(
 					'e2ee.message.encryption.text'
 				);
-				const formattedMessages = matrixEvents
-					.map((event: any) =>
-						formatMatrixTimelineEvent(
-							event,
-							matrixRoom,
-							encryptedFallbackText
+
+				const loadRoomMessages = (roomId?: string | null) => {
+					if (!roomId) {
+						return [];
+					}
+					const matrixRoom =
+						chatTransportService.getMatrixRoom(roomId);
+					return chatTransportService
+						.getMatrixRoomMessages(roomId, 100)
+						.map((event: any) =>
+							formatMatrixTimelineEvent(
+								event,
+								matrixRoom,
+								encryptedFallbackText
+							)
 						)
-					)
-					.filter(Boolean);
+						.filter(Boolean);
+				};
+
+				const clientMessages = loadRoomMessages(resolvedMatrixRoomId);
+				// ADR-008: merge the supervision side room's asides so they
+				// render for members. The client is never a member of the side
+				// room, so it never loads these.
+				const supervisionMessages = supervisionRoomId
+					? loadRoomMessages(supervisionRoomId)
+					: [];
+				const formattedMessages = mergeMatrixMessages(
+					clientMessages,
+					supervisionMessages
+				);
 
 				setMessagesItem({
 					messages: prepareMessages(formattedMessages)
@@ -240,6 +300,7 @@ export const SessionStream = ({
 			caseHandoverGateNeeded,
 			caseHandoverStatus?.canViewContent,
 			resolvedChatSession,
+			supervisionRoomId,
 			translate
 		]
 	);
@@ -324,23 +385,32 @@ export const SessionStream = ({
 		if (!resolvedChatSession.isMatrixSession) {
 			return;
 		}
-		const matrixRoomId = resolvedChatSession.matrixRoomId;
+		const clientRoomId = resolvedChatSession.matrixRoomId;
 
-		if (!matrixRoomId) {
+		if (!clientRoomId) {
 			return;
 		}
 
+		// ADR-008: listen on the client room AND (for members) the supervision
+		// side room, so newly-sent asides appear live for authorized viewers.
+		const watchedRoomIds = supervisionRoomId
+			? [clientRoomId, supervisionRoomId]
+			: [clientRoomId];
+
 		let retryTimer: number | null = null;
-		let detachTimelineListener: (() => void) | null = null;
+		let detachTimelineListeners: Array<() => void> = [];
 		let lastRefreshAt = 0;
 
-		const attachTimelineListener = () => {
+		const attachTimelineListeners = () => {
 			const handleMatrixTimeline = (
 				event: any,
 				room: any,
 				toStartOfTimeline: boolean
 			) => {
-				if (toStartOfTimeline || room?.roomId !== matrixRoomId) {
+				if (
+					toStartOfTimeline ||
+					!watchedRoomIds.includes(room?.roomId)
+				) {
 					return;
 				}
 
@@ -364,17 +434,29 @@ export const SessionStream = ({
 				});
 			};
 
-			detachTimelineListener = chatTransportService.onMatrixTimeline(
-				matrixRoomId,
-				handleMatrixTimeline
-			);
-			return Boolean(detachTimelineListener);
+			const detachers = watchedRoomIds
+				.map((roomId) =>
+					chatTransportService.onMatrixTimeline(
+						roomId,
+						handleMatrixTimeline
+					)
+				)
+				.filter(Boolean) as Array<() => void>;
+
+			// Only consider attach successful once every watched room is bound.
+			if (detachers.length !== watchedRoomIds.length) {
+				detachers.forEach((detach) => detach());
+				return false;
+			}
+
+			detachTimelineListeners = detachers;
+			return true;
 		};
 
 		// Try immediately, then retry until Matrix client is ready.
-		if (!attachTimelineListener()) {
+		if (!attachTimelineListeners()) {
 			retryTimer = window.setInterval(() => {
-				if (attachTimelineListener() && retryTimer) {
+				if (attachTimelineListeners() && retryTimer) {
 					window.clearInterval(retryTimer);
 					retryTimer = null;
 				}
@@ -385,9 +467,9 @@ export const SessionStream = ({
 			if (retryTimer) {
 				window.clearInterval(retryTimer);
 			}
-			detachTimelineListener?.();
+			detachTimelineListeners.forEach((detach) => detach());
 		};
-	}, [resolvedChatSession, fetchSessionMessages]);
+	}, [resolvedChatSession, supervisionRoomId, fetchSessionMessages]);
 
 	const groupChatStoppedOverlay: OverlayItem = useMemo(
 		() => ({

--- a/src/components/session/mergeMatrixMessages.test.ts
+++ b/src/components/session/mergeMatrixMessages.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { mergeMatrixMessages } from './sessionHelpers';
+
+const msg = (id: string, tsMs: number, body = id) => ({
+	_id: id,
+	msg: body,
+	ts: new Date(tsMs),
+	u: { _id: `@${id}:matrix`, username: id, name: id }
+});
+
+describe('mergeMatrixMessages (ADR-008 side-room merge)', () => {
+	it('interleaves client and supervision messages sorted ascending by timestamp', () => {
+		const client = [msg('c1', 1000), msg('c2', 3000)];
+		const supervision = [msg('s1', 2000), msg('s2', 4000)];
+
+		const merged = mergeMatrixMessages(client, supervision);
+
+		expect(merged.map((m) => m._id)).toEqual(['c1', 's1', 'c2', 's2']);
+	});
+
+	it('dedupes by event id (client wins over a later duplicate)', () => {
+		const client = [msg('shared', 1000, 'from-client')];
+		const supervision = [msg('shared', 1000, 'from-side')];
+
+		const merged = mergeMatrixMessages(client, supervision);
+
+		expect(merged).toHaveLength(1);
+		expect(merged[0].msg).toBe('from-client');
+	});
+
+	it('returns only client messages when there is no side room stream', () => {
+		const client = [msg('c1', 1000)];
+
+		const merged = mergeMatrixMessages(client, []);
+
+		expect(merged.map((m) => m._id)).toEqual(['c1']);
+	});
+
+	it('tolerates null/undefined inputs', () => {
+		expect(mergeMatrixMessages(null as any, undefined as any)).toEqual([]);
+	});
+});

--- a/src/components/session/sessionHelpers.ts
+++ b/src/components/session/sessionHelpers.ts
@@ -148,6 +148,32 @@ const findLastVideoCallIndex = (messagesData) =>
 					'IGNORED_CALL')
 	);
 
+/**
+ * ADR-008: merge the client-room timeline with the supervision side-room
+ * timeline into a single ordered stream. Messages are formatted Matrix events
+ * ({ _id, ts, ... }). Deduped by event id (`_id`) and sorted ascending by
+ * timestamp so asides interleave with client messages in chronological order.
+ */
+export const mergeMatrixMessages = (
+	clientMessages: any[],
+	supervisionMessages: any[]
+): any[] => {
+	const byId = new Map<string, any>();
+	[...(clientMessages || []), ...(supervisionMessages || [])].forEach(
+		(message) => {
+			if (message && message._id != null && !byId.has(message._id)) {
+				byId.set(message._id, message);
+			}
+		}
+	);
+
+	return Array.from(byId.values()).sort((a, b) => {
+		const aTs = new Date(a?.ts ?? 0).getTime();
+		const bTs = new Date(b?.ts ?? 0).getTime();
+		return aTs - bTs;
+	});
+};
+
 export const prepareMessages = (messagesData): MessageItem[] => {
 	let lastDate = '';
 	let userLeftChatShown = false;


### PR DESCRIPTION
## Summary

Frontend half of the ADR-008 side-channel fix. Pairs with backend **OpenResilienceInitiative/ORISO-UserService#293** (which provisions a per-session supervision **side room** the client is never invited to) and closes the leak **in the running app**: supervisor feedback and `[VISIBLE_TO:…]` asides are now sent to that side room, never the client-facing room, and are rendered back only to authorized members.

**Stacked on the Matrix-only migration branch** (`feat/matrix-only-rc-teardown`, PR #359) because it builds on the Matrix-only send path — retarget to `dev` once #359 merges.

## What changed (3 files + 2 small helpers)

**Send redirect** — `messageSubmitInterfaceComponent.tsx` + new pure helper `asideRouting.ts`:
- `isAside = isSupervisor || (humanTargetCount > 1 && explicitAudience.length > 0)`.
- `resolveAsideTargetRoomId({isAside, clientRoomId, supervisionRoomId})`: non-aside → client room; aside + side room → side room; **aside + no side room → abort** (`targetRoomId: null`). The send path aborts *before* both the text (`apiSendMessage`) and attachment (`apiSendMatrixAttachmentMessage`) sends, so an aside can only reach the side room or be refused — **never** the client room.

**Render (merge)** — `SessionStream.tsx` + new `mergeMatrixMessages` in `sessionHelpers.ts`:
- Resolves the side-room id via `apiGetSessionSupervisors`, **gated on `CONSULTANT_DEFAULT`** — an asker never resolves it, so an asker only ever loads/watches the client room.
- Loads client-room + side-room messages and merges (concat, dedupe by event id, sort by ts) before `prepareMessages`; attaches a timeline listener per watched room so new asides appear live; detaches all on unmount.

**Prop threading** — `SessionItemComponent.tsx` captures `supervisionRoomId` from the supervisors it already fetches and passes it to the composer.

## Why this is safe (verified at every layer)

- **Backend (proven live, #293):** the side room is `join_rule: invite` and the client is never invited — a `[SUPERVISOR_FEEDBACK]` aside sent to it does **not** appear in the asker's `/sync`, while a member's does.
- **Frontend send:** an aside's target room is `resolveAsideTargetRoomId(...).targetRoomId` — only the side room, or abort. Unit-tested.
- **Frontend render:** side-room resolution is consultant-gated; askers never load it.

## Tests + gates

- `asideRouting.test.ts` (5): supervisor aside → side room (not client); explicit VISIBLE_TO → side room; aside + no side room → abort (target null, ≠ client); empty side room → abort; non-aside → client room.
- `mergeMatrixMessages.test.ts` (4): interleave by ts, dedupe by event id, side-room-empty passthrough, null-safe.
- `npm run lint:scripts` 0 errors · `npm run test:unit` 53 files / 323 tests green · `CI=false npm run build` OK.

No Matrix SDK crypto enabled; no Rocket.Chat reintroduced.

## Follow-up (separate, ADR-008 AXIS 2)
Tighten `addSupervisor` authority to the assigned consultant + record consent/justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
