### PR TITLE
test(2fa): fix flaky email-resend query in TwoFactorSetupDialog test

### DIFF
--- a/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
@@ -450,6 +450,14 @@ describe('TwoFactorSetupDialog', () => {
 				'maxmuster@email.de'
 			)
 		);
+		// The connect step only renders after apiPutTwoFactorAuthEmail resolves
+		// and its state updates flush — on loaded CI runners that can exceed the
+		// 1s default findBy timeout, so anchor the step change generously first.
+		await screen.findByLabelText(
+			'twoFactorAuth.setupDialog.email.connect.input',
+			{},
+			{ timeout: 10000 }
+		);
 		fireEvent.click(
 			await screen.findByRole('button', {
 				name: 'twoFactorAuth.setupDialog.email.connect.resend'


### PR DESCRIPTION
The `sends, resends, and validates the email setup code` test intermittently failed in CI (seen on the dev "Frontend Build and Publish" run for the #375 merge commit) with `Unable to find an accessible element with the role "button" and name "twoFactorAuth.setupDialog.email.connect.resend"`.

Root cause: the email-connect step only renders after `apiPutTwoFactorAuthEmail` resolves and its state updates flush. On loaded CI runners that can exceed testing-library's 1s default `findBy` timeout — there is no cooldown timer involved.

Fix: anchor the step transition by awaiting the connect-step input with a generous 10s timeout before querying the resend button.

Verified: 50 consecutive local runs of the file, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)