### PR TITLE
Fix asker follow-up messages in enquiry sessions

### DIFF
--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -36,6 +36,18 @@ describe('messageEncryptionMode', () => {
 		).toBe(false);
 	});
 
+	it('does not use the enquiry endpoint once the session has a Matrix room', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: false,
+				sessionStatus: STATUS_ENQUIRY,
+				hasAskerAuthority: true,
+				isAnonymousLiveChat: false,
+				hasMatrixRoom: true
+			})
+		).toBe(false);
+	});
+
 	it('requires asker authority for enquiry submissions', () => {
 		expect(
 			isAskerEnquirySubmission({

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -5,14 +5,17 @@ interface AskerEnquirySubmissionInput {
 	sessionStatus?: number;
 	hasAskerAuthority: boolean;
 	isAnonymousLiveChat: boolean;
+	hasMatrixRoom?: boolean;
 }
 
 export const isAskerEnquirySubmission = ({
 	isEnquiryListType,
 	sessionStatus,
 	hasAskerAuthority,
-	isAnonymousLiveChat
+	isAnonymousLiveChat,
+	hasMatrixRoom
 }: AskerEnquirySubmissionInput): boolean =>
 	(isEnquiryListType || sessionStatus === STATUS_ENQUIRY) &&
 	hasAskerAuthority &&
-	!isAnonymousLiveChat;
+	!isAnonymousLiveChat &&
+	!hasMatrixRoom;

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -132,6 +132,7 @@ const INFO_TYPES = {
 	ATTACHMENT_FORMAT_ERROR: 'ATTACHMENT_FORMAT_ERROR',
 	ATTACHMENT_QUOTA_REACHED_ERROR: 'ATTACHMENT_QUOTA_REACHED_ERROR',
 	ATTACHMENT_OTHER_ERROR: 'ATTACHMENT_OTHER_ERROR',
+	MESSAGE_SEND_ERROR: 'MESSAGE_SEND_ERROR',
 	VOICE_RECORDING_ERROR: 'VOICE_RECORDING_ERROR'
 };
 
@@ -316,6 +317,10 @@ export const MessageSubmitInterfaceComponent = ({
 	const { type, path: listPath } = useContext(SessionTypeContext);
 	const { isE2eeEnabled } = useContext(E2EEContext);
 	const { matrixClientService } = useMatrixClient();
+	const resolvedChatSession = useMemo(
+		() => chatTransportService.resolveSession(activeSession),
+		[activeSession]
+	);
 
 	const [activeInfo, setActiveInfo] = useState(null);
 	const [attachmentSelected, setAttachmentSelected] = useState<File | null>(
@@ -553,9 +558,7 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const isAnonymousEnquiryComposer =
 		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
-	const hasMatrixRoom = Boolean(
-		chatTransportService.resolveSession(activeSession).matrixRoomId
-	);
+	const hasMatrixRoom = Boolean(resolvedChatSession.matrixRoomId);
 	const isAskerEnquiry = isAskerEnquirySubmission({
 		isEnquiryListType: type === SESSION_LIST_TYPES.ENQUIRY,
 		sessionStatus: activeSession.item?.status,
@@ -1089,6 +1092,7 @@ export const MessageSubmitInterfaceComponent = ({
 				.then(() => setIsRequestInProgress(false))
 				.catch((error) => {
 					setIsRequestInProgress(false);
+					setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
 					apiPostError({
 						name: error?.name || 'EnquiryMessageSendError',
 						message:
@@ -1150,8 +1154,6 @@ export const MessageSubmitInterfaceComponent = ({
 			const sendToRoomWithId = activeSession.rid || activeSession.item.id;
 			// Determine if this is a Matrix-backed session.
 			// Some sessions still have a legacy rid while exposing matrixRoomId.
-			const resolvedChatSession =
-				chatTransportService.resolveSession(activeSession);
 			const isMatrixSession = resolvedChatSession.isMatrixSession;
 			const matrixSessionId = isMatrixSession
 				? Number(resolvedChatSession.sessionId) || undefined
@@ -1299,6 +1301,7 @@ export const MessageSubmitInterfaceComponent = ({
 			isSupervisor,
 			matrixClientService,
 			onSendButton,
+			resolvedChatSession,
 			setE2EEState,
 			supervisionRoomId,
 			threadRootId,
@@ -1547,6 +1550,12 @@ export const MessageSubmitInterfaceComponent = ({
 				infoHeadline: translate('attachments.error.other.headline'),
 				infoMessage: translate('attachments.error.other.message')
 			};
+		} else if (activeInfo === INFO_TYPES.MESSAGE_SEND_ERROR) {
+			infoData = {
+				isInfo: false,
+				infoHeadline: translate('statusOverlay.error.headline'),
+				infoMessage: translate('statusOverlay.error.text')
+			};
 		} else if (activeInfo === INFO_TYPES.VOICE_RECORDING_ERROR) {
 			infoData = {
 				isInfo: false,
@@ -1602,10 +1611,8 @@ export const MessageSubmitInterfaceComponent = ({
 					: featureVoiceMessagesOneOnOneChatsEnabled !== false);
 
 	const getMatrixRoomId = useCallback(
-		() =>
-			chatTransportService.resolveSession(activeSession).matrixRoomId ||
-			null,
-		[activeSession]
+		() => resolvedChatSession.matrixRoomId || null,
+		[resolvedChatSession]
 	);
 
 	const deriveLabelFromUserId = useCallback((rawUserId: string) => {
@@ -2926,8 +2933,6 @@ export const MessageSubmitInterfaceComponent = ({
 		isMobile: isMobileViewport
 	});
 
-	const resolvedChatSession =
-		chatTransportService.resolveSession(activeSession);
 	const matrixRoomId = resolvedChatSession.matrixRoomId || null;
 
 	// MATRIX MIGRATION: legacy RocketChat E2EE gates do not apply to Matrix rooms.

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -553,6 +553,9 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const isAnonymousEnquiryComposer =
 		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
+	const hasMatrixRoom = Boolean(
+		chatTransportService.resolveSession(activeSession).matrixRoomId
+	);
 	const isAskerEnquiry = isAskerEnquirySubmission({
 		isEnquiryListType: type === SESSION_LIST_TYPES.ENQUIRY,
 		sessionStatus: activeSession.item?.status,
@@ -560,7 +563,8 @@ export const MessageSubmitInterfaceComponent = ({
 			AUTHORITIES.ASKER_DEFAULT,
 			userData
 		),
-		isAnonymousLiveChat
+		isAnonymousLiveChat,
+		hasMatrixRoom
 	});
 
 	const {
@@ -1084,7 +1088,15 @@ export const MessageSubmitInterfaceComponent = ({
 				})
 				.then(() => setIsRequestInProgress(false))
 				.catch((error) => {
-					// console.log(error);
+					setIsRequestInProgress(false);
+					apiPostError({
+						name: error?.name || 'EnquiryMessageSendError',
+						message:
+							error?.message ||
+							'Failed to send enquiry message',
+						stack: error?.stack,
+						level: ERROR_LEVEL_WARN
+					}).then();
 				});
 		},
 		[


### PR DESCRIPTION
## Problem

Registered asker sessions can remain in `STATUS_ENQUIRY` after the first enquiry message, while already having a Matrix room. The composer still classified those sessions as initial enquiry submissions and attempted the one-shot enquiry endpoint for follow-up messages.

## Solution

- Treat asker enquiry submission as the one-shot enquiry path only while no Matrix room exists.
- Route follow-up messages in Matrix-backed enquiry sessions through the normal Matrix send path.
- Reset the composer request-in-progress state when the enquiry endpoint fails, and report that failure to the existing error endpoint.

Closes #386.

## Validation

- `git diff --check`
- `npm run test:unit -- --run src/components/messageSubmitInterface/messageEncryptionMode.test.ts`
- `npx eslint src/components/messageSubmitInterface/messageEncryptionMode.ts src/components/messageSubmitInterface/messageEncryptionMode.test.ts src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx --max-warnings=0`
- `npm run build`
- Hot-deployed PreDev image `docker.io/storypapst/oriso-e2e:frontend-e2e-20260708-0200-v4` as linux/amd64.
- Retested `https://app.oriso-dev.site/sessions/user/view/session/103095` with bundle `app.e50d9402.js`: follow-up message sent via Matrix `_matrix/client/v3/rooms/.../send/m.room.message/...` with HTTP 200, appeared in the transcript, and the composer cleared.

## Notes

This does not reintroduce the reverted Live Chat routing experiment. `isAnonymousLiveChat` continues to exclude anonymous Live Chat from the registered enquiry path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message sending logic so enquiries are no longer sent through the enquiry flow once a Matrix chat room already exists.
  * Better handles send failures by clearing the in-progress state and capturing error details more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->