### PR TITLE
fix(registration): drop trailing slash from topics endpoint (SB4 404)

### DIFF
--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -119,7 +119,7 @@ export const endpoints = {
 		tenantServiceOrigin +
 		`/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`,
 	topicGroups: consultingTypeServiceOrigin + '/service/topic-groups',
-	topicsData: consultingTypeServiceOrigin + '/service/topic/public/',
+	topicsData: consultingTypeServiceOrigin + '/service/topic/public',
 	twoFactorAuth: userServiceOrigin + '/service/users/2fa',
 	twoFactorAuthApp: userServiceOrigin + '/service/users/2fa/app',
 	twoFactorAuthEmail: userServiceOrigin + '/service/users/2fa/email',


### PR DESCRIPTION
## Problem
Registration step 1 (`/registration/topic-selection`) renders an **empty topic panel** on Pre-Dev and against `api.oriso-dev.site` — Bug tracker entry *'Topics are not loading on Signup flow'* (07.07).

Root cause: Spring Boot 4 removed implicit trailing-slash matching. The FE calls `GET /service/topic/public/` (with slash, `endpoints.ts:122`) → **404 "No static resource topic/public."**, while `/service/topic/public` returns 200 + data. `TopicSelection` swallows the error in its catch and renders an empty list, so QA saw no error at all.

Verified live:
```
404  https://api.oriso-dev.site/service/topic/public/
200  https://api.oriso-dev.site/service/topic/public
```

## Fix
One line: drop the trailing slash from `endpoints.topicsData`. All other trailing-slash entries in `endpoints.ts` are base paths that get segments appended and are unaffected.

## Verification
Applied to the running local dev server against `api.oriso-dev.site`: topic panel renders again with all 5 topic groups and topics.

## Related
- Companion backend fix: OpenResilienceInitiative/ORISO-ConsultingTypeService#47 (restores trailing-slash tolerance for already-deployed FE builds — both should land)
- Follow-up worth tracking: `TopicSelection` renders silently empty on fetch errors; an error state would have surfaced this a day earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)