### PR TITLE
SessionStream retry caps + Matrix transport unit tests (B4 + C3)

### DIFF
--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -23,6 +23,7 @@ import {
 	CaseHandoverStatus,
 	FETCH_ERRORS
 } from '../../api';
+import { apiPostError, ERROR_LEVEL_WARN } from '../../api/apiPostError';
 import {
 	prepareMessages,
 	SESSION_LIST_TAB,
@@ -371,12 +372,31 @@ export const SessionStream = ({
 			return Boolean(detachTimelineListener);
 		};
 
-		// Try immediately, then retry until Matrix client is ready.
+		// Try immediately, then retry until the Matrix client is ready.
+		// Cap the retries so a client that never initializes stops spinning
+		// silently (20 attempts * 500ms = 10s) and surfaces a diagnostic.
+		const MAX_ATTACH_ATTEMPTS = 20;
+		let attachAttempts = 0;
 		if (!attachTimelineListener()) {
 			retryTimer = window.setInterval(() => {
-				if (attachTimelineListener() && retryTimer) {
-					window.clearInterval(retryTimer);
-					retryTimer = null;
+				attachAttempts += 1;
+				if (attachTimelineListener()) {
+					if (retryTimer) {
+						window.clearInterval(retryTimer);
+						retryTimer = null;
+					}
+					return;
+				}
+				if (attachAttempts >= MAX_ATTACH_ATTEMPTS) {
+					if (retryTimer) {
+						window.clearInterval(retryTimer);
+						retryTimer = null;
+					}
+					const attachError = new Error(
+						`SessionStream: gave up attaching Matrix timeline listener for room ${matrixRoomId} after ${MAX_ATTACH_ATTEMPTS} attempts (Matrix client never became ready)`
+					) as Error & { level?: typeof ERROR_LEVEL_WARN };
+					attachError.level = ERROR_LEVEL_WARN;
+					apiPostError(attachError).catch(() => undefined);
 				}
 			}, 500);
 		}
@@ -457,12 +477,29 @@ export const SessionStream = ({
 			return Boolean(detachLifecycleListener);
 		};
 
-		// Try immediately, then retry until Matrix client is ready.
+		// Try immediately, then retry until Matrix client is ready — but cap the
+		// attempts so a client that never initializes can't spin this interval
+		// forever silently (same hazard as the timeline-attach retry above).
+		const MAX_ATTACH_ATTEMPTS = 20;
+		let attachAttempts = 0;
 		if (!attachLifecycleListener()) {
 			retryTimer = window.setInterval(() => {
+				attachAttempts += 1;
 				if (attachLifecycleListener() && retryTimer) {
 					window.clearInterval(retryTimer);
 					retryTimer = null;
+					return;
+				}
+				if (attachAttempts >= MAX_ATTACH_ATTEMPTS) {
+					if (retryTimer) {
+						window.clearInterval(retryTimer);
+						retryTimer = null;
+					}
+					const attachError = new Error(
+						`SessionStream: gave up attaching Matrix room lifecycle listener for room ${matrixRoomId} after ${MAX_ATTACH_ATTEMPTS} attempts (Matrix client never became ready)`
+					);
+					(attachError as any).level = ERROR_LEVEL_WARN;
+					apiPostError(attachError).catch(() => undefined);
 				}
 			}, 500);
 		}

--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -11,6 +11,17 @@ vi.hoisted(() => {
 	env.REACT_APP_KEYCLOAK_REALM = 'oriso';
 });
 
+// The metadata-only notification is a network side effect; stub it so the
+// transport tests stay deterministic and offline. We assert it never leaks
+// message content (FE-H01) by inspecting the call args.
+const apiPostMessageEventNotification = vi.fn(
+	(_input: unknown): Promise<unknown> => Promise.resolve({})
+);
+vi.mock('../api/apiPostMessageEventNotification', () => ({
+	apiPostMessageEventNotification: (input: unknown) =>
+		apiPostMessageEventNotification(input)
+}));
+
 const ROOM_ID = '!room:matrix.oriso.org';
 const OTHER_ROOM_ID = '!other:matrix.oriso.org';
 
@@ -237,5 +248,168 @@ describe('chatTransportService Matrix room members', () => {
 		detach();
 		fakeClient.emit('RoomState.members', {}, { roomId: ROOM_ID }, {});
 		expect(listener).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('chatTransportService sendTextMessage (Matrix-only transport)', () => {
+	beforeEach(() => {
+		apiPostMessageEventNotification.mockClear();
+	});
+
+	afterEach(() => {
+		setMatrixClientServiceRef(null);
+	});
+
+	it('rejects (no silent success, no RC path) when the session has no Matrix room', async () => {
+		const sendMessage = vi.fn();
+		const override = {
+			getClient: () => createFakeMatrixClient(),
+			sendMessage
+		} as any;
+
+		await expect(
+			chatTransportService.sendTextMessage({
+				roomIdOrSessionId: 42,
+				message: 'hello',
+				sendMailNotification: false,
+				isEncrypted: false,
+				matrixRoomId: undefined,
+				matrixClientServiceOverride: override
+			})
+		).rejects.toThrow('Cannot send message: session has no Matrix room');
+
+		// The removed Rocket.Chat fallback must not be reached: no send, no
+		// metadata notification.
+		expect(sendMessage).not.toHaveBeenCalled();
+		expect(apiPostMessageEventNotification).not.toHaveBeenCalled();
+	});
+
+	it('rejects when a Matrix room exists but the client is not initialized', async () => {
+		const override = {
+			getClient: () => null,
+			sendMessage: vi.fn()
+		} as any;
+
+		await expect(
+			chatTransportService.sendTextMessage({
+				roomIdOrSessionId: ROOM_ID,
+				message: 'hello',
+				sendMailNotification: false,
+				isEncrypted: false,
+				matrixRoomId: ROOM_ID,
+				matrixClientServiceOverride: override
+			})
+		).rejects.toThrow('Matrix client not initialized');
+	});
+
+	it('sends via the Matrix client with the room id and message when a room id is present', async () => {
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$evt:matrix.oriso.org' })
+		);
+		const override = {
+			getClient: () => createFakeMatrixClient(),
+			sendMessage
+		} as any;
+
+		const result = await chatTransportService.sendTextMessage({
+			roomIdOrSessionId: ROOM_ID,
+			message: 'hello world',
+			sendMailNotification: false,
+			isEncrypted: false,
+			matrixRoomId: ROOM_ID,
+			matrixClientServiceOverride: override
+		});
+
+		expect(sendMessage).toHaveBeenCalledWith(ROOM_ID, 'hello world');
+		expect(result).toEqual({
+			success: true,
+			event_id: '$evt:matrix.oriso.org'
+		});
+
+		// A metadata-only notification fires, and it never carries the
+		// plaintext message body across the Matrix privacy boundary (FE-H01).
+		expect(apiPostMessageEventNotification).toHaveBeenCalledTimes(1);
+		const notificationArg =
+			apiPostMessageEventNotification.mock.calls[0][0];
+		expect(notificationArg).toMatchObject({
+			roomId: ROOM_ID,
+			matrixRoom: true
+		});
+		expect(JSON.stringify(notificationArg)).not.toContain('hello world');
+	});
+});
+
+describe('chatTransportService markRoomAsRead', () => {
+	afterEach(() => {
+		setMatrixClientServiceRef(null);
+	});
+
+	const setClientWithRoom = (room: any) => {
+		setMatrixClientServiceRef({
+			getClient: () => ({
+				getRoom: (roomId: string) =>
+					room && roomId === ROOM_ID ? room : null,
+				sendReadReceipt: room?.sendReadReceipt
+			})
+		} as any);
+	};
+
+	it('sends a read receipt for the latest live-timeline event', async () => {
+		const latestEvent = { id: 'latest' };
+		const sendReadReceipt = vi.fn(() => Promise.resolve());
+		const room = {
+			getLiveTimeline: () => ({
+				getEvents: () => [{ id: 'older' }, latestEvent]
+			}),
+			sendReadReceipt
+		};
+		setClientWithRoom(room);
+
+		await chatTransportService.markRoomAsRead(ROOM_ID);
+
+		expect(sendReadReceipt).toHaveBeenCalledTimes(1);
+		expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent);
+	});
+
+	it('is a safe no-op (no throw) when the Matrix client is missing', async () => {
+		setMatrixClientServiceRef(null);
+		await expect(
+			chatTransportService.markRoomAsRead(ROOM_ID)
+		).resolves.toBeUndefined();
+	});
+
+	it('is a safe no-op when the room is unknown', async () => {
+		setClientWithRoom(null);
+		await expect(
+			chatTransportService.markRoomAsRead(ROOM_ID)
+		).resolves.toBeUndefined();
+	});
+
+	it('is a safe no-op when the room has no events', async () => {
+		const sendReadReceipt = vi.fn(() => Promise.resolve());
+		const room = {
+			getLiveTimeline: () => ({ getEvents: () => [] }),
+			sendReadReceipt
+		};
+		setClientWithRoom(room);
+
+		await expect(
+			chatTransportService.markRoomAsRead(ROOM_ID)
+		).resolves.toBeUndefined();
+		expect(sendReadReceipt).not.toHaveBeenCalled();
+	});
+
+	it('swallows a failing read-receipt send (no throw)', async () => {
+		const room = {
+			getLiveTimeline: () => ({
+				getEvents: () => [{ id: 'latest' }]
+			}),
+			sendReadReceipt: () => Promise.reject(new Error('offline'))
+		};
+		setClientWithRoom(room);
+
+		await expect(
+			chatTransportService.markRoomAsRead(ROOM_ID)
+		).resolves.toBeUndefined();
 	});
 });

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+import { MatrixLiveEventBridge } from './matrixLiveEventBridge';
+
+// Hoisted above the imports by vitest: endpoints/runtimeConfig read these
+// REACT_APP_* vars at module load (transitively via CallManager).
+vi.hoisted(() => {
+	const env = process.env as Record<string, string>;
+	env.REACT_APP_API_URL = 'http://localhost:9001';
+	env.REACT_APP_KEYCLOAK_REALM = 'oriso';
+});
+
+// The bridge lazy-requires CallManager and videoCallHelpers inside its
+// handlers (to dodge a circular import with matrixClientService). Those real
+// modules pull in a heavy transitive graph (matrix-js-sdk webrtc, lottie,
+// endpoints). Because the bridge uses CommonJS require() (not a static ESM
+// import), vitest's vi.mock does not intercept it. Instead we intercept the
+// underlying Node module loader for exactly these two specifiers and return
+// lightweight stubs — keeping the test deterministic and free of the heavy
+// call/video subsystem. The bridge only require()s these lazily inside its
+// handlers (never at import time), so patching here — after the imports — is
+// still in place before any test triggers a handler.
+const receiveCall = vi.fn();
+const endCall = vi.fn();
+const isVideoCallFromMatrixInviteContent = vi.fn(
+	(_content: unknown): boolean => false
+);
+
+const nodeRequire = createRequire(import.meta.url);
+const Module = nodeRequire('module') as {
+	_load: (...args: unknown[]) => unknown;
+};
+const originalLoad = Module._load;
+Module._load = function patchedLoad(this: unknown, ...args: unknown[]) {
+	const request = args[0];
+	if (request === './CallManager') {
+		return {
+			callManager: {
+				receiveCall: (...callArgs: unknown[]) => receiveCall(...callArgs),
+				endCall: (...callArgs: unknown[]) => endCall(...callArgs)
+			}
+		};
+	}
+	if (request === '../utils/videoCallHelpers') {
+		return {
+			isVideoCallFromMatrixInviteContent: (content: unknown) =>
+				isVideoCallFromMatrixInviteContent(content)
+		};
+	}
+	return originalLoad.apply(this, args);
+};
+
+const ROOM_ID = '!room:matrix.oriso.org';
+const MY_USER_ID = '@me:matrix.oriso.org';
+const OTHER_USER_ID = '@peer:matrix.oriso.org';
+
+type Listener = (...args: any[]) => void;
+
+/**
+ * Minimal Matrix client double: enough EventEmitter surface for the bridge
+ * (on / removeAllListeners) plus getUserId and a manual emit helper.
+ */
+const createFakeMatrixClient = (userId = MY_USER_ID) => {
+	const listeners = new Map<string, Set<Listener>>();
+	return {
+		on: (event: string, listener: Listener) => {
+			if (!listeners.has(event)) {
+				listeners.set(event, new Set());
+			}
+			listeners.get(event)!.add(listener);
+		},
+		removeAllListeners: (event: string) => {
+			listeners.delete(event);
+		},
+		getUserId: () => userId,
+		listenerCount: (event: string) => listeners.get(event)?.size || 0,
+		emit: (event: string, ...args: any[]) => {
+			listeners.get(event)?.forEach((listener) => listener(...args));
+		}
+	};
+};
+
+const makeEvent = (overrides: Record<string, any> = {}) => {
+	const {
+		type = 'm.room.message',
+		content = {},
+		sender = OTHER_USER_ID,
+		ts = Date.now(),
+		id = '$evt:matrix.oriso.org'
+	} = overrides;
+	return {
+		getType: () => type,
+		getContent: () => content,
+		getSender: () => sender,
+		getTs: () => ts,
+		getId: () => id
+	};
+};
+
+const room = { roomId: ROOM_ID };
+
+describe('MatrixLiveEventBridge initialize / timeline binding', () => {
+	let bridge: MatrixLiveEventBridge;
+	let client: ReturnType<typeof createFakeMatrixClient>;
+
+	beforeEach(() => {
+		receiveCall.mockClear();
+		endCall.mockClear();
+		isVideoCallFromMatrixInviteContent.mockClear();
+		isVideoCallFromMatrixInviteContent.mockReturnValue(false);
+		bridge = new MatrixLiveEventBridge();
+		client = createFakeMatrixClient();
+	});
+
+	afterEach(() => {
+		bridge.destroy();
+	});
+
+	it('attaches a Room.timeline listener on initialize and marks itself initialized', () => {
+		expect(bridge.isInitialized()).toBe(false);
+
+		bridge.initialize(client as any);
+
+		expect(bridge.isInitialized()).toBe(true);
+		expect(bridge.getClient()).toBe(client);
+		expect(client.listenerCount('Room.timeline')).toBe(1);
+	});
+
+	it('ignores historical events (toStartOfTimeline === true)', () => {
+		bridge.initialize(client as any);
+		const callback = vi.fn();
+		bridge.on('directMessage', callback);
+
+		// Historical playback (scroll-back / initial sync backfill).
+		client.emit('Room.timeline', makeEvent(), room, true);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('forwards metadata-only directMessage for live m.room.message events', () => {
+		bridge.initialize(client as any);
+		const callback = vi.fn();
+		bridge.on('directMessage', callback);
+
+		client.emit(
+			'Room.timeline',
+			makeEvent({ content: { msgtype: 'm.text', body: 'secret body' } }),
+			room,
+			false
+		);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		const payload = callback.mock.calls[0][0];
+		expect(payload).toMatchObject({
+			roomId: ROOM_ID,
+			sender: OTHER_USER_ID,
+			isOwnMessage: false,
+			msgtype: 'm.text'
+		});
+		// Bodies never cross into the bridged event (Matrix privacy boundary).
+		expect(JSON.stringify(payload)).not.toContain('secret body');
+	});
+});
+
+describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
+	let bridge: MatrixLiveEventBridge;
+	let client: ReturnType<typeof createFakeMatrixClient>;
+
+	const emitInvite = (overrides: Record<string, any> = {}) =>
+		client.emit(
+			'Room.timeline',
+			makeEvent({ type: 'm.call.invite', ...overrides }),
+			room,
+			false
+		);
+
+	beforeEach(() => {
+		receiveCall.mockClear();
+		endCall.mockClear();
+		isVideoCallFromMatrixInviteContent.mockClear();
+		isVideoCallFromMatrixInviteContent.mockReturnValue(false);
+		bridge = new MatrixLiveEventBridge();
+		client = createFakeMatrixClient();
+		bridge.initialize(client as any);
+	});
+
+	afterEach(() => {
+		bridge.destroy();
+	});
+
+	it('ignores stale call invites older than 10s (history/replay on login)', () => {
+		emitInvite({
+			content: { call_id: 'call-stale' },
+			ts: Date.now() - 60_000
+		});
+
+		expect(receiveCall).not.toHaveBeenCalled();
+	});
+
+	it('ignores our own call invites', () => {
+		emitInvite({
+			content: { call_id: 'call-mine' },
+			sender: MY_USER_ID,
+			ts: Date.now()
+		});
+
+		expect(receiveCall).not.toHaveBeenCalled();
+	});
+
+	it('receives a fresh incoming invite and de-dupes repeats of the same call_id', () => {
+		emitInvite({
+			content: { call_id: 'call-fresh' },
+			ts: Date.now()
+		});
+		// A duplicate delivery of the same call must not re-trigger.
+		emitInvite({
+			content: { call_id: 'call-fresh' },
+			ts: Date.now()
+		});
+
+		expect(receiveCall).toHaveBeenCalledTimes(1);
+		// (roomId, isVideo, callId, sender, isGroupCall, notifyRoomId)
+		const args = receiveCall.mock.calls[0];
+		expect(args[0]).toBe(ROOM_ID);
+		expect(args[2]).toBe('call-fresh');
+		expect(args[3]).toBe(OTHER_USER_ID);
+		expect(args[4]).toBe(false);
+	});
+
+	it('routes an Element/LiveKit group call invite through CallManager as a group call', () => {
+		emitInvite({
+			content: {
+				call_id: 'call-group',
+				is_group_call: true,
+				is_video: true,
+				call_room_id: '!element:matrix.oriso.org'
+			},
+			ts: Date.now()
+		});
+
+		expect(receiveCall).toHaveBeenCalledTimes(1);
+		const args = receiveCall.mock.calls[0];
+		expect(args[0]).toBe('!element:matrix.oriso.org'); // callRoomId
+		expect(args[1]).toBe(true); // isVideo
+		expect(args[2]).toBe('call-group'); // callId
+		expect(args[4]).toBe(true); // isGroupCall
+	});
+
+	it('ignores stale hangups but ends the call for a fresh hangup', () => {
+		client.emit(
+			'Room.timeline',
+			makeEvent({
+				type: 'm.call.hangup',
+				content: { call_id: 'c' },
+				ts: Date.now() - 60_000
+			}),
+			room,
+			false
+		);
+		expect(endCall).not.toHaveBeenCalled();
+
+		client.emit(
+			'Room.timeline',
+			makeEvent({
+				type: 'm.call.hangup',
+				content: { call_id: 'c' },
+				ts: Date.now()
+			}),
+			room,
+			false
+		);
+		expect(endCall).toHaveBeenCalledTimes(1);
+		expect(endCall).toHaveBeenCalledWith(false);
+	});
+});


### PR DESCRIPTION
Two related frontend hardening items from the Matrix plan.

## B4 — cap the SessionStream attach-retry loops
Two `setInterval(…, 500)` retry loops in `SessionStream.tsx` (timeline-attach + room-lifecycle-attach) retried **forever** if the Matrix client never initialized — a silent resource spin with no signal. Both now cap at **20 attempts (10s)**, clear the interval when the cap is hit, and surface a diagnostic via `apiPostError` (level WARN), matching the file's existing error-reporting. Happy path unchanged; unmount cleanup preserved.

## C3 — unit tests for the Matrix-only transport substitutions (were untested)
- `chatTransportService.test.ts` (extended, +8): `sendTextMessage` rejects when there is no `matrixRoomId` (asserts the client send is NOT called and no metadata notification fires — no silent success, no RC fallback), rejects when the client is null, and on the happy path sends `(roomId, message)` + fires exactly one metadata notification with **no plaintext body** in the payload (FE-H01). `markRoomAsRead` sends a read receipt on the latest event and is a safe no-op (no throw) when client/room/event is missing or the receipt fails.
- `matrixLiveEventBridge.test.ts` (new, 8): attaches a `Room.timeline` listener; ignores historical events (`toStartOfTimeline`); ignores stale (>10s) and own invites; de-dupes repeated `call_id`; routes group-call invites; ends a call only on a fresh hangup. (Intercepts the bridge's CommonJS `require()` of the heavy CallManager/webrtc graph with light stubs — deterministic, no heavy harness.)

## Gates
`npm run lint:scripts` 0 errors · `npm run test:unit` **406 passed / 63 files** (+16) · `CI=false npm run build` OK. No crypto enabled, no Rocket.Chat reintroduced.

Part of the Matrix hardening plan (items B4, C3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)