### PR TITLE
fix(composer): Figma review feedback — send button, menu directions, mentions, recipient menu

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -29,6 +29,41 @@ const config: StorybookConfig = {
 	async viteFinal(cfg) {
 		return mergeConfig(cfg, {
 			plugins: [
+				// The virtual project-annotations module imports @storybook/react's
+				// dist files by absolute /node_modules/... path. Vite doesn't map
+				// bare `import React from 'react'` inside such files onto the
+				// pre-bundled dep, so the raw CJS react/index.js gets served as ESM
+				// and the preview boot dies ("does not provide an export named
+				// 'default'"). Re-resolving those imports as if they came from
+				// project source routes them through the optimizer again.
+				{
+					name: 'oriso-force-optimized-react',
+					enforce: 'pre' as const,
+					async resolveId(
+						id: string,
+						importer: string | undefined,
+						options: any
+					) {
+						if (
+							!importer ||
+							!importer.includes('node_modules') ||
+							importer.includes('.vite') ||
+							![
+								'react',
+								'react-dom',
+								'react-dom/client',
+								'react/jsx-runtime',
+								'react/jsx-dev-runtime'
+							].includes(id)
+						) {
+							return null;
+						}
+						return this.resolve(id, path.join(srcDir, 'index.ts'), {
+							...options,
+							skipSelf: true
+						});
+					}
+				},
 				// svgr handles the `?react` query -> React component
 				svgr(),
 				// CRA-faithful .svg dual export: replicate @svgr/webpack so that

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { useArgs } from '@storybook/preview-api';
+import { useArgs } from 'storybook/preview-api';
 import { Switch, SwitchProps } from './index';
 
 const meta = {

--- a/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
+++ b/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
@@ -5,7 +5,8 @@ import { MessageSubmitInterfaceComponent } from './messageSubmitInterfaceCompone
 import {
 	buildMockActiveSession,
 	buildMockGroupSession,
-	ComposerStoryDecorator
+	ComposerStoryDecorator,
+	storybookGroupRoomMembers
 } from './__storybook__/composerStoryDecorator';
 import './messageSubmitInterface.styles.scss';
 
@@ -14,7 +15,10 @@ const INPUT_FIELD_FIGMA_URL =
 
 const shellStyle: React.CSSProperties = {
 	background: '#eae7e8',
-	minHeight: 320,
+	// Tall enough that the docked toolbar menus (which open upward, like in
+	// the app where the composer sits at the bottom of the screen) stay
+	// visible inside the story canvas.
+	minHeight: 560,
 	padding: 24,
 	position: 'relative',
 	boxSizing: 'border-box',
@@ -25,13 +29,18 @@ const shellStyle: React.CSSProperties = {
 
 function ComposerShell({
 	activeSession,
+	roomMembers,
 	...composerProps
 }: {
 	activeSession?: any;
+	roomMembers?: Array<{ userId: string; name: string }>;
 } & Partial<React.ComponentProps<typeof MessageSubmitInterfaceComponent>>) {
 	return (
 		<div className="session" style={shellStyle}>
-			<ComposerStoryDecorator activeSession={activeSession}>
+			<ComposerStoryDecorator
+				activeSession={activeSession}
+				roomMembers={roomMembers}
+			>
 				<MessageSubmitInterfaceComponent
 					placeholder="Nachricht an Klient:in schreiben"
 					onSendButton={() => {}}
@@ -105,7 +114,12 @@ export const ReadyToSend: Story = {
 
 export const GroupChat: Story = {
 	name: 'Group chat (multiple recipients)',
-	render: () => <ComposerShell activeSession={buildMockGroupSession()} />
+	render: () => (
+		<ComposerShell
+			activeSession={buildMockGroupSession()}
+			roomMembers={storybookGroupRoomMembers}
+		/>
+	)
 };
 
 export const Supervisor: Story = {

--- a/src/components/messageSubmitInterface/TipTapComposer.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.tsx
@@ -41,6 +41,8 @@ export interface TipTapComposerRef {
 	setText: (value: string) => void;
 	getHTML: () => string;
 	insertText: (value: string) => void;
+	/** Inserts '@' so the mention suggestion reliably opens. */
+	insertMentionTrigger: () => void;
 	insertSnippet: (payload: HighlightSnippetPayload) => void;
 	runAction: (action: string) => void;
 	isActionActive: (action: string) => boolean;
@@ -502,6 +504,27 @@ export const TipTapComposer = forwardRef<
 					return;
 				}
 				editor.chain().focus().insertContent(nextValue).run();
+			},
+			insertMentionTrigger: () => {
+				if (!editor) {
+					return;
+				}
+				// The mention suggestion only fires on '@' at a line start or
+				// after whitespace — a bare '@' pasted right behind text would
+				// silently do nothing, so pad it when needed.
+				const { $from } = editor.state.selection;
+				const textBefore = $from.parent.textBetween(
+					0,
+					$from.parentOffset,
+					undefined,
+					'￼'
+				);
+				const needsSpace = /\S$/.test(textBefore);
+				editor
+					.chain()
+					.focus()
+					.insertContent(needsSpace ? ' @' : '@')
+					.run();
 			},
 			insertSnippet: (payload: HighlightSnippetPayload) => {
 				if (!editor || !payload?.text) {

--- a/src/components/messageSubmitInterface/__storybook__/composerStoryDecorator.tsx
+++ b/src/components/messageSubmitInterface/__storybook__/composerStoryDecorator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	ActiveSessionContext,
 	AUTHORITIES,
@@ -148,7 +148,11 @@ export const buildMockGroupSession = () =>
 			hintMessage: '',
 			messageDate: Date.now(),
 			messagesRead: false,
-			moderators: ['consultant-storybook'],
+			// Moderator ids intentionally without a homeserver domain — the
+			// audience matcher tokenizes on non-alphanumerics, so a domain
+			// token shared with every room member would classify everyone
+			// as moderator.
+			moderators: ['bruno.p', 'heinz.haltstill', 'volker.vorlaut'],
 			repetitive: false,
 			startDate: '2026-07-01',
 			startTime: '10:00',
@@ -156,11 +160,47 @@ export const buildMockGroupSession = () =>
 			topic: 'Träger Admins Caritas'
 		},
 		user: {
-			username: 'mario-k@example.invalid',
-			displayName: 'Mario K',
+			username: 'alpaka.leon@example.invalid',
+			displayName: 'Gutmütiges Alpaka Leon',
 			sessionData: {}
 		},
 		consultant: storybookConsultant
+	}) as any;
+
+/**
+ * Room membership for the group story — drives the real recipient split
+ * button + "Message visible to" audience menu (1 client, counsellors,
+ * 3 moderators, like the Figma group chat frame). The domain must not share
+ * tokens with the consultant's identity, or the self-filter would drop
+ * every member.
+ */
+export const storybookGroupRoomMembers = [
+	{ userId: '@beraterin:beratung.local', name: 'Beraterin ORISO' },
+	{ userId: '@alpaka.leon:beratung.local', name: 'Gutmütiges Alpaka Leon' },
+	{
+		userId: '@melania.paulstaetter:beratung.local',
+		name: 'Melania Paulstätter'
+	},
+	{ userId: '@a.kraeger:beratung.local', name: 'A. Kräger' },
+	{ userId: '@bruno.p:beratung.local', name: 'Bruno P.' },
+	{ userId: '@heinz.haltstill:beratung.local', name: 'Heinz Haltstill' },
+	{ userId: '@volker.vorlaut:beratung.local', name: 'Volker Vorlaut' }
+];
+
+/**
+ * Minimal Matrix client stand-in: just enough for the composer to read the
+ * room membership when building the audience options.
+ */
+export const buildMockMatrixClientService = (
+	members: Array<{ userId: string; name: string }>
+) =>
+	({
+		getClient: () => ({
+			getRoom: () => ({
+				getMembers: () => members,
+				getJoinedMembers: () => members
+			})
+		})
 	}) as any;
 
 const jsonResponse = (body: unknown, status = 200) =>
@@ -217,8 +257,15 @@ const installComposerFetchMocks = () => {
 			return jsonResponse(storybookAgencyConsultants);
 		}
 
-		if (/\/service\/users\/sessions\/\d+\/supervisors$/.test(pathname)) {
-			return jsonResponse(storybookSessionSupervisors);
+		// Supervisors only exist on the 1:1 session fixture. Returning them for
+		// the group chat too would flip the audience selector into supervision
+		// mode and hide the room members.
+		if (/\/service\/users\/sessions\/(\d+)\/supervisors$/.test(pathname)) {
+			return jsonResponse(
+				pathname.includes('/sessions/360/')
+					? storybookSessionSupervisors
+					: []
+			);
 		}
 
 		if (pathname.endsWith('/service/users/drafts')) {
@@ -239,17 +286,26 @@ const installComposerFetchMocks = () => {
 
 export function ComposerStoryDecorator({
 	activeSession,
+	roomMembers,
 	children
 }: {
 	activeSession?: any;
+	roomMembers?: Array<{ userId: string; name: string }>;
 	children: React.ReactNode;
 }) {
-	useEffect(() => installComposerFetchMocks(), []);
+	// Install during render (useState initializer), not in an effect: the
+	// composer fires its consultant/supervisor fetches from child effects,
+	// which run BEFORE this parent's effects — an effect-installed mock would
+	// always be one render too late and the @-mention directory stayed empty.
+	const [restoreFetchMocks] = useState(() => installComposerFetchMocks());
+	useEffect(() => restoreFetchMocks, [restoreFetchMocks]);
 
 	return (
 		<MatrixClientContext.Provider
 			value={{
-				matrixClientService: null,
+				matrixClientService: roomMembers?.length
+					? buildMockMatrixClientService(roomMembers)
+					: null,
 				setMatrixClientService: () => {}
 			}}
 		>

--- a/src/components/messageSubmitInterface/inputField/RecipientSplitButton.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/RecipientSplitButton.stories.tsx
@@ -14,9 +14,7 @@ const meta = {
 	tags: ['autodocs'],
 	parameters: {
 		layout: 'centered',
-		design: [
-			{ type: 'figma', name: 'Split button', url: SPLIT_FIGMA_URL }
-		],
+		design: [{ type: 'figma', name: 'Split button', url: SPLIT_FIGMA_URL }],
 		docs: {
 			description: {
 				component:
@@ -31,48 +29,40 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Hooks must live in a proper component — calling useState inside the
+// story's render() violates react-hooks/rules-of-hooks and fails CI lint.
+const SplitButtonDemo = ({
+	label,
+	icon,
+	isMulti = false
+}: {
+	label: string;
+	icon: React.ReactNode;
+	isMulti?: boolean;
+}) => {
+	const [open, setOpen] = useState(false);
+	return (
+		<RecipientSplitButton
+			label={label}
+			icon={icon}
+			isOpen={open}
+			isMulti={isMulti}
+			onToggle={() => setOpen((o) => !o)}
+			chevronLabel="Open send-to menu"
+		/>
+	);
+};
+
 export const SingleRecipient: Story = {
-	render: () => {
-		const [open, setOpen] = useState(false);
-		return (
-			<RecipientSplitButton
-				label="A. Kräger"
-				icon={<PersonIcon />}
-				isOpen={open}
-				onToggle={() => setOpen((o) => !o)}
-				chevronLabel="Open send-to menu"
-			/>
-		);
-	}
+	render: () => <SplitButtonDemo label="A. Kräger" icon={<PersonIcon />} />
 };
 
 export const MultipleRecipients: Story = {
-	render: () => {
-		const [open, setOpen] = useState(false);
-		return (
-			<RecipientSplitButton
-				label="3 Personen"
-				icon={<GroupIcon />}
-				isOpen={open}
-				isMulti
-				onToggle={() => setOpen((o) => !o)}
-				chevronLabel="Open send-to menu"
-			/>
-		);
-	}
+	render: () => (
+		<SplitButtonDemo label="3 Personen" icon={<GroupIcon />} isMulti />
+	)
 };
 
 export const AllRecipients: Story = {
-	render: () => {
-		const [open, setOpen] = useState(false);
-		return (
-			<RecipientSplitButton
-				label="Alle"
-				icon={<GroupIcon />}
-				isOpen={open}
-				onToggle={() => setOpen((o) => !o)}
-				chevronLabel="Open send-to menu"
-			/>
-		);
-	}
+	render: () => <SplitButtonDemo label="Alle" icon={<GroupIcon />} />
 };

--- a/src/components/messageSubmitInterface/inputField/SendButton.tsx
+++ b/src/components/messageSubmitInterface/inputField/SendButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ReactComponent as SendPlaneIcon } from '../../../resources/img/icons/paper-plane.svg';
+import SendIcon from '@mui/icons-material/Send';
 import {
 	deriveSendButtonState,
 	getSendButtonTransition,
@@ -34,7 +34,10 @@ export const SendButton = ({
 	const [isFlyingOut, setIsFlyingOut] = useState(false);
 
 	useEffect(() => {
-		const transition = getSendButtonTransition(previousState.current, state);
+		const transition = getSendButtonTransition(
+			previousState.current,
+			state
+		);
 		previousState.current = state;
 		if (transition === 'fly-out') {
 			setIsFlyingOut(true);
@@ -65,7 +68,7 @@ export const SendButton = ({
 				aria-hidden
 				onAnimationEnd={() => setIsFlyingOut(false)}
 			>
-				<SendPlaneIcon className="sendButton__planeIcon" />
+				<SendIcon className="sendButton__planeIcon" />
 			</span>
 		</button>
 	);

--- a/src/components/messageSubmitInterface/inputField/ToolbarMenu.tsx
+++ b/src/components/messageSubmitInterface/inputField/ToolbarMenu.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import {
-	autoUpdate,
-	computePosition,
-	flip,
-	offset,
-	shift
-} from '@floating-ui/dom';
+import { autoUpdate, computePosition, offset, shift } from '@floating-ui/dom';
 import type { MenuDirection } from './menuDirection';
 
 export interface ToolbarMenuItem {
@@ -53,13 +47,12 @@ export const ToolbarMenu = ({
 		}
 		return autoUpdate(anchorEl, menuEl, () => {
 			computePosition(anchorEl, menuEl, {
-				placement:
-					direction === 'up' ? 'top-start' : 'bottom-start',
-				middleware: [
-					offset(6),
-					flip({ padding: 8 }),
-					shift({ padding: 8 })
-				]
+				// The Figma direction rule is authoritative: docked/mobile menus
+				// always open upward, the maximized editor opens them downward.
+				// No flip() — flipping against the rule renders the menu over
+				// the editor content instead of on top of the toolbar.
+				placement: direction === 'up' ? 'top-start' : 'bottom-start',
+				middleware: [offset(6), shift({ padding: 8 })]
 			}).then(({ x, y }) => setPosition({ left: x, top: y }));
 		});
 	}, [anchorEl, direction]);

--- a/src/components/messageSubmitInterface/inputField/emojiInsert.test.tsx
+++ b/src/components/messageSubmitInterface/inputField/emojiInsert.test.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import { createRef } from 'react';
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-	TipTapComposer,
-	TipTapComposerRef
-} from '../TipTapComposer';
+import { TipTapComposer, TipTapComposerRef } from '../TipTapComposer';
 
 afterEach(() => cleanup());
 
@@ -34,14 +31,19 @@ describe('emoji insertion at cursor', () => {
 
 		await waitFor(() => expect(ref.current).toBeTruthy());
 
-		ref.current!.setText('Hallo');
-		ref.current!.focus();
-
-		// The emoji popup drives insertText — the emoji must be added to the
-		// existing content, not replace it.
-		ref.current!.insertText('😀');
-
-		await waitFor(() => expect(html).toContain('😀'));
-		expect(html).toContain('Hallo');
+		// On mount the composer syncs its initial `value` prop into the editor
+		// and, during that window, swallows editor updates (isSyncingFromValue)
+		// and can even reset content just after an imperative edit. That settle
+		// is not directly observable, so drive the whole sequence through a
+		// retrying waitFor: setText replaces the content with 'Hallo' (no
+		// accumulation across retries) and insertText appends the emoji — the
+		// emoji popup's contract is to add to existing content, not replace it.
+		// Once the sync window has closed a single retry lands both.
+		await waitFor(() => {
+			ref.current!.setText('Hallo');
+			ref.current!.insertText('😀');
+			expect(html).toContain('Hallo');
+			expect(html).toContain('😀');
+		});
 	});
 });

--- a/src/components/messageSubmitInterface/inputField/menuDirection.test.ts
+++ b/src/components/messageSubmitInterface/inputField/menuDirection.test.ts
@@ -8,17 +8,17 @@ describe('getMenuDirection', () => {
 		);
 	});
 
-	it('opens bottom-to-top on mobile, even in fullscreen', () => {
+	it('opens bottom-to-top on docked mobile', () => {
 		expect(getMenuDirection({ isExpanded: false, isMobile: true })).toBe(
-			'up'
-		);
-		expect(getMenuDirection({ isExpanded: true, isMobile: true })).toBe(
 			'up'
 		);
 	});
 
-	it('opens top-down in desktop fullscreen mode', () => {
+	it('opens top-down in the maximized editor on desktop and mobile', () => {
 		expect(getMenuDirection({ isExpanded: true, isMobile: false })).toBe(
+			'down'
+		);
+		expect(getMenuDirection({ isExpanded: true, isMobile: true })).toBe(
 			'down'
 		);
 	});

--- a/src/components/messageSubmitInterface/inputField/menuDirection.ts
+++ b/src/components/messageSubmitInterface/inputField/menuDirection.ts
@@ -2,13 +2,12 @@ export type MenuDirection = 'up' | 'down';
 
 /**
  * Figma TipTap menu rule (node 7086:46390): use a bottom-to-top approach for
- * minimized or mobile menus, as space is limited. In fullscreen mode, display
- * the menu from the top down.
+ * docked/minimized menus, as space is limited. In the maximized editor —
+ * desktop and mobile alike — every menu opens from the top down.
  */
 export const getMenuDirection = ({
-	isExpanded,
-	isMobile
+	isExpanded
 }: {
 	isExpanded: boolean;
-	isMobile: boolean;
-}): MenuDirection => (isExpanded && !isMobile ? 'down' : 'up');
+	isMobile?: boolean;
+}): MenuDirection => (isExpanded ? 'down' : 'up');

--- a/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
+++ b/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
@@ -32,14 +32,10 @@
 	}
 
 	&__planeIcon {
+		// Figma "Nachricht senden": filled M3 send plane, 24px, currentColor.
 		width: 24px;
 		height: 24px;
-
-		// paper-plane.svg paints a masked <rect>; recolor it via currentColor.
-		rect,
-		path {
-			fill: currentColor;
-		}
+		fill: currentColor;
 	}
 
 	// Ready / sending: red container, plane rotated up.

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -126,7 +126,8 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 				// Handle touched (Figma 1168:38130): the outer frame darkens
 				// while the composer is being resized.
 				&--resizing {
-					border: 2px solid var(--m3-on-primary-fixed-variant, #930008) !important;
+					border: 2px solid
+						var(--m3-on-primary-fixed-variant, #930008) !important;
 					transition: none;
 				}
 
@@ -517,7 +518,9 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			position: absolute;
 			top: 4px;
 			left: 8px;
-			right: 64px;
+
+			// keep clear of the 48px send button flush at right:16
+			right: 72px;
 			z-index: 20;
 			display: block;
 			overflow: visible;
@@ -985,9 +988,11 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			background: #fff !important;
 			opacity: 1;
 			padding: 8px;
+
+			// Regular M3 elevation — no spread halo bleeding over the composer.
 			box-shadow:
-				0 30px 28px rgba(0, 0, 0, 0.1),
-				0 0 30px 28px rgba(0, 0, 0, 0.05);
+				0 4px 8px 3px rgba(0, 0, 0, 0.08),
+				0 1px 3px rgba(0, 0, 0, 0.2);
 			z-index: 999999;
 			overflow: visible;
 		}
@@ -1788,17 +1793,21 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 		}
 
 		&__buttons {
+			// Send button sits flush in the input field's top-right corner:
+			// the inputWrapper is inset 16px, so the button's 4px corner meets
+			// the field's 4px corner and the 24px bottom-left radius forms the
+			// Figma notch (489:16565).
 			position: absolute;
-			top: 23px;
-			right: 22px;
+			top: 16px;
+			right: 16px;
 			z-index: 8;
 			display: flex;
 			align-items: center;
 			gap: 0;
 
 			@media screen and (width <= 899px) {
-				right: -6px;
-				top: -4px;
+				right: 0;
+				top: 0;
 			}
 
 			.textarea__wrapper-send-message--expanded & {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -56,12 +56,7 @@ import {
 	ATTACHMENT_MAX_SIZE_IN_MB,
 	getAttachmentSizeMBForKB
 } from './attachmentHelpers';
-import {
-	ContentState,
-	convertToRaw,
-	EditorState,
-	RichUtils
-} from 'draft-js';
+import { ContentState, convertToRaw, EditorState, RichUtils } from 'draft-js';
 import { draftToMarkdown } from 'markdown-draft-js';
 import {
 	escapeMarkdownChars,
@@ -184,36 +179,6 @@ export const MessageSubmitInterfaceComponent = ({
 	onMobileNavigateDown,
 	onMobileNavigateBottom
 }: MessageSubmitInterfaceComponentProps) => {
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 	const ComposerMobileBackIcon = () => (
 		<svg
 			width="5"
@@ -2875,7 +2840,7 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const handleMentionInsert = useCallback(() => {
 		composerRef.current?.focus();
-		composerRef.current?.insertText('@');
+		composerRef.current?.insertMentionTrigger();
 	}, []);
 
 	// Live snapshot for the mention provider — the TipTap extension is created
@@ -2966,7 +2931,8 @@ export const MessageSubmitInterfaceComponent = ({
 	);
 
 	const clampComposerHeight = useCallback(
-		(height: number) => clampComposerHeightPure(height, getComposerHeightBounds()),
+		(height: number) =>
+			clampComposerHeightPure(height, getComposerHeightBounds()),
 		[getComposerHeightBounds]
 	);
 
@@ -3681,9 +3647,15 @@ export const MessageSubmitInterfaceComponent = ({
 															hasUploadFunctionality &&
 															isVoiceMessageEnabledForCurrentChat
 														}
-														isRecording={isVoiceRecording}
-														onMicClick={toggleVoiceRecording}
-														isEmojiOpen={isEmojiStripOpen}
+														isRecording={
+															isVoiceRecording
+														}
+														onMicClick={
+															toggleVoiceRecording
+														}
+														isEmojiOpen={
+															isEmojiStripOpen
+														}
 														onEmojiClick={() =>
 															setIsEmojiStripOpen(
 																(prev) => !prev
@@ -3698,7 +3670,9 @@ export const MessageSubmitInterfaceComponent = ({
 														onAttachmentClick={
 															handleAttachmentSelect
 														}
-														isExpanded={isExpandedComposer}
+														isExpanded={
+															isExpandedComposer
+														}
 														onExpandToggle={
 															toggleExpandedComposer
 														}
@@ -3709,7 +3683,9 @@ export const MessageSubmitInterfaceComponent = ({
 															direction={
 																composerMenuDirection
 															}
-															onPick={handleEmojiPick}
+															onPick={
+																handleEmojiPick
+															}
 															onClose={() =>
 																setIsEmojiStripOpen(
 																	false
@@ -3720,14 +3696,22 @@ export const MessageSubmitInterfaceComponent = ({
 												</span>
 											) : (
 												<ComposerToolbar
-													direction={composerMenuDirection}
+													direction={
+														composerMenuDirection
+													}
 													isMobile={isMobileViewport}
-													isExpanded={isExpandedComposer}
-													onAction={handleToolbarAction}
+													isExpanded={
+														isExpandedComposer
+													}
+													onAction={
+														handleToolbarAction
+													}
 													isActionSelected={
 														isToolbarActionSelected
 													}
-													onCollapse={openCompactActionStrip}
+													onCollapse={
+														openCompactActionStrip
+													}
 													onExpandToggle={
 														toggleExpandedComposer
 													}

--- a/src/components/sessionsListItem/SessionListItem.stories.tsx
+++ b/src/components/sessionsListItem/SessionListItem.stories.tsx
@@ -31,8 +31,6 @@ import {
 	STATUS_ACTIVE
 } from '../../globalState/interfaces';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
-import { RocketChatSubscriptionsContext } from '../../globalState/provider/RocketChatSubscriptionsProvider';
-import { RocketChatUsersOfRoomContext } from '../../globalState/provider/RocketChatUsersOfRoomProvider';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { SessionListItemComponent } from './SessionListItemComponent';
 import './sessionsListItem.styles.scss';
@@ -702,53 +700,30 @@ function RuntimeSessionListItem() {
 									dispatch: () => {}
 								}}
 							>
-								<RocketChatSubscriptionsContext.Provider
+								<E2EEContext.Provider
 									value={{
-										subscriptionsReady: true,
-										subscriptions: [],
-										roomsReady: true,
-										rooms: []
+										key: '',
+										reloadPrivateKey: () => {},
+										isE2eeEnabled: false,
+										e2EEReady: true
 									}}
 								>
-									<RocketChatUsersOfRoomContext.Provider
-										value={{
-											ready: true,
-											users: [],
-											moderators: [],
-											total: 0,
-											reload: async () => []
-										}}
-									>
-										<E2EEContext.Provider
+									<LegalLinksContext.Provider value={[]}>
+										<ActiveSessionContext.Provider
 											value={{
-												key: '',
-												reloadPrivateKey: () => {},
-												isE2eeEnabled: false,
-												e2EEReady: true
+												activeSession,
+												reloadActiveSession: () => {},
+												readActiveSession: () => {}
 											}}
 										>
-											<LegalLinksContext.Provider
-												value={[]}
-											>
-												<ActiveSessionContext.Provider
-													value={{
-														activeSession,
-														reloadActiveSession:
-															() => {},
-														readActiveSession:
-															() => {}
-													}}
-												>
-													<SessionListItemComponent
-														defaultLanguage="de"
-														handleKeyDownLisItemContent={() => {}}
-														index={0}
-													/>
-												</ActiveSessionContext.Provider>
-											</LegalLinksContext.Provider>
-										</E2EEContext.Provider>
-									</RocketChatUsersOfRoomContext.Provider>
-								</RocketChatSubscriptionsContext.Provider>
+											<SessionListItemComponent
+												defaultLanguage="de"
+												handleKeyDownLisItemContent={() => {}}
+												index={0}
+											/>
+										</ActiveSessionContext.Provider>
+									</LegalLinksContext.Provider>
+								</E2EEContext.Provider>
 							</SessionsDataContext.Provider>
 						</TopicsContext.Provider>
 					</ConsultingTypesContext.Provider>

--- a/src/test/jsdomPolyfills.ts
+++ b/src/test/jsdomPolyfills.ts
@@ -1,0 +1,52 @@
+/**
+ * jsdom is missing a few layout APIs that ProseMirror/TipTap call from their
+ * focus + scroll-into-view path. When the editor is focused in a test, that
+ * path runs asynchronously (via a timer), so the missing method surfaces as an
+ * *unhandled* error that Vitest counts as a failure — even when the assertion
+ * itself would pass. It is timing-dependent, which is why it only flaked in CI.
+ *
+ * Polyfilling the missing methods with harmless empty-rect stubs removes the
+ * error class deterministically. Everything here is guarded so the file is a
+ * no-op in the node test environment (no DOM globals present).
+ */
+
+const emptyRect = (): DOMRect => ({
+	x: 0,
+	y: 0,
+	width: 0,
+	height: 0,
+	top: 0,
+	left: 0,
+	right: 0,
+	bottom: 0,
+	toJSON: () => ({})
+});
+
+const emptyRectList = (): DOMRectList => {
+	const list = {
+		length: 0,
+		item: () => null,
+		[Symbol.iterator]: function* () {
+			// no rects in a headless DOM
+		}
+	};
+	return list as unknown as DOMRectList;
+};
+
+if (typeof Range !== 'undefined') {
+	if (typeof Range.prototype.getClientRects !== 'function') {
+		Range.prototype.getClientRects = emptyRectList;
+	}
+	if (typeof Range.prototype.getBoundingClientRect !== 'function') {
+		Range.prototype.getBoundingClientRect = emptyRect;
+	}
+}
+
+if (typeof Element !== 'undefined') {
+	if (typeof Element.prototype.getClientRects !== 'function') {
+		Element.prototype.getClientRects = emptyRectList;
+	}
+	if (typeof Element.prototype.scrollIntoView !== 'function') {
+		Element.prototype.scrollIntoView = () => {};
+	}
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,6 +20,11 @@ export default defineConfig({
 	},
 	test: {
 		include: ['src/**/*.test.{ts,tsx}'],
+		// Polyfill the layout APIs jsdom lacks (Range.getClientRects,
+		// Element.scrollIntoView) so TipTap's focus/scroll path doesn't throw
+		// an async unhandled error that flakes the composer emoji test in CI.
+		// Guarded internally, so it is a no-op under the node environment.
+		setupFiles: ['./src/test/jsdomPolyfills.ts'],
 		// The app's runtimeConfig reads REACT_APP_* vars at module load and
 		// throws if the Keycloak realm is missing. Vite only auto-loads VITE_*
 		// vars, so provide the minimum here to let component/router tests that


### PR DESCRIPTION
## Kontext

Umsetzung des annotierten Screenshot-Feedbacks zum Composer (Figma [7086:40434](https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=7086-40434&m=dev)). Alle Punkte wurden lokal im Storybook (SB 10, Vite) reproduziert, gefixt und interaktiv verifiziert.

## Fixes (Screenshot-Feedback → Änderung)

| Feedback | Fix |
| --- | --- |
| „Send icon falsch" | Gefüllter M3-Send-Plane (`@mui/icons-material/Send`) statt des alten maskierten paper-plane Assets |
| „Send button is falsch alligned" / „send element falsch gerendert" | Button sitzt jetzt bündig in der oberen rechten Ecke des Eingabefelds (Notch, Figma 489:16565): Desktop `top/right: 16px`, Mobile `0/0` statt `-4/-6` (ragte über den Rand hinaus) |
| „nur bei Text roter Sende-Zustand" | War bereits über `deriveSendButtonState` korrekt — verifiziert: leer = blass, mit Text = rot |
| „liste falsch gerendert, muss on top" (Heading-/Listen-/Overflow-Menü) | Figma-Richtungsregel ist jetzt verbindlich: gedockt/mobil öffnen alle Toolbar-Menüs **über** der Toolbar. Das `flip()`-Middleware von floating-ui hat die Richtung gegen die Regel umgekippt und die Menüs über den Editor-Inhalt gelegt — entfernt |
| „menus müssen wenn maximized alle nach unten öffnen" | `getMenuDirection`: maximiert → `down`, jetzt auch auf Mobile (vorher nur Desktop) |
| „emoji icons bricht bei maximize" | Folgt derselben Richtungsregel — Picker öffnet im maximierten Editor nach unten und wird nicht mehr am oberen Rand abgeschnitten |
| „@ sign funktioniert garnicht" | 1) TipTaps Mention-Suggestion feuert nur nach Whitespace/Zeilenanfang — der @-Button fügt jetzt bei Bedarf ` @` ein (`insertMentionTrigger` prüft das Zeichen vor dem Cursor). 2) Storybook: Fetch-Mocks wurden eine Render-Runde zu spät installiert (Child-Effects laufen vor Parent-Effects), dadurch war das Berater-Verzeichnis immer leer — Mocks werden jetzt beim Render installiert |
| „altes custom Menü ist weg" | Das Menü (`Adressaten wählen` mit Client/Counsellor/Moderator-Sektionen) existiert im Produkt-Code — es war im Storybook unsichtbar, weil der Mock keinen Matrix-Client lieferte. Die Group-Chat-Story hat jetzt einen Matrix-Client-Stub mit Room-Membern (1 Client, 2 Counsellors, 3 Moderatoren) und zeigt Button + Menü wieder voll funktionsfähig |
| „komischer schatten muss weg" | Der seltsame Spread-Halo (`0 0 30px 28px`) am Adressaten-Menü wurde durch eine normale M3-Elevation ersetzt |

## Storybook-Infrastruktur

- **Preview-Boot-Fix (Vite 6 + React 19):** `@storybook/react`-Dist-Chunks werden per absolutem Pfad importiert und bekamen für `import React from 'react'` das rohe CJS `react/index.js` als ESM serviert → `does not provide an export named 'default'`, keine einzige Story hat gerendert. Ein kleines `resolveId`-Plugin re-resolved diese Imports über den Dep-Optimizer.
- Story-Shell auf 560px erhöht, damit die aufwärts öffnenden Menüs im Canvas sichtbar sind (im Produkt sitzt der Composer am unteren Bildschirmrand).

## Verifiziert

- `vitest run src/components/messageSubmitInterface` — 53/53 grün (menuDirection-Tests an die neue Regel angepasst)
- `tsc` sauber, `stylelint` sauber; verbleibende ESLint-Fehler sind vorbestehend (preview.tsx, RecipientSplitButton.stories)
- Interaktiv im lokalen Storybook: Default/ReadyToSend/GroupChat/Mobile-Stories, Menürichtungen gedockt + maximiert, Emoji-Picker, @-Mentions (inkl. „nicht im Chat"-Badge), Adressaten-Menü mit allen Sektionen

## Offen / Follow-up

- Avatar-/Message-Varianten aus Figma [7086:40367](https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=7086-40367&m=dev) und [7086:57409](https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=7086-57409&m=dev) (60px-Kreise links/rechts, weißer Ring bei System-Nachrichten, Touch-Zonen, Initialen-Avatar vs. Tier-Icon) betreffen die Message-Anzeige, nicht den Composer — separater PR sinnvoll.
- Die Client-Filter im Adressaten-Menü matchen Identitäten token-basiert und sehr unscharf (z. B. kollidiert ein Display-Name mit „ORISO" mit der Homeserver-Domain) — das erklärt vermutlich „die Filter bei Client haben nicht immer perfekt funktioniert" und sollte separat gehärtet werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)