### PR TITLE
feat(registration): visible error state for failed topic loading

### DIFF
--- a/src/components/registration/topicSelection/TopicSelection.test.tsx
+++ b/src/components/registration/topicSelection/TopicSelection.test.tsx
@@ -263,4 +263,37 @@ describe('TopicSelection', () => {
 		});
 		expect(apiGetTopicGroupsMock).not.toHaveBeenCalled();
 	});
+
+	it('shows a visible error alert with retry when the topics request fails', async () => {
+		apiGetTopicsDataMock.mockRejectedValueOnce(new Error('network'));
+
+		renderTopicSelection();
+
+		const alert = await screen.findByRole('alert');
+		expect(alert.textContent).toContain('registration.topic.loadError');
+
+		// Retry refetches and replaces the alert with the loaded topics.
+		apiGetTopicsDataMock.mockResolvedValueOnce([
+			topic(9, 'Schuldenberatung')
+		]);
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'registration.topic.loadErrorRetry'
+			})
+		);
+
+		expect(await screen.findByText('Schuldenberatung')).toBeDefined();
+		expect(screen.queryByRole('alert')).toBeNull();
+		expect(apiGetTopicsDataMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('shows an empty state instead of an error when the request succeeds with no topics', async () => {
+		apiGetTopicsDataMock.mockResolvedValue([]);
+
+		renderTopicSelection();
+
+		const emptyState = await screen.findByRole('status');
+		expect(emptyState.textContent).toContain('registration.topic.empty');
+		expect(screen.queryByRole('alert')).toBeNull();
+	});
 });

--- a/src/components/registration/topicSelection/TopicSelection.tsx
+++ b/src/components/registration/topicSelection/TopicSelection.tsx
@@ -4,8 +4,10 @@ import {
 	Accordion,
 	AccordionDetails,
 	AccordionSummary,
+	Alert,
 	Avatar,
 	Box,
+	Button,
 	Divider,
 	List,
 	ListItemButton,
@@ -75,6 +77,8 @@ export const TopicSelection: FC<{
 	const [selectedPlacementId, setSelectedPlacementId] = useState<
 		string | undefined
 	>();
+	const [loadError, setLoadError] = useState<boolean>(false);
+	const [reloadKey, setReloadKey] = useState<number>(0);
 	const [expandedTopicGroupIds, setExpandedTopicGroupIds] = useState<
 		number[]
 	>([]);
@@ -281,6 +285,7 @@ export const TopicSelection: FC<{
 		(async () => {
 			setTopics(undefined);
 			setTopicGroups(undefined);
+			setLoadError(false);
 
 			try {
 				const topicsResponse = await apiGetTopicsData();
@@ -320,13 +325,20 @@ export const TopicSelection: FC<{
 				setTopicGroups([]);
 				setListView(true);
 				setTopics([]);
+				setLoadError(true);
 			}
 		})();
 
 		return () => {
 			cancelled = true;
 		};
-	}, [locale, preselectedConsultant, preselectedAgency, preselectedTopic]);
+	}, [
+		locale,
+		preselectedConsultant,
+		preselectedAgency,
+		preselectedTopic,
+		reloadKey
+	]);
 
 	return (
 		<>
@@ -369,6 +381,32 @@ export const TopicSelection: FC<{
 				>
 					<Loading />
 				</Box>
+			) : loadError ? (
+				<Alert
+					severity="error"
+					role="alert"
+					data-cy="topic-selection-load-error"
+					sx={{ mt: '8px', borderRadius: '16px' }}
+					action={
+						<Button
+							color="inherit"
+							size="small"
+							onClick={() => setReloadKey((key) => key + 1)}
+						>
+							{t('registration.topic.loadErrorRetry')}
+						</Button>
+					}
+				>
+					{t('registration.topic.loadError')}
+				</Alert>
+			) : topics.length === 0 ? (
+				<Typography
+					role="status"
+					data-cy="topic-selection-empty"
+					sx={{ mt: '8px', ...registrationScreenIntroSx }}
+				>
+					{t('registration.topic.empty')}
+				</Typography>
 			) : (
 				<FormControl sx={{ width: '100%' }}>
 					<Box

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -2221,6 +2221,9 @@
 				"backButtonLabel": "Anderes Thema auswählen",
 				"nextButtonLabel": "Thema auswählen und fortfahren"
 			},
+			"empty": "Derzeit sind keine Themen verfügbar. Bitte versuchen Sie es später erneut.",
+			"loadError": "Die Themen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+			"loadErrorRetry": "Erneut versuchen",
 			"oneResult": "Wir beraten Sie zum Thema",
 			"subline": "Wählen Sie ein Thema aus unserem Beratungsangebot aus.",
 			"summary": "Ihr Thema:"

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -2075,6 +2075,9 @@
 				"backButtonLabel": "Select another topic",
 				"nextButtonLabel": "Select topic and continue"
 			},
+			"empty": "No topics are available at the moment. Please try again later.",
+			"loadError": "The topics could not be loaded. Please try again.",
+			"loadErrorRetry": "Try again",
 			"oneResult": "We advise you on the topic",
 			"subline": "Choose a topic from our counseling services.",
 			"summary": "Your topic:"


### PR DESCRIPTION
## Problem
`TopicSelection` swallowed `apiGetTopicsData()` failures in its catch block and rendered a silently **empty topic panel**. That's why the SB4 trailing-slash 404 (fix: #381) went unnoticed for a day — QA only saw a blank page with no error.

## Change
- **Error path**: translated MUI `Alert` (`role="alert"`, screenreader-announced) with a **retry button** that refetches.
- **Empty-data path** (HTTP 200, empty list) is now distinct from the error path: neutral `role="status"` empty-state text, no alert.
- i18n DE/EN: `registration.topic.{empty,loadError,loadErrorRetry}` (other locales fall back).
- `data-cy` hooks for both states.

## Tests
`vitest run TopicSelection.test.tsx` → 5/5 green, including two new tests:
1. rejected fetch → alert visible, retry refetches and renders topics, alert gone
2. empty success → empty state visible, no alert

## Related
- #381 (trailing-slash fix this state would have surfaced immediately)
- Origin: Bug tracker 07.07 'Topics are not loading on Signup flow'

🤖 Generated with [Claude Code](https://claude.com/claude-code)