### PR TITLE
chore(ci): gate :dev image on unit tests + supply-chain hardening (audit items 4/6)

### DIFF
--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -22,6 +22,12 @@ runs:
     shell: bash
     run: npm run lint:scripts
 
+  - name: Run unit tests
+    shell: bash
+    # Runs before the Docker image is built/published so a red test blocks
+    # the (previously untested) :dev image on pushes to dev/main.
+    run: npm run test:unit
+
   - name: Build app
     shell: bash
     run: CI=false npm run build

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -128,8 +128,23 @@ jobs:
 
       - name: Install Cursor CLI
         if: steps.guard.outputs.run == 'true'
+        env:
+          # Pin the Cursor Agent CLI to an immutable versioned build instead of
+          # piping the mutable `curl https://cursor.com/install | bash` installer
+          # into a shell. That installer runs whatever code the vendor serves at
+          # request time inside a job that holds a write-capable token, which is a
+          # prompt-injection / supply-chain surface. Cursor does not publish a
+          # checksum for the tarball, so the pinned immutable version URL is the
+          # integrity anchor. Bump CURSOR_CLI_VERSION deliberately to upgrade.
+          CURSOR_CLI_VERSION: "2026.07.01-41b2de7"
         run: |
-          curl https://cursor.com/install -fsS | bash
+          set -euo pipefail
+          arch="$(uname -m)"; case "$arch" in x86_64|amd64) arch=x64;; arm64|aarch64) arch=arm64;; esac
+          install_dir="$HOME/.local/share/cursor-agent/versions/${CURSOR_CLI_VERSION}"
+          mkdir -p "$install_dir" "$HOME/.local/bin"
+          curl -fSL "https://downloads.cursor.com/lab/${CURSOR_CLI_VERSION}/linux/${arch}/agent-cli-package.tar.gz" \
+            | tar --strip-components=1 -xzf - -C "$install_dir"
+          ln -sf "$install_dir/cursor-agent" "$HOME/.local/bin/cursor-agent"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/cursor-agent" --version
 

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -24,7 +24,7 @@ jobs:
     environment: development
     steps:
       - name: Deploy to development server
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.DEV_SSH_HOST }}
           username: ${{ secrets.DEV_SSH_USER }}
@@ -46,7 +46,7 @@ jobs:
     environment: production
     steps:
       - name: Deploy to production server
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.PROD_SSH_HOST }}
           username: ${{ secrets.PROD_SSH_USER }}

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
 		"dev:server": "nodemon",
 		"build": "node scripts/build.js",
 		"test": "cross-env NODE_ENV=development FAST_REFRESH=false BROWSER=none REACT_APP_API_URL=http://127.0.0.1:9001 HTTPS=0 PORT=9001 WDS_SOCKET_PORT=9001 concurrently --kill-others --success first \"npm run dev\" \"wait-on http://127.0.0.1:9001 && cypress run\"",
-		"test:unit": "vitest run --passWithNoTests",
+		"test:unit": "vitest run",
 		"test:smoke": "playwright test",
 		"test:components": "NODE_ENV=development cypress run --component --headed",
 		"test:build": "cross-env NODE_ENV=production FAST_REFRESH=false BROWSER=none PORT=9001 CYPRESS_WS_URL=http://127.0.0.1:9002 REACT_APP_API_URL=http://127.0.0.1:9001 concurrently --kill-others --success first \"npm run start\" \"wait-on http://127.0.0.1:9001 && cypress run\"",


### PR DESCRIPTION
Part of **Test Quality Audit 2026-07-04, items 4 & 6** (Frontend repo group).

### Item 4 — the `:dev` image was published untested
On direct pushes to `dev`/`main`, `ci-main` built and published the frontend Docker image without running any unit tests.

- Added a blocking **Run unit tests** step (`npm run test:unit` → `vitest run`) to the shared `.github/actions/node-build` composite action, positioned **before the app build** — and therefore before the Docker image build/publish in `ci-main`. A red test now blocks the image.
- **Dropped `--passWithNoTests`** from the `test:unit` script so an empty or errored run is no longer a silent pass.

**Verified locally:** `npm ci --ignore-scripts --legacy-peer-deps && npm run test:unit` → **62 test files, 390 tests passed** (with `--passWithNoTests` removed, vitest still discovers and runs the real suite).

### Item 6 — supply-chain hardening
- **Removed `curl https://cursor.com/install | bash`** from `ai-pr-review.yml` (mutable installer running under a write-capable token). Replaced with a **pinned, immutable versioned tarball** download + extract + symlink, reproducing the installer's `$HOME/.local/bin/cursor-agent` output. Cursor publishes no checksum, so the pinned immutable version URL is the integrity anchor.
- **SHA-pinned `appleboy/ssh-action`** in `frontend-deploy.yml` (both dev and prod jobs — it holds `DEV_SSH_KEY` / `PROD_SSH_KEY`) from the mutable tag `v1.0.3` to its release commit `029f5b4aeeeb58fdfe1410a5d17f967dacf36262`, with `# v1.0.3` kept as a trailing comment. SHA resolved via the GitHub API (`git/ref/tags/v1.0.3` → lightweight tag → commit `029f5b4…`).
- `--ignore-scripts` is **already present** on this repo's `npm ci`, so no change needed there.

### Notes / observations (out of scope, not changed here)
- The pre-existing Cursor review step interpolates `github.base_ref` and (in this repo) `github.event.pull_request.title` via env. The title is attacker-influenceable; it's already routed through `env:` here, but the downstream `run:` usage is worth a follow-up review per GitHub's workflow-injection guidance.

### Collision status
No open Frontend PR touches `node-build`, `ai-pr-review.yml`, `frontend-deploy.yml`, or the `test:unit` script (surveyed `gh pr list`; Hassan9215 has no open CI PR here). Isolated worktree off `origin/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
