### PR TITLE
fix(storybook): make dev pass the new tsconfig.storybook type-check

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -757,6 +757,7 @@ function MuiStoryShell({
 			<LocaleContext.Provider
 				value={{
 					locale: 'de',
+					locales: ['de', 'en'],
 					selectableLocales: ['de', 'en'],
 					setLocale: () => {},
 					initLocale: 'de'
@@ -771,8 +772,8 @@ function MuiStoryShell({
 					<UserDataContext.Provider
 						value={{
 							userData: mockUserData,
-							reloadUserData: async () => null as any,
-							loaded: true
+							setUserData: () => {},
+							reloadUserData: async () => null as any
 						}}
 					>
 						<UrlParamsContext.Provider
@@ -797,10 +798,17 @@ function MuiStoryShell({
 								<NotificationsContext.Provider
 									value={{
 										notifications: [],
+										notificationFeed: [],
+										unreadNotificationCount: 0,
 										setNotifications: () => {},
 										hasNotification: () => false,
 										addNotification: () => {},
-										removeNotification: () => {}
+										addEventNotification: () => {},
+										refreshNotificationFeed: () => {},
+										removeNotification: () => {},
+										markNotificationAsRead: () => {},
+										markAllNotificationsAsRead: () => {},
+										clearNotificationFeed: () => {}
 									}}
 								>
 									<RegistrationContext.Provider
@@ -910,7 +918,7 @@ const preview: Preview = {
 			]
 		}
 	},
-	globals: {
+	initialGlobals: {
 		locale: FALLBACK_LNG,
 		locales: {
 			de: { icon: '🇩🇪', title: 'Deutsch', right: 'DE' },

--- a/src/components/app/NavigationSidebar.stories.tsx
+++ b/src/components/app/NavigationSidebar.stories.tsx
@@ -109,8 +109,8 @@ function RuntimeNavigationRail() {
 		<UserDataContext.Provider
 			value={{
 				userData: consultantUserData,
-				reloadUserData: async () => consultantUserData,
-				loaded: true
+				setUserData: () => {},
+				reloadUserData: async () => consultantUserData
 			}}
 		>
 			<ConsultingTypesContext.Provider
@@ -141,6 +141,7 @@ function RuntimeNavigationRail() {
 						<LocaleContext.Provider
 							value={{
 								locale: 'de',
+								locales: ['de', 'en'],
 								selectableLocales: ['de', 'en'],
 								setLocale: () => {},
 								initLocale: 'de'

--- a/src/components/messageSubmitInterface/inputField/EmojiPickerPopup.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/EmojiPickerPopup.stories.tsx
@@ -49,6 +49,6 @@ function PickerDemo() {
 	);
 }
 
-export const Picker: Story = {
+export const Picker: StoryObj = {
 	render: () => <PickerDemo />
 };

--- a/src/components/messageSubmitInterface/inputField/RecipientSplitButton.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/RecipientSplitButton.stories.tsx
@@ -53,16 +53,16 @@ const SplitButtonDemo = ({
 	);
 };
 
-export const SingleRecipient: Story = {
+export const SingleRecipient: StoryObj = {
 	render: () => <SplitButtonDemo label="A. Kräger" icon={<PersonIcon />} />
 };
 
-export const MultipleRecipients: Story = {
+export const MultipleRecipients: StoryObj = {
 	render: () => (
 		<SplitButtonDemo label="3 Personen" icon={<GroupIcon />} isMulti />
 	)
 };
 
-export const AllRecipients: Story = {
+export const AllRecipients: StoryObj = {
 	render: () => <SplitButtonDemo label="Alle" icon={<GroupIcon />} />
 };

--- a/src/components/messageSubmitInterface/inputField/SendButton.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/SendButton.stories.tsx
@@ -70,7 +70,7 @@ function ArmDemo() {
 	);
 }
 
-export const ArmTransition: Story = {
+export const ArmTransition: StoryObj = {
 	name: 'Transition empty → ready (rotate in)',
 	render: () => <ArmDemo />,
 	play: async ({ canvasElement }) => {
@@ -102,7 +102,7 @@ function FlyOutDemo() {
 	);
 }
 
-export const FlyOutOnSend: Story = {
+export const FlyOutOnSend: StoryObj = {
 	name: 'Fly-out on send',
 	render: () => <FlyOutDemo />,
 	play: async ({ canvasElement }) => {

--- a/src/components/messageSubmitInterface/inputField/extensions/MentionList.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/extensions/MentionList.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const MixedMembership: Story = {
+export const MixedMembership: StoryObj = {
 	render: () => (
 		<MentionList
 			ref={createRef<MentionListRef>()}
@@ -51,7 +51,7 @@ export const MixedMembership: Story = {
 	)
 };
 
-export const AllInChat: Story = {
+export const AllInChat: StoryObj = {
 	render: () => (
 		<MentionList
 			ref={createRef<MentionListRef>()}

--- a/src/components/sessionsListItem/SessionListItem.stories.tsx
+++ b/src/components/sessionsListItem/SessionListItem.stories.tsx
@@ -671,8 +671,8 @@ function RuntimeSessionListItem() {
 			<UserDataContext.Provider
 				value={{
 					userData: runtimeUserData,
-					reloadUserData: async () => runtimeUserData,
-					loaded: true
+					setUserData: () => {},
+					reloadUserData: async () => runtimeUserData
 				}}
 			>
 				<SessionTypeContext.Provider


### PR DESCRIPTION
The #351 merge landed `tsconfig.storybook.json` — a type-check this repo never ran before — together with preview/story files written against older context types. The Storybook Docker validation on dev now fails with 15 type errors (see the #351 merge-commit run).

This aligns the story mocks with the real types, no runtime behavior change:

- `LocaleContext` mocks: add required `locales`
- `UserDataContext` mocks: drop unknown `loaded`, add `setUserData`
- `NotificationsContext` mock: full `NotificationsContextProps` shape
- preview: `globals` → `initialGlobals` (Storybook 10 `ProjectAnnotations`)
- render-only composer stories typed as plain `StoryObj` so `args` isn't required

Verified locally: `tsc -p tsconfig.storybook.json` 0 errors, `tsc -p tsconfig.json` 0 errors, 456/456 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)