### PR TITLE
fix: production console should no longer fill with Matrix sync HTTP logs; only errors from the SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /playwright-report
 /test-results
 /playwright/.cache
+/.playwright-cli/
+/output/playwright/
 
 # production
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ graphify-out/*
 
 # chromatic build log
 build-storybook.log
+docs/*

--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -1,0 +1,3 @@
+# 2026-07-08 — matrix-js-sdk production logging
+
+`matrix-js-sdk` defaults child loggers to `DEBUG`, so `FetchHttpApi` sync lines appear even when app `console.log` calls are removed. Call `logger.setLevel('error')` at startup and patch `getChild` so child namespaces inherit the same level; pass `logger` into every `createClient` call.

--- a/package.json
+++ b/package.json
@@ -223,6 +223,8 @@
 		"test": "cross-env NODE_ENV=development FAST_REFRESH=false BROWSER=none REACT_APP_API_URL=http://127.0.0.1:9001 HTTPS=0 PORT=9001 WDS_SOCKET_PORT=9001 concurrently --kill-others --success first \"npm run dev\" \"wait-on http://127.0.0.1:9001 && cypress run\"",
 		"test:unit": "vitest run --maxWorkers=2 --minWorkers=1",
 		"test:smoke": "playwright test",
+		"test:matrix-megolm": "node scripts/matrixMegolmSmoke.mjs",
+		"test:matrix-browser-reload": "concurrently --kill-others --success first \"vite --config vite.matrix-smoke.config.ts --host 127.0.0.1 --port 9010\" \"wait-on http://127.0.0.1:9010/playwright/matrix-crypto-browser-harness.html && PLAYWRIGHT_BASE_URL=http://127.0.0.1:9010 playwright test playwright/matrix-crypto-reload.smoke.spec.ts --project=chromium --reporter=list\"",
 		"test:smoke:baseline": "playwright test playwright/registration-baseline.smoke.spec.ts",
 		"test:components": "NODE_ENV=development cypress run --component --headed",
 		"test:build": "cross-env NODE_ENV=production FAST_REFRESH=false BROWSER=none PORT=9001 CYPRESS_WS_URL=http://127.0.0.1:9002 REACT_APP_API_URL=http://127.0.0.1:9001 concurrently --kill-others --success first \"npm run start\" \"wait-on http://127.0.0.1:9001 && cypress run\"",

--- a/playwright/matrix-crypto-browser-harness.html
+++ b/playwright/matrix-crypto-browser-harness.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Matrix crypto reload harness</title>
+	</head>
+	<body>
+		<main>
+			<p data-testid="matrix-crypto-status">starting</p>
+		</main>
+		<script type="module" src="/playwright/matrix-crypto-browser-harness.ts"></script>
+	</body>
+</html>

--- a/playwright/matrix-crypto-browser-harness.ts
+++ b/playwright/matrix-crypto-browser-harness.ts
@@ -1,0 +1,191 @@
+import { ClientEvent, createClient, MatrixClient } from 'matrix-js-sdk';
+import { buildMatrixCryptoStorePrefix } from '../src/services/matrixCrypto';
+
+const baseUrl = 'http://localhost:18008';
+const stateKey = 'oriso-matrix-browser-reload-smoke';
+const status = document.querySelector<HTMLElement>(
+	'[data-testid="matrix-crypto-status"]'
+)!;
+
+interface ReloadState {
+	accessToken: string;
+	deviceId: string;
+	eventId: string;
+	expectedBody: string;
+	roomId: string;
+	userId: string;
+}
+
+const withTimeout = async <T>(
+	promise: Promise<T>,
+	label: string
+): Promise<T> => {
+	let timeout: ReturnType<typeof setTimeout>;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${label}`)),
+					20_000
+				);
+			})
+		]);
+	} finally {
+		clearTimeout(timeout!);
+	}
+};
+
+const startClient = async (state: {
+	accessToken: string;
+	deviceId: string;
+	userId: string;
+}): Promise<MatrixClient> => {
+	const client = createClient({
+		baseUrl,
+		accessToken: state.accessToken,
+		deviceId: state.deviceId,
+		userId: state.userId
+	});
+	await client.initRustCrypto({
+		useIndexedDB: true,
+		cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+			state.userId,
+			state.deviceId
+		)
+	});
+	const prepared = new Promise<void>((resolve, reject) => {
+		const onSync = (
+			syncState: string,
+			_previous: string | null,
+			data?: any
+		) => {
+			if (syncState === 'PREPARED') {
+				client.off(ClientEvent.Sync, onSync);
+				resolve();
+			} else if (syncState === 'ERROR') {
+				client.off(ClientEvent.Sync, onSync);
+				reject(data?.error ?? new Error('Matrix sync failed'));
+			}
+		};
+		client.on(ClientEvent.Sync, onSync);
+	});
+	client.startClient({ initialSyncLimit: 20 });
+	await withTimeout(prepared, 'Matrix PREPARED state');
+	return client;
+};
+
+const register = async () => {
+	const suffix = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+	const localpart = `browser_reload_${suffix}`;
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/register`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			auth: { type: 'm.login.dummy' },
+			username: localpart,
+			password: `local-only-${localpart}`,
+			initial_device_display_name: 'Browser reload smoke'
+		})
+	});
+	if (!response.ok)
+		throw new Error(`Registration failed: ${response.status}`);
+	return response.json();
+};
+
+const waitForHistoricEvent = (client: MatrixClient, state: ReloadState) =>
+	withTimeout(
+		new Promise<void>((resolve) => {
+			const inspect = () => {
+				const event = client
+					.getRoom(state.roomId)
+					?.getLiveTimeline()
+					.getEvents()
+					.find((candidate) => candidate.getId() === state.eventId);
+				if (
+					event?.getWireType() === 'm.room.encrypted' &&
+					event.getType() === 'm.room.message' &&
+					event.getContent()?.body === state.expectedBody
+				) {
+					clearInterval(interval);
+					resolve();
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'historic browser event decryption'
+	);
+
+const waitForEncryptedRoom = (client: MatrixClient, roomId: string) =>
+	withTimeout(
+		new Promise<void>((resolve) => {
+			const inspect = () => {
+				const encryption = client
+					.getRoom(roomId)
+					?.currentState.getStateEvents('m.room.encryption', '');
+				if (
+					encryption?.getContent()?.algorithm ===
+					'm.megolm.v1.aes-sha2'
+				) {
+					clearInterval(interval);
+					resolve();
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'encrypted room state'
+	);
+
+const run = async () => {
+	const previous = localStorage.getItem(stateKey);
+	if (previous) {
+		const state = JSON.parse(previous) as ReloadState;
+		const client = await startClient(state);
+		await waitForHistoricEvent(client, state);
+		status.textContent = 'recovered';
+		return;
+	}
+
+	const registration = await register();
+	const client = await startClient({
+		accessToken: registration.access_token,
+		deviceId: registration.device_id,
+		userId: registration.user_id
+	});
+	const room = await client.createRoom({
+		name: 'Browser reload crypto smoke',
+		preset: 'private_chat',
+		initial_state: [
+			{
+				type: 'm.room.encryption',
+				state_key: '',
+				content: { algorithm: 'm.megolm.v1.aes-sha2' }
+			}
+		]
+	});
+	await waitForEncryptedRoom(client, room.room_id);
+	const expectedBody = `IndexedDB reload proof ${Date.now()}`;
+	const sent = await client.sendMessage(room.room_id, {
+		msgtype: 'm.text',
+		body: expectedBody
+	});
+	const state: ReloadState = {
+		accessToken: registration.access_token,
+		deviceId: registration.device_id,
+		eventId: sent.event_id,
+		expectedBody,
+		roomId: room.room_id,
+		userId: registration.user_id
+	};
+	// Wait for the encrypted remote echo to be decrypted and committed to the
+	// IndexedDB-backed Rust store before the browser is reloaded.
+	await waitForHistoricEvent(client, state);
+	localStorage.setItem(stateKey, JSON.stringify(state));
+	status.textContent = 'prepared';
+};
+
+run().catch((error) => {
+	status.textContent = `error: ${error instanceof Error ? error.message : String(error)}`;
+});

--- a/playwright/matrix-crypto-reload.smoke.spec.ts
+++ b/playwright/matrix-crypto-reload.smoke.spec.ts
@@ -1,0 +1,39 @@
+import { expect, Page, test } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const artifactPath = (name: string) =>
+	resolve(process.cwd(), '../../_e2e-artifacts/self-help-group', name);
+
+const proveReload = async (page: Page) => {
+	await page.goto('/playwright/matrix-crypto-browser-harness.html');
+	await expect(
+		page.locator('[data-testid="matrix-crypto-status"]')
+	).toHaveText('prepared', { timeout: 30_000 });
+
+	await page.reload();
+
+	await expect(
+		page.locator('[data-testid="matrix-crypto-status"]')
+	).toHaveText('recovered', { timeout: 30_000 });
+};
+
+test('keeps Megolm history decryptable after a desktop browser reload', async ({
+	page
+}) => {
+	await proveReload(page);
+	await page.screenshot({
+		path: artifactPath('matrix-crypto-reload-desktop.png'),
+		fullPage: true
+	});
+});
+
+test('keeps Megolm history decryptable after a mobile browser reload', async ({
+	page
+}) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await proveReload(page);
+	await page.screenshot({
+		path: artifactPath('matrix-crypto-reload-mobile.png'),
+		fullPage: true
+	});
+});

--- a/scripts/matrixMegolmSmoke.mjs
+++ b/scripts/matrixMegolmSmoke.mjs
@@ -1,0 +1,369 @@
+import {
+	createClient,
+	ClientEvent,
+	MatrixEventEvent,
+	RoomEvent
+} from 'matrix-js-sdk';
+import { logger } from 'matrix-js-sdk/lib/logger.js';
+import { decodeRecoveryKey } from 'matrix-js-sdk/lib/crypto-api/recovery-key.js';
+
+const baseUrl = process.env.MATRIX_SMOKE_BASE_URL ?? 'http://localhost:18008';
+const timeoutMs = 30_000;
+
+logger.setLevel('silent', false);
+
+const withTimeout = async (promise, label) => {
+	let timeout;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${label}`)),
+					timeoutMs
+				);
+			})
+		]);
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const silentLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error(...args) {
+		console.error(...args);
+	},
+	getChild() {
+		return this;
+	}
+};
+
+const registerDevice = async (localpart, displayName) => {
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/register`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			auth: { type: 'm.login.dummy' },
+			username: localpart,
+			password: `local-only-${localpart}`,
+			initial_device_display_name: displayName
+		})
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Matrix registration failed with HTTP ${response.status}`
+		);
+	}
+
+	const registration = await response.json();
+	if (
+		!registration.user_id ||
+		!registration.device_id ||
+		!registration.access_token
+	) {
+		throw new Error('Matrix registration response is incomplete');
+	}
+
+	return registration;
+};
+
+const loginDevice = async (localpart, password, displayName) => {
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/login`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			type: 'm.login.password',
+			identifier: { type: 'm.id.user', user: localpart },
+			password,
+			initial_device_display_name: displayName
+		})
+	});
+	if (!response.ok) {
+		throw new Error(`Matrix login failed with HTTP ${response.status}`);
+	}
+	return response.json();
+};
+
+const createSecretStorageCallbacks = (seededPrivateKey = null) => {
+	let keyId = null;
+	let privateKey = seededPrivateKey;
+	return {
+		cacheSecretStorageKey(id, _keyInfo, key) {
+			keyId = id;
+			privateKey = new Uint8Array(key);
+		},
+		async getSecretStorageKey({ keys }) {
+			const requestedKeyId =
+				(keyId && keys[keyId] && keyId) || Object.keys(keys)[0];
+			return requestedKeyId && privateKey
+				? [requestedKeyId, privateKey]
+				: null;
+		}
+	};
+};
+
+const passwordUiAuth = (userId, password) => async (makeRequest) => {
+	try {
+		return await makeRequest(null);
+	} catch (error) {
+		return makeRequest({
+			type: 'm.login.password',
+			identifier: { type: 'm.id.user', user: userId },
+			password,
+			session: error?.data?.session
+		});
+	}
+};
+
+const startEncryptedClient = async (registration, cryptoCallbacks = {}) => {
+	const client = createClient({
+		baseUrl,
+		userId: registration.user_id,
+		deviceId: registration.device_id,
+		accessToken: registration.access_token,
+		logger: silentLogger,
+		cryptoCallbacks
+	});
+
+	await client.initRustCrypto({ useIndexedDB: false });
+	const prepared = new Promise((resolve, reject) => {
+		const onSync = (state, _previousState, error) => {
+			if (state === 'PREPARED') {
+				client.off(ClientEvent.Sync, onSync);
+				resolve();
+			} else if (state === 'ERROR') {
+				client.off(ClientEvent.Sync, onSync);
+				reject(error ?? new Error('Matrix sync failed'));
+			}
+		};
+		client.on(ClientEvent.Sync, onSync);
+	});
+	client.startClient({ initialSyncLimit: 20 });
+	await withTimeout(prepared, `initial sync for ${registration.user_id}`);
+	return client;
+};
+
+const waitForKeyBackup = (registration) =>
+	withTimeout(
+		(async () => {
+			for (;;) {
+				const response = await fetch(
+					`${baseUrl}/_matrix/client/v3/room_keys/version`,
+					{
+						headers: {
+							Authorization: `Bearer ${registration.access_token}`
+						}
+					}
+				);
+				if (response.ok) {
+					const info = await response.json();
+					if (Number(info.count) > 0) return info;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 200));
+			}
+		})(),
+		'uploaded Matrix key backup'
+	);
+
+const waitForRoom = (client, roomId) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const existing = client.getRoom(roomId);
+			if (existing) {
+				resolve(existing);
+				return;
+			}
+
+			const onRoom = (room) => {
+				if (room.roomId === roomId) {
+					client.off(ClientEvent.Room, onRoom);
+					resolve(room);
+				}
+			};
+			client.on(ClientEvent.Room, onRoom);
+		}),
+		`room ${roomId}`
+	);
+
+const waitForEncryptedMessage = (client, roomId, expectedBody) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const finishIfDecrypted = (event) => {
+				if (
+					event.getWireType() === 'm.room.encrypted' &&
+					event.getType() === 'm.room.message' &&
+					event.getContent()?.body === expectedBody
+				) {
+					client.off(RoomEvent.Timeline, inspect);
+					resolve(event);
+				}
+			};
+
+			const inspect = (event, room) => {
+				if (
+					room?.roomId !== roomId ||
+					event.getWireType() !== 'm.room.encrypted'
+				) {
+					return;
+				}
+
+				finishIfDecrypted(event);
+				event.once(MatrixEventEvent.Decrypted, () =>
+					finishIfDecrypted(event)
+				);
+			};
+			client.on(RoomEvent.Timeline, inspect);
+		}),
+		'encrypted and decrypted Matrix message'
+	);
+
+const waitForHistoricDecryption = (client, roomId, expectedBody) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const inspect = () => {
+				const event = client
+					.getRoom(roomId)
+					?.getLiveTimeline()
+					.getEvents()
+					.find(
+						(candidate) =>
+							candidate.getWireType() === 'm.room.encrypted' &&
+							candidate.getType() === 'm.room.message' &&
+							candidate.getContent()?.body === expectedBody
+					);
+				if (event) {
+					clearInterval(interval);
+					resolve(event);
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'historic decryption on a fresh device'
+	);
+
+const suffix = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+let alice;
+let bob;
+let bobSecondDevice;
+
+try {
+	const aliceRegistration = await registerDevice(
+		`megolm_alice_${suffix}`,
+		'Megolm smoke Alice'
+	);
+	const bobLocalpart = `megolm_bob_${suffix}`;
+	const bobPassword = `local-only-${bobLocalpart}`;
+	const bobRegistration = await registerDevice(
+		bobLocalpart,
+		'Megolm smoke Bob'
+	);
+	const bobSecretStorageCallbacks = createSecretStorageCallbacks();
+	alice = await startEncryptedClient(aliceRegistration);
+	bob = await startEncryptedClient(
+		bobRegistration,
+		bobSecretStorageCallbacks
+	);
+
+	const { room_id: roomId } = await alice.createRoom({
+		name: `Megolm smoke ${suffix}`,
+		preset: 'private_chat',
+		invite: [bobRegistration.user_id],
+		initial_state: [
+			{
+				type: 'm.room.encryption',
+				state_key: '',
+				content: { algorithm: 'm.megolm.v1.aes-sha2' }
+			}
+		]
+	});
+
+	await waitForRoom(bob, roomId);
+	await bob.joinRoom(roomId);
+	const body = `Megolm transport proof ${suffix}`;
+	const received = waitForEncryptedMessage(bob, roomId, body);
+	await alice.sendMessage(roomId, { msgtype: 'm.text', body });
+	await received;
+
+	const bobCrypto = bob.getCrypto();
+	await bobCrypto.bootstrapCrossSigning({
+		setupNewCrossSigning: true,
+		authUploadDeviceSigningKeys: passwordUiAuth(
+			bobRegistration.user_id,
+			bobPassword
+		)
+	});
+	if (!(await bobCrypto.isCrossSigningReady())) {
+		throw new Error(
+			'Cross-signing did not become ready on the first device'
+		);
+	}
+	let recoveryKey;
+	await bobCrypto.bootstrapSecretStorage({
+		setupNewSecretStorage: true,
+		setupNewKeyBackup: true,
+		createSecretStorageKey: async () => {
+			recoveryKey = await bobCrypto.createRecoveryKeyFromPassphrase(
+				`recovery-${suffix}`
+			);
+			return recoveryKey;
+		}
+	});
+	await waitForKeyBackup(bobRegistration);
+	if (!recoveryKey?.encodedPrivateKey) {
+		throw new Error('SDK did not create an encoded recovery key');
+	}
+
+	const secondRegistration = await loginDevice(
+		bobLocalpart,
+		bobPassword,
+		'Megolm smoke Bob recovery device'
+	);
+	const recoveredPrivateKey = decodeRecoveryKey(
+		recoveryKey.encodedPrivateKey
+	);
+	bobSecondDevice = await startEncryptedClient(
+		secondRegistration,
+		createSecretStorageCallbacks(recoveredPrivateKey)
+	);
+	await waitForRoom(bobSecondDevice, roomId);
+	const secondCrypto = bobSecondDevice.getCrypto();
+	await secondCrypto.loadSessionBackupPrivateKeyFromSecretStorage();
+	const restoreResult = await secondCrypto.restoreKeyBackup();
+	if (restoreResult.imported < 1) {
+		throw new Error('Fresh device restored no Megolm sessions');
+	}
+	await bobCrypto.getUserDeviceInfo([bobRegistration.user_id], true);
+	await bobCrypto.crossSignDevice(secondRegistration.device_id);
+	await secondCrypto.bootstrapCrossSigning({ setupNewCrossSigning: false });
+	if (!(await secondCrypto.isCrossSigningReady())) {
+		throw new Error('Cross-signing recovery did not become ready');
+	}
+	await waitForHistoricDecryption(bobSecondDevice, roomId, body);
+
+	const encryptionState = alice
+		.getRoom(roomId)
+		?.currentState.getStateEvents('m.room.encryption', '');
+	if (
+		!encryptionState ||
+		encryptionState.getContent()?.algorithm !== 'm.megolm.v1.aes-sha2'
+	) {
+		throw new Error('Room is missing the Megolm encryption state');
+	}
+
+	console.log('Matrix Megolm smoke: PASS');
+} finally {
+	for (const client of [alice, bob, bobSecondDevice]) {
+		client?.stopClient();
+		client?.removeAllListeners();
+	}
+}
+
+// The SDK's aborted long-poll fetches can retain Node handles after the clients
+// and Rust crypto machines have been stopped. This is a one-shot smoke command.
+process.exit(0);

--- a/src/api/apiChatOccurrenceCommands.test.ts
+++ b/src/api/apiChatOccurrenceCommands.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchData } from './fetchData';
+import { apiSkipChatOccurrence } from './apiGetChatOccurrences';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { chatSeriesBase: '/service/users/chat-series/' }
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST' },
+	fetchData: vi.fn(() => Promise.resolve())
+}));
+
+describe('chat occurrence commands', () => {
+	it('skips exactly the original occurrence instant', async () => {
+		await apiSkipChatOccurrence(42, '2026-09-21T17:30:00Z');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/users/chat-series/42/occurrences/skip?originalStartUtc=2026-09-21T17%3A30%3A00Z',
+			method: 'POST'
+		});
+	});
+});

--- a/src/api/apiEventNotifications.ts
+++ b/src/api/apiEventNotifications.ts
@@ -10,6 +10,7 @@ export interface EventNotificationFeedItem {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: number;
+	params?: string | Record<string, unknown>;
 	createdAt: string | null;
 	readAt: string | null;
 }
@@ -49,4 +50,3 @@ export const apiClearEventNotifications = async (): Promise<any> =>
 		url: endpoints.eventNotifications,
 		method: FETCH_METHODS.DELETE
 	});
-

--- a/src/api/apiGetAgencyConsultantList.ts
+++ b/src/api/apiGetAgencyConsultantList.ts
@@ -25,3 +25,15 @@ export const apiGetAgencyConsultantList = async (
 		return [];
 	}
 };
+
+export const apiGetTenantConsultantList = async (): Promise<Consultant[]> => {
+	try {
+		return await fetchData({
+			url: `${endpoints.chatSeriesBase}consultants`,
+			method: FETCH_METHODS.GET,
+			responseHandling: [FETCH_ERRORS.CATCH_ALL]
+		});
+	} catch {
+		return [];
+	}
+};

--- a/src/api/apiGetChatOccurrences.test.ts
+++ b/src/api/apiGetChatOccurrences.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiGetChatOccurrences } from './apiGetChatOccurrences';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { chatSeriesBase: '/service/users/chat-series/' }
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { GET: 'GET' },
+	FETCH_SUCCESS: {},
+	fetchData: vi.fn()
+}));
+
+describe('apiGetChatOccurrences', () => {
+	it('encodes the bounded occurrence query on the Series URL', async () => {
+		vi.mocked(fetchData).mockResolvedValue([]);
+
+		await apiGetChatOccurrences(
+			42,
+			'2026-08-01T00:00:00+02:00',
+			'2026-11-01T00:00:00+01:00',
+			25
+		);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/users/chat-series/42/occurrences?from=2026-08-01T00%3A00%3A00%2B02%3A00&to=2026-11-01T00%3A00%3A00%2B01%3A00&limit=25',
+			method: 'GET'
+		});
+	});
+});

--- a/src/api/apiGetChatOccurrences.ts
+++ b/src/api/apiGetChatOccurrences.ts
@@ -1,0 +1,40 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS } from './fetchData';
+
+export interface ChatOccurrence {
+	seriesId: number;
+	occurrenceIndex: number;
+	originalStart: string;
+	start: string;
+	duration: number;
+	capacity?: number;
+	modality: 'TEXT' | 'AUDIO' | 'VIDEO';
+}
+
+export const apiGetChatOccurrences = (
+	seriesId: number,
+	from: string,
+	to: string,
+	limit = 50
+): Promise<ChatOccurrence[]> => {
+	const query = new URLSearchParams({
+		from,
+		to,
+		limit: String(limit)
+	});
+	return fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/occurrences?${query}`,
+		method: FETCH_METHODS.GET
+	});
+};
+
+export const apiSkipChatOccurrence = (
+	seriesId: number,
+	originalStartUtc: string
+): Promise<void> => {
+	const query = new URLSearchParams({ originalStartUtc });
+	return fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/occurrences/skip?${query}`,
+		method: FETCH_METHODS.POST
+	});
+};

--- a/src/api/apiGetConsultantAppointments.test.ts
+++ b/src/api/apiGetConsultantAppointments.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BookingsStatus } from '../utils/consultant';
+import { fetchData } from './fetchData';
+import { apiGetConsultantAppointments } from './apiGetConsultantAppointments';
+
+const appointmentsServiceConsultantBookings = vi.hoisted(() =>
+	vi.fn(
+		() =>
+			'/service/appointservice/consultants/consultant-1/bookings?status=ACTIVE'
+	)
+);
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		appointmentsServiceConsultantBookings
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn(() => Promise.resolve([]))
+}));
+
+describe('apiGetConsultantAppointments', () => {
+	it('requests the optional appointment service with catch-all response handling', async () => {
+		await apiGetConsultantAppointments(
+			'consultant-1',
+			BookingsStatus.ACTIVE
+		);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/appointservice/consultants/consultant-1/bookings?status=ACTIVE',
+			method: 'GET',
+			responseHandling: ['CATCH_ALL']
+		});
+		expect(appointmentsServiceConsultantBookings).toHaveBeenCalledWith(
+			'consultant-1',
+			BookingsStatus.ACTIVE
+		);
+	});
+});

--- a/src/api/apiGetConsultantAppointments.ts
+++ b/src/api/apiGetConsultantAppointments.ts
@@ -1,7 +1,7 @@
 import { BookingEventsInterface } from '../globalState/interfaces';
 import { endpoints } from '../resources/scripts/endpoints';
 import { BookingsStatus } from '../utils/consultant';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
 
 export const apiGetConsultantAppointments = async (
 	userId: string,
@@ -11,6 +11,7 @@ export const apiGetConsultantAppointments = async (
 
 	return fetchData({
 		url,
-		method: FETCH_METHODS.GET
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
 	});
 };

--- a/src/api/apiGetTenantConsultantList.test.ts
+++ b/src/api/apiGetTenantConsultantList.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiGetTenantConsultantList } from './apiGetAgencyConsultantList';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		chatSeriesBase: 'https://api.example/service/users/chat-series/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn(() => Promise.resolve([]))
+}));
+
+describe('apiGetTenantConsultantList', () => {
+	it('loads the tenant-scoped Series invitation directory', async () => {
+		await apiGetTenantConsultantList();
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/consultants',
+			method: 'GET',
+			responseHandling: ['CATCH_ALL']
+		});
+	});
+});

--- a/src/api/apiGroupChatAuthorTranslation.test.ts
+++ b/src/api/apiGroupChatAuthorTranslation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiTranslateGroupChatAuthorContent } from './apiGroupChatAuthorTranslation';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { tenantServiceBase: 'https://tenant/service/tenant' }
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST' },
+	FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+	fetchData: vi.fn()
+}));
+
+describe('apiTranslateGroupChatAuthorContent', () => {
+	it('uses the consultant-scoped translation endpoint', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			translations: { en: { welcome: 'Welcome' } }
+		});
+
+		await apiTranslateGroupChatAuthorContent({
+			sourceLang: 'de',
+			targetLangs: ['en'],
+			texts: { welcome: 'Willkommen' }
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://tenant/service/tenant/translate/group-chat-author-content',
+			method: 'POST',
+			bodyData: JSON.stringify({
+				sourceLang: 'de',
+				targetLangs: ['en'],
+				texts: { welcome: 'Willkommen' }
+			}),
+			responseHandling: ['CONTENT']
+		});
+	});
+});

--- a/src/api/apiGroupChatAuthorTranslation.ts
+++ b/src/api/apiGroupChatAuthorTranslation.ts
@@ -1,0 +1,24 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+
+export interface GroupChatAuthorTranslationRequest {
+	sourceLang: string;
+	targetLangs: string[];
+	texts: Record<string, string>;
+}
+
+export interface GroupChatAuthorTranslationResponse {
+	translations: Record<string, Record<string, string>>;
+	provider?: string;
+	model?: string;
+}
+
+export const apiTranslateGroupChatAuthorContent = async (
+	request: GroupChatAuthorTranslationRequest
+): Promise<GroupChatAuthorTranslationResponse> =>
+	fetchData({
+		url: `${endpoints.tenantServiceBase}/translate/group-chat-author-content`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify(request),
+		responseHandling: [FETCH_SUCCESS.CONTENT]
+	});

--- a/src/api/apiGroupChatRoles.test.ts
+++ b/src/api/apiGroupChatRoles.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchData } from './fetchData';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership
+} from './apiGroupChatRoles';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		chatSeriesBase: 'https://api.example/service/users/chat-series/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { DELETE: 'DELETE', POST: 'POST', PUT: 'PUT' },
+	fetchData: vi.fn(() => Promise.resolve())
+}));
+
+describe('group-chat role API helpers', () => {
+	it('changes a participant role through the stable Series identity', async () => {
+		await apiChangeGroupChatParticipantRole(
+			42,
+			'consultant-7',
+			'CO_MODERATOR'
+		);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/participants/consultant-7/role',
+			method: 'PUT',
+			bodyData: JSON.stringify({ role: 'CO_MODERATOR' })
+		});
+	});
+
+	it('transfers primary ownership without display-name routing', async () => {
+		await apiTransferGroupChatOwnership(42, 'consultant-9');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/transfer-ownership',
+			method: 'POST',
+			bodyData: JSON.stringify({ consultantId: 'consultant-9' })
+		});
+	});
+
+	it('removes a participant through the stable Series identity', async () => {
+		await apiRemoveGroupChatParticipant(42, 'consultant-9');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/participants/consultant-9',
+			method: 'DELETE'
+		});
+	});
+});

--- a/src/api/apiGroupChatRoles.ts
+++ b/src/api/apiGroupChatRoles.ts
@@ -1,0 +1,38 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS } from './fetchData';
+
+export type GroupChatParticipantRole = 'OWNER' | 'CO_MODERATOR' | 'PARTICIPANT';
+
+export const apiChangeGroupChatParticipantRole = (
+	seriesId: number,
+	consultantId: string,
+	role: GroupChatParticipantRole
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/participants/${encodeURIComponent(
+			consultantId
+		)}/role`,
+		method: FETCH_METHODS.PUT,
+		bodyData: JSON.stringify({ role })
+	});
+
+export const apiTransferGroupChatOwnership = (
+	seriesId: number,
+	consultantId: string
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/transfer-ownership`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify({ consultantId })
+	});
+
+export const apiRemoveGroupChatParticipant = (
+	seriesId: number,
+	consultantId: string
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/participants/${encodeURIComponent(
+			consultantId
+		)}`,
+		method: FETCH_METHODS.DELETE
+	});

--- a/src/api/apiGroupChatSettings.test.ts
+++ b/src/api/apiGroupChatSettings.test.ts
@@ -43,15 +43,49 @@ describe('group chat API helpers', () => {
 	it('creates a v2 chat room when the feature flag is enabled', async () => {
 		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-v2' });
 
-		await apiCreateGroupChat({
-			...groupChat,
-			featureGroupChatV2Enabled: true
-		});
+		await expect(
+			apiCreateGroupChat({
+				...groupChat,
+				featureGroupChatV2Enabled: true
+			})
+		).resolves.toEqual({ groupId: 'group-v2' });
 
 		expect(fetchData).toHaveBeenCalledWith(
 			expect.objectContaining({
 				url: 'https://api.oriso-dev.site/service/users/chat/v2/new',
 				method: 'POST'
+			})
+		);
+	});
+
+	it('sends finite Series settings without leaking the client feature flag', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-series' });
+
+		await expect(
+			apiCreateGroupChat({
+				...groupChat,
+				featureGroupChatV2Enabled: true,
+				repeatCount: 4,
+				chatInterval: 'BIWEEKLY',
+				modality: 'VIDEO',
+				timezone: 'Europe/Berlin',
+				consultantIds: ['co-mod-1']
+			})
+		).resolves.toEqual({ groupId: 'group-series' });
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.oriso-dev.site/service/users/chat/v2/new',
+				method: 'POST',
+				bodyData: JSON.stringify({
+					...groupChat,
+					repeatCount: 4,
+					chatInterval: 'BIWEEKLY',
+					modality: 'VIDEO',
+					timezone: 'Europe/Berlin',
+					consultantIds: ['co-mod-1']
+				}),
+				responseHandling: ['CONTENT']
 			})
 		);
 	});

--- a/src/api/apiGroupChatSettings.ts
+++ b/src/api/apiGroupChatSettings.ts
@@ -9,13 +9,32 @@ export interface groupChatSettings {
 	duration: number;
 	agencyId: number;
 	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
 	repetitive: boolean;
+	repeatCount?: number;
+	chatInterval?:
+		| 'DAILY'
+		| 'WEEKLY'
+		| 'BIWEEKLY'
+		| 'MONTHLY'
+		| 'QUARTERLY'
+		| 'YEARLY';
+	modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+	timezone?: string;
+	consultantIds?: string[];
 	featureGroupChatV2Enabled?: boolean;
 }
 
 export interface chatLinkData {
 	groupId: string;
 }
+
+const groupChatPayload = ({
+	featureGroupChatV2Enabled: _clientRoutingFlag,
+	...payload
+}: groupChatSettings) => payload;
 
 export const apiCreateGroupChat = async (
 	createChatItem: groupChatSettings
@@ -25,7 +44,7 @@ export const apiCreateGroupChat = async (
 		(createChatItem.featureGroupChatV2Enabled
 			? GROUP_CHAT_API.CREATEV2
 			: GROUP_CHAT_API.CREATE);
-	const chatData = JSON.stringify({ ...createChatItem });
+	const chatData = JSON.stringify(groupChatPayload(createChatItem));
 
 	return fetchData({
 		url: url,
@@ -40,7 +59,7 @@ export const apiUpdateGroupChat = async (
 	createChatItem: groupChatSettings
 ): Promise<chatLinkData> => {
 	const url = endpoints.groupChatBase + groupChatId + GROUP_CHAT_API.UPDATE;
-	const chatData = JSON.stringify({ ...createChatItem });
+	const chatData = JSON.stringify(groupChatPayload(createChatItem));
 
 	return fetchData({
 		url: url,

--- a/src/components/agencyRadioSelect/AgencyRadioSelect.tsx
+++ b/src/components/agencyRadioSelect/AgencyRadioSelect.tsx
@@ -29,10 +29,7 @@ export const AgencyRadioSelect = ({
 	const agencyIdAsString = agency.id.toString();
 
 	return (
-		<div 
-			className="agencyRadioSelect__wrapper"
-			onClick={() => console.log('🟣 Wrapper clicked!', agency.id)}
-		>
+		<div className="agencyRadioSelect__wrapper">
 			{prefix && (
 				<Headline semanticLevel="4" styleLevel="5" text={prefix} />
 			)}
@@ -40,11 +37,10 @@ export const AgencyRadioSelect = ({
 				className={clsx('agencyRadioSelect__radioContainer', {
 					'agencyRadioSelect__radioContainer--withHeadline': !!prefix
 				})}
-				onClick={() => console.log('🟡 RadioContainer clicked!', agency.id)}
 			>
 				<RadioButton
 					name="agencySelection"
-				handleRadioButton={(e) => onChange && onChange(agency)}
+					handleRadioButton={(e) => onChange && onChange(agency)}
 					onKeyDown={(e: KeyboardEvent) => onKeyDown && onKeyDown(e)}
 					type="smaller"
 					value={agencyIdAsString}

--- a/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
+++ b/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
@@ -983,6 +983,7 @@ function SessionListPanel() {
 						)
 					}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip
 					showLiveChatChip
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { Routing } from './Routing';
 import {
 	UserDataContext,
@@ -36,6 +36,7 @@ import {
 	markConsultantLoginBlocked
 } from '../auth/consultantLoginBlock';
 import { appConfig } from '../../utils/appConfig';
+import { withTimeout } from '../../utils/promiseTimeout';
 
 interface AuthenticatedAppProps {
 	onAppReady: Function;
@@ -55,6 +56,13 @@ export const AuthenticatedApp = ({
 	const { setNotifications } = useContext(NotificationsContext);
 	const callContext = useCall();
 	const { setMatrixClientService } = useMatrixClient();
+	const mounted = useRef(true);
+	useEffect(
+		() => () => {
+			mounted.current = false;
+		},
+		[]
+	);
 
 	const [appReady, setAppReady] = useState<boolean>(false);
 	const [loading, setLoading] = useState<boolean>(true);
@@ -119,58 +127,88 @@ export const AuthenticatedApp = ({
 							}
 							return userProfileData;
 						})
-						.then(async (userProfileData) => {
-							// 🔷 CRITICAL: Initialize Matrix client for all authenticated users
+						.then(async () => {
+							const matrixBootstrapActive = { current: true };
 							try {
-								const matrixLoginData =
-									await getMatrixAccessToken();
-								persistMatrixLoginData(matrixLoginData);
-								try {
-									const { MatrixClientService } =
-										await import(
-											'../../services/matrixClientService'
-										);
-									const matrixClientService =
-										new MatrixClientService();
-
-									const homeserverUrl =
-										getMatrixHomeserverUrl();
-									if (!homeserverUrl) {
-										// console.warn('⚠️ REACT_APP_MATRIX_HOMESERVER_URL is not set; skipping Matrix client init');
-									} else {
-										matrixClientService.initializeClient({
-											userId: matrixLoginData.userId,
-											accessToken:
-												matrixLoginData.accessToken,
-											deviceId: matrixLoginData.deviceId,
-											homeserverUrl: homeserverUrl
-										});
-
-										setMatrixClientService(
-											matrixClientService
-										);
-										(window as any).callContext =
-											callContext;
-
-										const { matrixLiveEventBridge } =
-											await import(
-												'../../services/matrixLiveEventBridge'
+								await withTimeout(
+									(async () => {
+										const matrixLoginData =
+											await getMatrixAccessToken();
+										persistMatrixLoginData(matrixLoginData);
+										const homeserverUrl =
+											getMatrixHomeserverUrl();
+										if (homeserverUrl) {
+											const { MatrixClientService } =
+												await import(
+													'../../services/matrixClientService'
+												);
+											const matrixClientService =
+												new MatrixClientService();
+											await matrixClientService.initializeClient(
+												{
+													userId: matrixLoginData.userId,
+													accessToken:
+														matrixLoginData.accessToken,
+													deviceId:
+														matrixLoginData.deviceId,
+													homeserverUrl
+												}
 											);
-										matrixLiveEventBridge.initialize(
-											matrixClientService.getClient()!
-										);
-									}
-								} catch (error) {
-									// console.warn('⚠️ Matrix client initialization failed:', error);
-									// Don't fail app startup if Matrix fails
-								}
-							} catch {
-								// console.warn('⚠️ No Matrix credentials found in localStorage');
+											if (
+												!matrixBootstrapActive.current ||
+												!mounted.current
+											) {
+												matrixClientService.stopAndCleanup();
+												return;
+											}
+
+											setMatrixClientService(
+												matrixClientService
+											);
+											(window as any).callContext =
+												callContext;
+
+											const { matrixLiveEventBridge } =
+												await import(
+													'../../services/matrixLiveEventBridge'
+												);
+											if (
+												!matrixBootstrapActive.current ||
+												!mounted.current
+											) {
+												matrixClientService.stopAndCleanup();
+												return;
+											}
+											const matrixClient =
+												matrixClientService.getClient();
+											if (!matrixClient) {
+												throw new Error(
+													'Matrix client missing after initialization'
+												);
+											}
+											matrixLiveEventBridge.initialize(
+												matrixClient
+											);
+										}
+									})(),
+									15_000,
+									'Matrix bootstrap timed out'
+								);
+							} catch (matrixError) {
+								matrixBootstrapActive.current = false;
+								console.error(
+									'Matrix bootstrap failed; continuing with non-chat features',
+									matrixError
+								);
 							}
 
 							setAppReady(true);
 						})
-						.catch(() => {
+						.catch((error) => {
+							console.error(
+								'Authenticated app bootstrap failed',
+								error
+							);
 							setLoading(false);
 						});
 				})

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -11,6 +11,7 @@ import {
 	getMatrixHomeserverUrl
 } from '../../resources/scripts/runtimeConfig';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
+import { getElementCallAccessToken } from '../sessionCookie/getMatrixAccessToken';
 import './GroupCallWidget.scss';
 
 export const GroupCallWidget: React.FC = () => {
@@ -33,6 +34,7 @@ export const GroupCallWidget: React.FC = () => {
 	} | null>(null);
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const setupInProgressRef = useRef(false);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 
 	// Subscribe to CallManager
@@ -46,6 +48,7 @@ export const GroupCallWidget: React.FC = () => {
 			}
 			if (!newCallData) {
 				setElementCallUrl('');
+				setupInProgressRef.current = false;
 			}
 		});
 		const currentCall = callManager.getCurrentCall();
@@ -130,7 +133,7 @@ export const GroupCallWidget: React.FC = () => {
 		if (callState !== 'connecting' && callState !== 'in_call') return;
 
 		// console.log('✅ Incoming group call moving to state', callState, '- setting up Element Call for receiver...');
-		setupElementCall();
+		void setupElementCall();
 		// setupElementCall is re-created every render; including it would make
 		// this effect run on each render instead of on call-state changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -143,15 +146,16 @@ export const GroupCallWidget: React.FC = () => {
 		if (elementCallUrl) return; // Already set up
 
 		// console.log('📞 Starting outgoing call, setting up Element Call...');
-		setupElementCall();
+		void setupElementCall();
 		// setupElementCall is re-created every render and elementCallUrl is only
 		// used as an "already set up" guard; adding them would re-run this
 		// effect on every render.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [callData, matrixClientService]);
 
-	const setupElementCall = () => {
-		if (!callData) return;
+	const setupElementCall = async () => {
+		if (!callData || setupInProgressRef.current) return;
+		setupInProgressRef.current = true;
 
 		try {
 			const client = matrixClientService?.getClient();
@@ -160,26 +164,27 @@ export const GroupCallWidget: React.FC = () => {
 			// For group calls we use the dedicated Element Call room if present.
 			const roomId =
 				(callData as any).elementCallRoomId || callData.roomId;
+			const elementCallLogin = await getElementCallAccessToken();
 			const homeserverUrl =
-				client.getHomeserverUrl() || getMatrixHomeserverUrl();
+				elementCallLogin.homeserverUrl ||
+				client.getHomeserverUrl() ||
+				getMatrixHomeserverUrl();
 			if (!homeserverUrl) {
 				throw new Error(
 					'Matrix homeserver URL is missing. Set REACT_APP_MATRIX_HOMESERVER_URL or ensure the client reports a homeserver URL.'
 				);
 			}
 
-			// Get Matrix credentials
-			const accessToken =
-				(client as any).accessToken ||
-				localStorage.getItem('matrix_access_token');
-			const userId =
-				client.getUserId() || localStorage.getItem('matrix_user_id');
-			const deviceId =
-				(client as any).deviceId ||
-				localStorage.getItem('matrix_device_id');
+			// Element Call runs on a different origin and therefore must own a
+			// separate Matrix device/crypto store. Reusing the ORISO app device
+			// causes the two clients to overwrite each other's device keys.
+			const { accessToken, userId, deviceId } = elementCallLogin;
 
-			if (!accessToken || !userId) {
+			if (!accessToken || !userId || !deviceId) {
 				throw new Error('Matrix authentication not available');
+			}
+			if (client.getUserId() && client.getUserId() !== userId) {
+				throw new Error('Element Call Matrix identity mismatch');
 			}
 
 			// Element Call - open the specific Matrix room directly.
@@ -251,6 +256,7 @@ export const GroupCallWidget: React.FC = () => {
 				iframeRef.current.onload = sendCredentials;
 			}
 		} catch (err) {
+			setupInProgressRef.current = false;
 			// console.error('❌ Failed to setup Element Call:', err);
 			alert(`Failed to start call: ${(err as Error).message}`);
 			callManager.endCall();
@@ -267,7 +273,7 @@ export const GroupCallWidget: React.FC = () => {
 		// directly in the call UI without any extra "Join" step.
 		if (!elementCallUrl) {
 			// console.log('📞 Answer clicked, setting up Element Call immediately for receiver...');
-			setupElementCall();
+			void setupElementCall();
 		}
 	};
 

--- a/src/components/groupChat/CreateChatView.tsx
+++ b/src/components/groupChat/CreateChatView.tsx
@@ -7,7 +7,7 @@ import {
 	useMemo,
 	useRef
 } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import {
 	desktopView,
 	mobileDetailView,
@@ -16,11 +16,24 @@ import {
 import {
 	SessionsDataContext,
 	UPDATE_SESSIONS,
-	UserDataContext
+	UserDataContext,
+	useTenant,
+	useTenantState
 } from '../../globalState';
 import { InputField, InputFieldItem } from '../inputField/InputField';
 import { OrisoSelect } from '../form/OrisoSelect';
-import { TOPIC_LENGTHS } from './createChatHelpers';
+import {
+	buildGroupChatSeriesRequest,
+	buildOneOffDuplicateFields,
+	getValidDateFormatForSelectedDate,
+	getValidTimeFormatForSelectedTime,
+	isGroupChatFeatureEnabled,
+	TOPIC_LENGTHS
+} from './createChatHelpers';
+import {
+	GroupChatSeriesFields,
+	GroupChatSeriesFieldsValue
+} from './GroupChatSeriesFields';
 import { ReactComponent as CheckIcon } from '../../resources/img/illustrations/check.svg';
 import { ReactComponent as XIcon } from '../../resources/img/illustrations/x.svg';
 import { ButtonItem, BUTTON_TYPES, Button } from '../button/Button';
@@ -31,11 +44,19 @@ import { useResponsive } from '../../hooks/useResponsive';
 import { apiGetSessionRoomsByGroupIds } from '../../api/apiGetSessionRooms';
 import { useTranslation } from 'react-i18next';
 import {
-	apiGetAgencyConsultantList,
+	apiGetTenantConsultantList,
 	Consultant
 } from '../../api/apiGetAgencyConsultantList';
 import { apiCreateGroupChat } from '../../api/apiGroupChatSettings';
 import { SelectChangeEvent } from '@mui/material/Select';
+import { GroupChatAuthorContentFields } from './GroupChatAuthorContentFields';
+import {
+	GroupChatAuthorContentDraft,
+	normalizeGroupChatLanguages,
+	syncGroupChatAuthorContentLanguages
+} from './groupChatAuthorContent';
+import { translateWithFallback } from '../../utils/translationFallback';
+import { Loading } from '../app/Loading';
 
 const IconPlusCircle = ({ open }: { open: boolean }) => (
 	<svg
@@ -128,17 +149,74 @@ const IconUnselected = () => (
 	</svg>
 );
 
-export const CreateGroupChatView = () => {
-	const { t: translate } = useTranslation();
+const CreateGroupChatForm = () => {
+	const { t: translate, i18n } = useTranslation();
+	const tenantData = useTenant();
+	const activeLanguages = useMemo(
+		() =>
+			normalizeGroupChatLanguages(
+				tenantData?.settings?.activeLanguages?.length
+					? tenantData.settings.activeLanguages
+					: [i18n.resolvedLanguage || i18n.language || 'de']
+			),
+		[
+			i18n.language,
+			i18n.resolvedLanguage,
+			tenantData?.settings?.activeLanguages
+		]
+	);
+	const initialAuthorLanguage = activeLanguages[0] || 'de';
+	const [authorContent, setAuthorContent] =
+		useState<GroupChatAuthorContentDraft>({
+			sourceLanguage: initialAuthorLanguage,
+			hintMessageTranslations: { [initialAuthorLanguage]: '' },
+			groupChatRulesTranslations: { [initialAuthorLanguage]: [''] }
+		});
+	useEffect(() => {
+		setAuthorContent((current) =>
+			syncGroupChatAuthorContentLanguages(current, activeLanguages)
+		);
+	}, [activeLanguages]);
 	const navigate = useNavigate();
+	const location = useLocation();
+	const duplicateOccurrence = (
+		location.state as {
+			duplicateOccurrence?: {
+				topic: string;
+				start: string;
+				duration: number;
+				modality: GroupChatSeriesFieldsValue['modality'];
+			};
+		} | null
+	)?.duplicateOccurrence;
 	const {
 		userData,
 		userData: { agencies = [] }
 	} = useContext(UserDataContext);
 
 	const { dispatch } = useContext(SessionsDataContext);
-	const [selectedChatTopic, setSelectedChatTopic] = useState('');
+	const [selectedChatTopic, setSelectedChatTopic] = useState(
+		() => duplicateOccurrence?.topic || ''
+	);
 	const [selectedAgency, setSelectedAgency] = useState<number | null>(null);
+	const [seriesFields, setSeriesFields] =
+		useState<GroupChatSeriesFieldsValue>(() =>
+			duplicateOccurrence
+				? buildOneOffDuplicateFields(duplicateOccurrence)
+				: {
+						startDate: getValidDateFormatForSelectedDate(
+							new Date()
+						),
+						startTime: getValidTimeFormatForSelectedTime(
+							new Date()
+						),
+						duration: 60,
+						repeatCount: 1,
+						interval: 'WEEKLY',
+						modality: 'TEXT'
+					}
+		);
+	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 	const [selectedConsultants, setSelectedConsultants] = useState<string[]>(
 		[]
 	);
@@ -215,7 +293,7 @@ export const CreateGroupChatView = () => {
 	// Fetch consultants when agency changes
 	useEffect(() => {
 		if (selectedAgency) {
-			apiGetAgencyConsultantList(selectedAgency.toString())
+			apiGetTenantConsultantList()
 				.then((consultants) => {
 					// ✅ FIX 1: Filter out current user from consultant list
 					// ✅ FIX 2: Remove duplicates using consultantId as unique key
@@ -284,13 +362,22 @@ export const CreateGroupChatView = () => {
 		if (
 			isChatTopicValid &&
 			selectedAgency &&
-			selectedConsultants.length > 0
+			seriesFields.startDate &&
+			seriesFields.startTime &&
+			seriesFields.repeatCount >= 1 &&
+			seriesFields.repeatCount <= 365
 		) {
 			setIsCreateButtonDisabled(false);
 		} else {
 			setIsCreateButtonDisabled(true);
 		}
-	}, [selectedChatTopic, selectedAgency, selectedConsultants]);
+	}, [
+		selectedChatTopic,
+		selectedAgency,
+		seriesFields.startDate,
+		seriesFields.startTime,
+		seriesFields.repeatCount
+	]);
 
 	const handleBackButton = () => {
 		navigate('/sessions/consultant/sessionView');
@@ -335,10 +422,8 @@ export const CreateGroupChatView = () => {
 	);
 
 	const tr = useCallback(
-		(key: string, fallback: string) => {
-			const value = translate(key);
-			return !value || value === key ? fallback : value;
-		},
+		(key: string, fallback: string, options?: Record<string, unknown>) =>
+			translateWithFallback(translate, key, fallback, options),
 		[translate]
 	);
 
@@ -437,23 +522,34 @@ export const CreateGroupChatView = () => {
 	);
 
 	const handleCreateButton = useCallback(() => {
-		if (isRequestInProgress) {
+		if (isRequestInProgress || selectedAgency === null) {
 			return;
 		}
 		setIsRequestInProgress(true);
 
 		// Use the proper API function
-		apiCreateGroupChat({
-			topic: selectedChatTopic,
-			startDate: new Date().toISOString().split('T')[0],
-			startTime: '00:00',
-			duration: 60,
-			agencyId: selectedAgency,
-			hintMessage: '',
-			repetitive: false,
-			featureGroupChatV2Enabled: true,
-			consultantIds: selectedConsultants
-		} as any)
+		apiCreateGroupChat(
+			buildGroupChatSeriesRequest({
+				topic: selectedChatTopic,
+				startDate: seriesFields.startDate,
+				startTime: seriesFields.startTime,
+				duration: seriesFields.duration,
+				agencyId: selectedAgency,
+				hintMessage:
+					authorContent.hintMessageTranslations[
+						authorContent.sourceLanguage
+					] || '',
+				sourceLanguage: authorContent.sourceLanguage,
+				hintMessageTranslations: authorContent.hintMessageTranslations,
+				groupChatRulesTranslations:
+					authorContent.groupChatRulesTranslations,
+				repeatCount: seriesFields.repeatCount,
+				chatInterval: seriesFields.interval,
+				modality: seriesFields.modality,
+				timezone,
+				consultantIds: selectedConsultants
+			})
+		)
 			.then((response) => {
 				// Refresh session list
 				return apiGetSessionRoomsByGroupIds([response.groupId])
@@ -482,7 +578,10 @@ export const CreateGroupChatView = () => {
 		isRequestInProgress,
 		selectedChatTopic,
 		selectedAgency,
+		seriesFields,
+		timezone,
 		selectedConsultants,
+		authorContent,
 		dispatch,
 		navigate,
 		createChatErrorOverlayItem
@@ -538,6 +637,16 @@ export const CreateGroupChatView = () => {
 					options={agencyOptions}
 					value={selectedAgency?.toString() || ''}
 					onChange={handleAgencySelect}
+				/>
+
+				<GroupChatSeriesFields
+					value={seriesFields}
+					onChange={setSeriesFields}
+				/>
+				<GroupChatAuthorContentFields
+					activeLanguages={activeLanguages}
+					value={authorContent}
+					onChange={setAuthorContent}
 				/>
 				<div
 					className="createChat__participantsPicker"
@@ -713,4 +822,18 @@ export const CreateGroupChatView = () => {
 			)}
 		</div>
 	);
+};
+
+export const CreateGroupChatView = () => {
+	const { tenant: tenantData, isLoading } = useTenantState();
+
+	if (isLoading) {
+		return <Loading />;
+	}
+
+	if (!isGroupChatFeatureEnabled(tenantData)) {
+		return <Navigate to="/sessions/consultant/sessionView" replace />;
+	}
+
+	return <CreateGroupChatForm />;
 };

--- a/src/components/groupChat/GroupChatAuthorContentFields.test.tsx
+++ b/src/components/groupChat/GroupChatAuthorContentFields.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiTranslateGroupChatAuthorContent } from '../../api/apiGroupChatAuthorTranslation';
+import { GroupChatAuthorContentDraft } from './groupChatAuthorContent';
+import { GroupChatAuthorContentFields } from './GroupChatAuthorContentFields';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../../api/apiGroupChatAuthorTranslation', () => ({
+	apiTranslateGroupChatAuthorContent: vi.fn()
+}));
+
+const draft = (hint = 'Willkommen'): GroupChatAuthorContentDraft => ({
+	sourceLanguage: 'de',
+	hintMessageTranslations: { de: hint },
+	groupChatRulesTranslations: { de: ['Respektvoll bleiben'] }
+});
+
+describe('GroupChatAuthorContentFields', () => {
+	afterEach(cleanup);
+
+	it('keeps the selected language valid when active languages change', () => {
+		const { rerender } = render(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={draft()}
+				onChange={vi.fn()}
+			/>
+		);
+		fireEvent.click(screen.getByRole('tab', { name: 'EN' }));
+
+		rerender(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de']}
+				value={draft()}
+				onChange={vi.fn()}
+			/>
+		);
+
+		expect(
+			screen
+				.getByRole('tab', { name: 'DE' })
+				.getAttribute('aria-selected')
+		).toBe('true');
+	});
+
+	it('connects language tabs to their tab panel', () => {
+		render(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={draft()}
+				onChange={vi.fn()}
+			/>
+		);
+
+		const tab = screen.getByRole('tab', { name: 'DE' });
+		const panel = screen.getByRole('tabpanel');
+		expect(tab.getAttribute('aria-controls')).toBe(panel.id);
+		expect(panel.getAttribute('aria-labelledby')).toBe(tab.id);
+	});
+
+	it('moves tab selection and focus with arrow keys', () => {
+		render(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={draft()}
+				onChange={vi.fn()}
+			/>
+		);
+		const german = screen.getByRole('tab', { name: 'DE' });
+		const english = screen.getByRole('tab', { name: 'EN' });
+
+		german.focus();
+		fireEvent.keyDown(german, { key: 'ArrowRight' });
+
+		expect(english.getAttribute('aria-selected')).toBe('true');
+		expect(document.activeElement).toBe(english);
+	});
+
+	it('ignores a translation response after the source content changes', async () => {
+		let resolveTranslation!: (value: any) => void;
+		vi.mocked(apiTranslateGroupChatAuthorContent).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveTranslation = resolve;
+			})
+		);
+		const onChange = vi.fn();
+		const { rerender } = render(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={draft()}
+				onChange={onChange}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.create.authorContent.translate'
+			})
+		);
+
+		rerender(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={draft('Neu bearbeitet')}
+				onChange={onChange}
+			/>
+		);
+		resolveTranslation({ translations: { en: ['Stale'] } });
+		await Promise.resolve();
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('shows an error when translation request construction fails synchronously', async () => {
+		render(
+			<GroupChatAuthorContentFields
+				activeLanguages={['de', 'en']}
+				value={
+					{
+						...draft(),
+						hintMessageTranslations: null
+					} as any
+				}
+				onChange={vi.fn()}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.create.authorContent.translate'
+			})
+		);
+
+		expect(await screen.findByRole('alert')).toBeTruthy();
+	});
+});

--- a/src/components/groupChat/GroupChatAuthorContentFields.tsx
+++ b/src/components/groupChat/GroupChatAuthorContentFields.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiTranslateGroupChatAuthorContent } from '../../api/apiGroupChatAuthorTranslation';
+import {
+	applyGroupChatAuthorTranslations,
+	buildGroupChatAuthorTranslationRequest,
+	GroupChatAuthorContentDraft,
+	normalizeGroupChatLanguages
+} from './groupChatAuthorContent';
+
+interface GroupChatAuthorContentFieldsProps {
+	activeLanguages: string[];
+	value: GroupChatAuthorContentDraft;
+	onChange: (value: GroupChatAuthorContentDraft) => void;
+}
+
+export const GroupChatAuthorContentFields = ({
+	activeLanguages,
+	value,
+	onChange
+}: GroupChatAuthorContentFieldsProps) => {
+	const { t } = useTranslation();
+	const languages = useMemo(
+		() => normalizeGroupChatLanguages(activeLanguages),
+		[activeLanguages]
+	);
+	const [selectedLanguage, setSelectedLanguage] = useState(
+		languages.includes(value.sourceLanguage)
+			? value.sourceLanguage
+			: languages[0] || value.sourceLanguage
+	);
+	const [isTranslating, setIsTranslating] = useState(false);
+	const [translationError, setTranslationError] = useState(false);
+	const rules = value.groupChatRulesTranslations?.[selectedLanguage] || [''];
+	const inputSignature = JSON.stringify({ languages, value });
+	const latestInputSignature = useRef(inputSignature);
+	latestInputSignature.current = inputSignature;
+	const idPrefix = React.useId().replace(/:/g, '');
+	const tabIdFor = (language: string) =>
+		`${idPrefix}-group-chat-author-tab-${language}`;
+	const panelIdFor = (language: string) =>
+		`${idPrefix}-group-chat-author-panel-${language}`;
+	const tabId = tabIdFor(selectedLanguage);
+	const panelId = panelIdFor(selectedLanguage);
+
+	useEffect(() => {
+		setSelectedLanguage((current) =>
+			languages.includes(current)
+				? current
+				: languages[0] || value.sourceLanguage
+		);
+	}, [languages, value.sourceLanguage]);
+
+	const handleTabKeyDown = (
+		event: React.KeyboardEvent<HTMLButtonElement>,
+		index: number
+	) => {
+		let nextIndex: number | undefined;
+		if (event.key === 'ArrowRight') {
+			nextIndex = (index + 1) % languages.length;
+		} else if (event.key === 'ArrowLeft') {
+			nextIndex = (index - 1 + languages.length) % languages.length;
+		} else if (event.key === 'Home') {
+			nextIndex = 0;
+		} else if (event.key === 'End') {
+			nextIndex = languages.length - 1;
+		}
+		if (nextIndex === undefined || !languages[nextIndex]) {
+			return;
+		}
+		event.preventDefault();
+		const nextLanguage = languages[nextIndex];
+		setSelectedLanguage(nextLanguage);
+		document.getElementById(tabIdFor(nextLanguage))?.focus();
+	};
+
+	const updateHint = (hintMessage: string) =>
+		onChange({
+			...value,
+			hintMessageTranslations: {
+				...value.hintMessageTranslations,
+				[selectedLanguage]: hintMessage
+			}
+		});
+
+	const updateRules = (nextRules: string[]) =>
+		onChange({
+			...value,
+			groupChatRulesTranslations: {
+				...value.groupChatRulesTranslations,
+				[selectedLanguage]: nextRules
+			}
+		});
+
+	const translateContent = async () => {
+		setTranslationError(false);
+		try {
+			const request = buildGroupChatAuthorTranslationRequest({
+				...value,
+				activeLanguages: languages
+			});
+			if (
+				request.targetLangs.length === 0 ||
+				Object.values(request.texts).every((text) => !text.trim())
+			) {
+				return;
+			}
+			setIsTranslating(true);
+			const requestInputSignature = inputSignature;
+			const response = await apiTranslateGroupChatAuthorContent(request);
+			if (latestInputSignature.current !== requestInputSignature) {
+				return;
+			}
+			onChange(
+				applyGroupChatAuthorTranslations(value, response.translations)
+			);
+		} catch {
+			setTranslationError(true);
+		} finally {
+			setIsTranslating(false);
+		}
+	};
+
+	return (
+		<fieldset className="createChat__authorContent">
+			<legend>{t('groupChat.create.authorContent.title')}</legend>
+			<div className="createChat__languageTabs" role="tablist">
+				{languages.map((language, index) => (
+					<button
+						type="button"
+						role="tab"
+						id={tabIdFor(language)}
+						aria-controls={panelIdFor(language)}
+						aria-selected={language === selectedLanguage}
+						tabIndex={language === selectedLanguage ? 0 : -1}
+						key={language}
+						onClick={() => setSelectedLanguage(language)}
+						onKeyDown={(event) => handleTabKeyDown(event, index)}
+					>
+						{language.toUpperCase()}
+					</button>
+				))}
+			</div>
+			<div role="tabpanel" id={panelId} aria-labelledby={tabId}>
+				<label>
+					{t('groupChat.create.authorContent.sourceLanguage')}
+					<select
+						value={value.sourceLanguage}
+						onChange={(event) =>
+							onChange({
+								...value,
+								sourceLanguage: event.target.value
+							})
+						}
+					>
+						{languages.map((language) => (
+							<option key={language} value={language}>
+								{language.toUpperCase()}
+							</option>
+						))}
+					</select>
+				</label>
+				<label>
+					{t('groupChat.create.authorContent.welcome')}
+					<textarea
+						maxLength={120}
+						value={
+							value.hintMessageTranslations?.[selectedLanguage] ||
+							''
+						}
+						onChange={(event) => updateHint(event.target.value)}
+					/>
+				</label>
+				<div className="createChat__rules">
+					<span>{t('groupChat.create.authorContent.rules')}</span>
+					{rules.map((rule, index) => (
+						<div key={`${selectedLanguage}-rule-${index}`}>
+							<textarea
+								aria-label={`${t(
+									'groupChat.create.authorContent.rule'
+								)} ${index + 1}`}
+								maxLength={120}
+								value={rule}
+								onChange={(event) =>
+									updateRules(
+										rules.map((current, ruleIndex) =>
+											ruleIndex === index
+												? event.target.value
+												: current
+										)
+									)
+								}
+							/>
+							<button
+								type="button"
+								onClick={() =>
+									updateRules(
+										rules.filter(
+											(_, ruleIndex) =>
+												ruleIndex !== index
+										)
+									)
+								}
+							>
+								{t('groupChat.create.authorContent.removeRule')}
+							</button>
+						</div>
+					))}
+					{rules.length < 10 && (
+						<button
+							type="button"
+							onClick={() => updateRules([...rules, ''])}
+						>
+							{t('groupChat.create.authorContent.addRule')}
+						</button>
+					)}
+				</div>
+			</div>
+			<button
+				type="button"
+				disabled={isTranslating}
+				onClick={translateContent}
+			>
+				{isTranslating
+					? t('groupChat.create.authorContent.translating')
+					: t('groupChat.create.authorContent.translate')}
+			</button>
+			{translationError && (
+				<p role="alert">
+					{t('groupChat.create.authorContent.translationError')}
+				</p>
+			)}
+		</fieldset>
+	);
+};

--- a/src/components/groupChat/GroupChatCalendarMenu.test.tsx
+++ b/src/components/groupChat/GroupChatCalendarMenu.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GroupChatCalendarMenu } from './GroupChatCalendarMenu';
+
+const translations: Record<string, string> = {
+	'groupChat.calendar.add': 'Add to calendar',
+	'groupChat.calendar.defaultTitle': 'Online appointment',
+	'groupChat.calendar.download': 'Download ICS',
+	'groupChat.calendar.google': 'Google Calendar',
+	'groupChat.calendar.outlook': 'Outlook Calendar',
+	'groupChat.calendar.titleLabel': 'Neutral calendar title'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key
+	})
+}));
+
+describe('GroupChatCalendarMenu', () => {
+	afterEach(cleanup);
+
+	it('opens translated, confidentiality-neutral calendar actions', async () => {
+		render(
+			<GroupChatCalendarMenu
+				start={new Date('2026-08-04T18:00:00Z')}
+				durationMinutes={60}
+				eventId={42}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Add to calendar' })
+		);
+
+		const titleInput = await screen.findByRole('textbox', {
+			name: 'Neutral calendar title'
+		});
+		expect((titleInput as HTMLInputElement).value).toBe(
+			'Online appointment'
+		);
+		expect(screen.getByText('Download ICS')).toBeTruthy();
+		const googleLink = screen.getByRole('menuitem', {
+			name: 'Google Calendar'
+		});
+		expect(googleLink.getAttribute('href')).toContain(
+			'calendar.google.com'
+		);
+		expect(googleLink.getAttribute('href')).not.toMatch(
+			/oriso|support|sucht/i
+		);
+
+		const parentKeyDown = vi.fn();
+		document.addEventListener('keydown', parentKeyDown);
+		fireEvent.keyDown(titleInput, { key: 'o' });
+		expect(parentKeyDown).not.toHaveBeenCalled();
+		document.removeEventListener('keydown', parentKeyDown);
+
+		fireEvent.click(googleLink);
+		await waitFor(() =>
+			expect(screen.queryByText('Download ICS')).toBeNull()
+		);
+	});
+
+	it('wires trigger state and lets Escape close the title editor', async () => {
+		render(
+			<GroupChatCalendarMenu
+				start={new Date('2026-08-04T18:00:00Z')}
+				durationMinutes={60}
+				eventId={42}
+			/>
+		);
+		const trigger = screen.getByRole('button', { name: 'Add to calendar' });
+		expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+		fireEvent.click(trigger);
+		const titleInput = await screen.findByRole('textbox', {
+			name: 'Neutral calendar title'
+		});
+		expect(trigger.getAttribute('aria-expanded')).toBe('true');
+		expect(trigger.getAttribute('aria-controls')).toContain(
+			'group-chat-calendar-menu'
+		);
+
+		fireEvent.keyDown(titleInput, { key: 'Escape' });
+		await waitFor(() =>
+			expect(screen.queryByText('Download ICS')).toBeNull()
+		);
+	});
+});

--- a/src/components/groupChat/GroupChatCalendarMenu.tsx
+++ b/src/components/groupChat/GroupChatCalendarMenu.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Box, Button, Menu, MenuItem, TextField } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import {
+	buildNeutralGroupChatCalendar,
+	downloadNeutralGroupChatIcs
+} from './groupChatCalendar';
+
+interface GroupChatCalendarMenuProps {
+	start: Date;
+	durationMinutes: number;
+	eventId: string | number;
+}
+
+export const GroupChatCalendarMenu = ({
+	start,
+	durationMinutes,
+	eventId
+}: GroupChatCalendarMenuProps) => {
+	const { t: translate } = useTranslation();
+	const instanceId = useId().replace(/:/g, '');
+	const triggerId = `${instanceId}-group-chat-calendar-trigger`;
+	const menuId = `${instanceId}-group-chat-calendar-menu`;
+	const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+	const defaultTitle = translate('groupChat.calendar.defaultTitle');
+	const [title, setTitle] = useState(() => defaultTitle);
+	const titleEdited = useRef(false);
+	useEffect(() => {
+		if (!titleEdited.current) {
+			setTitle(defaultTitle);
+		}
+	}, [defaultTitle]);
+	const closeMenu = () => setAnchor(null);
+	const calendar = useMemo(
+		() =>
+			buildNeutralGroupChatCalendar({
+				start,
+				durationMinutes,
+				title,
+				defaultTitle,
+				eventId
+			}),
+		[defaultTitle, durationMinutes, eventId, start, title]
+	);
+
+	return (
+		<>
+			<Button
+				id={triggerId}
+				variant="outlined"
+				onClick={(event) => setAnchor(event.currentTarget)}
+				aria-haspopup="menu"
+				aria-expanded={Boolean(anchor)}
+				aria-controls={anchor ? menuId : undefined}
+			>
+				{translate('groupChat.calendar.add')}
+			</Button>
+			<Menu
+				id={menuId}
+				MenuListProps={{ 'aria-labelledby': triggerId }}
+				anchorEl={anchor}
+				open={Boolean(anchor)}
+				onClose={closeMenu}
+			>
+				<Box component="div" role="none" sx={{ padding: 1 }}>
+					<TextField
+						label={translate('groupChat.calendar.titleLabel')}
+						value={title}
+						onChange={(event) => {
+							titleEdited.current = true;
+							setTitle(event.target.value);
+						}}
+						onKeyDown={(event) => {
+							if (event.key !== 'Escape') {
+								event.stopPropagation();
+							}
+						}}
+						size="small"
+					/>
+				</Box>
+				<MenuItem
+					onClick={() => {
+						downloadNeutralGroupChatIcs(calendar.ics);
+						closeMenu();
+					}}
+				>
+					{translate('groupChat.calendar.download')}
+				</MenuItem>
+				<MenuItem
+					component="a"
+					href={calendar.googleUrl}
+					target="_blank"
+					rel="noreferrer"
+					onClick={closeMenu}
+				>
+					{translate('groupChat.calendar.google')}
+				</MenuItem>
+				<MenuItem
+					component="a"
+					href={calendar.outlookUrl}
+					target="_blank"
+					rel="noreferrer"
+					onClick={closeMenu}
+				>
+					{translate('groupChat.calendar.outlook')}
+				</MenuItem>
+			</Menu>
+		</>
+	);
+};

--- a/src/components/groupChat/GroupChatCopyLinks.tsx
+++ b/src/components/groupChat/GroupChatCopyLinks.tsx
@@ -10,18 +10,15 @@ import { GenerateQrCode } from '../generateQrCode/GenerateQrCode';
 import './groupChatCopyLinks.scss';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
+import { buildGroupChatInviteLink } from './groupChatInviteLink';
 
 type GroupChatCopyLinksProps = {
-	id: string;
-	groupChatId: string;
+	seriesId: number;
 };
 
-export const GroupChatCopyLinks = ({
-	id,
-	groupChatId
-}: GroupChatCopyLinksProps) => {
+export const GroupChatCopyLinks = ({ seriesId }: GroupChatCopyLinksProps) => {
 	const settings = useAppConfig();
-	const url = `${settings.urls.toLogin}?gcid=${id}`;
+	const url = buildGroupChatInviteLink(settings.urls.toLogin, seriesId);
 	const { addNotification } = useContext(NotificationsContext);
 	const { t: translate } = useTranslation();
 
@@ -43,7 +40,7 @@ export const GroupChatCopyLinks = ({
 					url={url}
 					headline={translate('groupChat.qrCode.headline')}
 					text={translate('groupChat.qrCode.text')}
-					filename={`group-chat-${groupChatId}`}
+					filename={`group-chat-${seriesId}`}
 				/>
 			</div>
 			<div className="GroupChatCopyLinks_copyLink">

--- a/src/components/groupChat/GroupChatInfo.tsx
+++ b/src/components/groupChat/GroupChatInfo.tsx
@@ -18,7 +18,11 @@ import {
 	apiPutGroupChat,
 	GROUP_CHAT_API
 } from '../../api';
-import { canModerateGroupChat, isGroupChatOwner } from './groupChatHelpers';
+import {
+	canModerateGroupChat,
+	isGroupChatOwner,
+	isV2GroupChatSession
+} from './groupChatHelpers';
 import { getGroupChatDate } from '../session/sessionDateHelpers';
 import { durationSelectOptionsSet } from './createChatHelpers';
 import {
@@ -108,9 +112,7 @@ export const GroupChatInfo = () => {
 			return;
 		}
 
-		if (activeSession.isGroup && !activeSession.item.consultingType) {
-			setIsV2GroupChat(true);
-		}
+		setIsV2GroupChat(isV2GroupChatSession(activeSession));
 	}, [activeSession, navigate, listPath, ready, sessionListTab]);
 
 	const handleStopGroupChatButton = () => {
@@ -313,8 +315,7 @@ export const GroupChatInfo = () => {
 							{featureGroupChatV2Enabled && isV2GroupChat && (
 								<div className="groupChatInfo__groupChatContainer">
 									<GroupChatCopyLinks
-										id={activeSession.item.groupId}
-										groupChatId={activeSession.item.id.toString()}
+										seriesId={activeSession.item.id}
 									/>
 								</div>
 							)}

--- a/src/components/groupChat/GroupChatInfo.tsx
+++ b/src/components/groupChat/GroupChatInfo.tsx
@@ -18,7 +18,7 @@ import {
 	apiPutGroupChat,
 	GROUP_CHAT_API
 } from '../../api';
-import { isGroupChatOwner } from './groupChatHelpers';
+import { canModerateGroupChat, isGroupChatOwner } from './groupChatHelpers';
 import { getGroupChatDate } from '../session/sessionDateHelpers';
 import { durationSelectOptionsSet } from './createChatHelpers';
 import {
@@ -49,6 +49,9 @@ import { useAppConfig } from '../../hooks/useAppConfig';
 import { useTranslation } from 'react-i18next';
 import { getPrettyDateFromMessageDate } from '../../utils/dateHelpers';
 import { useMatrixRoomUsers } from '../../hooks/useMatrixRoomUsers';
+import { GroupChatCalendarMenu } from './GroupChatCalendarMenu';
+import { GroupChatRoleManager } from './GroupChatRoleManager';
+import { getGroupChatPlannedStart } from './groupChatDate';
 
 export const GroupChatInfo = () => {
 	const settings = useAppConfig();
@@ -173,7 +176,7 @@ export const GroupChatInfo = () => {
 	if (redirectToSessionsList) {
 		return <Navigate to={listPath + getSessionListTab()} replace />;
 	}
-
+	const calendarStart = getGroupChatPlannedStart(activeSession.item);
 	const showCreator =
 		settings.groupChat?.info?.showCreator &&
 		activeSession?.consultant?.displayName;
@@ -181,10 +184,12 @@ export const GroupChatInfo = () => {
 		settings.groupChat?.info?.showCreationDate &&
 		activeSession?.item?.createdAt;
 
-	const isCurrentUserModerator = isUserModerator({
-		chatItem: activeSession.item,
-		rcUserId: getValueFromCookie('rc_uid')
-	});
+	const isCurrentUserModerator =
+		canModerateGroupChat(activeSession, userData) ||
+		isUserModerator({
+			chatItem: activeSession.item,
+			rcUserId: getValueFromCookie('rc_uid')
+		});
 
 	const preparedSettings: Array<{ label: string; value: string }> = [
 		{
@@ -277,7 +282,8 @@ export const GroupChatInfo = () => {
 								: activeSession.item.topic?.name || ''}
 						</h2>
 					</div>
-					{activeSession.item.active &&
+					{canModerateGroupChat(activeSession, userData) &&
+					activeSession.item.active &&
 					activeSession.item.subscribed ? (
 						<div className="groupChatInfo__innerWrapper__stopButton">
 							<Button
@@ -286,6 +292,15 @@ export const GroupChatInfo = () => {
 							/>
 						</div>
 					) : null}
+					{calendarStart && (
+						<div className="groupChatInfo__calendar">
+							<GroupChatCalendarMenu
+								start={calendarStart}
+								durationMinutes={activeSession.item.duration}
+								eventId={activeSession.item.id}
+							/>
+						</div>
+					)}
 					<div className="groupChatInfo__content">
 						<div className="groupChatInfo__content__item groupChatInfo__data">
 							<Text
@@ -306,6 +321,16 @@ export const GroupChatInfo = () => {
 							<SubscriberList
 								isCurrentUserModerator={isCurrentUserModerator}
 							/>
+							{activeSession.item.participants?.length &&
+							userData?.userId ? (
+								<GroupChatRoleManager
+									seriesId={activeSession.item.id}
+									currentUserId={userData.userId}
+									participants={
+										activeSession.item.participants
+									}
+								/>
+							) : null}
 						</div>
 
 						<div className="groupChatInfo__content__item groupChatInfo__data">

--- a/src/components/groupChat/GroupChatRoleManager.test.tsx
+++ b/src/components/groupChat/GroupChatRoleManager.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership
+} from '../../api/apiGroupChatRoles';
+import { GroupChatRoleManager } from './GroupChatRoleManager';
+
+vi.mock('../../api/apiGroupChatRoles', () => ({
+	apiChangeGroupChatParticipantRole: vi.fn(() => Promise.resolve()),
+	apiRemoveGroupChatParticipant: vi.fn(() => Promise.resolve()),
+	apiTransferGroupChatOwnership: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string, options?: { name?: string }) =>
+			options?.name ? `${key} ${options.name}` : key
+	})
+}));
+
+const participants: UserService.Schemas.GroupChatParticipantDTO[] = [
+	{ consultantId: 'owner', displayName: 'Alice', role: 'OWNER' },
+	{ consultantId: 'target', displayName: 'Bob', role: 'PARTICIPANT' },
+	{ consultantId: 'other', displayName: 'Charlie', role: 'PARTICIPANT' }
+];
+
+describe('GroupChatRoleManager', () => {
+	beforeEach(() => vi.clearAllMocks());
+	afterEach(cleanup);
+
+	it('lets an owner assign explicit Series roles', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.change(
+			screen.getByLabelText('groupChat.roles.roleLabel Bob'),
+			{
+				target: { value: 'CO_MODERATOR' }
+			}
+		);
+
+		await waitFor(() =>
+			expect(apiChangeGroupChatParticipantRole).toHaveBeenCalledWith(
+				42,
+				'target',
+				'CO_MODERATOR'
+			)
+		);
+		expect(
+			screen.queryAllByRole('option', { name: 'groupChat.roles.OWNER' })
+		).toHaveLength(0);
+	});
+
+	it('locks every mutation control while one role update is pending', () => {
+		vi.mocked(apiChangeGroupChatParticipantRole).mockReturnValueOnce(
+			new Promise(() => undefined)
+		);
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.change(
+			screen.getByLabelText('groupChat.roles.roleLabel Bob'),
+			{
+				target: { value: 'CO_MODERATOR' }
+			}
+		);
+
+		expect(
+			(
+				screen.getByRole('button', {
+					name: 'groupChat.roles.transferLabel Charlie'
+				}) as HTMLButtonElement
+			).disabled
+		).toBe(true);
+		expect(
+			(
+				screen.getByLabelText(
+					'groupChat.roles.roleLabel Charlie'
+				) as HTMLSelectElement
+			).disabled
+		).toBe(true);
+	});
+
+	it('keeps the previous role and shows an error when an update fails', async () => {
+		vi.mocked(apiChangeGroupChatParticipantRole).mockRejectedValueOnce(
+			new Error('network')
+		);
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		const select = screen.getByLabelText(
+			'groupChat.roles.roleLabel Bob'
+		) as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: 'CO_MODERATOR' } });
+
+		await screen.findByRole('alert');
+		expect(select.value).toBe('PARTICIPANT');
+	});
+
+	it('transfers primary ownership through a stable consultant id', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.roles.transferLabel Bob'
+			})
+		);
+
+		await waitFor(() =>
+			expect(apiTransferGroupChatOwnership).toHaveBeenCalledWith(
+				42,
+				'target'
+			)
+		);
+	});
+
+	it('keeps role controls read-only for non-owners', () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="target"
+				participants={participants}
+			/>
+		);
+
+		expect(
+			screen.queryByLabelText('groupChat.roles.roleLabel Alice')
+		).toBeNull();
+		expect(screen.getByText('Alice')).toBeTruthy();
+	});
+
+	it('lets an owner remove a non-owner participant', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.roles.remove Bob'
+			})
+		);
+
+		await waitFor(() =>
+			expect(apiRemoveGroupChatParticipant).toHaveBeenCalledWith(
+				42,
+				'target'
+			)
+		);
+		expect(screen.queryByText('Bob')).toBeNull();
+	});
+});

--- a/src/components/groupChat/GroupChatRoleManager.tsx
+++ b/src/components/groupChat/GroupChatRoleManager.tsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership,
+	GroupChatParticipantRole
+} from '../../api/apiGroupChatRoles';
+
+interface GroupChatRoleManagerProps {
+	seriesId: number;
+	currentUserId: string;
+	participants: UserService.Schemas.GroupChatParticipantDTO[];
+}
+
+const EDITABLE_ROLES: GroupChatParticipantRole[] = [
+	'CO_MODERATOR',
+	'PARTICIPANT'
+];
+
+export const GroupChatRoleManager = ({
+	seriesId,
+	currentUserId,
+	participants
+}: GroupChatRoleManagerProps) => {
+	const { t: translate } = useTranslation();
+	const [items, setItems] = React.useState(participants);
+	const [pendingId, setPendingId] = React.useState<string | null>(null);
+	const [error, setError] = React.useState<
+		'update' | 'transfer' | 'remove' | null
+	>(null);
+	const lastAppliedParticipants = React.useRef(participants);
+
+	React.useEffect(() => {
+		if (
+			pendingId === null &&
+			participants !== lastAppliedParticipants.current
+		) {
+			setItems(participants);
+			lastAppliedParticipants.current = participants;
+		}
+	}, [participants, pendingId]);
+
+	const currentUserIsOwner = items.some(
+		(item) => item.consultantId === currentUserId && item.role === 'OWNER'
+	);
+
+	const updateRole = async (
+		consultantId: string,
+		role: GroupChatParticipantRole
+	) => {
+		setPendingId(consultantId);
+		setError(null);
+		try {
+			await apiChangeGroupChatParticipantRole(
+				seriesId,
+				consultantId,
+				role
+			);
+			setItems((current) =>
+				current.map((item) =>
+					item.consultantId === consultantId
+						? { ...item, role }
+						: item
+				)
+			);
+		} catch {
+			setError('update');
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const transferOwnership = async (consultantId: string) => {
+		setPendingId(consultantId);
+		setError(null);
+		try {
+			await apiTransferGroupChatOwnership(seriesId, consultantId);
+			setItems((current) =>
+				current.map((item) => {
+					if (item.consultantId === currentUserId) {
+						return { ...item, role: 'CO_MODERATOR' };
+					}
+					if (item.consultantId === consultantId) {
+						return { ...item, role: 'OWNER' };
+					}
+					return item;
+				})
+			);
+		} catch {
+			setError('transfer');
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const removeParticipant = async (consultantId: string) => {
+		setPendingId(consultantId);
+		setError(null);
+		try {
+			await apiRemoveGroupChatParticipant(seriesId, consultantId);
+			setItems((current) =>
+				current.filter((item) => item.consultantId !== consultantId)
+			);
+		} catch {
+			setError('remove');
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	if (items.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="groupChatInfo__roles">
+			<h4>{translate('groupChat.roles.headline')}</h4>
+			{items.map((participant) => {
+				const isSelf = participant.consultantId === currentUserId;
+				const canManageParticipant =
+					currentUserIsOwner &&
+					!isSelf &&
+					participant.role !== 'OWNER';
+				const canEditRole = canManageParticipant;
+				const canRemove = canManageParticipant;
+				return (
+					<div
+						className="groupChatInfo__roleRow"
+						key={participant.consultantId}
+					>
+						<span>{participant.displayName}</span>
+						{canEditRole ? (
+							<>
+								<select
+									aria-label={translate(
+										'groupChat.roles.roleLabel',
+										{ name: participant.displayName }
+									)}
+									value={participant.role}
+									disabled={pendingId !== null}
+									onChange={(event) =>
+										void updateRole(
+											participant.consultantId,
+											event.target
+												.value as GroupChatParticipantRole
+										)
+									}
+								>
+									{EDITABLE_ROLES.map((role) => (
+										<option value={role} key={role}>
+											{translate(
+												`groupChat.roles.${role}`
+											)}
+										</option>
+									))}
+								</select>
+							</>
+						) : (
+							<span>
+								{translate(
+									`groupChat.roles.${participant.role}`
+								)}
+							</span>
+						)}
+						{currentUserIsOwner && !isSelf && (
+							<button
+								type="button"
+								disabled={pendingId !== null}
+								onClick={() =>
+									void transferOwnership(
+										participant.consultantId
+									)
+								}
+								aria-label={translate(
+									'groupChat.roles.transferLabel',
+									{ name: participant.displayName }
+								)}
+							>
+								{translate('groupChat.roles.transfer')}
+							</button>
+						)}
+						{canRemove && (
+							<button
+								type="button"
+								disabled={pendingId !== null}
+								onClick={() =>
+									void removeParticipant(
+										participant.consultantId
+									)
+								}
+								aria-label={`${translate(
+									'groupChat.roles.remove'
+								)} ${participant.displayName}`}
+							>
+								{translate('groupChat.roles.remove')}
+							</button>
+						)}
+					</div>
+				);
+			})}
+			{error && (
+				<p role="alert">{translate(`groupChat.roles.${error}Error`)}</p>
+			)}
+		</div>
+	);
+};

--- a/src/components/groupChat/GroupChatSeriesFields.test.tsx
+++ b/src/components/groupChat/GroupChatSeriesFields.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GroupChatSeriesFields } from './GroupChatSeriesFields';
+
+const translations: Record<string, string> = {
+	'groupChat.create.schedule': 'Schedule',
+	'groupChat.create.startDate': 'Start date',
+	'groupChat.create.startTime': 'Start time',
+	'groupChat.create.duration': 'Duration',
+	'groupChat.create.repeatCount': 'Occurrences',
+	'groupChat.create.interval.label': 'Interval',
+	'groupChat.create.modality.label': 'Format',
+	'groupChat.create.interval.options.daily': 'Daily',
+	'groupChat.create.interval.options.weekly': 'Weekly',
+	'groupChat.create.interval.options.biweekly': 'Every two weeks',
+	'groupChat.create.interval.options.monthly': 'Monthly',
+	'groupChat.create.interval.options.quarterly': 'Quarterly',
+	'groupChat.create.interval.options.yearly': 'Yearly',
+	'groupChat.create.modality.options.text': 'Text',
+	'groupChat.create.modality.options.audio': 'Audio',
+	'groupChat.create.modality.options.video': 'Video',
+	'groupChat.create.durationSelect.option1': '30 minutes',
+	'groupChat.create.durationSelect.option2': '1 hour',
+	'groupChat.create.durationSelect.option3': '1.5 hours',
+	'groupChat.create.durationSelect.option4': '2 hours',
+	'groupChat.create.durationSelect.option5': '2.5 hours',
+	'groupChat.create.durationSelect.option6': '3 hours'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key
+	})
+}));
+
+describe('GroupChatSeriesFields', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-10T12:00:00Z'));
+	});
+	afterEach(() => vi.useRealTimers());
+
+	it('uses translated controls and keeps interval disabled for one occurrence', () => {
+		const onChange = vi.fn();
+		render(
+			<GroupChatSeriesFields
+				value={{
+					startDate: '2026-08-04',
+					startTime: '18:00',
+					duration: 60,
+					repeatCount: 1,
+					interval: 'WEEKLY',
+					modality: 'TEXT'
+				}}
+				onChange={onChange}
+			/>
+		);
+
+		const interval = screen.getByRole('combobox', { name: 'Interval' });
+		expect(interval.getAttribute('aria-disabled')).toBe('true');
+		fireEvent.keyDown(interval, { key: 'ArrowDown' });
+		expect(onChange).not.toHaveBeenCalled();
+
+		fireEvent.change(screen.getByLabelText('Start date'), {
+			target: { value: '2026-08-05' }
+		});
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({ startDate: '2026-08-05' })
+		);
+		expect(screen.getByLabelText('Start date').getAttribute('min')).toBe(
+			'2026-07-10'
+		);
+
+		const repeatCount = screen.getByLabelText(
+			'Occurrences'
+		) as HTMLInputElement;
+		fireEvent.change(repeatCount, {
+			target: { value: '0' }
+		});
+		expect(repeatCount.value).toBe('0');
+		fireEvent.blur(repeatCount);
+		expect(onChange).toHaveBeenLastCalledWith(
+			expect.objectContaining({ repeatCount: 1 })
+		);
+
+		fireEvent.change(repeatCount, {
+			target: { value: '500' }
+		});
+		expect(repeatCount.value).toBe('500');
+		fireEvent.blur(repeatCount);
+		expect(onChange).toHaveBeenLastCalledWith(
+			expect.objectContaining({ repeatCount: 365 })
+		);
+	});
+});

--- a/src/components/groupChat/GroupChatSeriesFields.tsx
+++ b/src/components/groupChat/GroupChatSeriesFields.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { OrisoSelect } from '../form/OrisoSelect';
+import {
+	durationSelectOptionsSet,
+	getValidDateFormatForSelectedDate,
+	GroupChatInterval,
+	GroupChatModality
+} from './createChatHelpers';
+
+export interface GroupChatSeriesFieldsValue {
+	startDate: string;
+	startTime: string;
+	duration: number;
+	repeatCount: number;
+	interval: GroupChatInterval;
+	modality: GroupChatModality;
+}
+
+interface GroupChatSeriesFieldsProps {
+	value: GroupChatSeriesFieldsValue;
+	onChange: (value: GroupChatSeriesFieldsValue) => void;
+}
+
+const INTERVALS: GroupChatInterval[] = [
+	'DAILY',
+	'WEEKLY',
+	'BIWEEKLY',
+	'MONTHLY',
+	'QUARTERLY',
+	'YEARLY'
+];
+
+const MODALITIES: GroupChatModality[] = ['TEXT', 'AUDIO', 'VIDEO'];
+
+export const GroupChatSeriesFields = ({
+	value,
+	onChange
+}: GroupChatSeriesFieldsProps) => {
+	const { t: translate } = useTranslation();
+	const [repeatCountInput, setRepeatCountInput] = React.useState(
+		String(value.repeatCount)
+	);
+	React.useEffect(() => {
+		setRepeatCountInput(String(value.repeatCount));
+	}, [value.repeatCount]);
+	const update = <Key extends keyof GroupChatSeriesFieldsValue>(
+		key: Key,
+		fieldValue: GroupChatSeriesFieldsValue[Key]
+	) => onChange({ ...value, [key]: fieldValue });
+	const commitRepeatCount = () => {
+		const parsed = Number(repeatCountInput);
+		const next = Math.min(
+			365,
+			Math.max(1, Number.isFinite(parsed) ? Math.round(parsed) : 1)
+		);
+		setRepeatCountInput(String(next));
+		update('repeatCount', next);
+	};
+
+	return (
+		<fieldset className="createChat__seriesFields">
+			<legend>{translate('groupChat.create.schedule')}</legend>
+			<label>
+				{translate('groupChat.create.startDate')}
+				<input
+					type="date"
+					min={getValidDateFormatForSelectedDate(new Date())}
+					value={value.startDate}
+					onChange={(event) =>
+						update('startDate', event.target.value)
+					}
+					required
+				/>
+			</label>
+			<label>
+				{translate('groupChat.create.startTime')}
+				<input
+					type="time"
+					value={value.startTime}
+					onChange={(event) =>
+						update('startTime', event.target.value)
+					}
+					required
+				/>
+			</label>
+			<OrisoSelect
+				id="group-chat-duration"
+				label={translate('groupChat.create.duration')}
+				value={String(value.duration)}
+				options={durationSelectOptionsSet.map((option) => ({
+					value: option.value,
+					label: translate(option.label)
+				}))}
+				onChange={(event) =>
+					update('duration', Number(event.target.value))
+				}
+			/>
+			<label>
+				{translate('groupChat.create.repeatCount')}
+				<input
+					type="number"
+					min="1"
+					max="365"
+					value={repeatCountInput}
+					onChange={(event) =>
+						setRepeatCountInput(event.target.value)
+					}
+					onBlur={commitRepeatCount}
+				/>
+			</label>
+			<OrisoSelect
+				id="group-chat-interval"
+				label={translate('groupChat.create.interval.label')}
+				value={value.interval}
+				disabled={value.repeatCount === 1}
+				options={INTERVALS.map((interval) => ({
+					value: interval,
+					label: translate(
+						`groupChat.create.interval.options.${interval.toLowerCase()}`
+					)
+				}))}
+				onChange={(event) =>
+					update('interval', event.target.value as GroupChatInterval)
+				}
+			/>
+			<OrisoSelect
+				id="group-chat-modality"
+				label={translate('groupChat.create.modality.label')}
+				value={value.modality}
+				options={MODALITIES.map((modality) => ({
+					value: modality,
+					label: translate(
+						`groupChat.create.modality.options.${modality.toLowerCase()}`
+					)
+				}))}
+				onChange={(event) =>
+					update('modality', event.target.value as GroupChatModality)
+				}
+			/>
+		</fieldset>
+	);
+};

--- a/src/components/groupChat/JoinGroupChatView.tsx
+++ b/src/components/groupChat/JoinGroupChatView.tsx
@@ -33,6 +33,10 @@ import { useTranslation } from 'react-i18next';
 import { useTimeoutOverlay } from '../../hooks/useTimeoutOverlay';
 import { OVERLAY_REQUEST } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { FALLBACK_LNG } from '../../i18n';
+import { getWaitingAreaTime } from './groupChatWaitingArea';
+import { resolveGroupChatAuthorContent } from './groupChatAuthorContent';
+import { getGroupChatPlannedStart } from './groupChatDate';
+import { translateWithFallback } from '../../utils/translationFallback';
 
 interface JoinGroupChatViewProps {
 	forceBannedOverlay?: boolean;
@@ -43,7 +47,15 @@ export const JoinGroupChatView = ({
 	forceBannedOverlay = false,
 	bannedUsers = []
 }: JoinGroupChatViewProps) => {
-	const { t: translate } = useTranslation(['common', 'consultingTypes']);
+	const { t: translate, i18n } = useTranslation([
+		'common',
+		'consultingTypes'
+	]);
+	const tr = useCallback(
+		(key: string, fallback: string, options?: Record<string, unknown>) =>
+			translateWithFallback(translate, key, fallback, options),
+		[translate]
+	);
 	const { activeSession, reloadActiveSession } =
 		useContext(ActiveSessionContext);
 	const { userData } = useContext(UserDataContext);
@@ -55,6 +67,7 @@ export const JoinGroupChatView = ({
 
 	const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
+	const [now, setNow] = useState(() => new Date());
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
 	const getSessionListTab = () =>
 		`${sessionListTab ? `?sessionListTab=${sessionListTab}` : ''}`;
@@ -251,7 +264,7 @@ export const JoinGroupChatView = ({
 		}
 	}, [forceBannedOverlay, bannedUserOverlay]);
 
-	const groupChatRules = useMemo(() => {
+	const legacyGroupChatRules = useMemo(() => {
 		const transKeys = [
 			`consultingType.${topic?.id ?? 'noConsultingType'}.groupChatRules`,
 			`consultingType.fallback.groupChatRules`
@@ -277,6 +290,44 @@ export const JoinGroupChatView = ({
 		);
 	}, [consultingType?.groupChat?.groupChatRules, topic?.id, translate]);
 
+	const authorContent = useMemo(
+		() =>
+			resolveGroupChatAuthorContent({
+				language: i18n.resolvedLanguage || i18n.language,
+				sourceLanguage: activeSession.item.sourceLanguage,
+				hintMessageTranslations:
+					activeSession.item.hintMessageTranslations,
+				groupChatRulesTranslations:
+					activeSession.item.groupChatRulesTranslations,
+				legacyHintMessage: activeSession.item.hintMessage,
+				legacyRules: legacyGroupChatRules
+			}),
+		[
+			activeSession.item.groupChatRulesTranslations,
+			activeSession.item.hintMessage,
+			activeSession.item.hintMessageTranslations,
+			activeSession.item.sourceLanguage,
+			i18n.language,
+			i18n.resolvedLanguage,
+			legacyGroupChatRules
+		]
+	);
+	const groupChatRules = authorContent.rules;
+	const plannedStart = getGroupChatPlannedStart(activeSession.item);
+	const plannedStartMillis = plannedStart?.getTime();
+
+	useEffect(() => {
+		if (plannedStartMillis === undefined) {
+			return;
+		}
+		const timer = window.setInterval(() => setNow(new Date()), 1000);
+		return () => window.clearInterval(timer);
+	}, [plannedStartMillis]);
+
+	const waitingTime = plannedStart
+		? getWaitingAreaTime(now, plannedStart)
+		: null;
+
 	if (redirectToSessionsList) {
 		mobileListView();
 		return <Navigate to={listPath + getSessionListTab()} replace />;
@@ -293,8 +344,46 @@ export const JoinGroupChatView = ({
 					text={translate('groupChat.join.content.headline')}
 					semanticLevel="4"
 				/>
-				{groupChatRules.map((groupChatRuleText, i) => (
-					<Text text={groupChatRuleText} type="standard" key={i} />
+				{!!authorContent.hintMessage && (
+					<Text text={authorContent.hintMessage} type="standard" />
+				)}
+				{waitingTime && (
+					<div className="joinChat__countdown">
+						<span
+							className="joinChat__countdownValue"
+							aria-label={`${waitingTime.label} ${tr(
+								`groupChat.join.waitingArea.discomfort.${waitingTime.discomfortLabel}`,
+								waitingTime.discomfortLabel
+							)}`}
+						>
+							{waitingTime.label}{' '}
+							<span aria-hidden="true">
+								{waitingTime.discomfortEmoji}
+							</span>
+						</span>
+						<div
+							className="joinChat__timePills"
+							tabIndex={0}
+							role="list"
+							aria-label={tr(
+								'groupChat.join.timeConversions',
+								'Playful time conversions'
+							)}
+						>
+							{waitingTime.pills.map((pill) => (
+								<span key={pill.kind} role="listitem">
+									{tr(
+										`groupChat.join.waitingArea.${pill.kind}Minutes`,
+										`${pill.value} ${pill.kind} minutes`,
+										{ value: pill.value }
+									)}
+								</span>
+							))}
+						</div>
+					</div>
+				)}
+				{groupChatRules.map((rule, index) => (
+					<Text text={rule} type="standard" key={index} />
 				))}
 			</div>
 			<div className="joinChat__button-container">

--- a/src/components/groupChat/createChat.styles.scss
+++ b/src/components/groupChat/createChat.styles.scss
@@ -135,6 +135,43 @@ $inputSpacing: 32px;
 		margin: 0 0 $inputSpacing 0;
 	}
 
+	&__seriesFields {
+		width: min(100%, $chat-input-width);
+		box-sizing: border-box;
+		margin: 0 0 $inputSpacing;
+		padding: $grid-base-two;
+		border: 1px solid var(--m3-outline-variant, #c8c5ca);
+		border-radius: $box-border-radius;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: $grid-base-two;
+
+		legend {
+			padding: 0 $grid-base;
+		}
+
+		label {
+			display: flex;
+			flex-direction: column;
+			gap: $grid-base;
+			font-size: $font-size-secondary;
+		}
+
+		input,
+		select {
+			min-height: $input-field-height;
+			padding: $grid-base;
+			border: 1px solid var(--m3-outline, #747878);
+			border-radius: $input-field-border-radius;
+			background: var(--m3-surface-container-lowest, $white);
+			font: inherit;
+		}
+
+		@media (width <= 480px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
 	&__participantsRow {
 		display: flex;
 		align-items: center;
@@ -394,6 +431,40 @@ $inputSpacing: 32px;
 	&__explanation {
 		font-size: 12px;
 		margin: 0 0 $grid-base-four;
+	}
+
+	&__authorContent {
+		width: min(100%, $chat-input-width);
+		box-sizing: border-box;
+		margin: 0 0 $inputSpacing;
+		padding: $grid-base-three;
+		border: 1px solid var(--m3-outline-variant, #d8dcdf);
+		border-radius: $box-border-radius;
+
+		label,
+		.createChat__rules {
+			display: grid;
+			gap: $grid-base;
+			margin-top: $grid-base-two;
+		}
+
+		textarea,
+		select {
+			box-sizing: border-box;
+			width: 100%;
+			padding: $grid-base-two;
+		}
+	}
+
+	&__languageTabs {
+		display: flex;
+		gap: $grid-base;
+		margin-top: $grid-base-two;
+
+		button[aria-selected='true'] {
+			border-color: var(--m3-primary, $primary);
+			color: var(--m3-primary, $primary);
+		}
 	}
 }
 

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -89,13 +89,32 @@ describe('buildGroupChatSeriesRequest', () => {
 			modality: 'AUDIO',
 			timezone: 'Europe/Berlin',
 			hintMessage: '',
-			groupChatRulesTranslations: { de: ['', '  ', 'Respect'] },
+			groupChatRulesTranslations: { de: ['', '  ', '  Respect  '] },
 			consultantIds: []
 		});
 
 		expect(request.groupChatRulesTranslations).toEqual({
 			de: ['Respect']
 		});
+	});
+
+	it('omits group rules when every locale contains only blanks', () => {
+		const request = buildGroupChatSeriesRequest({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 60,
+			repeatCount: 1,
+			chatInterval: 'WEEKLY',
+			modality: 'TEXT',
+			timezone: 'Europe/Berlin',
+			hintMessage: '',
+			groupChatRulesTranslations: { de: ['', '  '] },
+			consultantIds: []
+		});
+
+		expect(request.groupChatRulesTranslations).toBeUndefined();
 	});
 });
 

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildGroupChatSeriesRequest,
+	buildOneOffDuplicateFields,
+	isGroupChatFeatureEnabled
+} from './createChatHelpers';
+
+describe('isGroupChatFeatureEnabled', () => {
+	it('fails closed unless the tenant explicitly enables group chat v2', () => {
+		expect(isGroupChatFeatureEnabled(undefined)).toBe(false);
+		expect(isGroupChatFeatureEnabled({ settings: undefined })).toBe(false);
+		expect(
+			isGroupChatFeatureEnabled({
+				settings: { featureGroupChatV2Enabled: false }
+			})
+		).toBe(false);
+		expect(
+			isGroupChatFeatureEnabled({
+				settings: { featureGroupChatV2Enabled: true }
+			})
+		).toBe(true);
+	});
+});
+
+describe('buildGroupChatSeriesRequest', () => {
+	it('builds an explicit finite text-only one-off Series', () => {
+		expect(
+			buildGroupChatSeriesRequest({
+				topic: 'Peer support',
+				agencyId: 17,
+				startDate: '2026-08-04',
+				startTime: '18:30',
+				duration: 90,
+				repeatCount: 1,
+				chatInterval: 'WEEKLY',
+				modality: 'TEXT',
+				timezone: 'Europe/Berlin',
+				hintMessage: 'Welcome',
+				consultantIds: []
+			})
+		).toEqual({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 90,
+			repetitive: false,
+			repeatCount: 1,
+			modality: 'TEXT',
+			timezone: 'Europe/Berlin',
+			hintMessage: 'Welcome',
+			consultantIds: [],
+			featureGroupChatV2Enabled: true
+		});
+	});
+
+	it('builds a finite recurring Series with its explicit interval', () => {
+		expect(
+			buildGroupChatSeriesRequest({
+				topic: 'Peer support',
+				agencyId: 17,
+				startDate: '2026-08-04',
+				startTime: '18:30',
+				duration: 90,
+				repeatCount: 4,
+				chatInterval: 'BIWEEKLY',
+				modality: 'VIDEO',
+				timezone: 'Europe/Berlin',
+				hintMessage: 'Welcome',
+				consultantIds: ['co-mod-1']
+			})
+		).toMatchObject({
+			repetitive: true,
+			repeatCount: 4,
+			chatInterval: 'BIWEEKLY',
+			modality: 'VIDEO'
+		});
+	});
+});
+
+describe('buildOneOffDuplicateFields', () => {
+	it('prefills a skipped virtual occurrence as a standalone one-off Series', () => {
+		expect(
+			buildOneOffDuplicateFields({
+				topic: 'Peer support',
+				start: '2026-09-21T18:30:00',
+				duration: 90,
+				modality: 'VIDEO'
+			})
+		).toEqual({
+			topic: 'Peer support',
+			startDate: '2026-09-21',
+			startTime: '18:30',
+			duration: 90,
+			repeatCount: 1,
+			interval: 'WEEKLY',
+			modality: 'VIDEO'
+		});
+	});
+
+	it('rejects an invalid occurrence start instead of producing NaN fields', () => {
+		expect(() =>
+			buildOneOffDuplicateFields({
+				topic: 'Peer support',
+				start: 'not-a-date',
+				duration: 90,
+				modality: 'TEXT'
+			})
+		).toThrow('A valid occurrence start is required for duplication');
+	});
+});

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -76,6 +76,27 @@ describe('buildGroupChatSeriesRequest', () => {
 			modality: 'VIDEO'
 		});
 	});
+
+	it('does not submit blank group rules that the API rejects', () => {
+		const request = buildGroupChatSeriesRequest({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 60,
+			repeatCount: 1,
+			chatInterval: 'WEEKLY',
+			modality: 'AUDIO',
+			timezone: 'Europe/Berlin',
+			hintMessage: '',
+			groupChatRulesTranslations: { de: ['', '  ', 'Respect'] },
+			consultantIds: []
+		});
+
+		expect(request.groupChatRulesTranslations).toEqual({
+			de: ['Respect']
+		});
+	});
 });
 
 describe('buildOneOffDuplicateFields', () => {

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -29,14 +29,31 @@ export const isGroupChatFeatureEnabled = (
 export const buildGroupChatSeriesRequest = ({
 	repeatCount,
 	chatInterval,
+	groupChatRulesTranslations,
 	...form
-}: GroupChatSeriesFormValue): groupChatSettings => ({
-	...form,
-	repetitive: repeatCount > 1,
-	repeatCount,
-	...(repeatCount > 1 ? { chatInterval } : {}),
-	featureGroupChatV2Enabled: true
-});
+}: GroupChatSeriesFormValue): groupChatSettings => {
+	const normalizedRules = groupChatRulesTranslations
+		? Object.fromEntries(
+				Object.entries(groupChatRulesTranslations).map(
+					([language, rules]) => [
+						language,
+						rules.map((rule) => rule.trim()).filter(Boolean)
+					]
+				)
+			)
+		: undefined;
+
+	return {
+		...form,
+		...(normalizedRules
+			? { groupChatRulesTranslations: normalizedRules }
+			: {}),
+		repetitive: repeatCount > 1,
+		repeatCount,
+		...(repeatCount > 1 ? { chatInterval } : {}),
+		featureGroupChatV2Enabled: true
+	};
+};
 
 export const buildOneOffDuplicateFields = ({
 	topic,

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -1,3 +1,69 @@
+import { groupChatSettings } from '../../api/apiGroupChatSettings';
+
+export type GroupChatInterval = NonNullable<groupChatSettings['chatInterval']>;
+export type GroupChatModality = NonNullable<groupChatSettings['modality']>;
+
+export interface GroupChatSeriesFormValue {
+	topic: string;
+	agencyId: number;
+	startDate: string;
+	startTime: string;
+	duration: number;
+	repeatCount: number;
+	chatInterval: GroupChatInterval;
+	modality: GroupChatModality;
+	timezone: string;
+	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
+	consultantIds: string[];
+}
+
+export const isGroupChatFeatureEnabled = (
+	tenant?: {
+		settings?: { featureGroupChatV2Enabled?: boolean };
+	} | null
+) => tenant?.settings?.featureGroupChatV2Enabled === true;
+
+export const buildGroupChatSeriesRequest = ({
+	repeatCount,
+	chatInterval,
+	...form
+}: GroupChatSeriesFormValue): groupChatSettings => ({
+	...form,
+	repetitive: repeatCount > 1,
+	repeatCount,
+	...(repeatCount > 1 ? { chatInterval } : {}),
+	featureGroupChatV2Enabled: true
+});
+
+export const buildOneOffDuplicateFields = ({
+	topic,
+	start,
+	duration,
+	modality
+}: {
+	topic: string;
+	start: string;
+	duration: number;
+	modality: GroupChatModality;
+}) => {
+	const plannedStart = new Date(start);
+	if (Number.isNaN(plannedStart.getTime())) {
+		throw new Error('A valid occurrence start is required for duplication');
+	}
+	return {
+		topic,
+		startDate: getValidDateFormatForSelectedDate(plannedStart),
+		startTime: getValidTimeFormatForSelectedTime(plannedStart),
+		duration,
+		repeatCount: 1,
+		interval: 'WEEKLY' as GroupChatInterval,
+		modality
+	};
+};
+
 export const TOPIC_LENGTHS = {
 	MIN: 3,
 	MAX: 50

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -34,18 +34,22 @@ export const buildGroupChatSeriesRequest = ({
 }: GroupChatSeriesFormValue): groupChatSettings => {
 	const normalizedRules = groupChatRulesTranslations
 		? Object.fromEntries(
-				Object.entries(groupChatRulesTranslations).map(
-					([language, rules]) => [
-						language,
-						rules.map((rule) => rule.trim()).filter(Boolean)
-					]
+				Object.entries(groupChatRulesTranslations).flatMap(
+					([language, rules]) => {
+						const normalized = rules
+							.map((rule) => rule.trim())
+							.filter(Boolean);
+						return normalized.length
+							? [[language, normalized]]
+							: [];
+					}
 				)
 			)
 		: undefined;
 
 	return {
 		...form,
-		...(normalizedRules
+		...(normalizedRules && Object.keys(normalizedRules).length
 			? { groupChatRulesTranslations: normalizedRules }
 			: {}),
 		repetitive: repeatCount > 1,

--- a/src/components/groupChat/groupChatAuthorContent.test.ts
+++ b/src/components/groupChat/groupChatAuthorContent.test.ts
@@ -62,6 +62,22 @@ describe('resolveGroupChatAuthorContent', () => {
 			rules: ['Legacy rule']
 		});
 	});
+
+	it('falls back to legacy fields when the API returns null translation maps', () => {
+		const legacyPayload = JSON.parse(`{
+			"language": "de",
+			"sourceLanguage": "de",
+			"hintMessageTranslations": null,
+			"groupChatRulesTranslations": null,
+			"legacyHintMessage": "Legacy welcome",
+			"legacyRules": ["Legacy rule"]
+		}`);
+
+		expect(resolveGroupChatAuthorContent(legacyPayload)).toEqual({
+			hintMessage: 'Legacy welcome',
+			rules: ['Legacy rule']
+		});
+	});
 });
 
 describe('group-chat language normalization', () => {

--- a/src/components/groupChat/groupChatAuthorContent.test.ts
+++ b/src/components/groupChat/groupChatAuthorContent.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyGroupChatAuthorTranslations,
+	buildGroupChatAuthorTranslationRequest,
+	normalizeGroupChatLanguages,
+	resolveGroupChatAuthorContent,
+	syncGroupChatAuthorContentLanguages
+} from './groupChatAuthorContent';
+
+describe('resolveGroupChatAuthorContent', () => {
+	it('prefers the requested language', () => {
+		expect(
+			resolveGroupChatAuthorContent({
+				language: 'fr-FR',
+				sourceLanguage: 'de',
+				hintMessageTranslations: {
+					fr: 'Bienvenue',
+					en: 'Welcome',
+					de: 'Willkommen'
+				},
+				groupChatRulesTranslations: {
+					fr: ['Respectez-vous'],
+					en: ['Be respectful'],
+					de: ['Respektvoll bleiben']
+				},
+				legacyHintMessage: 'Legacy',
+				legacyRules: ['Legacy rule']
+			})
+		).toEqual({ hintMessage: 'Bienvenue', rules: ['Respectez-vous'] });
+	});
+
+	it('falls back independently through English, source language, then legacy', () => {
+		expect(
+			resolveGroupChatAuthorContent({
+				language: 'it',
+				sourceLanguage: 'de',
+				hintMessageTranslations: { en: 'Welcome' },
+				groupChatRulesTranslations: {
+					de: ['Respektvoll bleiben']
+				},
+				legacyHintMessage: 'Legacy',
+				legacyRules: ['Legacy rule']
+			})
+		).toEqual({
+			hintMessage: 'Welcome',
+			rules: ['Respektvoll bleiben']
+		});
+	});
+
+	it('falls back to legacy fields when translated fields are blank', () => {
+		expect(
+			resolveGroupChatAuthorContent({
+				language: 'de',
+				sourceLanguage: 'de',
+				hintMessageTranslations: { de: '   ' },
+				groupChatRulesTranslations: { de: [' ', ''] },
+				legacyHintMessage: 'Legacy welcome',
+				legacyRules: ['Legacy rule']
+			})
+		).toEqual({
+			hintMessage: 'Legacy welcome',
+			rules: ['Legacy rule']
+		});
+	});
+});
+
+describe('group-chat language normalization', () => {
+	it('normalizes locale variants, blanks and duplicates once', () => {
+		expect(
+			normalizeGroupChatLanguages(['de-DE', ' en ', 'de', '', 'EN-us'])
+		).toEqual(['de', 'en']);
+	});
+
+	it('moves an unresolved draft to the first active language without losing content', () => {
+		expect(
+			syncGroupChatAuthorContentLanguages(
+				{
+					sourceLanguage: 'de',
+					hintMessageTranslations: { de: 'Willkommen' },
+					groupChatRulesTranslations: {
+						de: ['Respektvoll bleiben']
+					}
+				},
+				['en-US', 'fr']
+			)
+		).toEqual({
+			sourceLanguage: 'en',
+			hintMessageTranslations: { de: 'Willkommen', en: '' },
+			groupChatRulesTranslations: {
+				de: ['Respektvoll bleiben'],
+				en: ['']
+			}
+		});
+	});
+});
+
+describe('group-chat author translation draft', () => {
+	it('maps welcome and rules to stable translation keys', () => {
+		expect(
+			buildGroupChatAuthorTranslationRequest({
+				sourceLanguage: 'de',
+				activeLanguages: ['de', 'en', 'fr'],
+				hintMessageTranslations: { de: 'Willkommen' },
+				groupChatRulesTranslations: {
+					de: ['Respektvoll bleiben', 'Keine Werbung']
+				}
+			})
+		).toEqual({
+			sourceLang: 'de',
+			targetLangs: ['en', 'fr'],
+			texts: {
+				'welcome': 'Willkommen',
+				'rule-0': 'Respektvoll bleiben',
+				'rule-1': 'Keine Werbung'
+			}
+		});
+	});
+
+	it('merges translated fields into editable per-language content', () => {
+		expect(
+			applyGroupChatAuthorTranslations(
+				{
+					sourceLanguage: 'de',
+					hintMessageTranslations: { de: 'Willkommen' },
+					groupChatRulesTranslations: {
+						de: ['Respektvoll bleiben']
+					}
+				},
+				{
+					en: {
+						'welcome': 'Welcome',
+						'rule-0': 'Be respectful'
+					}
+				}
+			)
+		).toMatchObject({
+			hintMessageTranslations: { de: 'Willkommen', en: 'Welcome' },
+			groupChatRulesTranslations: {
+				de: ['Respektvoll bleiben'],
+				en: ['Be respectful']
+			}
+		});
+	});
+});

--- a/src/components/groupChat/groupChatAuthorContent.ts
+++ b/src/components/groupChat/groupChatAuthorContent.ts
@@ -1,0 +1,146 @@
+export interface GroupChatAuthorContent {
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
+}
+
+export interface GroupChatAuthorContentDraft {
+	sourceLanguage: string;
+	hintMessageTranslations: Record<string, string>;
+	groupChatRulesTranslations: Record<string, string[]>;
+}
+
+const normalizeLanguage = (language?: string) =>
+	language?.trim().toLowerCase().split('-')[0];
+
+export const normalizeGroupChatLanguages = (languages: string[]) =>
+	Array.from(
+		new Set(
+			languages
+				.map(normalizeLanguage)
+				.filter((language): language is string => !!language)
+		)
+	);
+
+export const syncGroupChatAuthorContentLanguages = (
+	draft: GroupChatAuthorContentDraft,
+	activeLanguages: string[]
+): GroupChatAuthorContentDraft => {
+	const languages = normalizeGroupChatLanguages(activeLanguages);
+	const currentSource = normalizeLanguage(draft.sourceLanguage);
+	const sourceLanguage =
+		(currentSource && languages.includes(currentSource)
+			? currentSource
+			: languages[0]) ||
+		currentSource ||
+		'de';
+
+	if (
+		draft.sourceLanguage === sourceLanguage &&
+		draft.hintMessageTranslations[sourceLanguage] !== undefined &&
+		draft.groupChatRulesTranslations[sourceLanguage] !== undefined
+	) {
+		return draft;
+	}
+
+	return {
+		...draft,
+		sourceLanguage,
+		hintMessageTranslations: {
+			...draft.hintMessageTranslations,
+			[sourceLanguage]:
+				draft.hintMessageTranslations[sourceLanguage] || ''
+		},
+		groupChatRulesTranslations: {
+			...draft.groupChatRulesTranslations,
+			[sourceLanguage]: draft.groupChatRulesTranslations[
+				sourceLanguage
+			] || ['']
+		}
+	};
+};
+
+const fallbackLanguages = (language?: string, sourceLanguage?: string) =>
+	Array.from(
+		new Set(
+			[
+				normalizeLanguage(language),
+				'en',
+				normalizeLanguage(sourceLanguage)
+			].filter((value): value is string => !!value)
+		)
+	);
+
+export const resolveGroupChatAuthorContent = ({
+	language,
+	sourceLanguage,
+	hintMessageTranslations = {},
+	groupChatRulesTranslations = {},
+	legacyHintMessage,
+	legacyRules
+}: GroupChatAuthorContent & {
+	language?: string;
+	legacyHintMessage?: string;
+	legacyRules: string[];
+}) => {
+	const languages = fallbackLanguages(language, sourceLanguage);
+	const hintMessage =
+		languages
+			.map((candidate) => hintMessageTranslations[candidate])
+			.find((candidate) => !!candidate?.trim()) ||
+		legacyHintMessage ||
+		'';
+	const rules =
+		languages
+			.map((candidate) => groupChatRulesTranslations[candidate])
+			.find((candidate) => candidate?.some((rule) => !!rule.trim()))
+			?.filter((rule) => !!rule.trim()) || legacyRules;
+
+	return { hintMessage, rules };
+};
+
+export const buildGroupChatAuthorTranslationRequest = ({
+	sourceLanguage,
+	activeLanguages,
+	hintMessageTranslations,
+	groupChatRulesTranslations
+}: GroupChatAuthorContentDraft & { activeLanguages: string[] }) => ({
+	sourceLang: normalizeLanguage(sourceLanguage) || sourceLanguage,
+	targetLangs: normalizeGroupChatLanguages(activeLanguages).filter(
+		(language) => language !== normalizeLanguage(sourceLanguage)
+	),
+	texts: {
+		welcome: hintMessageTranslations[sourceLanguage] || '',
+		...Object.fromEntries(
+			(groupChatRulesTranslations[sourceLanguage] || []).map(
+				(rule, index) => [`rule-${index}`, rule]
+			)
+		)
+	}
+});
+
+export const applyGroupChatAuthorTranslations = (
+	draft: GroupChatAuthorContentDraft,
+	translations: Record<string, Record<string, string>>
+): GroupChatAuthorContentDraft => {
+	const nextHints = { ...draft.hintMessageTranslations };
+	const nextRules = { ...draft.groupChatRulesTranslations };
+
+	Object.entries(translations).forEach(([language, fields]) => {
+		nextHints[language] = fields.welcome || '';
+		nextRules[language] = Object.entries(fields)
+			.filter(([key]) => key.startsWith('rule-'))
+			.sort(
+				([left], [right]) =>
+					Number(left.slice('rule-'.length)) -
+					Number(right.slice('rule-'.length))
+			)
+			.map(([, value]) => value);
+	});
+
+	return {
+		...draft,
+		hintMessageTranslations: nextHints,
+		groupChatRulesTranslations: nextRules
+	};
+};

--- a/src/components/groupChat/groupChatAuthorContent.ts
+++ b/src/components/groupChat/groupChatAuthorContent.ts
@@ -1,7 +1,7 @@
 export interface GroupChatAuthorContent {
 	sourceLanguage?: string;
-	hintMessageTranslations?: Record<string, string>;
-	groupChatRulesTranslations?: Record<string, string[]>;
+	hintMessageTranslations?: Record<string, string> | null;
+	groupChatRulesTranslations?: Record<string, string[]> | null;
 }
 
 export interface GroupChatAuthorContentDraft {
@@ -84,15 +84,17 @@ export const resolveGroupChatAuthorContent = ({
 	legacyRules: string[];
 }) => {
 	const languages = fallbackLanguages(language, sourceLanguage);
+	const safeHintMessageTranslations = hintMessageTranslations || {};
+	const safeGroupChatRulesTranslations = groupChatRulesTranslations || {};
 	const hintMessage =
 		languages
-			.map((candidate) => hintMessageTranslations[candidate])
+			.map((candidate) => safeHintMessageTranslations[candidate])
 			.find((candidate) => !!candidate?.trim()) ||
 		legacyHintMessage ||
 		'';
 	const rules =
 		languages
-			.map((candidate) => groupChatRulesTranslations[candidate])
+			.map((candidate) => safeGroupChatRulesTranslations[candidate])
 			.find((candidate) => candidate?.some((rule) => !!rule.trim()))
 			?.filter((rule) => !!rule.trim()) || legacyRules;
 

--- a/src/components/groupChat/groupChatCalendar.test.ts
+++ b/src/components/groupChat/groupChatCalendar.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	buildNeutralGroupChatCalendar,
+	downloadNeutralGroupChatIcs
+} from './groupChatCalendar';
+
+describe('buildNeutralGroupChatCalendar', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		delete (URL as unknown as Record<string, unknown>).createObjectURL;
+		delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+	});
+
+	it('creates content-neutral ICS and provider URLs', () => {
+		const calendar = buildNeutralGroupChatCalendar({
+			start: new Date('2026-08-04T18:00:00Z'),
+			durationMinutes: 60,
+			title: 'Online appointment',
+			defaultTitle: 'Online appointment',
+			eventId: 'series-42-occurrence-3'
+		});
+
+		expect(calendar.ics).toContain('SUMMARY:Online appointment');
+		expect(calendar.ics).not.toMatch(/support|oriso|sucht/i);
+		expect(calendar.googleUrl).toContain('calendar.google.com');
+		expect(calendar.outlookUrl).toContain('outlook.live.com');
+	});
+
+	it('escapes CRLF and punctuation without injecting ICS fields', () => {
+		const calendar = buildNeutralGroupChatCalendar({
+			start: new Date('2026-08-04T18:00:00Z'),
+			durationMinutes: 60,
+			title: 'Private, meeting; note\r\nLOCATION:leak',
+			defaultTitle: 'Online appointment',
+			eventId: 'series-42-occurrence-3'
+		});
+
+		expect(calendar.ics).toContain(
+			'SUMMARY:Private\\, meeting\\; note\\nLOCATION:leak'
+		);
+		expect(calendar.ics).not.toContain('\r\nLOCATION:leak');
+	});
+
+	it('creates stable, distinct UIDs for different Series occurrences', () => {
+		const input = {
+			start: new Date('2026-08-04T18:00:00Z'),
+			durationMinutes: 60,
+			title: 'Online appointment',
+			defaultTitle: 'Online appointment'
+		};
+		const first = buildNeutralGroupChatCalendar({
+			...input,
+			eventId: 'series-42-occurrence-3'
+		});
+		const repeated = buildNeutralGroupChatCalendar({
+			...input,
+			eventId: 'series-42-occurrence-3'
+		});
+		const second = buildNeutralGroupChatCalendar({
+			...input,
+			eventId: 'series-43-occurrence-3'
+		});
+
+		expect(first.ics.match(/UID:(.+)/)?.[1]).toBe(
+			repeated.ics.match(/UID:(.+)/)?.[1]
+		);
+		expect(first.ics.match(/UID:(.+)/)?.[1]).not.toBe(
+			second.ics.match(/UID:(.+)/)?.[1]
+		);
+	});
+
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+		'rejects an invalid duration boundary (%s)',
+		(durationMinutes) => {
+			expect(() =>
+				buildNeutralGroupChatCalendar({
+					start: new Date('2026-08-04T18:00:00Z'),
+					durationMinutes,
+					title: 'Online appointment',
+					defaultTitle: 'Online appointment',
+					eventId: 42
+				})
+			).toThrow(
+				'Calendar duration must be a finite, non-negative number'
+			);
+		}
+	);
+
+	it('uses the localized default title and folds long UTF-8 summary lines', () => {
+		const calendar = buildNeutralGroupChatCalendar({
+			start: new Date('2026-08-04T18:00:00Z'),
+			durationMinutes: 60,
+			title: '',
+			defaultTitle: `Online-Termin ${'🙂'.repeat(40)}`,
+			eventId: 42
+		});
+		const summaryLines = calendar.ics
+			.split('\r\n')
+			.filter(
+				(line, index, lines) =>
+					line.startsWith('SUMMARY:') ||
+					(index > 0 &&
+						line.startsWith(' ') &&
+						(lines[index - 1].startsWith('SUMMARY:') ||
+							lines[index - 1].startsWith(' ')))
+			);
+
+		expect(summaryLines[0]).toContain('Online-Termin');
+		expect(summaryLines.length).toBeGreaterThan(1);
+		summaryLines.forEach((line) =>
+			expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(
+				75
+			)
+		);
+	});
+
+	it('attaches the temporary download link and revokes it after the click', () => {
+		vi.useFakeTimers();
+		const createObjectURL = vi.fn(() => 'blob:calendar');
+		const revokeObjectURL = vi.fn();
+		Object.defineProperty(URL, 'createObjectURL', {
+			configurable: true,
+			value: createObjectURL
+		});
+		Object.defineProperty(URL, 'revokeObjectURL', {
+			configurable: true,
+			value: revokeObjectURL
+		});
+		const appendChild = vi.spyOn(document.body, 'appendChild');
+		const remove = vi
+			.spyOn(HTMLAnchorElement.prototype, 'remove')
+			.mockImplementation(() => undefined);
+		vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+			() => undefined
+		);
+
+		downloadNeutralGroupChatIcs('BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+		vi.runAllTimers();
+
+		expect(createObjectURL).toHaveBeenCalledOnce();
+		expect(appendChild).toHaveBeenCalledWith(expect.any(HTMLAnchorElement));
+		expect(remove).toHaveBeenCalledOnce();
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:calendar');
+	});
+});

--- a/src/components/groupChat/groupChatCalendar.ts
+++ b/src/components/groupChat/groupChatCalendar.ts
@@ -1,0 +1,102 @@
+interface GroupChatCalendarInput {
+	start: Date;
+	durationMinutes: number;
+	title: string;
+	defaultTitle: string;
+	eventId: string | number;
+}
+
+const compactUtc = (date: Date) =>
+	date
+		.toISOString()
+		.replace(/[-:]/g, '')
+		.replace(/\.\d{3}/, '');
+
+const escapeIcs = (value: string) =>
+	value
+		.replace(/\\/g, '\\\\')
+		.replace(/[,;]/g, '\\$&')
+		.replace(/\r\n|\r|\n/g, '\\n');
+
+const safeUidSegment = (value: string | number) =>
+	String(value)
+		.trim()
+		.replace(/[^a-zA-Z0-9._-]/g, '-');
+
+const foldIcsLine = (line: string): string => {
+	const encoder = new TextEncoder();
+	const lines: string[] = [];
+	let current = '';
+	for (const character of line) {
+		if (encoder.encode(current + character).length > 75) {
+			lines.push(current);
+			current = ` ${character}`;
+		} else {
+			current += character;
+		}
+	}
+	lines.push(current);
+	return lines.join('\r\n');
+};
+
+export const buildNeutralGroupChatCalendar = ({
+	start,
+	durationMinutes,
+	title,
+	defaultTitle,
+	eventId
+}: GroupChatCalendarInput) => {
+	if (!Number.isFinite(durationMinutes) || durationMinutes < 0) {
+		throw new Error(
+			'Calendar duration must be a finite, non-negative number'
+		);
+	}
+	const end = new Date(start.getTime() + durationMinutes * 60_000);
+	const startUtc = compactUtc(start);
+	const endUtc = compactUtc(end);
+	const safeTitle = title.trim() || defaultTitle.trim();
+	if (!safeTitle) {
+		throw new Error('Calendar default title is required');
+	}
+	const ics = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//Online Appointment//Calendar//EN',
+		'BEGIN:VEVENT',
+		`UID:${safeUidSegment(eventId)}-${start.getTime()}-online-appointment@localhost`,
+		`DTSTAMP:${compactUtc(new Date())}`,
+		`DTSTART:${startUtc}`,
+		`DTEND:${endUtc}`,
+		foldIcsLine(`SUMMARY:${escapeIcs(safeTitle)}`),
+		'END:VEVENT',
+		'END:VCALENDAR'
+	].join('\r\n');
+	const common = new URLSearchParams({
+		text: safeTitle,
+		dates: `${startUtc}/${endUtc}`
+	});
+	const outlook = new URLSearchParams({
+		path: '/calendar/action/compose',
+		rru: 'addevent',
+		subject: safeTitle,
+		startdt: start.toISOString(),
+		enddt: end.toISOString()
+	});
+
+	return {
+		ics,
+		googleUrl: `https://calendar.google.com/calendar/render?action=TEMPLATE&${common}`,
+		outlookUrl: `https://outlook.live.com/calendar/0/deeplink/compose?${outlook}`
+	};
+};
+
+export const downloadNeutralGroupChatIcs = (ics: string): void => {
+	const url = URL.createObjectURL(new Blob([ics], { type: 'text/calendar' }));
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = 'online-appointment.ics';
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	window.setTimeout(() => URL.revokeObjectURL(url), 0);
+};

--- a/src/components/groupChat/groupChatDate.test.ts
+++ b/src/components/groupChat/groupChatDate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getGroupChatPlannedStart } from './groupChatDate';
+
+describe('getGroupChatPlannedStart', () => {
+	it('prefers the combined backend start instant', () => {
+		expect(
+			getGroupChatPlannedStart({
+				startDateWithTime: '2026-08-04T18:00:00Z',
+				startDate: 'wrong',
+				startTime: 'wrong'
+			})?.toISOString()
+		).toBe('2026-08-04T18:00:00.000Z');
+	});
+
+	it('falls back to separate date and time fields', () => {
+		expect(
+			getGroupChatPlannedStart({
+				startDate: '2026-08-04',
+				startTime: '18:00:00Z'
+			})?.toISOString()
+		).toBe('2026-08-04T18:00:00.000Z');
+	});
+
+	it('returns null instead of exposing an invalid Date', () => {
+		expect(
+			getGroupChatPlannedStart({
+				startDate: 'not-a-date',
+				startTime: 'not-a-time'
+			})
+		).toBeNull();
+	});
+});

--- a/src/components/groupChat/groupChatDate.ts
+++ b/src/components/groupChat/groupChatDate.ts
@@ -1,0 +1,17 @@
+interface GroupChatStartFields {
+	startDateWithTime?: string;
+	startDate?: string;
+	startTime?: string;
+}
+
+export const getGroupChatPlannedStart = (
+	item: GroupChatStartFields
+): Date | null => {
+	const raw =
+		item.startDateWithTime ||
+		(item.startDate && item.startTime
+			? `${item.startDate}T${item.startTime}`
+			: '');
+	const parsed = new Date(raw);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+};

--- a/src/components/groupChat/groupChatHelpers.test.ts
+++ b/src/components/groupChat/groupChatHelpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+	canModerateGroupChat,
+	shouldShowGroupChatJoinView
+} from './groupChatHelpers';
+
+describe('canModerateGroupChat', () => {
+	it('allows the primary owner and explicitly invited Series moderators only', () => {
+		const activeSession = {
+			consultant: { id: 'owner' },
+			item: { moderators: ['owner', 'co-mod'] }
+		};
+
+		expect(canModerateGroupChat(activeSession, { userId: 'owner' })).toBe(
+			true
+		);
+		expect(canModerateGroupChat(activeSession, { userId: 'co-mod' })).toBe(
+			true
+		);
+		expect(
+			canModerateGroupChat(activeSession, { userId: 'participant' })
+		).toBe(false);
+		expect(canModerateGroupChat(activeSession, undefined)).toBe(false);
+	});
+
+	it('never treats two missing identifiers as an owner match', () => {
+		expect(
+			canModerateGroupChat(
+				{ consultant: {}, item: { moderators: [] } },
+				{}
+			)
+		).toBe(false);
+	});
+});
+
+describe('shouldShowGroupChatJoinView', () => {
+	it('keeps a subscribed moderator on the start view while the chat is inactive', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: true,
+				active: false,
+				subscribed: true,
+				isBanned: false
+			})
+		).toBe(true);
+	});
+
+	it('opens the stream only for an active subscribed non-banned member', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: true,
+				active: true,
+				subscribed: true,
+				isBanned: false
+			})
+		).toBe(false);
+	});
+
+	it('keeps a banned member on the join view', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: true,
+				active: true,
+				subscribed: true,
+				isBanned: true
+			})
+		).toBe(true);
+	});
+
+	it('never applies the group join view to a non-group session', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: false,
+				active: false,
+				subscribed: false,
+				isBanned: true
+			})
+		).toBe(false);
+	});
+});

--- a/src/components/groupChat/groupChatHelpers.test.ts
+++ b/src/components/groupChat/groupChatHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	canModerateGroupChat,
+	isV2GroupChatSession,
 	shouldShowGroupChatJoinView
 } from './groupChatHelpers';
 
@@ -76,5 +77,16 @@ describe('shouldShowGroupChatJoinView', () => {
 				isBanned: true
 			})
 		).toBe(false);
+	});
+});
+
+describe('isV2GroupChatSession', () => {
+	it('recognizes a self-help Series even when consultingType is present', () => {
+		expect(
+			isV2GroupChatSession({
+				isGroup: true,
+				item: { modality: 'TEXT', consultingType: 1 }
+			})
+		).toBe(true);
 	});
 });

--- a/src/components/groupChat/groupChatHelpers.ts
+++ b/src/components/groupChat/groupChatHelpers.ts
@@ -7,6 +7,22 @@ interface GroupChatAuthorizationUser {
 	userId?: string;
 }
 
+interface V2GroupChatSession {
+	isGroup?: boolean;
+	item?: {
+		modality?: string;
+		consultingType?: number;
+	};
+}
+
+export const isV2GroupChatSession = ({
+	isGroup,
+	item
+}: V2GroupChatSession): boolean =>
+	Boolean(
+		isGroup && ['TEXT', 'AUDIO', 'VIDEO'].includes(item?.modality || '')
+	);
+
 export const isGroupChatOwner = (
 	activeSession: GroupChatAuthorizationSession,
 	userData?: GroupChatAuthorizationUser

--- a/src/components/groupChat/groupChatHelpers.ts
+++ b/src/components/groupChat/groupChatHelpers.ts
@@ -1,7 +1,44 @@
-export const isGroupChatOwner = (activeSession, userData) => {
-	if (activeSession.consultant && userData) {
+interface GroupChatAuthorizationSession {
+	consultant?: { id?: string };
+	item?: { moderators?: string[] };
+}
+
+interface GroupChatAuthorizationUser {
+	userId?: string;
+}
+
+export const isGroupChatOwner = (
+	activeSession: GroupChatAuthorizationSession,
+	userData?: GroupChatAuthorizationUser
+) => {
+	if (activeSession.consultant?.id && userData?.userId) {
 		return activeSession.consultant.id === userData.userId;
 	} else {
 		return false;
 	}
 };
+
+export const canModerateGroupChat = (
+	activeSession: GroupChatAuthorizationSession,
+	userData?: GroupChatAuthorizationUser
+): boolean =>
+	Boolean(
+		userData?.userId &&
+			(isGroupChatOwner(activeSession, userData) ||
+				activeSession.item?.moderators?.includes(userData.userId))
+	);
+
+interface GroupChatJoinViewOptions {
+	isGroup: boolean;
+	active?: boolean;
+	subscribed?: boolean;
+	isBanned: boolean;
+}
+
+export const shouldShowGroupChatJoinView = ({
+	isGroup,
+	active,
+	subscribed,
+	isBanned
+}: GroupChatJoinViewOptions): boolean =>
+	isGroup && (!active || !subscribed || isBanned);

--- a/src/components/groupChat/groupChatInfo.styles.scss
+++ b/src/components/groupChat/groupChatInfo.styles.scss
@@ -275,3 +275,22 @@ $inputMaxWidth: 500px;
 		}
 	}
 }
+
+.groupChatInfo__roles {
+	margin-top: $grid-base-three;
+	display: grid;
+	gap: $grid-base-two;
+}
+
+.groupChatInfo__roleRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: $grid-base-two;
+	flex-wrap: wrap;
+
+	select,
+	button {
+		min-height: $input-field-height;
+	}
+}

--- a/src/components/groupChat/groupChatInviteLink.test.ts
+++ b/src/components/groupChat/groupChatInviteLink.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { buildGroupChatInviteLink } from './groupChatInviteLink';
+
+describe('buildGroupChatInviteLink', () => {
+	it('uses the stable numeric Series id as gcid', () => {
+		expect(
+			buildGroupChatInviteLink('https://app.oriso-dev.site/login', 1013)
+		).toBe('https://app.oriso-dev.site/login?gcid=1013');
+	});
+});

--- a/src/components/groupChat/groupChatInviteLink.ts
+++ b/src/components/groupChat/groupChatInviteLink.ts
@@ -1,0 +1,8 @@
+export const buildGroupChatInviteLink = (
+	loginUrl: string,
+	seriesId: number
+) => {
+	const url = new URL(loginUrl);
+	url.searchParams.set('gcid', String(seriesId));
+	return url.toString();
+};

--- a/src/components/groupChat/groupChatWaitingArea.test.ts
+++ b/src/components/groupChat/groupChatWaitingArea.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getWaitingAreaTime } from './groupChatWaitingArea';
+
+describe('getWaitingAreaTime', () => {
+	it.each([
+		['before', '2026-08-04T17:59:30Z', 1, '00:01'],
+		['after', '2026-08-04T18:00:30Z', -1, '-00:01'],
+		['exactly at', '2026-08-04T18:00:00Z', 0, '00:00']
+	])(
+		'rounds sign-aware %s the planned start',
+		(_label, now, signedMinutes, display) => {
+			const result = getWaitingAreaTime(
+				new Date(now),
+				new Date('2026-08-04T18:00:00Z')
+			);
+
+			expect(result.signedMinutes).toBe(signedMinutes);
+			expect(result.label).toBe(display);
+		}
+	);
+
+	it('keeps counting negatively after the planned start', () => {
+		const result = getWaitingAreaTime(
+			new Date('2026-08-04T18:07:00Z'),
+			new Date('2026-08-04T18:00:00Z')
+		);
+
+		expect(result.signedMinutes).toBe(-7);
+		expect(result.label).toBe('-00:07');
+		expect(result.discomfortEmoji).toBe('😬');
+		expect(result.discomfortLabel).toBe('late');
+		expect(result.pills).toEqual([
+			{ kind: 'dog', value: 49 },
+			{ kind: 'cat', value: 32 },
+			{ kind: 'roman', value: 'VII' }
+		]);
+	});
+
+	it('does not truncate Roman waiting time values above 399 minutes', () => {
+		const result = getWaitingAreaTime(
+			new Date('2026-08-04T11:20:00Z'),
+			new Date('2026-08-04T18:00:00Z')
+		);
+
+		expect(result.signedMinutes).toBe(400);
+		expect(result.pills[2]).toEqual({ kind: 'roman', value: 'CD' });
+	});
+
+	it.each([
+		['2026-08-04T18:04:01Z', -5, 'slightlyLate', '😅'],
+		['2026-08-04T18:14:01Z', -15, 'late', '😬']
+	] as const)(
+		'classifies raw time before applying display rounding',
+		(now, signedMinutes, discomfortLabel, discomfortEmoji) => {
+			const result = getWaitingAreaTime(
+				new Date(now),
+				new Date('2026-08-04T18:00:00Z')
+			);
+			expect(result.signedMinutes).toBe(signedMinutes);
+			expect(result.discomfortLabel).toBe(discomfortLabel);
+			expect(result.discomfortEmoji).toBe(discomfortEmoji);
+		}
+	);
+});

--- a/src/components/groupChat/groupChatWaitingArea.ts
+++ b/src/components/groupChat/groupChatWaitingArea.ts
@@ -1,0 +1,84 @@
+export interface WaitingAreaTime {
+	signedMinutes: number;
+	label: string;
+	discomfortEmoji: string;
+	discomfortLabel: 'onTime' | 'slightlyLate' | 'late' | 'veryLate';
+	pills: Array<{
+		kind: 'dog' | 'cat' | 'roman';
+		value: number | string;
+	}>;
+}
+
+const EMOJI_BY_SEVERITY: Record<WaitingAreaTime['discomfortLabel'], string> = {
+	onTime: '🙂',
+	slightlyLate: '😅',
+	late: '😬',
+	veryLate: '😵'
+};
+
+const roman = (value: number): string => {
+	if (value <= 0) return '0';
+	const numerals: Array<[number, string]> = [
+		[1000, 'M'],
+		[900, 'CM'],
+		[500, 'D'],
+		[400, 'CD'],
+		[100, 'C'],
+		[90, 'XC'],
+		[50, 'L'],
+		[40, 'XL'],
+		[10, 'X'],
+		[9, 'IX'],
+		[5, 'V'],
+		[4, 'IV'],
+		[1, 'I']
+	];
+	let remaining = value;
+	let result = '';
+	for (const [amount, symbol] of numerals) {
+		while (remaining >= amount) {
+			result += symbol;
+			remaining -= amount;
+		}
+	}
+	return result;
+};
+
+export const getWaitingAreaTime = (
+	now: Date,
+	plannedStart: Date
+): WaitingAreaTime => {
+	const deltaMinutes = (plannedStart.getTime() - now.getTime()) / 60_000;
+	const signedMinutes =
+		deltaMinutes < 0 ? Math.floor(deltaMinutes) : Math.ceil(deltaMinutes);
+	const absoluteMinutes = Math.abs(signedMinutes);
+	const hours = Math.floor(absoluteMinutes / 60)
+		.toString()
+		.padStart(2, '0');
+	const minutes = (absoluteMinutes % 60).toString().padStart(2, '0');
+	const label = `${signedMinutes < 0 ? '-' : ''}${hours}:${minutes}`;
+	const discomfortLabel: WaitingAreaTime['discomfortLabel'] =
+		deltaMinutes <= -15
+			? 'veryLate'
+			: deltaMinutes <= -5
+				? 'late'
+				: deltaMinutes < 0
+					? 'slightlyLate'
+					: 'onTime';
+	const discomfortEmoji = EMOJI_BY_SEVERITY[discomfortLabel];
+
+	return {
+		signedMinutes,
+		label,
+		discomfortEmoji,
+		discomfortLabel,
+		pills: [
+			{ kind: 'dog', value: absoluteMinutes * 7 },
+			{
+				kind: 'cat',
+				value: Math.max(1, Math.round(absoluteMinutes * 4.5))
+			},
+			{ kind: 'roman', value: roman(absoluteMinutes) }
+		]
+	};
+};

--- a/src/components/groupChat/joinChat.styles.scss
+++ b/src/components/groupChat/joinChat.styles.scss
@@ -40,6 +40,35 @@
 		}
 	}
 
+	&__countdown {
+		width: min(100%, $grid-base * 56);
+		text-align: center;
+		margin: $grid-base-two 0;
+	}
+
+	&__countdownValue {
+		display: block;
+		font-size: clamp(2.5rem, 10vw, 5rem);
+		font-variant-numeric: tabular-nums;
+		line-height: 1;
+	}
+
+	&__timePills {
+		display: flex;
+		gap: $grid-base;
+		overflow-x: auto;
+		padding: $grid-base-two 0;
+		scroll-snap-type: x proximity;
+
+		span {
+			flex: 0 0 auto;
+			padding: $grid-base $grid-base-two;
+			border-radius: 999px;
+			background: var(--m3-secondary-container, #e0e7ef);
+			scroll-snap-align: start;
+		}
+	}
+
 	&__button-container {
 		text-align: center;
 		padding: $grid-base-six $grid-base-four;

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -37,6 +37,7 @@ import '../../resources/styles/styles';
 import './login.styles';
 import useIsFirstVisit from '../../utils/useIsFirstVisit';
 import { VALIDITY_INVALID } from '../registration/registrationHelpers';
+import { buildRegistrationLink } from './groupChatRegistrationLink';
 import { TwoFactorAuthResendMail } from '../twoFactorAuth/TwoFactorAuthResendMail';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
@@ -717,7 +718,11 @@ export const Login = () => {
 									<button
 										onClick={() =>
 											window.open(
-												settings.urls.toRegistration,
+												buildRegistrationLink(
+													settings.urls
+														.toRegistration,
+													gcid
+												),
 												'_self'
 											)
 										}

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -72,6 +72,10 @@ export const Login = () => {
 	const { userData, reloadUserData } = useContext(UserDataContext);
 	const { Stage } = useContext(GlobalComponentContext);
 	const gcid = useSearchParam<string>('gcid');
+	const registrationUrl = buildRegistrationLink(
+		settings.urls.toRegistration,
+		gcid
+	);
 	const magicToken = useSearchParam<string>('magicToken');
 	const isFirstVisit = useIsFirstVisit();
 
@@ -389,6 +393,7 @@ export const Login = () => {
 				stage={<Stage hasAnimation={isFirstVisit} isReady={isReady} />}
 				showLegalLinks
 				showRegistrationLink={hasTenant}
+				registrationUrl={registrationUrl}
 			>
 				<div className="loginForm">
 					<div className="loginForm__inner">
@@ -718,11 +723,7 @@ export const Login = () => {
 									<button
 										onClick={() =>
 											window.open(
-												buildRegistrationLink(
-													settings.urls
-														.toRegistration,
-													gcid
-												),
+												registrationUrl,
 												'_self'
 											)
 										}

--- a/src/components/login/groupChatRegistrationLink.test.ts
+++ b/src/components/login/groupChatRegistrationLink.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildRegistrationLink } from './groupChatRegistrationLink';
+
+describe('buildRegistrationLink', () => {
+	it('preserves the Series invitation when login continues to registration', () => {
+		expect(
+			buildRegistrationLink(
+				'https://app.oriso-dev.site/registration',
+				'1013'
+			)
+		).toBe('https://app.oriso-dev.site/registration?gcid=1013');
+	});
+
+	it('keeps the normal registration URL without an invitation', () => {
+		expect(
+			buildRegistrationLink(
+				'https://app.oriso-dev.site/registration',
+				null
+			)
+		).toBe('https://app.oriso-dev.site/registration');
+	});
+});

--- a/src/components/login/groupChatRegistrationLink.ts
+++ b/src/components/login/groupChatRegistrationLink.ts
@@ -1,0 +1,9 @@
+export const buildRegistrationLink = (
+	registrationUrl: string,
+	gcid?: string | null
+): string => {
+	if (!gcid?.trim()) return registrationUrl;
+	const url = new URL(registrationUrl);
+	url.searchParams.set('gcid', gcid.trim());
+	return url.toString();
+};

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -16,7 +16,7 @@ import { MessageDisplayName } from './MessageDisplayName';
 import { formatToHHMM } from '../../utils/dateHelpers';
 import { markdownToDraft } from 'markdown-draft-js';
 import { stateToHTML } from 'draft-js-export-html';
-import { convertFromRaw, ContentState } from 'draft-js';
+import { convertFromRaw } from 'draft-js';
 import {
 	markdownToDraftDefaultOptions,
 	normalizeHighlightColor,
@@ -861,27 +861,32 @@ export const MessageItemComponent = ({
 			return;
 		}
 
-		const rawMessageObject = markdownToDraft(
-			preparedMessage,
-			markdownToDraftDefaultOptions
-		);
-		const contentStateMessage: ContentState =
-			convertFromRaw(rawMessageObject);
+		try {
+			const rawMessageObject = markdownToDraft(
+				preparedMessage,
+				markdownToDraftDefaultOptions
+			);
+			const contentStateMessage = convertFromRaw(rawMessageObject);
 
-		setRenderedMessage(
-			contentStateMessage.hasText()
-				? sanitizeHtml(
-						renderHighlightTokens(
-							renderImageMarkers(
-								urlifyLinksInText(
-									stateToHTML(contentStateMessage)
+			setRenderedMessage(
+				contentStateMessage.hasText()
+					? sanitizeHtml(
+							renderHighlightTokens(
+								renderImageMarkers(
+									urlifyLinksInText(
+										stateToHTML(contentStateMessage)
+									)
 								)
-							)
-						),
-						sanitizeHtmlDefaultOptions
-					)
-				: ''
-		);
+							),
+							sanitizeHtmlDefaultOptions
+						)
+					: ''
+			);
+		} catch {
+			setRenderedMessage(
+				sanitizeHtml(preparedMessage, sanitizeHtmlDefaultOptions)
+			);
+		}
 		// parsedMessage is memoized on decryptedMessage, so this stays
 		// equivalent to depending on decryptedMessage alone.
 	}, [decryptedMessage, parsedMessage.cleanedMessage]);

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -4,7 +4,13 @@ $message-lineheight: 21px;
 $message-attachment-color: $secondary !default;
 $message-avatar-ring: #ebe2e2;
 $message-incoming-bg: var(--m3-surface-container-high, #eae7e8);
-$message-outgoing-bg: var(--m3-on-primary-container, #ffe2de);
+// Use the always-light `primary-fixed` (tonal palette tone 90) rather than
+// `on-primary-container`. The latter is a foreground/contrast role whose
+// lightness flips with the tenant seed brightness, so bright-red tenants
+// (e.g. Kiel) got a dark bubble under the fixed-dark outgoing text below,
+// making outgoing messages unreadable. `primary-fixed` stays light for
+// every seed and keeps the branded tint.
+$message-outgoing-bg: var(--m3-primary-fixed, #ffdad5);
 $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 
 .messageItem__mention {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -27,6 +27,7 @@ import { isAskerEnquirySubmission } from './messageEncryptionMode';
 import { resolveAsideTargetRoomId } from './asideRouting';
 import { chatTransportService } from '../../services/chatTransportService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 import {
 	AUTHORITIES,
@@ -499,12 +500,7 @@ export const MessageSubmitInterfaceComponent = ({
 	}, [location.pathname, location.search, threadRootId]);
 
 	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 
 	const draftTitle = useMemo(() => {
 		const topicName =
@@ -1096,8 +1092,7 @@ export const MessageSubmitInterfaceComponent = ({
 					apiPostError({
 						name: error?.name || 'EnquiryMessageSendError',
 						message:
-							error?.message ||
-							'Failed to send enquiry message',
+							error?.message || 'Failed to send enquiry message',
 						stack: error?.stack,
 						level: ERROR_LEVEL_WARN
 					}).then();

--- a/src/components/messageSubmitInterface/richtextHelpers.ts
+++ b/src/components/messageSubmitInterface/richtextHelpers.ts
@@ -105,8 +105,7 @@ export const markdownToDraftDefaultOptions = {
 	remarkablePreset: 'commonmark',
 	remarkableOptions: {
 		html: true,
-		breaks: true,
-		linkify: true
+		breaks: true
 	}
 };
 

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -20,6 +20,7 @@ import {
 	isKnownEventType
 } from './eventDescriptors';
 import { EventFamily } from './eventDescriptors/types';
+import { resolveNotificationActionPath } from './notificationActionTarget';
 import { useActiveListItem } from '../../hooks/useActiveListItem';
 import { pickActiveItemKey } from '../../utils/listItemSelection';
 import {
@@ -120,8 +121,14 @@ const describeItem = (
 };
 
 const resolveSessionId = (item: any): string | null => {
-	if (item?.sourceSessionId) {
+	if (item?.sourceSessionId != null) {
 		return String(item.sourceSessionId);
+	}
+	if (item?.params?.sourceSessionId != null) {
+		return String(item.params.sourceSessionId);
+	}
+	if (item?.params?.seriesId != null) {
+		return String(item.params.seriesId);
 	}
 	const path = item?.actionPath;
 	if (!path) {
@@ -351,6 +358,13 @@ export const NotificationsCenter = () => {
 				: '/sessions/user/view',
 		[userData]
 	);
+	const getNotificationActionPath = useCallback(
+		(item: (typeof notificationFeed)[number]) =>
+			toNonEmbeddedPath(
+				resolveNotificationActionPath(item, getDefaultSessionsPath())
+			),
+		[getDefaultSessionsPath]
+	);
 	const embeddedChatPath = useMemo(() => {
 		if (!canShowChatPreview) {
 			return null;
@@ -406,7 +420,7 @@ export const NotificationsCenter = () => {
 	const openNotification = (item: (typeof notificationFeed)[number]) => {
 		markNotificationAsRead(item.id);
 		if (untilL) {
-			const directPath = toNonEmbeddedPath(item.actionPath);
+			const directPath = getNotificationActionPath(item);
 			if (directPath) {
 				navigate(directPath);
 				return;
@@ -427,7 +441,7 @@ export const NotificationsCenter = () => {
 		if (nextUnreadId && nextUnreadId !== selectedNotification.id) {
 			setSelectedNotificationId(nextUnreadId);
 		}
-		const directPath = toNonEmbeddedPath(selectedNotification.actionPath);
+		const directPath = getNotificationActionPath(selectedNotification);
 		if (directPath) {
 			navigate(directPath);
 			return;
@@ -804,7 +818,16 @@ export const NotificationsCenter = () => {
 						}}
 					>
 						{selectedNotification?.actionLabel ||
-							translate('notifications.center.open', 'Open chat')}
+							translate(
+								selectedNotification?.eventType ===
+									'group_chat.opened'
+									? 'notifications.center.join'
+									: 'notifications.center.open',
+								selectedNotification?.eventType ===
+									'group_chat.opened'
+									? 'Join'
+									: 'Open chat'
+							)}
 					</MenuItem>
 					<MenuItem
 						onClick={() => {
@@ -935,8 +958,14 @@ export const NotificationsCenter = () => {
 									<OpenInFullIcon />
 									{selectedNotification.actionLabel ||
 										translate(
-											'notifications.center.open',
-											'View Conversation'
+											selectedNotification.eventType ===
+												'group_chat.opened'
+												? 'notifications.center.join'
+												: 'notifications.center.open',
+											selectedNotification.eventType ===
+												'group_chat.opened'
+												? 'Join'
+												: 'Open chat'
 										)}
 								</button>
 								<button

--- a/src/components/notificationsCenter/eventDescriptors/icons.tsx
+++ b/src/components/notificationsCenter/eventDescriptors/icons.tsx
@@ -22,6 +22,7 @@ import { ReactComponent as CallMissedIcon } from '../../../resources/img/icons/c
 import { ReactComponent as SupervisorIcon } from '../../../resources/img/icons/shield.svg';
 import { ReactComponent as RenameIcon } from '../../../resources/img/icons/pen.svg';
 import { ReactComponent as SystemIcon } from '../../../resources/img/icons/notification_bell.svg';
+import { ReactComponent as AppointmentIcon } from '../../../resources/img/icons/chat-booking.svg';
 import { EventIconId } from './types';
 
 type SvgIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
@@ -39,6 +40,7 @@ export const EVENT_ICONS: Record<EventIconId, SvgIcon> = {
 	callMissed: CallMissedIcon,
 	supervisor: SupervisorIcon,
 	rename: RenameIcon,
+	appointment: AppointmentIcon,
 	system: SystemIcon
 };
 

--- a/src/components/notificationsCenter/eventDescriptors/registry.test.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.test.ts
@@ -61,6 +61,7 @@ const KNOWN_ICON_IDS: EventIconId[] = [
 	'callMissed',
 	'supervisor',
 	'rename',
+	'appointment',
 	'system'
 ];
 
@@ -85,7 +86,10 @@ const EXPECTED_TARGET_KIND: Record<string, string> = {
 	'case.handover.consent.declined': 'conversation',
 	'call.started': 'join',
 	'call.ended': 'conversation',
-	'call.missed': 'conversation'
+	'call.missed': 'conversation',
+	'group_chat.reminder': 'conversation',
+	'group_chat.opened': 'groupChatJoin',
+	'group_chat.cancelled': 'conversation'
 };
 
 // Resolve a dotted i18n key against a loaded common.json object.
@@ -102,9 +106,10 @@ describe('WP-06 event-descriptor registry', () => {
 		});
 	});
 
-	it('seeds every designed family (Appointments deferred) — 20 types total', () => {
-		// 7 existing + request.new + draft.created + 8 handover + 3 call = 20.
-		expect(KNOWN_EVENT_TYPES.length).toBe(20);
+	it('seeds group-chat lifecycle events in the appointments family', () => {
+		// 7 existing + request.new + draft.created + 8 handover + 3 call
+		// + 3 group-chat lifecycle = 23.
+		expect(KNOWN_EVENT_TYPES.length).toBe(23);
 		[
 			'request.new',
 			'draft.created',
@@ -118,7 +123,10 @@ describe('WP-06 event-descriptor registry', () => {
 			'case.handover.consent.declined',
 			'call.started',
 			'call.ended',
-			'call.missed'
+			'call.missed',
+			'group_chat.reminder',
+			'group_chat.opened',
+			'group_chat.cancelled'
 		].forEach((type) => expect(isKnownEventType(type)).toBe(true));
 	});
 
@@ -158,8 +166,7 @@ describe('WP-06 event-descriptor registry', () => {
 				'system'
 			] as EventFamily[]
 		).forEach((fam) => expect(seededFamilies.has(fam)).toBe(true));
-		// Appointments family is declared but intentionally not seeded yet.
-		expect(seededFamilies.has('appointments')).toBe(false);
+		expect(seededFamilies.has('appointments')).toBe(true);
 	});
 
 	it('returns the fallback descriptor for unknown / empty types', () => {
@@ -202,6 +209,20 @@ describe('WP-06 event-descriptor registry', () => {
 			expect(target).toEqual({
 				kind: 'conversation',
 				path: '/sessions/user/view/session/7'
+			});
+		});
+
+		it('opens a group-chat occurrence through its stable series conversation', () => {
+			const target = getEventDescriptor(
+				'group_chat.opened'
+			).resolveActionTarget({
+				seriesId: 42,
+				sessionsBasePath: '/sessions/consultant/sessionView'
+			});
+
+			expect(target).toEqual({
+				kind: 'groupChatJoin',
+				path: '/sessions/consultant/sessionView/session/42'
 			});
 		});
 

--- a/src/components/notificationsCenter/eventDescriptors/registry.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.ts
@@ -38,11 +38,20 @@ const buildConversationPath = (params: EventActionParams): string | null => {
 		const base = params.sessionsBasePath || DEFAULT_SESSIONS_BASE_PATH;
 		return `${base}/session/${params.sourceSessionId}`;
 	}
+	if (params.seriesId != null && params.seriesId !== '') {
+		const base = params.sessionsBasePath || DEFAULT_SESSIONS_BASE_PATH;
+		return `${base}/session/${params.seriesId}`;
+	}
 	return null;
 };
 
 const conversationTarget = (params: EventActionParams): EventActionTarget => ({
 	kind: 'conversation',
+	path: buildConversationPath(params)
+});
+
+const groupChatJoinTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'groupChatJoin',
 	path: buildConversationPath(params)
 });
 
@@ -258,6 +267,29 @@ const seeds: EventDescriptor[] = [
 		category: 'system',
 		icon: 'callMissed',
 		i18nKey: 'callMissed',
+		resolveActionTarget: conversationTarget
+	}),
+
+	// ----- Self-help group occurrence lifecycle -----
+	descriptor('group_chat.reminder', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatReminder',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('group_chat.opened', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatOpened',
+		resolveActionTarget: groupChatJoinTarget
+	}),
+	descriptor('group_chat.cancelled', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatCancelled',
 		resolveActionTarget: conversationTarget
 	})
 ];

--- a/src/components/notificationsCenter/eventDescriptors/types.ts
+++ b/src/components/notificationsCenter/eventDescriptors/types.ts
@@ -57,6 +57,7 @@ export type EventIconId =
 	| 'callMissed'
 	| 'supervisor'
 	| 'rename'
+	| 'appointment'
 	| 'system';
 
 /**
@@ -71,6 +72,8 @@ export interface EventActionParams {
 	actionPath?: string | null;
 	/** Session id the event belongs to, when known. */
 	sourceSessionId?: string | number | null;
+	/** Stable self-help group Series id, used when no materialized Session id exists. */
+	seriesId?: string | number | null;
 	/** Matrix room id / RC group id, when known. */
 	roomRef?: string | null;
 	/** Draft resume scope key (`forcedScopeKey`) for draft events. */
@@ -102,6 +105,7 @@ export interface EventActionParams {
  */
 export type EventActionTarget =
 	| { kind: 'conversation'; path: string | null }
+	| { kind: 'groupChatJoin'; path: string | null }
 	| { kind: 'request'; path: string | null }
 	| { kind: 'draft'; forcedScopeKey: string | null; path: string | null }
 	| { kind: 'join'; callRoomId: string | null; isVideo: boolean }

--- a/src/components/notificationsCenter/notificationActionTarget.test.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+	parseEventActionParams,
+	resolveNotificationActionPath
+} from './notificationActionTarget';
+
+describe('notification action targets', () => {
+	it('opens a group-chat lifecycle event at its stable Series conversation', () => {
+		const params = parseEventActionParams(
+			'{"seriesId":42,"occurrenceIndex":3,"roomRef":"!room:matrix.example"}'
+		);
+
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'group_chat.opened',
+					params
+				},
+				'/sessions/consultant/sessionView'
+			)
+		).toBe('/sessions/consultant/sessionView/session/42');
+	});
+
+	it('keeps a direct action path authoritative', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'message.new',
+					actionPath: '/sessions/user/view/session/7',
+					params: { seriesId: 42 }
+				},
+				'/sessions/consultant/sessionView'
+			)
+		).toBe('/sessions/user/view/session/7');
+	});
+
+	it('treats malformed params as absent instead of breaking the timeline', () => {
+		expect(parseEventActionParams('{not-json')).toEqual({});
+	});
+
+	it('falls back to the nested source session id when the top-level id is absent', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'message.new',
+					params: { sourceSessionId: 7 }
+				},
+				'/sessions/user/view'
+			)
+		).toBe('/sessions/user/view/session/7');
+	});
+});

--- a/src/components/notificationsCenter/notificationActionTarget.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.ts
@@ -1,0 +1,70 @@
+import { getEventDescriptor } from './eventDescriptors';
+import { EventActionParams } from './eventDescriptors/types';
+
+type Identifier = string | number | null;
+
+interface NotificationActionInput {
+	eventType?: string | null;
+	actionPath?: string | null;
+	sourceSessionId?: Identifier;
+	params?: EventActionParams;
+}
+
+const isIdentifier = (value: unknown): value is Identifier =>
+	value === null || typeof value === 'string' || typeof value === 'number';
+
+const asNullableString = (value: unknown): string | null | undefined =>
+	value === null || typeof value === 'string'
+		? (value as string | null)
+		: undefined;
+
+/** Parse only the known, non-content fields accepted by action-target resolvers. */
+export const parseEventActionParams = (raw: unknown): EventActionParams => {
+	let value: unknown = raw;
+	if (typeof raw === 'string') {
+		try {
+			value = JSON.parse(raw);
+		} catch {
+			return {};
+		}
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return {};
+	}
+
+	const source = value as Record<string, unknown>;
+	const params: EventActionParams = {};
+	if (isIdentifier(source.sourceSessionId)) {
+		params.sourceSessionId = source.sourceSessionId;
+	}
+	if (isIdentifier(source.seriesId)) {
+		params.seriesId = source.seriesId;
+	}
+	params.roomRef = asNullableString(source.roomRef);
+	params.forcedScopeKey = asNullableString(source.forcedScopeKey);
+	params.threadRootId = asNullableString(source.threadRootId);
+	params.callRoomId = asNullableString(source.callRoomId);
+	if (typeof source.isVideo === 'boolean' || source.isVideo === null) {
+		params.isVideo = source.isVideo as boolean | null;
+	}
+	return params;
+};
+
+export const resolveNotificationActionPath = (
+	item: NotificationActionInput,
+	sessionsBasePath: string
+): string | null => {
+	const target = getEventDescriptor(item.eventType).resolveActionTarget({
+		...(item.params || {}),
+		actionPath: item.actionPath,
+		sourceSessionId: item.sourceSessionId ?? item.params?.sourceSessionId,
+		sessionsBasePath
+	});
+
+	return target.kind === 'conversation' ||
+		target.kind === 'groupChatJoin' ||
+		target.kind === 'request' ||
+		target.kind === 'draft'
+		? target.path
+		: null;
+};

--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -31,6 +31,7 @@ import {
 import { GlobalComponentContext } from '../../globalState/provider/GlobalComponentContext';
 import {
 	redirectToApp,
+	getPostRegistrationGroupChatId,
 	POST_REGISTRATION_LOADER_KEY
 } from '../../components/registration/autoLogin';
 import { PreselectionBox } from './preselectionBox/PreselectionBox';
@@ -296,7 +297,9 @@ export const Registration = () => {
 			.filter((missingStep) => missingStep < currStepIndex);
 
 		if (missingPreviousSteps.length > 0) {
-			navigate(makeStepUrl(availableSteps[missingPreviousSteps[0]]?.name));
+			navigate(
+				makeStepUrl(availableSteps[missingPreviousSteps[0]]?.name)
+			);
 		}
 	}, [
 		availableSteps,
@@ -356,7 +359,9 @@ export const Registration = () => {
 						POST_REGISTRATION_LOADER_KEY,
 						'true'
 					);
-					redirectToApp();
+					redirectToApp(
+						getPostRegistrationGroupChatId(location.search)
+					);
 				})
 				.catch((error) => {
 					// console.error('Registration failed:', error);
@@ -387,7 +392,8 @@ export const Registration = () => {
 		addNotification,
 		t,
 		locale,
-		isRegistering
+		isRegistering,
+		location.search
 	]);
 
 	const handleSubmit = useCallback(
@@ -463,7 +469,8 @@ export const Registration = () => {
 										}}
 									>
 										{(() => {
-											const StepComponent = activeStep.component;
+											const StepComponent =
+												activeStep.component;
 											return (
 												<StepComponent
 													key={`${activeStep.name}-${clearSelectionVersion}`}

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { autoLogin } from './autoLogin';
+import { autoLogin, getPostRegistrationGroupChatId } from './autoLogin';
 import { getKeycloakAccessToken } from '../sessionCookie/getKeycloakAccessToken';
 import {
 	getMatrixAccessToken,
@@ -240,4 +240,25 @@ describe('autoLogin', () => {
 			{ featureToolsEnabled: true }
 		);
 	});
+});
+
+describe('getPostRegistrationGroupChatId', () => {
+	it('preserves the group chat deep link through registration', () => {
+		expect(
+			getPostRegistrationGroupChatId('?gcid=%21room%3Amatrix.localhost')
+		).toBe('!room:matrix.localhost');
+	});
+
+	it('returns undefined without a group chat deep link', () => {
+		expect(
+			getPostRegistrationGroupChatId('?topic=counseling')
+		).toBeUndefined();
+	});
+
+	it.each(['?gcid=', '?gcid=%20%20%20'])(
+		'returns undefined for an empty group chat deep link',
+		(search) => {
+			expect(getPostRegistrationGroupChatId(search)).toBeUndefined();
+		}
+	);
 });

--- a/src/components/registration/autoLogin.ts
+++ b/src/components/registration/autoLogin.ts
@@ -157,7 +157,15 @@ export const autoLogin = async ({
 export const POST_REGISTRATION_LOADER_KEY =
 	'onlineBeratung_postRegistrationLoader';
 
+export const getPostRegistrationGroupChatId = (search: string) => {
+	const value = new URLSearchParams(search).get('gcid')?.trim();
+	return value || undefined;
+};
+
 export const redirectToApp = (gcid?: string) => {
-	const params = gcid ? `?gcid=${gcid}` : '';
+	const value = gcid?.trim();
+	const params = value
+		? `?${new URLSearchParams({ gcid: value }).toString()}`
+		: '';
 	window.location.href = appConfig.urls.redirectToApp + params;
 };

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -12,6 +12,7 @@ import {
 import { ResizeObserver } from '@juggle/resize-observer';
 import clsx from 'clsx';
 import { scrollToEnd, isMyMessage, SESSION_LIST_TYPES } from './sessionHelpers';
+import { getModality, Modality } from './getModality';
 import { formatToHHMM } from '../../utils/dateHelpers';
 import {
 	isMatrixRoom,
@@ -596,12 +597,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		featureThreadsSupervisionChatsEnabled = true
 	} = getTenantSettings();
 	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const chatType: 'anonymous' | 'oneOnOne' | 'group' | 'supervision' =
 		isSupervisor
 			? 'supervision'

--- a/src/components/session/SessionStream.test.tsx
+++ b/src/components/session/SessionStream.test.tsx
@@ -24,7 +24,13 @@ const mocks = vi.hoisted(() => {
 		navigate: vi.fn(),
 		logout: vi.fn(),
 		lifecycleListeners: [] as ((change: any) => void)[],
+		timelineListeners: [] as ((
+			event: any,
+			room: any,
+			toStart: boolean
+		) => void)[],
 		detachLifecycle: vi.fn(),
+		getMatrixRoomMessages: vi.fn(() => []),
 		resolveSession: vi.fn(() => ({
 			isMatrixSession: true,
 			matrixRoomId: ROOM_ID,
@@ -64,10 +70,21 @@ vi.mock('../../services/chatTransportService', () => ({
 	chatTransportService: {
 		resolveSession: mocks.resolveSession,
 		getMatrixRoom: vi.fn(() => null),
-		getMatrixRoomMessages: vi.fn(() => []),
+		getMatrixRoomMessages: mocks.getMatrixRoomMessages,
 		sendTyping: vi.fn(() => Promise.resolve()),
 		markRoomAsRead: vi.fn(() => Promise.resolve()),
-		onMatrixTimeline: vi.fn(() => () => {}),
+		onMatrixTimeline: vi.fn(
+			(
+				_roomId: string,
+				listener: (event: any, room: any, toStart: boolean) => void
+			) => {
+				mocks.timelineListeners.push(listener);
+				return () => {
+					const index = mocks.timelineListeners.indexOf(listener);
+					if (index >= 0) mocks.timelineListeners.splice(index, 1);
+				};
+			}
+		),
 		onMatrixRoomLifecycle: vi.fn(
 			(_roomId: string, listener: (change: any) => void) => {
 				mocks.lifecycleListeners.push(listener);
@@ -197,6 +214,7 @@ describe('SessionStream Matrix room lifecycle', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.lifecycleListeners.length = 0;
+		mocks.timelineListeners.length = 0;
 		mocks.sessionItemProps = null;
 	});
 
@@ -279,5 +297,34 @@ describe('SessionStream Matrix room lifecycle', () => {
 
 		unmount();
 		expect(mocks.detachLifecycle).toHaveBeenCalled();
+	});
+
+	it('refreshes a clear message when delayed decryption lands inside the coalescing window', async () => {
+		renderSessionStream({ isGroup: true });
+
+		await waitFor(() => {
+			expect(mocks.timelineListeners.length).toBe(1);
+		});
+		const callsBeforeTimelineEvents =
+			mocks.getMatrixRoomMessages.mock.calls.length;
+		const encryptedEvent = { getType: () => 'm.room.encrypted' };
+		const decryptedEvent = { getType: () => 'm.room.message' };
+		const room = { roomId: ROOM_ID };
+
+		act(() => {
+			mocks.timelineListeners.forEach((listener) => {
+				listener(encryptedEvent, room, false);
+				listener(decryptedEvent, room, false);
+			});
+		});
+
+		await waitFor(
+			() => {
+				expect(mocks.getMatrixRoomMessages).toHaveBeenCalledTimes(
+					callsBeforeTimelineEvents + 2
+				);
+			},
+			{ timeout: 500 }
+		);
 	});
 });

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -401,6 +401,12 @@ export const SessionStream = ({
 		let retryTimer: number | null = null;
 		let detachTimelineListeners: Array<() => void> = [];
 		let lastRefreshAt = 0;
+		const refreshMessages = () => {
+			lastRefreshAt = Date.now();
+			fetchSessionMessages().catch(() => {
+				// keep UI stable if a timeline event races with navigation
+			});
+		};
 
 		const attachTimelineListeners = () => {
 			const handleMatrixTimeline = (
@@ -423,16 +429,14 @@ export const SessionStream = ({
 					return;
 				}
 
-				// Coalesce bursts (decrypt + relation updates) into one fetch.
+				// Coalesce encrypted/metadata bursts, but never drop a clear message:
+				// delayed Matrix decryption mutates the event after its fallback rendered.
 				const now = Date.now();
-				if (now - lastRefreshAt < 120) {
+				const elapsed = now - lastRefreshAt;
+				if (eventType !== 'm.room.message' && elapsed < 120) {
 					return;
 				}
-				lastRefreshAt = now;
-
-				fetchSessionMessages().catch(() => {
-					// keep UI stable if a timeline event races with navigation
-				});
+				refreshMessages();
 			};
 
 			const detachers = watchedRoomIds

--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -24,6 +24,7 @@ import { useSession } from '../../hooks/useSession';
 import { SessionStream } from './SessionStream';
 import { useSetAtom } from 'jotai';
 import { agencyLogoAtom } from '../../store/agencyLogoAtom';
+import { shouldShowGroupChatJoinView } from '../groupChat/groupChatHelpers';
 
 export const SessionView = () => {
 	const { rcGroupId: groupIdFromParam, sessionId: sessionIdFromParam } =
@@ -205,9 +206,12 @@ export const SessionView = () => {
 	// });
 
 	if (
-		activeSession.isGroup &&
-		(!activeSession.item.subscribed ||
-			bannedUsers.includes(userData.userName))
+		shouldShowGroupChatJoinView({
+			isGroup: activeSession.isGroup,
+			active: activeSession.item.active,
+			subscribed: activeSession.item.subscribed,
+			isBanned: bannedUsers.includes(userData.userName)
+		})
 	) {
 		// console.log('🔥 Showing JoinGroupChatView');
 		return (

--- a/src/components/session/getModality.test.ts
+++ b/src/components/session/getModality.test.ts
@@ -33,6 +33,13 @@ describe('getModality', () => {
 		expect(getModality(item)).toBe(Modality.SELF_HELP);
 	});
 
+	it('classifies a one-occurrence Series as SELF_HELP', () => {
+		const item = asItem({
+			chat: { repetitive: false, repeatCount: 1 }
+		});
+		expect(getModality(item)).toBe(Modality.SELF_HELP);
+	});
+
 	it('prefers an explicit backend conversationType over the heuristic', () => {
 		// looks like AGENCY_COUNSELLING by heuristic, but the backend says LIVE_CHAT
 		const item = asItem({

--- a/src/components/session/getModality.test.ts
+++ b/src/components/session/getModality.test.ts
@@ -11,6 +11,24 @@ describe('getModality', () => {
 		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
 	});
 
+	it('keeps the legacy anonymous-postcode fallback during backend rollout', () => {
+		const item = asItem({
+			session: { registrationType: 'REGISTERED', postcode: 0 }
+		});
+		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('keeps the legacy anonymous-username fallback on the active-session shape', () => {
+		const activeSession = {
+			item: { registrationType: 'REGISTERED', postcode: 10115 },
+			user: { username: 'Anonymous-legacy' },
+			isGroup: false,
+			isSession: true
+		};
+
+		expect(getModality(activeSession)).toBe(Modality.LIVE_CHAT);
+	});
+
 	it('classifies a registered session as AGENCY_COUNSELLING', () => {
 		const item = asItem({ session: { registrationType: 'REGISTERED' } });
 		expect(getModality(item)).toBe(Modality.AGENCY_COUNSELLING);
@@ -49,6 +67,20 @@ describe('getModality', () => {
 			}
 		});
 		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('prefers an explicit modality on the active-session shape over conflicting legacy fields', () => {
+		const activeSession = {
+			item: {
+				conversationType: 'LIVE_CHAT',
+				registrationType: 'REGISTERED',
+				postcode: 10115
+			},
+			isGroup: false,
+			isSession: true
+		};
+
+		expect(getModality(activeSession)).toBe(Modality.LIVE_CHAT);
 	});
 
 	it('ignores an unknown explicit conversationType and falls back to the heuristic', () => {

--- a/src/components/session/getModality.ts
+++ b/src/components/session/getModality.ts
@@ -23,6 +23,34 @@ const isModality = (value: unknown): value is Modality =>
 	typeof value === 'string' &&
 	(Object.values(Modality) as string[]).includes(value);
 
+type ConversationItem = Partial<SessionItemInterface> &
+	Partial<GroupChatItemInterface> & {
+		askerUserName?: string;
+		conversationType?: string;
+		teamSession?: boolean;
+	};
+
+type ModalityInput =
+	| ListItemInterface
+	| {
+			item?: ConversationItem | null;
+			isGroup?: boolean;
+			isSession?: boolean;
+			user?: { username?: string | null };
+	  };
+
+const isAnonymousUsername = (username?: string | null): boolean =>
+	typeof username === 'string' &&
+	(username.startsWith('Anonymous-') || username.startsWith('anon_'));
+
+const isAnonymousPostcode = (postcode?: number | string | null): boolean => {
+	if (postcode === null || postcode === undefined) {
+		return false;
+	}
+	const value = String(postcode).trim();
+	return value === '0' || value === '00000';
+};
+
 /**
  * The single source of truth for a conversation's modality on the frontend.
  *
@@ -36,16 +64,24 @@ const isModality = (value: unknown): value is Modality =>
  * significant: a group `chat` is checked before `teamSession`, which is checked before the
  * anonymous (live-chat) signal, so an internal group is never mislabelled as agency counselling.
  */
-export const getModality = (item?: ListItemInterface): Modality => {
-	const session = item?.session as
+export const getModality = (item?: ModalityInput): Modality => {
+	const activeSession = item && 'item' in item ? item : undefined;
+	const listItem =
+		item && !('item' in item) ? (item as ListItemInterface) : undefined;
+	const activeItem = activeSession?.item;
+	const user = activeSession?.user ?? listItem?.user;
+	const session = (
+		activeItem && !activeSession?.isGroup ? activeItem : listItem?.session
+	) as
 		| (SessionItemInterface & {
+				askerUserName?: string;
 				teamSession?: boolean;
 				conversationType?: string;
 		  })
 		| undefined;
-	const chat = item?.chat as
-		| (GroupChatItemInterface & { conversationType?: string })
-		| undefined;
+	const chat = (
+		activeItem && activeSession?.isGroup ? activeItem : listItem?.chat
+	) as (GroupChatItemInterface & { conversationType?: string }) | undefined;
 
 	// 1. An explicit backend modality wins once it is populated (ADR-006 target state).
 	const explicit = session?.conversationType ?? chat?.conversationType;
@@ -64,7 +100,11 @@ export const getModality = (item?: ListItemInterface): Modality => {
 			return Modality.INTERNAL_GROUP;
 		}
 		if (
-			(session.registrationType as string) === REGISTRATION_TYPE_ANONYMOUS
+			(session.registrationType as string) ===
+				REGISTRATION_TYPE_ANONYMOUS ||
+			isAnonymousPostcode(session.postcode) ||
+			isAnonymousUsername(session.askerUserName) ||
+			isAnonymousUsername(user?.username)
 		) {
 			return Modality.LIVE_CHAT;
 		}

--- a/src/components/session/getModality.ts
+++ b/src/components/session/getModality.ts
@@ -55,7 +55,9 @@ export const getModality = (item?: ListItemInterface): Modality => {
 
 	// 2. Fallback heuristic (centralised here, deleted once the column is populated everywhere).
 	if (chat) {
-		return chat.repetitive ? Modality.SELF_HELP : Modality.INTERNAL_GROUP;
+		return chat.repeatCount !== undefined || chat.repetitive
+			? Modality.SELF_HELP
+			: Modality.INTERNAL_GROUP;
 	}
 	if (session) {
 		if (session.teamSession === true) {

--- a/src/components/sessionAssign/RequestSessionAssign.tsx
+++ b/src/components/sessionAssign/RequestSessionAssign.tsx
@@ -174,7 +174,7 @@ export const RequestSessionAssign = (props: { value?: string }) => {
 					.catch((error) => {
 						if (error === FETCH_ERRORS.CONFLICT) {
 							return null;
-						} else console.log(error);
+						}
 					});
 				break;
 			case OVERLAY_FUNCTIONS.REASSIGN:

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -92,6 +92,7 @@ describe('persistMatrixLoginData', () => {
 
 describe('getMatrixAccessToken', () => {
 	it('loads Matrix credentials from the API and uses the response device id', async () => {
+		localStorage.setItem('matrix_device_id', 'ORISO_WEB_EXISTING_DEVICE');
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
 			deviceId: 'RESPONSE_DEVICE',
@@ -108,14 +109,34 @@ describe('getMatrixAccessToken', () => {
 		});
 
 		expect(fetchData).toHaveBeenCalledWith({
-			url: 'https://api.example.test/service/matrix/me/token',
+			url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_WEB_EXISTING_DEVICE',
 			method: 'GET',
 			responseHandling: ['CATCH_ALL'],
 			recoverOnPublicAuthRoute: false
 		});
 	});
 
-	it('reuses a stored browser device id when the API omits one', async () => {
+	it('creates and sends a stable browser device id before requesting a token', async () => {
+		Object.defineProperty(globalThis, 'crypto', {
+			value: { randomUUID: () => '12345678-90ab-cdef-1234-567890abcdef' },
+			configurable: true
+		});
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_1234567890ABCDEF12345678',
+			userId: '@new-user:matrix.example.test'
+		});
+
+		await getMatrixAccessToken();
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_WEB_1234567890ABCDEF12345678'
+			})
+		);
+	});
+
+	it('rejects a token response without a device-bound identity', async () => {
 		localStorage.setItem(
 			'matrix_device_id:@user:matrix.example.test',
 			'STORED_DEVICE'
@@ -125,9 +146,9 @@ describe('getMatrixAccessToken', () => {
 			userId: '@user:matrix.example.test'
 		});
 
-		await expect(getMatrixAccessToken()).resolves.toMatchObject({
-			deviceId: 'STORED_DEVICE'
-		});
+		await expect(getMatrixAccessToken()).rejects.toThrow(
+			'Matrix login did not return a device-bound access token'
+		);
 	});
 
 	it('creates a browser device id when neither API nor storage has one', async () => {
@@ -137,6 +158,7 @@ describe('getMatrixAccessToken', () => {
 		});
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_1234567890ABCDEF12345678',
 			userId: '@new-user:matrix.example.test'
 		});
 
@@ -153,6 +175,7 @@ describe('getMatrixAccessToken', () => {
 	it('throws when Matrix homeserver URL is missing', async () => {
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
 			userId: '@user:matrix.example.test'
 		});
 		vi.mocked(getMatrixHomeserverUrl).mockReturnValue('');

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -8,6 +8,7 @@ import {
 import { fetchData } from '../../api/fetchData';
 import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { createClient } from 'matrix-js-sdk';
+import { getMatrixClientLogger } from '../../utils/matrixLogging';
 
 vi.mock('../../resources/scripts/endpoints', () => ({
 	endpoints: {
@@ -186,7 +187,8 @@ describe('getMatrixAccessToken', () => {
 			accessToken: 'matrix-token',
 			userId: '@consultant:matrix.example.test',
 			deviceId: 'ORISO_WEB_TEST_DEVICE',
-			fallbackICEServerAllowed: true
+			fallbackICEServerAllowed: true,
+			logger: getMatrixClientLogger()
 		});
 		expect(client).toEqual({
 			config: {
@@ -194,7 +196,8 @@ describe('getMatrixAccessToken', () => {
 				accessToken: 'matrix-token',
 				userId: '@consultant:matrix.example.test',
 				deviceId: 'ORISO_WEB_TEST_DEVICE',
-				fallbackICEServerAllowed: true
+				fallbackICEServerAllowed: true,
+				logger: getMatrixClientLogger()
 			}
 		});
 	});

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createMatrixClient,
+	getElementCallAccessToken,
 	getMatrixAccessToken,
 	persistMatrixLoginData
 } from './getMatrixAccessToken';
@@ -50,6 +51,9 @@ beforeEach(() => {
 		configurable: true
 	});
 	vi.clearAllMocks();
+	vi.mocked(getMatrixHomeserverUrl).mockReturnValue(
+		'https://matrix.example.test'
+	);
 });
 
 afterEach(() => {
@@ -220,5 +224,35 @@ describe('getMatrixAccessToken', () => {
 				fallbackICEServerAllowed: true
 			}
 		});
+	});
+});
+
+describe('getElementCallAccessToken', () => {
+	it('uses a dedicated stable device instead of the ORISO app device', async () => {
+		localStorage.setItem('matrix_device_id', 'ORISO_WEB_MAIN_DEVICE');
+		Object.defineProperty(globalThis, 'crypto', {
+			value: { randomUUID: () => '12345678-90ab-cdef-1234-567890abcdef' },
+			configurable: true
+		});
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'element-call-token',
+			deviceId: 'ORISO_CALL_1234567890ABCDEF12345678',
+			userId: '@user:matrix.example.test'
+		});
+
+		const result = await getElementCallAccessToken();
+
+		expect(result.deviceId).toBe('ORISO_CALL_1234567890ABCDEF12345678');
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_CALL_1234567890ABCDEF12345678'
+			})
+		);
+		expect(localStorage.getItem('matrix_device_id')).toBe(
+			'ORISO_WEB_MAIN_DEVICE'
+		);
+		expect(localStorage.getItem('matrix_call_device_id')).toBe(
+			'ORISO_CALL_1234567890ABCDEF12345678'
+		);
 	});
 });

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -2,6 +2,7 @@ import { createClient, MatrixClient } from 'matrix-js-sdk';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { fetchData, FETCH_ERRORS, FETCH_METHODS } from '../../api/fetchData';
+import { getMatrixClientLogger } from '../../utils/matrixLogging';
 
 export interface MatrixLoginData {
 	accessToken: string;
@@ -106,6 +107,7 @@ export const createMatrixClient = (
 		accessToken: loginData.accessToken,
 		userId: loginData.userId,
 		deviceId: loginData.deviceId,
-		fallbackICEServerAllowed: true
+		fallbackICEServerAllowed: true,
+		logger: getMatrixClientLogger()
 	});
 };

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -31,11 +31,12 @@ const getOrCreateMatrixDeviceId = (
 	userId: string,
 	responseDeviceId?: string
 ): string => {
+	const userStorageKey = `${MATRIX_DEVICE_ID_STORAGE_KEY}:${userId}`;
 	if (responseDeviceId) {
+		localStorage.setItem(userStorageKey, responseDeviceId);
 		return responseDeviceId;
 	}
 
-	const userStorageKey = `${MATRIX_DEVICE_ID_STORAGE_KEY}:${userId}`;
 	const storedDeviceId = localStorage.getItem(userStorageKey);
 	if (storedDeviceId) {
 		return storedDeviceId;
@@ -46,11 +47,28 @@ const getOrCreateMatrixDeviceId = (
 	return deviceId;
 };
 
+const getOrCreateRequestedDeviceId = (): string => {
+	const storedDeviceId = localStorage.getItem(MATRIX_DEVICE_ID_STORAGE_KEY);
+	if (storedDeviceId) {
+		return storedDeviceId;
+	}
+
+	const deviceId = createBrowserDeviceId();
+	localStorage.setItem(MATRIX_DEVICE_ID_STORAGE_KEY, deviceId);
+	return deviceId;
+};
+
 export const getMatrixAccessToken = (
 	_username?: string,
 	_password?: string
 ): Promise<MatrixLoginData> => {
-	const tokenUrl = endpoints.matrixAccessToken;
+	const requestedDeviceId = getOrCreateRequestedDeviceId();
+	const querySeparator = endpoints.matrixAccessToken.includes('?')
+		? '&'
+		: '?';
+	const tokenUrl = `${endpoints.matrixAccessToken}${querySeparator}deviceId=${encodeURIComponent(
+		requestedDeviceId
+	)}`;
 	return fetchData({
 		url: tokenUrl,
 		method: FETCH_METHODS.GET,
@@ -61,6 +79,11 @@ export const getMatrixAccessToken = (
 		if (!homeserverUrl) {
 			throw new Error(
 				'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			);
+		}
+		if (!response.accessToken || !response.userId || !response.deviceId) {
+			throw new Error(
+				'Matrix login did not return a device-bound access token'
 			);
 		}
 

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -12,9 +12,13 @@ export interface MatrixLoginData {
 }
 
 const MATRIX_DEVICE_ID_STORAGE_KEY = 'matrix_device_id';
+const MATRIX_CALL_DEVICE_ID_STORAGE_KEY = 'matrix_call_device_id';
 const MATRIX_DEVICE_ID_PREFIX = 'ORISO_WEB_';
+const MATRIX_CALL_DEVICE_ID_PREFIX = 'ORISO_CALL_';
 
-const createBrowserDeviceId = (): string => {
+const createBrowserDeviceId = (
+	prefix: string = MATRIX_DEVICE_ID_PREFIX
+): string => {
 	const randomValue =
 		typeof crypto !== 'undefined' && crypto.randomUUID
 			? crypto.randomUUID().replace(/-/g, '')
@@ -22,9 +26,7 @@ const createBrowserDeviceId = (): string => {
 					.toString(36)
 					.slice(2)}`;
 
-	return `${MATRIX_DEVICE_ID_PREFIX}${randomValue
-		.toUpperCase()
-		.slice(0, 24)}`;
+	return `${prefix}${randomValue.toUpperCase().slice(0, 24)}`;
 };
 
 const getOrCreateMatrixDeviceId = (
@@ -47,15 +49,62 @@ const getOrCreateMatrixDeviceId = (
 	return deviceId;
 };
 
-const getOrCreateRequestedDeviceId = (): string => {
-	const storedDeviceId = localStorage.getItem(MATRIX_DEVICE_ID_STORAGE_KEY);
+const getOrCreateRequestedDeviceId = (
+	storageKey: string = MATRIX_DEVICE_ID_STORAGE_KEY,
+	prefix: string = MATRIX_DEVICE_ID_PREFIX
+): string => {
+	const storedDeviceId = localStorage.getItem(storageKey);
 	if (storedDeviceId) {
 		return storedDeviceId;
 	}
 
-	const deviceId = createBrowserDeviceId();
-	localStorage.setItem(MATRIX_DEVICE_ID_STORAGE_KEY, deviceId);
+	const deviceId = createBrowserDeviceId(prefix);
+	localStorage.setItem(storageKey, deviceId);
 	return deviceId;
+};
+
+export const getElementCallAccessToken = (): Promise<MatrixLoginData> => {
+	const requestedDeviceId = getOrCreateRequestedDeviceId(
+		MATRIX_CALL_DEVICE_ID_STORAGE_KEY,
+		MATRIX_CALL_DEVICE_ID_PREFIX
+	);
+	const querySeparator = endpoints.matrixAccessToken.includes('?')
+		? '&'
+		: '?';
+	const tokenUrl = `${endpoints.matrixAccessToken}${querySeparator}deviceId=${encodeURIComponent(
+		requestedDeviceId
+	)}`;
+
+	return fetchData({
+		url: tokenUrl,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL],
+		recoverOnPublicAuthRoute: false
+	}).then((response) => {
+		const homeserverUrl = getMatrixHomeserverUrl();
+		if (!homeserverUrl) {
+			throw new Error(
+				'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			);
+		}
+		if (!response.accessToken || !response.userId || !response.deviceId) {
+			throw new Error(
+				'Element Call login did not return a device-bound access token'
+			);
+		}
+
+		localStorage.setItem(
+			MATRIX_CALL_DEVICE_ID_STORAGE_KEY,
+			response.deviceId
+		);
+		return {
+			accessToken: response.accessToken,
+			userId: response.userId,
+			deviceId: response.deviceId,
+			homeserverUrl,
+			expiresInMs: response.expiresInMs
+		};
+	});
 };
 
 export const getMatrixAccessToken = (

--- a/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.test.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { groupChatCallCapabilities } from './groupChatCallCapabilities';
+
+describe('groupChatCallCapabilities', () => {
+	it('preserves audio and video controls for legacy chats without a modality', () => {
+		expect(groupChatCallCapabilities()).toEqual({
+			audio: true,
+			video: true
+		});
+	});
+
+	it.each([
+		['TEXT', false, false],
+		['AUDIO', true, false],
+		['VIDEO', true, true]
+	] as const)(
+		'%s modality exposes the intended controls',
+		(modality, audio, video) => {
+			expect(groupChatCallCapabilities(modality)).toEqual({
+				audio,
+				video
+			});
+		}
+	);
+});

--- a/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.ts
@@ -1,0 +1,9 @@
+export const groupChatCallCapabilities = (
+	modality?: 'TEXT' | 'AUDIO' | 'VIDEO'
+): { audio: boolean; video: boolean } => {
+	if (!modality) return { audio: true, video: true };
+	return {
+		audio: modality === 'AUDIO' || modality === 'VIDEO',
+		video: modality === 'VIDEO'
+	};
+};

--- a/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.test.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowGroupChatMenu } from './groupChatHeaderMenu';
+
+describe('shouldShowGroupChatMenu', () => {
+	it('shows the role-independent menu in an active joined group chat', () => {
+		expect(
+			shouldShowGroupChatMenu({
+				isActive: true,
+				isJoinGroupChatView: false
+			})
+		).toBe(true);
+	});
+
+	it.each([
+		{ isActive: false, isJoinGroupChatView: false },
+		{ isActive: true, isJoinGroupChatView: true }
+	])('hides the menu when the active joined view is unavailable', (state) => {
+		expect(shouldShowGroupChatMenu(state)).toBe(false);
+	});
+});

--- a/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.ts
@@ -1,0 +1,9 @@
+interface GroupChatMenuState {
+	isActive: boolean;
+	isJoinGroupChatView: boolean;
+}
+
+export const shouldShowGroupChatMenu = ({
+	isActive,
+	isJoinGroupChatView
+}: GroupChatMenuState) => isActive && !isJoinGroupChatView;

--- a/src/components/sessionHeader/GroupChatHeader/index.tsx
+++ b/src/components/sessionHeader/GroupChatHeader/index.tsx
@@ -19,6 +19,9 @@ import { RoomMember } from 'matrix-js-sdk';
 import { UserAvatar } from '../../message/UserAvatar';
 import { getTenantSettings } from '../../../utils/tenantSettingsHelper';
 import { ChatroomMainInteractionIcon } from '../ChatroomMainInteractionIcon';
+import { groupChatCallCapabilities } from './groupChatCallCapabilities';
+import { SessionMenu } from '../../sessionMenu/SessionMenu';
+import { shouldShowGroupChatMenu } from './groupChatHeaderMenu';
 
 interface GroupChatHeaderProps {
 	hasUserInitiatedStopOrLeaveRequest: React.MutableRefObject<boolean>;
@@ -285,12 +288,17 @@ export const GroupChatHeader = ({
 	} = getTenantSettings();
 
 	const isCallsEnabled = featureCallsEnabled !== false;
+	const modalityCalls = groupChatCallCapabilities(
+		activeSession.item.modality
+	);
 	const isAudioCallsEnabled =
 		isCallsEnabled &&
+		modalityCalls.audio &&
 		featureAudioCallsEnabled !== false &&
 		featureAudioCallsGroupChatsEnabled !== false;
 	const isVideoCallsEnabled =
 		isCallsEnabled &&
+		modalityCalls.video &&
 		featureVideoCallsEnabled !== false &&
 		featureVideoCallsGroupChatsEnabled !== false;
 
@@ -431,132 +439,20 @@ export const GroupChatHeader = ({
 						</div>
 					)}
 
-				{/* Group header uses only inline call controls; hide flyout 3-dot menu here. */}
+				{shouldShowGroupChatMenu({
+					isActive,
+					isJoinGroupChatView
+				}) && (
+					<SessionMenu
+						hasUserInitiatedStopOrLeaveRequest={
+							hasUserInitiatedStopOrLeaveRequest
+						}
+						isAskerInfoAvailable={false}
+						isJoinGroupChatView={isJoinGroupChatView}
+						bannedUsers={bannedUsers}
+					/>
+				)}
 			</div>
-			{/* <div className="sessionInfo__metaInfo">
-			{activeSession.item.active &&
-				activeSession.item.subscribed &&
-				!isJoinGroupChatView && (
-						<div
-							className="sessionInfo__metaInfo__content sessionInfo__metaInfo__content--clickable"
-							id="subscriberButton"
-							onClick={(e) => handleFlyout(e)}
-						>
-							{t('groupChat.active.sessionInfo.subscriber')}
-							{isSubscriberFlyoutOpen && (
-								<div className="sessionInfo__metaInfo__flyout">
-									<ul>
-										{users.map((subscriber, index) => (
-											<li
-												className={
-													isCurrentUserModerator &&
-													!bannedUsers.includes(
-														subscriber.username
-													) &&
-													!moderators.includes(
-														subscriber._id
-													)
-														? 'has-flyout'
-														: ''
-												}
-												key={`subscriber-${subscriber._id}`}
-												onClick={() => {
-													if (
-														!bannedUsers.includes(
-															subscriber.username
-														)
-													) {
-														setFlyoutOpenId(
-															subscriber._id
-														);
-													}
-												}}
-											>
-												<span>
-													{decodeUsername(
-														subscriber.displayName ||
-															subscriber.username
-													)}
-												</span>
-												{isCurrentUserModerator &&
-													!moderators.includes(
-														subscriber._id
-													) && (
-														<>
-															<FlyoutMenu
-																isHidden={bannedUsers.includes(
-																	subscriber.username
-																)}
-																position={
-																	window.innerWidth <=
-																	520
-																		? 'left'
-																		: 'right'
-																}
-																isOpen={
-																	flyoutOpenId ===
-																	subscriber._id
-																}
-																handleClose={() =>
-																	setFlyoutOpenId(
-																		null
-																	)
-																}
-															>
-																<BanUser
-																	userName={decodeUsername(
-																		subscriber.username
-																	)}
-																	rcUserId={
-																		subscriber._id
-																	}
-																	chatId={
-																		activeSession
-																			.item
-																			.id
-																	}
-																	handleUserBan={() => {
-																		setIsUserBanOverlayOpen(
-																			true
-																		);
-																	}}
-																/>
-															</FlyoutMenu>{' '}
-															<BanUserOverlay
-																overlayActive={
-																	isUserBanOverlayOpen
-																}
-																userName={decodeUsername(
-																	subscriber.username
-																)}
-																handleOverlay={() => {
-																	setIsUserBanOverlayOpen(
-																		false
-																	);
-																}}
-															></BanUserOverlay>
-														</>
-													)}
-												{isCurrentUserModerator &&
-													bannedUsers.includes(
-														subscriber.username
-													) && (
-														<Tag
-															className="bannedUserTag"
-															color="red"
-															text={t(
-																'banUser.is.banned'
-															)}
-														/>
-													)}
-											</li>
-										))}
-									</ul>
-								</div>
-							)}
-						</div>
-					)}
-			</div> */}
 		</div>
 	);
 };

--- a/src/components/sessionHeader/SessionHeaderComponent.tsx
+++ b/src/components/sessionHeader/SessionHeaderComponent.tsx
@@ -43,6 +43,7 @@ import {
 	SESSION_LIST_TAB,
 	SESSION_LIST_TYPES
 } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { SessionMenu } from '../sessionMenu/SessionMenu';
 import {
 	finishAnonymousChatErrorOverlayItem,
@@ -135,11 +136,7 @@ export const SessionHeaderComponent = (props: SessionHeaderProps) => {
 	);
 
 	// Check if this is an anonymous chat
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const isSupervisionEnabledForCurrentChat =
 		featureSupervisionEnabled !== false &&
 		(isAnonymousChat

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -72,6 +72,7 @@ import {
 	ChatMenuDropdownHeader,
 	ChatMenuDropdownItemContent as SessionMenuItemContent
 } from '../chatMenuDropdown/ChatMenuDropdown';
+import { sessionMenuOwnsCallControls } from './callControlOwnership';
 
 export interface SessionMenuProps {
 	hasUserInitiatedStopOrLeaveRequest: React.MutableRefObject<boolean>;
@@ -522,7 +523,8 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 	return (
 		<div className="sessionMenu__wrapper">
-			{hasVideoCallFeatures() &&
+			{sessionMenuOwnsCallControls(activeSession.isGroup) &&
+				hasVideoCallFeatures() &&
 				!props.isSupervisor &&
 				(isAudioCallsEnabled || isVideoCallsEnabled) && (
 					<div

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -41,7 +41,10 @@ import {
 } from '../../api';
 import { logout } from '../logout/logout';
 import { mobileListView } from '../app/navigationHandler';
-import { isGroupChatOwner } from '../groupChat/groupChatHelpers';
+import {
+	canModerateGroupChat,
+	isGroupChatOwner
+} from '../groupChat/groupChatHelpers';
 import { ReactComponent as LeaveChatIcon } from '../../resources/img/icons/out.svg';
 import { ReactComponent as GroupChatInfoIcon } from '../../resources/img/icons/i.svg';
 import { ReactComponent as StopGroupChatIcon } from '../../resources/img/icons/x.svg';
@@ -564,6 +567,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 						className="sessionMenu__icon sessionMenu__icon--desktop"
 						aria-expanded={Boolean(flyoutOpen)}
 						aria-controls="flyout"
+						aria-label={translate('app.menu')}
 					>
 						<MenuVerticalIcon
 							title={translate('app.menu')}
@@ -577,6 +581,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 						className="sessionMenu__icon sessionMenu__icon--mobile"
 						aria-expanded={Boolean(flyoutOpen)}
 						aria-controls="flyout"
+						aria-label={translate('app.menu')}
 					>
 						<MenuVerticalIcon
 							title={translate('app.menu')}
@@ -958,7 +963,8 @@ const SessionMenuFlyoutGroup = ({
 				</Link>
 			)}
 			{activeSession.item.subscribed &&
-				hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) && (
+				hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) &&
+				canModerateGroupChat(activeSession, userData) && (
 					<div
 						onClick={handleStopGroupChat}
 						className="sessionMenu__item chatMenuDropdown__item sessionMenu__button"

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -9,7 +9,6 @@ import {
 import { generatePath, Link, Navigate, useNavigate } from 'react-router-dom';
 import {
 	AUTHORITIES,
-	getContact,
 	hasUserAuthority,
 	SessionTypeContext,
 	useConsultingType,
@@ -24,6 +23,7 @@ import {
 	SESSION_LIST_TAB_ARCHIVE,
 	SESSION_LIST_TYPES
 } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { Overlay, OVERLAY_FUNCTIONS } from '../overlay/Overlay';
 import {
 	archiveSessionSuccessOverlayItem,
@@ -160,7 +160,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 	const handleStopGroupChat = () => {
 		stopGroupChatSecurityOverlayItem.copy =
-			activeSession.isGroup && activeSession.item.repetitive
+			getModality(activeSession) === Modality.SELF_HELP
 				? translate('groupChat.stopChat.securityOverlay.copyRepeat')
 				: translate('groupChat.stopChat.securityOverlay.copySingle');
 		setOverlayItem(stopGroupChatSecurityOverlayItem);
@@ -338,13 +338,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 		icon: <VideoCallHeaderIcon />
 	};
 
-	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const showAnonymousMobileMenu =
 		Boolean(props.showMobileEndAnonymousChatAction) ||
 		Boolean(props.showMobileDeleteAnonymousAccountAction) ||

--- a/src/components/sessionMenu/callControlOwnership.test.ts
+++ b/src/components/sessionMenu/callControlOwnership.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { sessionMenuOwnsCallControls } from './callControlOwnership';
+
+describe('sessionMenuOwnsCallControls', () => {
+	it('leaves group-call controls exclusively to GroupChatHeader', () => {
+		expect(sessionMenuOwnsCallControls(true)).toBe(false);
+	});
+
+	it('keeps call controls for non-group sessions', () => {
+		expect(sessionMenuOwnsCallControls(false)).toBe(true);
+	});
+});

--- a/src/components/sessionMenu/callControlOwnership.ts
+++ b/src/components/sessionMenu/callControlOwnership.ts
@@ -1,0 +1,2 @@
+export const sessionMenuOwnsCallControls = (isGroup: boolean): boolean =>
+	!isGroup;

--- a/src/components/sessionsList/FutureTimelinePanel.component.test.tsx
+++ b/src/components/sessionsList/FutureTimelinePanel.component.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetChatOccurrences,
+	apiSkipChatOccurrence
+} from '../../api/apiGetChatOccurrences';
+import { apiGetConsultantAppointments } from '../../api/apiGetConsultantAppointments';
+import { FutureTimelinePanel } from './FutureTimelinePanel';
+
+const translations: Record<string, string> = {
+	'groupChat.futureTimeline.appointmentFallback': 'Appointment',
+	'groupChat.futureTimeline.ariaLabel': 'Future timeline',
+	'groupChat.futureTimeline.empty': 'No upcoming events.',
+	'groupChat.futureTimeline.duplicate': 'Duplicate as one-off',
+	'groupChat.futureTimeline.groupChatFallback': 'Group chat',
+	'groupChat.futureTimeline.hide': 'Hide future events',
+	'groupChat.futureTimeline.loadMore': 'Load three more months',
+	'groupChat.futureTimeline.loadError':
+		'Some future events could not be loaded.',
+	'groupChat.futureTimeline.loading': 'Loading future events…',
+	'groupChat.futureTimeline.now': 'Now',
+	'groupChat.futureTimeline.revealAriaLabel': 'Reveal future timeline',
+	'groupChat.futureTimeline.show': 'Show future events',
+	'groupChat.futureTimeline.skip': 'Skip occurrence',
+	'groupChat.create.modality.options.audio': 'Audio'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key,
+		i18n: { language: 'en', resolvedLanguage: 'en' }
+	})
+}));
+
+vi.mock('../../api/apiGetChatOccurrences', () => ({
+	apiGetChatOccurrences: vi.fn(),
+	apiSkipChatOccurrence: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock('../../api/apiGetConsultantAppointments', () => ({
+	apiGetConsultantAppointments: vi.fn()
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('FutureTimelinePanel', () => {
+	it('does not mix appointments into a filtered group-chat timeline', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([]);
+		vi.mocked(apiGetConsultantAppointments).mockResolvedValue([
+			{
+				id: 1,
+				title: 'Private appointment',
+				startTime: new Date(Date.now() + 60_000).toISOString()
+			} as never
+		]);
+
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group' }]}
+				consultantId="consultant-1"
+				includeAppointments={false}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		await screen.findByText('No upcoming events.');
+		expect(apiGetConsultantAppointments).not.toHaveBeenCalled();
+		expect(screen.queryByText('Private appointment')).toBeNull();
+	});
+
+	it('keeps group occurrences visible when the optional appointment service is unavailable', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 0,
+				occurrenceIndex: 1,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T17:30:00Z',
+				duration: 120,
+				capacity: 14,
+				modality: 'AUDIO'
+			}
+		]);
+		vi.mocked(apiGetConsultantAppointments).mockRejectedValue(
+			new Error('CATCH_ALL')
+		);
+
+		const { rerender } = render(
+			<FutureTimelinePanel
+				series={[{ id: 0, topic: 'Selbsthilfegruppe E2E' }]}
+				consultantId="consultant-1"
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		expect(await screen.findByText('Selbsthilfegruppe E2E')).toBeTruthy();
+		expect(screen.getByText(/Audio/)).toBeTruthy();
+
+		await act(async () => {
+			rerender(
+				<FutureTimelinePanel
+					series={[{ id: 0, topic: 'Selbsthilfegruppe E2E' }]}
+					consultantId="consultant-1"
+				/>
+			);
+		});
+
+		expect(apiGetChatOccurrences).toHaveBeenCalledTimes(1);
+		expect(apiGetConsultantAppointments).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps successful Series results and reports partial loading failures', async () => {
+		vi.mocked(apiGetChatOccurrences).mockImplementation((seriesId) =>
+			seriesId === 42
+				? Promise.resolve([
+						{
+							seriesId: 42,
+							occurrenceIndex: 1,
+							originalStart: '2026-09-21T17:30:00Z',
+							start: '2026-09-21T17:30:00Z',
+							duration: 60,
+							modality: 'AUDIO'
+						}
+					])
+				: Promise.reject(new Error('series unavailable'))
+		);
+
+		render(
+			<FutureTimelinePanel
+				series={[
+					{ id: 42, topic: 'Available group' },
+					{ id: 43, topic: 'Unavailable group' }
+				]}
+				includeAppointments={false}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		expect(await screen.findByText('Available group')).toBeTruthy();
+		expect(screen.getByRole('alert').textContent).toContain(
+			'Some future events could not be loaded.'
+		);
+	});
+
+	it('keeps appointment location separate from occurrence modality', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([]);
+		vi.mocked(apiGetConsultantAppointments).mockResolvedValue([
+			{
+				id: 5,
+				title: 'Consultation',
+				location: 'Room Berlin',
+				startTime: new Date(Date.now() + 60_000).toISOString()
+			} as never
+		]);
+
+		render(<FutureTimelinePanel series={[]} consultantId="consultant-1" />);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		expect(await screen.findByText(/Room Berlin/)).toBeTruthy();
+	});
+
+	it('lets an authorized moderator skip exactly one virtual occurrence', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 42,
+				occurrenceIndex: 2,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T17:30:00Z',
+				duration: 60,
+				modality: 'TEXT'
+			}
+		]);
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group', canModerate: true }]}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		fireEvent.click(
+			await screen.findByRole('button', { name: 'Skip occurrence' })
+		);
+
+		await act(async () => undefined);
+		expect(apiSkipChatOccurrence).toHaveBeenCalledWith(
+			42,
+			'2026-09-21T17:30:00Z'
+		);
+		expect(screen.queryByText('Peer group')).toBeNull();
+	});
+
+	it('hands a virtual occurrence to the one-off duplication flow', async () => {
+		const onDuplicateOccurrence = vi.fn();
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 42,
+				occurrenceIndex: 1,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T18:30:00Z',
+				duration: 90,
+				modality: 'VIDEO'
+			}
+		]);
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group', canModerate: true }]}
+				onDuplicateOccurrence={onDuplicateOccurrence}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+		fireEvent.click(
+			await screen.findByRole('button', { name: 'Duplicate as one-off' })
+		);
+
+		expect(onDuplicateOccurrence).toHaveBeenCalledWith(
+			expect.objectContaining({ seriesId: 42, duration: 90 }),
+			'Peer group'
+		);
+	});
+});

--- a/src/components/sessionsList/FutureTimelinePanel.test.ts
+++ b/src/components/sessionsList/FutureTimelinePanel.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeTimelineLocale,
+	toSeriesApiTimestamp
+} from './futureTimelineTime';
+
+describe('toSeriesApiTimestamp', () => {
+	it('keeps the UTC offset required by the chat series API', () => {
+		expect(toSeriesApiTimestamp(new Date('2026-07-20T16:00:00Z'))).toBe(
+			'2026-07-20T16:00:00.000Z'
+		);
+	});
+
+	it('normalizes app-specific and invalid locale variants', () => {
+		expect(normalizeTimelineLocale(undefined, 'de@informal')).toBe('de');
+		expect(normalizeTimelineLocale('not_a_locale_@@', undefined)).toBe(
+			'en'
+		);
+	});
+});

--- a/src/components/sessionsList/FutureTimelinePanel.tsx
+++ b/src/components/sessionsList/FutureTimelinePanel.tsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	apiGetChatOccurrences,
+	apiSkipChatOccurrence,
+	ChatOccurrence
+} from '../../api/apiGetChatOccurrences';
+import { apiGetConsultantAppointments } from '../../api/apiGetConsultantAppointments';
+import { BookingEventsInterface } from '../../globalState/interfaces';
+import { BookingsStatus } from '../../utils/consultant';
+import {
+	normalizeTimelineLocale,
+	toSeriesApiTimestamp
+} from './futureTimelineTime';
+import './futureTimelinePanel.styles';
+
+interface FutureTimelineSeries {
+	id: number;
+	topic: string;
+	canModerate?: boolean;
+}
+
+interface FutureTimelinePanelProps {
+	series: FutureTimelineSeries[];
+	consultantId?: string;
+	includeAppointments?: boolean;
+	onDuplicateOccurrence?: (occurrence: ChatOccurrence, topic: string) => void;
+}
+
+export const FutureTimelinePanel = ({
+	series,
+	consultantId,
+	includeAppointments = true,
+	onDuplicateOccurrence
+}: FutureTimelinePanelProps) => {
+	const { t: translate, i18n } = useTranslation();
+	const [expanded, setExpanded] = useState(false);
+	const [months, setMonths] = useState(3);
+	const [occurrences, setOccurrences] = useState<ChatOccurrence[]>([]);
+	const [appointments, setAppointments] = useState<BookingEventsInterface[]>(
+		[]
+	);
+	const [loading, setLoading] = useState(false);
+	const [loadError, setLoadError] = useState(false);
+	const [commandError, setCommandError] = useState(false);
+	const [pendingSkipKeys, setPendingSkipKeys] = useState<Set<string>>(
+		new Set()
+	);
+	const seriesQueryKey = JSON.stringify(
+		series.map((item) => [item.id, item.topic, item.canModerate])
+	);
+	const seriesById = useMemo(
+		() => new Map(series.map((item) => [item.id, item])),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[seriesQueryKey]
+	);
+
+	useEffect(() => {
+		if (!expanded) {
+			setOccurrences([]);
+			setAppointments([]);
+			setCommandError(false);
+			return;
+		}
+		const from = new Date();
+		const to = new Date(from);
+		to.setMonth(to.getMonth() + months);
+		setLoading(true);
+		setLoadError(false);
+		Promise.all([
+			Promise.all(
+				series.map(async (item) => {
+					try {
+						return {
+							failed: false,
+							items: await apiGetChatOccurrences(
+								item.id,
+								toSeriesApiTimestamp(from),
+								toSeriesApiTimestamp(to),
+								100
+							)
+						};
+					} catch {
+						return { failed: true, items: [] as ChatOccurrence[] };
+					}
+				})
+			),
+			consultantId && includeAppointments
+				? apiGetConsultantAppointments(
+						consultantId,
+						BookingsStatus.ACTIVE
+					).catch(() => [])
+				: Promise.resolve([])
+		])
+			.then(([seriesResults, appointmentItems]) => {
+				setLoadError(seriesResults.some((result) => result.failed));
+				setOccurrences(
+					seriesResults
+						.flatMap((result) => result.items)
+						.sort(
+							(a, b) =>
+								new Date(a.start).getTime() -
+								new Date(b.start).getTime()
+						)
+				);
+				setAppointments(
+					appointmentItems.filter((appointment) => {
+						const start = new Date(appointment.startTime);
+						return start >= from && start < to;
+					})
+				);
+			})
+			.catch(() => {
+				setLoadError(true);
+				setOccurrences([]);
+			})
+			.finally(() => setLoading(false));
+		// Session polling rebuilds equivalent arrays. Depend on semantic series identity so the
+		// expanded timeline does not refetch on every notification/list refresh.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [consultantId, expanded, includeAppointments, months, seriesQueryKey]);
+
+	const timelineItems = useMemo(
+		() =>
+			[
+				...occurrences.map((occurrence) => ({
+					key: `series-${occurrence.seriesId}-${occurrence.originalStart}`,
+					kind: 'occurrence' as const,
+					title:
+						seriesById.get(occurrence.seriesId)?.topic ||
+						translate('groupChat.futureTimeline.groupChatFallback'),
+					start: occurrence.start,
+					modality: occurrence.modality,
+					occurrence,
+					canModerate:
+						seriesById.get(occurrence.seriesId)?.canModerate ===
+						true
+				})),
+				...appointments.map((appointment) => ({
+					key: `appointment-${appointment.id}`,
+					kind: 'appointment' as const,
+					title:
+						appointment.title ||
+						translate(
+							'groupChat.futureTimeline.appointmentFallback'
+						),
+					start: appointment.startTime,
+					detail: appointment.location
+				}))
+			].sort(
+				(a, b) =>
+					new Date(a.start).getTime() - new Date(b.start).getTime()
+			),
+		[appointments, occurrences, seriesById, translate]
+	);
+
+	const skipOccurrence = async (occurrence: ChatOccurrence) => {
+		const key = `${occurrence.seriesId}-${occurrence.originalStart}`;
+		if (pendingSkipKeys.has(key)) {
+			return;
+		}
+		setPendingSkipKeys((current) => new Set(current).add(key));
+		setCommandError(false);
+		try {
+			await apiSkipChatOccurrence(
+				occurrence.seriesId,
+				occurrence.originalStart
+			);
+			setOccurrences((current) =>
+				current.filter(
+					(item) =>
+						item.seriesId !== occurrence.seriesId ||
+						item.originalStart !== occurrence.originalStart
+				)
+			);
+		} catch {
+			setCommandError(true);
+		} finally {
+			setPendingSkipKeys((current) => {
+				const next = new Set(current);
+				next.delete(key);
+				return next;
+			});
+		}
+	};
+
+	return (
+		<section
+			className="futureTimeline"
+			aria-label={translate('groupChat.futureTimeline.ariaLabel')}
+		>
+			<div className="futureTimeline__divider">
+				<span>{translate('groupChat.futureTimeline.now')}</span>
+				<button
+					type="button"
+					onClick={() => setExpanded((value) => !value)}
+				>
+					{translate(
+						expanded
+							? 'groupChat.futureTimeline.hide'
+							: 'groupChat.futureTimeline.show'
+					)}
+				</button>
+			</div>
+			{expanded && (
+				<div className="futureTimeline__events" aria-live="polite">
+					{commandError && (
+						<p role="alert">
+							{translate('groupChat.futureTimeline.commandError')}
+						</p>
+					)}
+					{loadError && (
+						<p role="alert">
+							{translate('groupChat.futureTimeline.loadError')}
+						</p>
+					)}
+					{loading && (
+						<p>{translate('groupChat.futureTimeline.loading')}</p>
+					)}
+					{!loading && !timelineItems.length && (
+						<p>{translate('groupChat.futureTimeline.empty')}</p>
+					)}
+					{timelineItems.map((item) => (
+						<article key={item.key}>
+							<strong>{item.title}</strong>
+							<span>
+								{new Date(item.start).toLocaleString(
+									normalizeTimelineLocale(
+										i18n.resolvedLanguage,
+										i18n.language
+									)
+								)}{' '}
+								·{' '}
+								{item.kind === 'occurrence'
+									? translate(
+											`groupChat.create.modality.options.${item.modality.toLowerCase()}`
+										)
+									: item.detail}
+							</span>
+							{item.kind === 'occurrence' && item.canModerate && (
+								<div className="futureTimeline__eventActions">
+									<button
+										type="button"
+										disabled={pendingSkipKeys.has(
+											`${item.occurrence.seriesId}-${item.occurrence.originalStart}`
+										)}
+										onClick={() =>
+											void skipOccurrence(item.occurrence)
+										}
+									>
+										{translate(
+											'groupChat.futureTimeline.skip'
+										)}
+									</button>
+									{onDuplicateOccurrence && (
+										<button
+											type="button"
+											onClick={() =>
+												onDuplicateOccurrence(
+													item.occurrence,
+													item.title
+												)
+											}
+										>
+											{translate(
+												'groupChat.futureTimeline.duplicate'
+											)}
+										</button>
+									)}
+								</div>
+							)}
+						</article>
+					))}
+					<button
+						type="button"
+						onClick={() => setMonths((value) => value + 3)}
+					>
+						{translate('groupChat.futureTimeline.loadMore')}
+					</button>
+				</div>
+			)}
+		</section>
+	);
+};

--- a/src/components/sessionsList/SessionListColumn.stories.tsx
+++ b/src/components/sessionsList/SessionListColumn.stories.tsx
@@ -143,6 +143,7 @@ function FullColumnPlayground() {
 					activeChip={chip}
 					onChipToggle={(c) => setChip((p) => (p === c ? null : c))}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 					archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"
@@ -220,6 +221,7 @@ function ToolbarCreateChatColumn() {
 					activeChip={null}
 					onChipToggle={() => {}}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip={false}
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 					archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -23,6 +23,7 @@ import {
 	SET_SESSIONS,
 	UPDATE_SESSIONS,
 	UserDataContext,
+	useTenant,
 	ActiveSessionProvider
 } from '../../globalState';
 import {
@@ -81,6 +82,9 @@ import {
 	REMOTE_DRAFT_INDEX_SCOPE
 } from '../../services/draftStore';
 import { isCaseHandoverCandidate } from '../session/caseHandoverHelpers';
+import { FutureTimelinePanel } from './FutureTimelinePanel';
+import { canModerateGroupChat } from '../groupChat/groupChatHelpers';
+import { ChatOccurrence } from '../../api/apiGetChatOccurrences';
 
 function buildSessionSearchHaystack(
 	raw: ListItemInterface,
@@ -393,6 +397,7 @@ export const SessionsList = ({
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
 
 	const { userData } = useContext(UserDataContext);
+	const tenantData = useTenant();
 
 	const [isLoading, setIsLoading] = useState(true);
 	const [currentOffset, setCurrentOffset] = useState(0);
@@ -1206,6 +1211,9 @@ export const SessionsList = ({
 	const showConsultantToolbarActions =
 		type === SESSION_LIST_TYPES.MY_SESSION &&
 		!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
+	const showCreateGroupChatAction =
+		showConsultantToolbarActions &&
+		tenantData?.settings?.featureGroupChatV2Enabled === true;
 	const showCaseHandoverBatchUi =
 		showConsultantToolbarActions &&
 		sessionListTab !== SESSION_LIST_TAB_ARCHIVE;
@@ -1778,6 +1786,39 @@ export const SessionsList = ({
 		(session?.rid && session.rid === groupIdFromParam) ||
 		(session?.item?.id !== undefined &&
 			String(session.item.id) === String(sessionIdFromParam || ''));
+	const futureTimelineSeries = React.useMemo(
+		() =>
+			sortedSessions
+				.filter(
+					(session) =>
+						session.isGroup &&
+						session.item.repeatCount !== undefined
+				)
+				.map((session) => ({
+					id: session.item.id,
+					canModerate: canModerateGroupChat(session, userData),
+					topic:
+						typeof session.item.topic === 'string'
+							? session.item.topic
+							: session.item.topic?.name || 'Group chat'
+				})),
+		[sortedSessions, userData]
+	);
+	const handleDuplicateOccurrence = React.useCallback(
+		(occurrence: ChatOccurrence, topic: string) => {
+			navigate(buildCreateGroupChatPath(sessionListTab || undefined), {
+				state: {
+					duplicateOccurrence: {
+						topic,
+						start: occurrence.start,
+						duration: occurrence.duration,
+						modality: occurrence.modality
+					}
+				}
+			});
+		},
+		[navigate, sessionListTab]
+	);
 
 	return (
 		<div className="sessionsList__innerWrapper">
@@ -1800,6 +1841,7 @@ export const SessionsList = ({
 					activeChip={isCreateChatActive ? null : sessionToolbarChip}
 					onChipToggle={handleToolbarChipToggle}
 					showConsultantActions={showConsultantToolbarActions}
+					showCreateGroupChatAction={showCreateGroupChatAction}
 					showSupervisionChip={showSupervisionChip}
 					/* Live-Chat chip shows on Gespräch too once the sidebar
 					   availability toggle is ON — it narrows the
@@ -1815,6 +1857,14 @@ export const SessionsList = ({
 					}
 					createGroupChatActive={isCreateChatActive}
 					chipCounts={toolbarChipCounts}
+				/>
+			)}
+			{showMySessionToolbar && futureTimelineSeries.length > 0 && (
+				<FutureTimelinePanel
+					series={futureTimelineSeries}
+					consultantId={userData.userId}
+					includeAppointments={sessionToolbarChip === null}
+					onDuplicateOccurrence={handleDuplicateOccurrence}
 				/>
 			)}
 			{showCaseHandoverBatchUi && (

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -14,7 +14,6 @@ import {
 	AUTHORITIES,
 	buildExtendedSession,
 	ExtendedSessionInterface,
-	getContact,
 	getExtendedSession,
 	hasUserAuthority,
 	REMOVE_SESSIONS,
@@ -33,7 +32,7 @@ import {
 } from '../../globalState/interfaces';
 import { SessionListItemComponent } from '../sessionsListItem/SessionListItemComponent';
 import { SessionsListSkeleton } from '../sessionsListItem/SessionsListItemSkeleton';
-import { isAnonymousAskerCandidate } from './sessionClassification';
+import { getModality, Modality } from '../session/getModality';
 import {
 	apiGetAskerSessionList,
 	apiGetCaseHandoverCandidates,
@@ -121,24 +120,9 @@ function buildSessionSearchHaystack(
  */
 function isAnonymousAskerSession(
 	raw: ListItemInterface,
-	extended: ExtendedSessionInterface
+	_extended: ExtendedSessionInterface
 ): boolean {
-	const registrationType =
-		(raw as any)?.session?.registrationType ??
-		(extended as any)?.item?.registrationType;
-	const postcode =
-		(raw as any)?.session?.postcode ?? (extended as any)?.item?.postcode;
-	const contact = getContact(extended as ListItemInterface);
-	return isAnonymousAskerCandidate({
-		registrationType,
-		postcode,
-		usernames: [
-			contact?.username,
-			(raw as any)?.user?.username,
-			(raw as any)?.session?.askerUserName,
-			(extended as any)?.item?.askerUserName
-		]
-	});
+	return getModality(raw) === Modality.LIVE_CHAT;
 }
 
 const getSessionIdentityValues = (
@@ -918,7 +902,11 @@ export const SessionsList = ({
 									(s) => s?.chat?.groupId === rid
 								);
 								// If repetitive group chat reload it by id because groupId has changed
-								if (loadedSession?.chat?.repetitive) {
+								if (
+									loadedSession &&
+									getModality(loadedSession) ===
+										Modality.SELF_HELP
+								) {
 									return ['reload', loadedSession.chat.id];
 								}
 								return ['removed', rid];
@@ -948,7 +936,11 @@ export const SessionsList = ({
 								(s) => s?.chat?.groupId === rid
 							);
 							// If repetitive group chat reload it by id because groupId has changed
-							if (loadedSession?.chat?.repetitive) {
+							if (
+								loadedSession &&
+								getModality(loadedSession) ===
+									Modality.SELF_HELP
+							) {
 								return ['reload', loadedSession.chat.id];
 							}
 							return ['removed', rid];
@@ -2140,14 +2132,16 @@ const useGroupWatcher = (isLoading: boolean) => {
 					dispatch({
 						type: REMOVE_SESSIONS,
 						ids: removedGroupSessions
-							.filter((s) => !s.chat.repetitive)
+							.filter(
+								(s) => getModality(s) !== Modality.SELF_HELP
+							)
 							.map((s) => s.chat.groupId)
 					});
 				}
 
 				// Update repetitive chats by id because groupId has changed
 				const repetitiveGroupSessions = removedGroupSessions.filter(
-					(s) => s.chat.repetitive
+					(s) => getModality(s) === Modality.SELF_HELP
 				);
 				if (repetitiveGroupSessions.length > 0) {
 					Promise.all(

--- a/src/components/sessionsList/SessionsListToolbar.stories.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.stories.tsx
@@ -83,6 +83,7 @@ function SessionsListToolbarPlayground({
 					setActiveChip((prev) => (prev === chip ? null : chip))
 				}
 				showConsultantActions={showConsultantActions}
+				showCreateGroupChatAction={showConsultantActions}
 				showSupervisionChip={showSupervisionChip}
 				showLiveChatChip
 				createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
@@ -151,6 +152,7 @@ function ToolbarWithSearchPreset() {
 					setActiveChip((p) => (p === chip ? null : chip))
 				}
 				showConsultantActions
+				showCreateGroupChatAction
 				showSupervisionChip
 				createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 				archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"

--- a/src/components/sessionsList/SessionsListToolbar.test.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionsListToolbar } from './SessionsListToolbar';
+
+vi.mock('./SessionToolbarFilterIcons', () => {
+	const Icon = () => <span aria-hidden />;
+	return {
+		ArchiveFilterIcon: Icon,
+		CreateChatFilterIcon: Icon,
+		DraftFilterIcon: Icon,
+		GroupFilterIcon: Icon,
+		InternalGroupFilterIcon: Icon,
+		LiveChatFilterIcon: Icon,
+		NearbyFilterIcon: Icon,
+		SupervisionFilterIcon: Icon,
+		UnreadFilterIcon: Icon
+	};
+});
+
+const renderToolbar = (showCreateGroupChatAction: boolean) =>
+	render(
+		<MemoryRouter>
+			<SessionsListToolbar
+				translate={(key) => key}
+				searchValue=""
+				onSearchChange={vi.fn()}
+				activeChip={null}
+				onChipToggle={vi.fn()}
+				showConsultantActions
+				showCreateGroupChatAction={showCreateGroupChatAction}
+				showSupervisionChip={false}
+				createGroupChatPath="/sessions/create"
+				archiveTabPath="/sessions/archive"
+				archiveTabActive={false}
+				createGroupChatActive={false}
+			/>
+		</MemoryRouter>
+	);
+
+describe('SessionsListToolbar group-chat feature gate', () => {
+	it('hides Create while preserving ordinary consultant actions when disabled', () => {
+		renderToolbar(false);
+
+		expect(
+			screen.queryByRole('link', {
+				name: 'sessionList.createChat.buttonTitle'
+			})
+		).toBeNull();
+		expect(
+			screen.getByRole('link', {
+				name: 'sessionList.view.archive.tab'
+			})
+		).toBeTruthy();
+	});
+
+	it('shows Create when the tenant enables the feature', () => {
+		renderToolbar(true);
+
+		expect(
+			screen.getByRole('link', {
+				name: 'sessionList.createChat.buttonTitle'
+			})
+		).toBeTruthy();
+	});
+});

--- a/src/components/sessionsList/SessionsListToolbar.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.tsx
@@ -28,6 +28,7 @@ interface SessionsListToolbarProps {
 	activeChip: SessionToolbarChipFilter | null;
 	onChipToggle: (chip: SessionToolbarChipFilter) => void;
 	showConsultantActions: boolean;
+	showCreateGroupChatAction: boolean;
 	showSupervisionChip: boolean;
 	/** Show the "Live-Chat" filter chip (tied to the sidebar availability toggle). */
 	showLiveChatChip?: boolean;
@@ -261,6 +262,7 @@ export const SessionsListToolbar = ({
 	activeChip,
 	onChipToggle,
 	showConsultantActions,
+	showCreateGroupChatAction,
 	showSupervisionChip,
 	showLiveChatChip = false,
 	createGroupChatPath,
@@ -643,7 +645,7 @@ export const SessionsListToolbar = ({
 				style={{ display: showSearchDropdown ? 'none' : undefined }}
 			>
 				<div className="sessionsListToolbar__chipsRow">
-					{showConsultantActions && (
+					{showCreateGroupChatAction && (
 						<Link
 							className={clsx('sessionsListToolbar__chip', {
 								'sessionsListToolbar__chip--iconOnly':

--- a/src/components/sessionsList/futureTimelinePanel.styles.scss
+++ b/src/components/sessionsList/futureTimelinePanel.styles.scss
@@ -1,0 +1,44 @@
+.futureTimeline {
+	padding: $grid-base $grid-base-two;
+	border-bottom: 1px solid var(--m3-outline-variant, #c8c5ca);
+
+	&__divider {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: $grid-base;
+
+		input {
+			width: 100%;
+		}
+
+		button {
+			border: 0;
+			background: transparent;
+			text-decoration: underline;
+			cursor: pointer;
+		}
+	}
+
+	&__events {
+		display: grid;
+		gap: $grid-base;
+		padding-top: $grid-base-two;
+		max-height: 320px;
+		overflow-y: auto;
+
+		article {
+			display: flex;
+			flex-direction: column;
+			padding: $grid-base-two;
+			border-radius: $box-border-radius;
+			background: var(--m3-surface-container, #f1f3f5);
+		}
+	}
+}
+
+.futureTimeline__eventActions {
+	display: flex;
+	gap: $grid-base;
+	flex-wrap: wrap;
+}

--- a/src/components/sessionsList/futureTimelineTime.ts
+++ b/src/components/sessionsList/futureTimelineTime.ts
@@ -1,0 +1,15 @@
+export const toSeriesApiTimestamp = (date: Date): string => date.toISOString();
+
+export const normalizeTimelineLocale = (
+	resolvedLanguage?: string,
+	language?: string
+): string => {
+	const candidate = (resolvedLanguage || language || 'en')
+		.split('@')[0]
+		.replace(/_/g, '-');
+	try {
+		return Intl.DateTimeFormat.supportedLocalesOf(candidate)[0] || 'en';
+	} catch {
+		return 'en';
+	}
+};

--- a/src/components/sessionsList/sessionClassification.test.ts
+++ b/src/components/sessionsList/sessionClassification.test.ts
@@ -1,43 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import {
-	getDisplayablePostcode,
-	isAnonymousAskerCandidate,
-	isAnonymousUsername
-} from './sessionClassification';
+import { getDisplayablePostcode } from './sessionClassification';
 
 describe('sessionClassification', () => {
-	it('keeps registered enquiry sessions with real postcodes out of live chat', () => {
-		expect(
-			isAnonymousAskerCandidate({
-				registrationType: 'REGISTERED',
-				postcode: 12345,
-				usernames: ['ruhiges Yak Kim']
-			})
-		).toBe(false);
-	});
-
 	it('formats real postcodes and suppresses anonymous postcode sentinels', () => {
 		expect(getDisplayablePostcode(12345)).toBe('12345');
 		expect(getDisplayablePostcode(' 99322 ')).toBe('99322');
 		expect(getDisplayablePostcode(0)).toBeNull();
 		expect(getDisplayablePostcode('00000')).toBeNull();
 		expect(getDisplayablePostcode('')).toBeNull();
-	});
-
-	it('detects anonymous sessions from registration, username, and postcode markers', () => {
-		expect(
-			isAnonymousAskerCandidate({
-				registrationType: 'ANONYMOUS',
-				postcode: 12345
-			})
-		).toBe(true);
-		expect(isAnonymousUsername('Anonymous-abc')).toBe(true);
-		expect(isAnonymousUsername('anon_abc')).toBe(true);
-		expect(
-			isAnonymousAskerCandidate({
-				postcode: '00000',
-				usernames: ['ruhiges Yak Kim']
-			})
-		).toBe(true);
 	});
 });

--- a/src/components/sessionsList/sessionClassification.ts
+++ b/src/components/sessionsList/sessionClassification.ts
@@ -1,13 +1,3 @@
-export type SessionClassificationInput = {
-	registrationType?: string | null;
-	postcode?: number | string | null;
-	usernames?: Array<string | null | undefined>;
-};
-
-export const isAnonymousUsername = (username?: string | null): boolean =>
-	typeof username === 'string' &&
-	(username.startsWith('Anonymous-') || username.startsWith('anon_'));
-
 export const getDisplayablePostcode = (
 	postcode?: number | string | null
 ): string | null => {
@@ -21,25 +11,4 @@ export const getDisplayablePostcode = (
 	}
 
 	return value;
-};
-
-export const isAnonymousAskerCandidate = ({
-	registrationType,
-	postcode,
-	usernames = []
-}: SessionClassificationInput): boolean => {
-	if (registrationType === 'ANONYMOUS') {
-		return true;
-	}
-
-	if (usernames.some(isAnonymousUsername)) {
-		return true;
-	}
-
-	if (postcode === null || postcode === undefined || postcode === '') {
-		return false;
-	}
-
-	const value = String(postcode).trim();
-	return value === '0' || value === '00000';
 };

--- a/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
+++ b/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
@@ -44,4 +44,25 @@ describe('session toolbar module helpers', () => {
 		).toBe(false);
 		expect(isInternalGroupChatSession({ isGroup: false })).toBe(false);
 	});
+
+	it('prefers explicit modality over conflicting repetitive metadata', () => {
+		expect(
+			isConversationCircleSession({
+				isGroup: true,
+				item: {
+					conversationType: 'INTERNAL_GROUP',
+					repetitive: true
+				}
+			})
+		).toBe(false);
+		expect(
+			isConversationCircleSession({
+				isGroup: true,
+				item: {
+					conversationType: 'SELF_HELP',
+					repetitive: false
+				}
+			})
+		).toBe(true);
+	});
 });

--- a/src/components/sessionsList/sessionToolbarFilters.ts
+++ b/src/components/sessionsList/sessionToolbarFilters.ts
@@ -1,3 +1,5 @@
+import { getModality, Modality } from '../session/getModality';
+
 export type SessionToolbarChipFilter =
 	| 'unread'
 	| 'drafts'
@@ -10,6 +12,7 @@ export type SessionToolbarChipFilter =
 export type SessionToolbarGroupSession = {
 	isGroup?: boolean;
 	item?: {
+		conversationType?: `${Modality}`;
 		repetitive?: boolean;
 	} | null;
 };
@@ -45,7 +48,8 @@ export const normalizeSessionToolbarChip = (
 // Group chat filters must rely on room metadata, never encrypted message bodies.
 export const isConversationCircleSession = (
 	session: SessionToolbarGroupSession
-): boolean => Boolean(session.isGroup && session.item?.repetitive);
+): boolean =>
+	Boolean(session.isGroup) && getModality(session) === Modality.SELF_HELP;
 
 export const isInternalGroupChatSession = (
 	session: SessionToolbarGroupSession

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -26,6 +26,9 @@ import { ReactComponent as HelpIcon } from '../../resources/img/icons/i.svg';
 import { ReactComponent as ImprintIcon } from '../../resources/img/icons/imprint.svg';
 import { ReactComponent as PlusIcon } from '../../resources/img/icons/plus.svg';
 import { ReactComponent as PackageIcon } from '../../resources/img/icons/documents.svg';
+import { ReactComponent as TextModalityIcon } from '../../resources/img/icons/chat.svg';
+import { ReactComponent as AudioModalityIcon } from '../../resources/img/icons/call.svg';
+import { ReactComponent as VideoModalityIcon } from '../../resources/img/icons/video-call.svg';
 import nearbyConversationIcon from '../../resources/img/icons/chatroom/nearby_conv_type_200.svg';
 import teamImage from '../../resources/img/illustrations/Team.svg';
 import {
@@ -61,6 +64,7 @@ import { parseMessagePrefixes } from '../message/messageConstants';
 import { useE2EE } from '../../hooks/useE2EE';
 import { useSearchParam } from '../../hooks/useSearchParams';
 import { SessionListItemLastMessage } from './SessionListItemLastMessage';
+import { getSessionNavigationPath } from './sessionsListItemHelpers';
 import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
 import { useTranslation } from 'react-i18next';
 import {
@@ -121,6 +125,12 @@ export const SessionListItemComponent = ({
 	const { isE2eeEnabled } = useContext(E2EEContext);
 	const activeSessionContext = useContext(ActiveSessionContext);
 	const activeSession = activeSessionContext?.activeSession;
+	const GroupModalityIcon =
+		activeSession?.item?.modality === 'VIDEO'
+			? VideoModalityIcon
+			: activeSession?.item?.modality === 'AUDIO'
+				? AudioModalityIcon
+				: TextModalityIcon;
 	const reloadActiveSession = activeSessionContext?.reloadActiveSession;
 	const sessionItem = activeSession?.item;
 	const { dispatch: sessionsDispatch } = useContext(SessionsDataContext);
@@ -514,32 +524,19 @@ export const SessionListItemComponent = ({
 		// isAsker: hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData)
 		// });
 
-		// For sessions without groupId (Matrix migration), navigate by session ID
 		if (activeSession.item.id !== undefined) {
-			// Check if groupId looks like a Matrix room ID (starts with ! or contains :)
-			const isMatrixRoomId = isMatrixRoomIdHeuristic(
-				activeSession.item.groupId
+			navigate(
+				getSessionNavigationPath({
+					listPath,
+					sessionId: activeSession.item.id,
+					groupId: activeSession.item.groupId,
+					rid: activeSession.rid,
+					isGroup: activeSession.isGroup,
+					isAsker,
+					isEmptyEnquiry: activeSession.isEmptyEnquiry,
+					tabSuffix: getSessionListTab()
+				})
 			);
-
-			if (activeSession.item.groupId && !isMatrixRoomId) {
-				// Original RocketChat behavior: navigate with groupId
-				const targetPath = `${listPath}/${activeSession.item.groupId}/${activeSession.item.id}${getSessionListTab()}`;
-				// console.log('🚀 Navigating with RocketChat groupId:', targetPath);
-				navigate(targetPath);
-			} else if (
-				hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
-				activeSession.isEmptyEnquiry
-			) {
-				// Empty enquiry: go to write view
-				const targetPath = `/sessions/user/view/write/${activeSession.item.id}`;
-				// console.log('🚀 Navigating to write view:', targetPath);
-				navigate(targetPath);
-			} else {
-				// MATRIX MIGRATION FIX: Navigate by session ID for Matrix rooms or sessions without groupId
-				const targetPath = `${listPath}/session/${activeSession.item.id}${getSessionListTab()}`;
-				// console.log('🚀 Navigating by session ID (Matrix or no groupId):', targetPath);
-				navigate(targetPath);
-			}
 		}
 	};
 
@@ -1426,6 +1423,15 @@ export const SessionListItemComponent = ({
 								'sessionsListItem__username--readLabel'
 						)}
 					>
+						{activeSession.isGroup &&
+							activeSession.item.modality && (
+								<GroupModalityIcon
+									className="sessionsListItem__groupModalityIcon"
+									aria-label={translate(
+										`groupChat.create.modality.options.${activeSession.item.modality.toLowerCase()}`
+									)}
+								/>
+							)}
 						{sessionTopic}
 					</div>
 				</div>

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -3,10 +3,8 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useActiveListItem } from '../../hooks/useActiveListItem';
-import {
-	getDisplayablePostcode,
-	isAnonymousAskerCandidate
-} from '../sessionsList/sessionClassification';
+import { getDisplayablePostcode } from '../sessionsList/sessionClassification';
+import { getModality, Modality } from '../session/getModality';
 import {
 	convertISO8601ToMSSinceEpoch,
 	getPrettyDateFromMessageDate,
@@ -867,14 +865,7 @@ export const SessionListItemComponent = ({
 	}
 
 	const postcodeLabel = getDisplayablePostcode(activeSession.item.postcode);
-	const isAnonymousChat = isAnonymousAskerCandidate({
-		registrationType: (activeSession.item as any).registrationType,
-		postcode: activeSession.item.postcode,
-		usernames: [
-			activeSession.user?.username,
-			(activeSession.item as any).askerUserName
-		]
-	});
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const shouldShowPostcode =
 		!isAsker &&
 		!autoSelectPostcode &&

--- a/src/components/sessionsListItem/sessionNavigationPath.test.ts
+++ b/src/components/sessionsListItem/sessionNavigationPath.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { getSessionNavigationPath } from './sessionsListItemHelpers';
+
+describe('getSessionNavigationPath', () => {
+	it('keeps Matrix group chats on the group-room route', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 1,
+				groupId: '!room:matrix.localhost',
+				isGroup: true,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/!room%3Amatrix.localhost/1');
+	});
+
+	it('falls back to the resolved room id for group chats', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 1,
+				groupId: undefined,
+				rid: '!resolved-room:matrix.localhost',
+				isGroup: true,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/!resolved-room%3Amatrix.localhost/1');
+	});
+
+	it('keeps ordinary Matrix sessions on the session-id route', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 4,
+				groupId: '!session:matrix.localhost',
+				isGroup: false,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/session/4');
+	});
+
+	it('keeps an empty enquiry on its current list route and tab', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 9,
+				isGroup: false,
+				isAsker: true,
+				isEmptyEnquiry: true,
+				tabSuffix: '?state=enquiry'
+			})
+		).toBe('/sessions/user/view/write/9?state=enquiry');
+	});
+
+	it('URL-encodes legacy non-Matrix group identifiers', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/consultant/sessionView',
+				sessionId: 12,
+				groupId: 'legacy/group?one',
+				isGroup: false,
+				isAsker: false,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/consultant/sessionView/legacy%2Fgroup%3Fone/12');
+	});
+});

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -25,6 +25,12 @@ $case-handover-denied-bg: var(--m3-error-container, #f7d7d7);
 $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 .sessionsListItem {
+	&__groupModalityIcon {
+		width: $grid-base-two;
+		height: $grid-base-two;
+		margin-right: $grid-base;
+		vertical-align: text-bottom;
+	}
 	display: flex;
 	color: $body-font-color;
 	margin-bottom: 0px;

--- a/src/components/sessionsListItem/sessionsListItemHelpers.ts
+++ b/src/components/sessionsListItem/sessionsListItemHelpers.ts
@@ -2,6 +2,7 @@ import { ReactComponent as OpenEnvelopeIcon } from '../../resources/img/icons/en
 import { ReactComponent as GroupChatIcon } from '../../resources/img/icons/speech-bubble.svg';
 import { ReactComponent as NewEnquiryIcon } from '../../resources/img/icons/plus.svg';
 import { ReactComponent as ClosedEnvelopeIcon } from '../../resources/img/icons/envelope.svg';
+import { isMatrixRoomIdHeuristic } from '../../utils/matrixRoomUtils';
 
 export const LIST_ICONS = {
 	IS_READ: 'IS_READ',
@@ -21,4 +22,48 @@ export const getSessionsListItemIcon = (variant: string) => {
 		default:
 			return ClosedEnvelopeIcon;
 	}
+};
+
+interface SessionNavigationPathOptions {
+	listPath: string;
+	sessionId: number | string;
+	groupId?: string;
+	rid?: string;
+	isGroup: boolean;
+	isAsker: boolean;
+	isEmptyEnquiry: boolean;
+	tabSuffix: string;
+}
+
+export const getSessionNavigationPath = ({
+	listPath,
+	sessionId,
+	groupId,
+	rid,
+	isGroup,
+	isAsker,
+	isEmptyEnquiry,
+	tabSuffix
+}: SessionNavigationPathOptions) => {
+	const roomId = groupId ?? rid;
+
+	if (isGroup && roomId) {
+		return `${listPath}/${encodeURIComponent(roomId)}/${sessionId}${tabSuffix}`;
+	}
+	if (isGroup) {
+		// A materialized room may be absent for a future Series occurrence.
+		// Resolve the Series through the supported session-id route instead of
+		// falling into asker-enquiry routing.
+		return `${listPath}/session/${sessionId}${tabSuffix}`;
+	}
+
+	if (groupId && !isMatrixRoomIdHeuristic(groupId)) {
+		return `${listPath}/${encodeURIComponent(groupId)}/${sessionId}${tabSuffix}`;
+	}
+
+	if (isAsker && isEmptyEnquiry) {
+		return `${listPath}/write/${sessionId}${tabSuffix}`;
+	}
+
+	return `${listPath}/session/${sessionId}${tabSuffix}`;
 };

--- a/src/components/stageLayout/StageLayout.test.tsx
+++ b/src/components/stageLayout/StageLayout.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { AgencySpecificContext, LocaleContext } from '../../globalState';
+import { StageLayout } from './StageLayout';
+
+vi.mock('../../hooks/useAppConfig', () => ({
+	useAppConfig: () => ({
+		urls: {
+			toLogin: 'https://app.oriso-dev.site/login',
+			toRegistration: 'https://app.oriso-dev.site/registration'
+		}
+	})
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) =>
+			key === 'login.register.linkLabel' ? 'Register' : key
+	})
+}));
+
+vi.mock('../registration/infoDrawer/InfoDrawer', () => ({
+	InfoDrawer: () => null
+}));
+
+vi.mock('lottie-react', () => ({ default: () => null }));
+
+describe('StageLayout registration invitation continuity', () => {
+	it('uses the invitation-aware registration URL supplied by Login', () => {
+		render(
+			<MemoryRouter>
+				<LocaleContext.Provider
+					value={{ selectableLocales: [] } as any}
+				>
+					<AgencySpecificContext.Provider
+						value={{ specificAgency: null } as any}
+					>
+						<StageLayout
+							stage={<div>stage</div>}
+							showRegistrationLink
+							registrationUrl="https://app.oriso-dev.site/registration?gcid=1017"
+						>
+							<div>content</div>
+						</StageLayout>
+					</AgencySpecificContext.Provider>
+				</LocaleContext.Provider>
+			</MemoryRouter>
+		);
+
+		expect(
+			screen.getByRole('link', { name: /register/i }).getAttribute('href')
+		).toBe('https://app.oriso-dev.site/registration?gcid=1017');
+	});
+});

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -37,6 +37,7 @@ interface StageLayoutProps {
 	showLoginLink?: boolean;
 	showRegistrationLink?: boolean;
 	loginParams?: string;
+	registrationUrl?: string;
 	showRegistrationInfoDrawer?: boolean;
 }
 
@@ -48,6 +49,7 @@ export const StageLayout = ({
 	showLoginLink,
 	showRegistrationLink,
 	loginParams,
+	registrationUrl,
 	showRegistrationInfoDrawer
 }: StageLayoutProps) => {
 	const trigger = useScrollTrigger();
@@ -63,8 +65,10 @@ export const StageLayout = ({
 		loginParams ? `?${loginParams}` : ''
 	}`;
 	const loginRoute = toSameOriginRoute(loginUrl);
-	const registrationRoute = toSameOriginRoute(settings.urls.toRegistration);
-	const registrationHref = registrationRoute || settings.urls.toRegistration;
+	const resolvedRegistrationUrl =
+		registrationUrl || settings.urls.toRegistration;
+	const registrationRoute = toSameOriginRoute(resolvedRegistrationUrl);
+	const registrationHref = registrationRoute || resolvedRegistrationUrl;
 
 	return (
 		<div className={clsx('stageLayout', className)}>

--- a/src/configureMatrixLogging.ts
+++ b/src/configureMatrixLogging.ts
@@ -1,0 +1,3 @@
+import { configureMatrixLogging } from './utils/matrixLogging';
+
+configureMatrixLogging();

--- a/src/generated/userservice.d.ts
+++ b/src/generated/userservice.d.ts
@@ -341,11 +341,24 @@ declare namespace UserService {
 			 * false
 			 */
 			repetitive: boolean;
+			repeatCount?: number;
+			chatInterval?:
+				| 'DAILY'
+				| 'WEEKLY'
+				| 'BIWEEKLY'
+				| 'MONTHLY'
+				| 'QUARTERLY'
+				| 'YEARLY';
+			modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+			timezone?: string;
 			/**
 			 * example:
 			 * Hint
 			 */
 			hintMessage?: string;
+			sourceLanguage?: string;
+			hintMessageTranslations?: Record<string, string>;
+			groupChatRulesTranslations?: Record<string, string[]>;
 		}
 		export interface ChatInfoResponseDTO {
 			/**
@@ -1947,6 +1960,11 @@ declare namespace UserService {
 			 */
 			tenantId?: number;
 		}
+		export interface GroupChatParticipantDTO {
+			consultantId: string;
+			role: 'OWNER' | 'CO_MODERATOR' | 'PARTICIPANT';
+			displayName: string;
+		}
 		export interface UserChatDTO {
 			/**
 			 * example:
@@ -1978,6 +1996,17 @@ declare namespace UserService {
 			 * false
 			 */
 			repetitive: boolean;
+			repeatCount?: number;
+			currentOccurrenceIndex?: number;
+			chatInterval?:
+				| 'DAILY'
+				| 'WEEKLY'
+				| 'BIWEEKLY'
+				| 'MONTHLY'
+				| 'QUARTERLY'
+				| 'YEARLY';
+			modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+			timezone?: string;
 			/**
 			 * example:
 			 * false
@@ -2016,6 +2045,7 @@ declare namespace UserService {
 			 */
 			subscribed?: boolean;
 			moderators?: string[];
+			participants?: GroupChatParticipantDTO[];
 			startDateWithTime?: string; // date-time
 			/**
 			 * example:
@@ -2028,6 +2058,9 @@ declare namespace UserService {
 			 * Hint
 			 */
 			hintMessage?: string;
+			sourceLanguage?: string;
+			hintMessageTranslations?: Record<string, string>;
+			groupChatRulesTranslations?: Record<string, string[]>;
 		}
 		export interface UserDTO {
 			/**

--- a/src/globalState/interfaces/SessionsDataInterface.ts
+++ b/src/globalState/interfaces/SessionsDataInterface.ts
@@ -61,6 +61,11 @@ export interface TopicSessionInterface {
 }
 
 export interface SessionItemInterface {
+	conversationType?:
+		| 'AGENCY_COUNSELLING'
+		| 'LIVE_CHAT'
+		| 'INTERNAL_GROUP'
+		| 'SELF_HELP';
 	agencyId: number;
 	askerRcId: string;
 	attachment: UserService.Schemas.SessionAttachmentDTO;
@@ -80,6 +85,7 @@ export interface SessionItemInterface {
 	messageTime?: number;
 	postcode: number;
 	registrationType: registrationTypeRegistered;
+	teamSession?: boolean;
 	status:
 		| statusEmpty
 		| statusEnquiry
@@ -92,6 +98,11 @@ export interface SessionItemInterface {
 }
 
 export interface GroupChatItemInterface {
+	conversationType?:
+		| 'AGENCY_COUNSELLING'
+		| 'LIVE_CHAT'
+		| 'INTERNAL_GROUP'
+		| 'SELF_HELP';
 	active: boolean;
 	assignedAgencies: AgencyService.Schemas.AgencyResponseDTO[];
 	attachment: UserService.Schemas.SessionAttachmentDTO;

--- a/src/globalState/interfaces/SessionsDataInterface.ts
+++ b/src/globalState/interfaces/SessionsDataInterface.ts
@@ -99,6 +99,9 @@ export interface GroupChatItemInterface {
 	duration: number;
 	groupId: string;
 	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
 	id: number;
 	lastMessage: string;
 	lastMessageType?: string;
@@ -109,9 +112,16 @@ export interface GroupChatItemInterface {
 	messageDate: number;
 	messagesRead: boolean;
 	moderators: string[];
+	participants?: UserService.Schemas.GroupChatParticipantDTO[];
 	repetitive: boolean;
+	repeatCount?: number;
+	currentOccurrenceIndex?: number;
+	chatInterval?: UserService.Schemas.UserChatDTO['chatInterval'];
+	modality?: UserService.Schemas.UserChatDTO['modality'];
+	timezone?: string;
 	startDate: string;
 	startTime: string;
+	startDateWithTime?: string;
 	subscribed: boolean;
 	topic: string;
 	createdAt: string;

--- a/src/globalState/provider/NotificationsProvider.tsx
+++ b/src/globalState/provider/NotificationsProvider.tsx
@@ -19,6 +19,8 @@ import {
 	apiMarkEventNotificationRead
 } from '../../api/apiEventNotifications';
 import { getValueFromCookie } from '../../components/sessionCookie/accessSessionCookie';
+import { EventActionParams } from '../../components/notificationsCenter/eventDescriptors';
+import { parseEventActionParams } from '../../components/notificationsCenter/notificationActionTarget';
 
 export const NOTIFICATION_DEFAULT_TIMEOUT = 3000;
 
@@ -80,6 +82,7 @@ export type NotificationFeedItem = {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: string;
+	params?: EventActionParams;
 	category: 'system' | 'message';
 };
 
@@ -92,6 +95,7 @@ export type EventNotificationInput = {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: string | number;
+	params?: EventActionParams;
 };
 
 const NOTIFICATION_FEED_MAX_ITEMS = 50;
@@ -154,6 +158,7 @@ export function NotificationsProvider(props) {
 					item.sourceSessionId != null
 						? String(item.sourceSessionId)
 						: undefined,
+				params: parseEventActionParams(item.params),
 				category: item.category === 'message' ? 'message' : 'system'
 			}));
 			setNotificationFeed(normalized);
@@ -224,6 +229,7 @@ export function NotificationsProvider(props) {
 					event.sourceSessionId != null
 						? String(event.sourceSessionId)
 						: undefined,
+				params: event.params,
 				category: event.category === 'message' ? 'message' : 'system'
 			};
 			setNotificationFeed((existing) =>

--- a/src/globalState/provider/TenantProvider.test.tsx
+++ b/src/globalState/provider/TenantProvider.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	TenantContext,
+	TenantProvider,
+	useTenantState
+} from './TenantProvider';
+
+const Probe = () => {
+	const state = useTenantState();
+	const context = React.useContext(TenantContext);
+	return (
+		<>
+			<span>
+				{state.isLoading ? 'loading' : state.tenant?.id || 'missing'}
+			</span>
+			<button
+				type="button"
+				onClick={() =>
+					context.setTenant({ id: 'tenant-17', settings: {} } as any)
+				}
+			>
+				resolve
+			</button>
+		</>
+	);
+};
+
+describe('useTenantState', () => {
+	it('distinguishes an unresolved tenant from a missing provider', () => {
+		const { rerender } = render(
+			<TenantProvider>
+				<Probe />
+			</TenantProvider>
+		);
+		expect(screen.getByText('loading')).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'resolve' }));
+		expect(screen.getByText('tenant-17')).toBeTruthy();
+
+		rerender(<Probe />);
+		expect(screen.getByText('missing')).toBeTruthy();
+	});
+});

--- a/src/globalState/provider/TenantProvider.tsx
+++ b/src/globalState/provider/TenantProvider.tsx
@@ -4,7 +4,7 @@ import { setTenantSettings } from '../../utils/tenantSettingsHelper';
 import { TenantDataInterface } from '../interfaces';
 
 export const TenantContext = createContext<{
-	tenant: TenantDataInterface;
+	tenant: TenantDataInterface | undefined;
 	setTenant(tenant: TenantDataInterface): void;
 }>(null);
 
@@ -25,4 +25,12 @@ export function TenantProvider(props) {
 
 export function useTenant() {
 	return useContext(TenantContext)?.tenant || null;
+}
+
+export function useTenantState() {
+	const context = useContext(TenantContext);
+	return {
+		tenant: context?.tenant || null,
+		isLoading: context !== null && context.tenant === undefined
+	};
 }

--- a/src/hooks/useJoinGroupChat.test.tsx
+++ b/src/hooks/useJoinGroupChat.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiPutGroupChat, GROUP_CHAT_API } from '../api';
+import { useJoinGroupChat } from './useJoinGroupChat';
+
+vi.mock('../api', () => ({
+	apiPutGroupChat: vi.fn(() => Promise.resolve()),
+	GROUP_CHAT_API: { ASSIGN: '/assign', JOIN: '/join' }
+}));
+
+vi.mock('../globalState', () => ({
+	useTenant: () => ({ settings: { featureGroupChatV2Enabled: true } })
+}));
+
+describe('useJoinGroupChat', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('joins a V2 Series through the canonical join endpoint', () => {
+		const { result } = renderHook(() => useJoinGroupChat());
+
+		act(() => result.current.joinGroupChat('1013'));
+
+		expect(apiPutGroupChat).toHaveBeenCalledWith(
+			'1013',
+			GROUP_CHAT_API.JOIN
+		);
+	});
+});

--- a/src/hooks/useJoinGroupChat.test.tsx
+++ b/src/hooks/useJoinGroupChat.test.tsx
@@ -17,14 +17,14 @@ vi.mock('../globalState', () => ({
 describe('useJoinGroupChat', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('joins a V2 Series through the canonical join endpoint', () => {
+	it('assigns an invited user before the visible join action', () => {
 		const { result } = renderHook(() => useJoinGroupChat());
 
 		act(() => result.current.joinGroupChat('1013'));
 
 		expect(apiPutGroupChat).toHaveBeenCalledWith(
 			'1013',
-			GROUP_CHAT_API.JOIN
+			GROUP_CHAT_API.ASSIGN
 		);
 	});
 });

--- a/src/hooks/useJoinGroupChat.ts
+++ b/src/hooks/useJoinGroupChat.ts
@@ -8,7 +8,7 @@ export const useJoinGroupChat = () => {
 	const joinGroupChat = useCallback(
 		(gcid: string) => {
 			if (tenantData?.settings?.featureGroupChatV2Enabled && gcid) {
-				apiPutGroupChat(gcid, GROUP_CHAT_API.ASSIGN).then();
+				apiPutGroupChat(gcid, GROUP_CHAT_API.JOIN).then();
 			}
 		},
 		[tenantData]

--- a/src/hooks/useJoinGroupChat.ts
+++ b/src/hooks/useJoinGroupChat.ts
@@ -8,7 +8,7 @@ export const useJoinGroupChat = () => {
 	const joinGroupChat = useCallback(
 		(gcid: string) => {
 			if (tenantData?.settings?.featureGroupChatV2Enabled && gcid) {
-				apiPutGroupChat(gcid, GROUP_CHAT_API.JOIN).then();
+				apiPutGroupChat(gcid, GROUP_CHAT_API.ASSIGN).then();
 			}
 		},
 		[tenantData]

--- a/src/hooks/useSession.test.tsx
+++ b/src/hooks/useSession.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetSessionRoomBySessionId,
+	apiGetSessionRoomsByGroupIds
+} from '../api/apiGetSessionRooms';
+import { apiGetChatRoomById } from '../api/apiGetChatRoomById';
+import { apiGetCaseHandoverCandidates } from '../api/apiCaseHandover';
+import { buildExtendedSession } from '../globalState';
+import { useSession } from './useSession';
+
+vi.mock('../api', () => ({
+	FETCH_ERRORS: { ABORT: 'ABORT' }
+}));
+
+vi.mock('../api/apiGetSessionRooms', () => ({
+	apiGetSessionRoomBySessionId: vi.fn(),
+	apiGetSessionRoomsByGroupIds: vi.fn()
+}));
+
+vi.mock('../api/apiGetChatRoomById', () => ({
+	apiGetChatRoomById: vi.fn()
+}));
+
+vi.mock('../api/apiCaseHandover', () => ({
+	apiGetCaseHandoverCandidates: vi.fn()
+}));
+
+vi.mock('../globalState', () => ({
+	buildExtendedSession: vi.fn()
+}));
+
+vi.mock('../services/chatTransportService', () => ({
+	chatTransportService: {
+		resolveSession: vi.fn(),
+		markRoomAsRead: vi.fn()
+	}
+}));
+
+describe('useSession', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('loads a valid zero-valued session id', async () => {
+		const rawSession = { session: { id: 0 } };
+		const extendedSession = { item: { id: 0 } };
+		vi.mocked(apiGetSessionRoomBySessionId).mockResolvedValue({
+			sessions: [rawSession]
+		} as any);
+		vi.mocked(buildExtendedSession).mockReturnValue(extendedSession as any);
+
+		const { result } = renderHook(() => useSession(null, 0));
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(apiGetSessionRoomBySessionId).toHaveBeenCalledWith(
+			0,
+			expect.any(AbortSignal)
+		);
+		expect(result.current.session).toBe(extendedSession);
+		expect(apiGetSessionRoomsByGroupIds).not.toHaveBeenCalled();
+		expect(apiGetChatRoomById).not.toHaveBeenCalled();
+		expect(apiGetCaseHandoverCandidates).not.toHaveBeenCalled();
+	});
+
+	it('loads a routed group chat by room id when both route params exist', async () => {
+		const rawSession = {
+			chat: { id: 1, groupId: '!room:matrix.localhost' }
+		};
+		const extendedSession = { item: rawSession.chat, isGroup: true };
+		vi.mocked(apiGetSessionRoomsByGroupIds).mockResolvedValue({
+			sessions: [rawSession]
+		} as any);
+		vi.mocked(buildExtendedSession).mockReturnValue(extendedSession as any);
+
+		const { result } = renderHook(() =>
+			useSession('!room:matrix.localhost', 1)
+		);
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(apiGetSessionRoomsByGroupIds).toHaveBeenCalledWith(
+			['!room:matrix.localhost'],
+			expect.any(AbortSignal)
+		);
+		expect(apiGetSessionRoomBySessionId).not.toHaveBeenCalled();
+		expect(result.current.session).toBe(extendedSession);
+	});
+
+	it('loads a valid zero-valued chat id', async () => {
+		const rawSession = { chat: { id: 0 } };
+		const extendedSession = { item: rawSession.chat, isGroup: true };
+		vi.mocked(apiGetChatRoomById).mockResolvedValue({
+			sessions: [rawSession]
+		} as any);
+		vi.mocked(buildExtendedSession).mockReturnValue(extendedSession as any);
+
+		const { result } = renderHook(() => useSession(null, undefined, 0));
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(apiGetChatRoomById).toHaveBeenCalledWith(
+			0,
+			expect.any(AbortSignal)
+		);
+		expect(result.current.session).toBe(extendedSession);
+	});
+
+	it('settles ready with no session when a fetch fails', async () => {
+		vi.mocked(apiGetSessionRoomBySessionId).mockRejectedValue(
+			new Error('network unavailable')
+		);
+		vi.mocked(apiGetCaseHandoverCandidates).mockRejectedValue(
+			new Error('candidate lookup unavailable')
+		);
+
+		const { result } = renderHook(() => useSession(null, 7));
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(result.current.session).toBeNull();
+	});
+
+	it('aborts an in-flight request when route parameters change', async () => {
+		const signals: AbortSignal[] = [];
+		const secondRawSession = { session: { id: 2 } };
+		const secondExtendedSession = { item: { id: 2 } };
+		vi.mocked(apiGetSessionRoomBySessionId).mockImplementation(
+			(sessionId, signal) => {
+				signals.push(signal);
+				return sessionId === 1
+					? new Promise(() => undefined)
+					: Promise.resolve({ sessions: [secondRawSession] } as any);
+			}
+		);
+		vi.mocked(buildExtendedSession).mockReturnValue(
+			secondExtendedSession as any
+		);
+		const { result, rerender } = renderHook(
+			({ sessionId }) => useSession(null, sessionId),
+			{ initialProps: { sessionId: 1 } }
+		);
+
+		rerender({ sessionId: 2 });
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(signals[0].aborted).toBe(true);
+		expect(result.current.session).toBe(secondExtendedSession);
+	});
+});

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -26,7 +26,7 @@ export const useSession = (
 
 	const loadCaseHandoverCandidateSession = useCallback(
 		async (signal?: AbortSignal): Promise<boolean> => {
-			if (!sessionId) {
+			if (sessionId === undefined || sessionId === null) {
 				return false;
 			}
 
@@ -67,26 +67,30 @@ export const useSession = (
 
 		let promise;
 
-		if (!rid && !sessionId && !chatId) {
+		if (
+			!rid &&
+			(sessionId === undefined || sessionId === null) &&
+			(chatId === undefined || chatId === null)
+		) {
 			// console.log('⚠️ useSession: No rid, sessionId, or chatId provided - returning early');
 			return;
 		}
 
-		if (chatId) {
+		if (chatId !== undefined && chatId !== null) {
 			// console.log('🔍 useSession: Loading by chatId:', chatId);
 			promise = apiGetChatRoomById(
 				chatId,
 				abortController.current.signal
 			);
-		} else if (sessionId) {
+		} else if (rid) {
+			promise = apiGetSessionRoomsByGroupIds(
+				[rid],
+				abortController.current.signal
+			);
+		} else if (sessionId !== undefined && sessionId !== null) {
 			// console.log('🔍 useSession: Loading by sessionId:', sessionId);
 			promise = apiGetSessionRoomBySessionId(
 				sessionId,
-				abortController.current.signal
-			);
-		} else {
-			promise = apiGetSessionRoomsByGroupIds(
-				[rid],
 				abortController.current.signal
 			);
 		}
@@ -101,7 +105,8 @@ export const useSession = (
 					setSession(extendedSession);
 				} else {
 					if (
-						sessionId &&
+						sessionId !== undefined &&
+						sessionId !== null &&
 						(await loadCaseHandoverCandidateSession(
 							abortController.current?.signal
 						).catch(() => false))
@@ -126,7 +131,8 @@ export const useSession = (
 					);
 				}
 				if (
-					sessionId &&
+					sessionId !== undefined &&
+					sessionId !== null &&
 					(await loadCaseHandoverCandidateSession(
 						abortController.current?.signal
 					).catch(() => false))

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -8,6 +8,7 @@ import { FETCH_ERRORS } from '../api';
 import { chatTransportService } from '../services/chatTransportService';
 import { apiGetChatRoomById } from '../api/apiGetChatRoomById';
 import { apiGetCaseHandoverCandidates } from '../api/apiCaseHandover';
+import { getModality, Modality } from '../components/session/getModality';
 
 export const useSession = (
 	rid: string | null,
@@ -50,9 +51,10 @@ export const useSession = (
 	);
 
 	useEffect(() => {
-		repetitiveId.current = session?.item?.repetitive
-			? session.item.id
-			: null;
+		repetitiveId.current =
+			getModality(session) === Modality.SELF_HELP
+				? session.item.id
+				: null;
 	}, [session]);
 
 	const loadSession = useCallback(() => {

--- a/src/initApp.tsx
+++ b/src/initApp.tsx
@@ -1,3 +1,4 @@
+import './configureMatrixLogging';
 import './polyfill';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -8,6 +8,10 @@ import 'element-scroll-polyfill';
 import elementClosest from 'element-closest';
 import * as ReactDOM from 'react-dom';
 
+(
+	globalThis as typeof globalThis & { TONE_SILENCE_LOGGING?: boolean }
+).TONE_SILENCE_LOGGING = true;
+
 elementClosest(window);
 
 // Polyfill for findDOMNode (removed in React 19) for intro.js-react compatibility

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -614,6 +614,43 @@
 		}
 	},
 	"groupChat": {
+		"calendar": {
+			"add": "Zum Kalender hinzufügen",
+			"defaultTitle": "Online-Termin",
+			"download": "ICS herunterladen",
+			"google": "Google Kalender",
+			"outlook": "Outlook Kalender",
+			"titleLabel": "Neutraler Kalendertitel"
+		},
+		"futureTimeline": {
+			"appointmentFallback": "Termin",
+			"ariaLabel": "Zukünftige Termine",
+			"commandError": "Der Termin konnte nicht geändert werden. Bitte erneut versuchen.",
+			"duplicate": "Als Einzeltermin duplizieren",
+			"empty": "Keine bevorstehenden Termine.",
+			"groupChatFallback": "Gruppenchat",
+			"hide": "Zukünftige Termine ausblenden",
+			"loadMore": "Drei weitere Monate laden",
+			"loadError": "Einige zukünftige Termine konnten nicht geladen werden.",
+			"loading": "Zukünftige Termine werden geladen…",
+			"now": "Jetzt",
+			"revealAriaLabel": "Zukünftige Termine anzeigen",
+			"show": "Zukünftige Termine anzeigen",
+			"skip": "Termin überspringen"
+		},
+		"roles": {
+			"CO_MODERATOR": "Co-Moderator:in",
+			"OWNER": "Eigentümer:in",
+			"PARTICIPANT": "Teilnehmende",
+			"headline": "Rollen im Beratungsteam",
+			"remove": "Aus der Gruppe entfernen",
+			"removeError": "Die Person konnte nicht aus der Gruppe entfernt werden. Bitte erneut versuchen.",
+			"roleLabel": "Rolle für {{name}}",
+			"transfer": "Primäre Eigentümerschaft übertragen",
+			"transferError": "Die primäre Eigentümerschaft konnte nicht übertragen werden. Bitte erneut versuchen.",
+			"transferLabel": "Primäre Eigentümerschaft an {{name}} übertragen",
+			"updateError": "Die Rolle konnte nicht aktualisiert werden. Bitte erneut versuchen."
+		},
 		"active": {
 			"sessionInfo": {
 				"subscriber": "Teilnehmende"
@@ -635,6 +672,30 @@
 			}
 		},
 		"create": {
+			"duration": "Dauer",
+			"interval": {
+				"label": "Intervall",
+				"options": {
+					"biweekly": "Alle zwei Wochen",
+					"daily": "Täglich",
+					"monthly": "Monatlich",
+					"quarterly": "Vierteljährlich",
+					"weekly": "Wöchentlich",
+					"yearly": "Jährlich"
+				}
+			},
+			"modality": {
+				"label": "Format",
+				"options": {
+					"audio": "Audio",
+					"text": "Text",
+					"video": "Video"
+				}
+			},
+			"repeatCount": "Anzahl der Termine",
+			"schedule": "Terminplanung",
+			"startDate": "Startdatum",
+			"startTime": "Startzeit",
 			"agencySelect": {
 				"label": "Beratungsstelle"
 			},
@@ -662,6 +723,18 @@
 			"hintMessage": {
 				"explanation": "Hinweis: Diese Informationen sind für alle Administrator:innen des Gruppenchats sichtbar.",
 				"label": "Hinweisfeld"
+			},
+			"authorContent": {
+				"title": "Begrüßung und Gruppenregeln",
+				"sourceLanguage": "Ausgangssprache",
+				"welcome": "Begrüßung (maximal 120 Zeichen)",
+				"rules": "Gruppenregeln",
+				"rule": "Regel",
+				"addRule": "Regel hinzufügen",
+				"removeRule": "Entfernen",
+				"translate": "In aktive Sprachen übersetzen",
+				"translating": "Wird übersetzt…",
+				"translationError": "Übersetzung fehlgeschlagen. Der Text wurde beibehalten; bitte erneut versuchen."
 			},
 			"listItem": {
 				"label": "Neuer Chat"
@@ -720,6 +793,18 @@
 			}
 		},
 		"join": {
+			"timeConversions": "Spielerische Zeitangaben",
+			"waitingArea": {
+				"catMinutes": "{{value}} Katzenminuten",
+				"discomfort": {
+					"late": "verspätet",
+					"onTime": "pünktlich",
+					"slightlyLate": "leicht verspätet",
+					"veryLate": "stark verspätet"
+				},
+				"dogMinutes": "{{value}} Hundeminuten",
+				"romanMinutes": "{{value}} Minuten"
+			},
 			"button": {
 				"label": {
 					"join": "Teilnehmen",
@@ -1445,6 +1530,18 @@
 			"callMissed": {
 				"title": "Verpasster Anruf",
 				"text": "Sie haben einen Anruf verpasst."
+			},
+			"groupChatReminder": {
+				"title": "Erinnerung an einen Online-Termin",
+				"text": "Ein Online-Termin steht bald an."
+			},
+			"groupChatOpened": {
+				"title": "Online-Termin geöffnet",
+				"text": "Der Online-Termin ist geöffnet. Sie können jetzt beitreten."
+			},
+			"groupChatCancelled": {
+				"title": "Online-Termin abgesagt",
+				"text": "Der Online-Termin wurde abgesagt."
 			}
 		},
 		"error": "Fehlgeschlagen",
@@ -1467,6 +1564,7 @@
 			"empty": "Noch keine Benachrichtigungen.",
 			"emptyDetail": "Wählen Sie eine Benachrichtigung aus, um Details zu sehen.",
 			"open": "Chat öffnen",
+			"join": "Beitreten",
 			"systemTag": "Systembenachrichtigung",
 			"messageTag": "Nachrichtenbenachrichtigung"
 		},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -602,6 +602,43 @@
 		}
 	},
 	"groupChat": {
+		"calendar": {
+			"add": "Add to calendar",
+			"defaultTitle": "Online appointment",
+			"download": "Download ICS",
+			"google": "Google Calendar",
+			"outlook": "Outlook Calendar",
+			"titleLabel": "Neutral calendar title"
+		},
+		"futureTimeline": {
+			"appointmentFallback": "Appointment",
+			"ariaLabel": "Future timeline",
+			"commandError": "The occurrence could not be changed. Please try again.",
+			"duplicate": "Duplicate as one-off",
+			"empty": "No upcoming events.",
+			"groupChatFallback": "Group chat",
+			"hide": "Hide future events",
+			"loadMore": "Load three more months",
+			"loadError": "Some future events could not be loaded.",
+			"loading": "Loading future events…",
+			"now": "Now",
+			"revealAriaLabel": "Reveal future timeline",
+			"show": "Show future events",
+			"skip": "Skip occurrence"
+		},
+		"roles": {
+			"CO_MODERATOR": "Co-moderator",
+			"OWNER": "Owner",
+			"PARTICIPANT": "Participant",
+			"headline": "Counsellor roles",
+			"remove": "Remove from group",
+			"removeError": "The participant could not be removed. Please try again.",
+			"roleLabel": "Role for {{name}}",
+			"transfer": "Transfer primary ownership",
+			"transferError": "Primary ownership could not be transferred. Please try again.",
+			"transferLabel": "Transfer primary ownership to {{name}}",
+			"updateError": "The role could not be updated. Please try again."
+		},
 		"active": {
 			"sessionInfo": {
 				"subscriber": "Participants"
@@ -623,6 +660,30 @@
 			}
 		},
 		"create": {
+			"duration": "Duration",
+			"interval": {
+				"label": "Interval",
+				"options": {
+					"biweekly": "Every two weeks",
+					"daily": "Daily",
+					"monthly": "Monthly",
+					"quarterly": "Quarterly",
+					"weekly": "Weekly",
+					"yearly": "Yearly"
+				}
+			},
+			"modality": {
+				"label": "Format",
+				"options": {
+					"audio": "Audio",
+					"text": "Text",
+					"video": "Video"
+				}
+			},
+			"repeatCount": "Occurrences",
+			"schedule": "Schedule",
+			"startDate": "Start date",
+			"startTime": "Start time",
 			"agencySelect": {
 				"label": "Agency"
 			},
@@ -650,6 +711,18 @@
 			"hintMessage": {
 				"explanation": "Note: This information is visible to all administrators of the group chat.",
 				"label": "Note field"
+			},
+			"authorContent": {
+				"title": "Welcome and group rules",
+				"sourceLanguage": "Source language",
+				"welcome": "Welcome message (maximum 120 characters)",
+				"rules": "Group rules",
+				"rule": "Rule",
+				"addRule": "Add rule",
+				"removeRule": "Remove",
+				"translate": "Translate into active languages",
+				"translating": "Translating…",
+				"translationError": "Translation failed. Your text was kept; please try again."
 			},
 			"listItem": {
 				"label": "New chat"
@@ -706,6 +779,18 @@
 			}
 		},
 		"join": {
+			"timeConversions": "Playful time conversions",
+			"waitingArea": {
+				"catMinutes": "{{value}} cat minutes",
+				"discomfort": {
+					"late": "late",
+					"onTime": "on time",
+					"slightlyLate": "slightly late",
+					"veryLate": "very late"
+				},
+				"dogMinutes": "{{value}} dog minutes",
+				"romanMinutes": "{{value}} roman minutes"
+			},
 			"button": {
 				"label": {
 					"join": "Join",
@@ -1421,6 +1506,18 @@
 			"callMissed": {
 				"title": "Missed call",
 				"text": "You missed a call."
+			},
+			"groupChatReminder": {
+				"title": "Online appointment reminder",
+				"text": "An online appointment is coming up."
+			},
+			"groupChatOpened": {
+				"title": "Online appointment opened",
+				"text": "The online appointment is open. Join when you are ready."
+			},
+			"groupChatCancelled": {
+				"title": "Online appointment cancelled",
+				"text": "The online appointment was cancelled."
 			}
 		},
 		"error": "failed",
@@ -1443,6 +1540,7 @@
 			"empty": "No notifications yet.",
 			"emptyDetail": "Select a notification to see the details.",
 			"open": "Open chat",
+			"join": "Join",
 			"systemTag": "System notification",
 			"messageTag": "Message notification"
 		},

--- a/src/resources/scripts/endpoints.test.ts
+++ b/src/resources/scripts/endpoints.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const loadEndpoints = async (env: Record<string, string | undefined> = {}) => {
+const loadEndpoints = async (
+	env: Record<string, string | undefined> = {},
+	nodeEnv: 'development' | 'production' = 'production'
+) => {
 	vi.resetModules();
-	vi.stubEnv('NODE_ENV', 'production');
+	vi.stubEnv('NODE_ENV', nodeEnv);
 	vi.stubEnv('REACT_APP_KEYCLOAK_REALM', 'online-beratung');
 	vi.stubEnv('REACT_APP_API_URL', 'https://api.oriso.org');
 
@@ -59,6 +62,22 @@ describe('endpoints service origins', () => {
 		);
 		expect(endpoints.keycloakAccessToken).toBe(
 			'https://api.oriso.org/auth/realms/online-beratung/protocol/openid-connect/token'
+		);
+	});
+
+	it('uses relative service paths in development to avoid CORS', async () => {
+		const { endpoints } = await loadEndpoints(
+			{
+				REACT_APP_API_URL: 'https://api.oriso-dev.site',
+				REACT_APP_USER_SERVICE_ORIGIN: 'https://api.oriso-dev.site'
+			},
+			'development'
+		);
+
+		expect(endpoints.userData).toBe('/service/users/data');
+		expect(endpoints.serviceSettings).toBe('/service/settings');
+		expect(endpoints.keycloakAccessToken).toBe(
+			'/auth/realms/online-beratung/protocol/openid-connect/token'
 		);
 	});
 });

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -82,6 +82,7 @@ export const endpoints = {
 	email: userServiceOrigin + '/service/users/email',
 	error: apiUrl + '/service/logstash',
 	groupChatBase: userServiceOrigin + '/service/users/chat/',
+	chatSeriesBase: userServiceOrigin + '/service/users/chat-series/',
 	keycloakAccessToken:
 		keycloakOrigin + getKeycloakAuthPath('/protocol/openid-connect/token'),
 	keycloakLogout:

--- a/src/resources/scripts/runtimeConfig.ts
+++ b/src/resources/scripts/runtimeConfig.ts
@@ -150,8 +150,34 @@ export const getMatrixHomeserverUrl = (): string =>
 export const getRuntimeApiBaseUrl = (): string =>
 	ensureHttps(pickValue('REACT_APP_API_URL', 'VITE_API_URL'));
 
+const isLocalServiceOrigin = (value?: string | null): boolean =>
+	/^(https?:\/\/)?(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(
+		String(value || '').trim()
+	);
+
+/**
+ * In local dev, remote service origins must stay same-origin so webpack-dev-server
+ * can proxy /service and /auth to REACT_APP_DEV_REMOTE_API_URL. Absolute remote
+ * URLs bypass the proxy and trigger browser CORS failures.
+ */
+const resolveServiceOriginForEnvironment = (origin: string): string => {
+	if (!origin) {
+		return '';
+	}
+
+	const nodeEnv =
+		typeof process !== 'undefined' ? process.env.NODE_ENV : undefined;
+	if (nodeEnv === 'development' && !isLocalServiceOrigin(origin)) {
+		return '';
+	}
+
+	return origin;
+};
+
 const getServiceOrigin = (key: string, fallbackOrigin: string): string =>
-	stripTrailingSlashes(ensureHttps(pickValue(key) || fallbackOrigin));
+	resolveServiceOriginForEnvironment(
+		stripTrailingSlashes(ensureHttps(pickValue(key) || fallbackOrigin))
+	);
 
 export const getUserServiceOrigin = (
 	fallbackOrigin = getRuntimeApiBaseUrl()

--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -51,6 +51,116 @@ const createFakeMatrixClient = (room: any = null) => {
 	};
 };
 
+const createFakeEncryptedMatrixEvent = () => {
+	const decryptionListeners = new Set<Listener>();
+	let eventType = 'm.room.encrypted';
+	const event = {
+		getType: () => eventType,
+		on: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted') decryptionListeners.add(listener);
+		},
+		off: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted')
+				decryptionListeners.delete(listener);
+		},
+		emitDecrypted: (error?: Error) => {
+			if (!error) eventType = 'm.room.message';
+			decryptionListeners.forEach((listener) => listener(event, error));
+		}
+	};
+	return { decryptionListeners, event };
+};
+
+describe('chatTransportService Matrix timeline', () => {
+	let fakeClient: ReturnType<typeof createFakeMatrixClient>;
+
+	beforeEach(() => {
+		fakeClient = createFakeMatrixClient();
+		setMatrixClientServiceRef({
+			getClient: () => fakeClient
+		} as any);
+	});
+
+	afterEach(() => {
+		setMatrixClientServiceRef(null);
+	});
+
+	it('notifies again when a live encrypted event decrypts after first delivery', () => {
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
+		const room = { roomId: ROOM_ID };
+		const listener = vi.fn();
+		const detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenLastCalledWith(event, room, false);
+
+		event.emitDecrypted(new Error('room key not available yet'));
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(2);
+		expect(listener).toHaveBeenLastCalledWith(event, room, false);
+
+		detach?.();
+		expect(decryptionListeners.size).toBe(0);
+	});
+
+	it('does not register a decryption listener after synchronous detach', () => {
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
+		const room = { roomId: ROOM_ID };
+		let detach: (() => void) | null = null;
+		const listener = vi.fn(() => detach?.());
+		detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(decryptionListeners.size).toBe(0);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('removes a pending decryption listener on detach', () => {
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
+		const room = { roomId: ROOM_ID };
+		const listener = vi.fn();
+		const detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(decryptionListeners.size).toBe(1);
+
+		detach?.();
+		expect(decryptionListeners.size).toBe(0);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('expires a pending decryption listener after five minutes', () => {
+		vi.useFakeTimers();
+		try {
+			const { decryptionListeners, event } =
+				createFakeEncryptedMatrixEvent();
+			const room = { roomId: ROOM_ID };
+			const listener = vi.fn();
+			chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+			fakeClient.emit('Room.timeline', event, room, false);
+			expect(decryptionListeners.size).toBe(1);
+
+			vi.advanceTimersByTime(5 * 60 * 1000);
+			expect(decryptionListeners.size).toBe(0);
+
+			event.emitDecrypted();
+			expect(listener).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
 describe('chatTransportService Matrix room lifecycle', () => {
 	let fakeClient: ReturnType<typeof createFakeMatrixClient>;
 

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -52,6 +52,11 @@ type TimelineListener = (
 	room: Room,
 	toStartOfTimeline: boolean
 ) => void;
+type DecryptionListener = (event: MatrixEvent, error?: Error) => void;
+type PendingDecryption = {
+	listener: DecryptionListener;
+	timeout: ReturnType<typeof setTimeout>;
+};
 
 export type MatrixRoomLifecycleChange =
 	| {
@@ -177,22 +182,68 @@ class ChatTransportService {
 		if (!matrixClient) {
 			return null;
 		}
+		const pendingDecryptions = new Map<MatrixEvent, PendingDecryption>();
+		let detached = false;
+		const clearPendingDecryption = (event: MatrixEvent) => {
+			const pending = pendingDecryptions.get(event);
+			if (!pending) return;
+			clearTimeout(pending.timeout);
+			event.off('Event.decrypted' as any, pending.listener as any);
+			pendingDecryptions.delete(event);
+		};
 
 		const handleTimeline = (
 			event: MatrixEvent,
 			room: Room,
 			toStartOfTimeline: boolean
 		) => {
-			if (room?.roomId !== matrixRoomId) {
+			if (detached || room?.roomId !== matrixRoomId) {
 				return;
 			}
 			listener(event, room, toStartOfTimeline);
+
+			if (
+				detached ||
+				toStartOfTimeline ||
+				event.getType() !== 'm.room.encrypted' ||
+				pendingDecryptions.has(event)
+			) {
+				return;
+			}
+
+			const handleDecrypted = (
+				decryptedEvent: MatrixEvent,
+				error?: Error
+			) => {
+				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
+					return;
+				}
+				clearPendingDecryption(event);
+				listener(decryptedEvent, room, false);
+			};
+
+			const timeout = setTimeout(
+				() => clearPendingDecryption(event),
+				5 * 60 * 1000
+			);
+			pendingDecryptions.set(event, {
+				listener: handleDecrypted,
+				timeout
+			});
+			event.on('Event.decrypted' as any, handleDecrypted as any);
+			if (event.getType() !== 'm.room.encrypted') {
+				handleDecrypted(event);
+			}
 		};
 
 		(matrixClient as any).on('Room.timeline', handleTimeline);
 
 		return () => {
+			detached = true;
 			(matrixClient as any).off('Room.timeline', handleTimeline);
+			Array.from(pendingDecryptions.keys()).forEach(
+				clearPendingDecryption
+			);
 		};
 	}
 

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,5 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getMatrixAccessToken } from '../components/sessionCookie/getMatrixAccessToken';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import { MatrixClientService } from './matrixClientService';
+
+const mockedMatrixClient = vi.hoisted(() => ({
+	initRustCrypto: vi.fn(),
+	on: vi.fn(),
+	removeAllListeners: vi.fn(),
+	startClient: vi.fn(),
+	stopClient: vi.fn()
+}));
+
+vi.mock('../components/sessionCookie/getMatrixAccessToken', () => ({
+	createMatrixClient: vi.fn(() => mockedMatrixClient),
+	getMatrixAccessToken: vi.fn(),
+	persistMatrixLoginData: vi.fn()
+}));
 
 vi.hoisted(() => {
 	process.env.REACT_APP_KEYCLOAK_REALM = 'oriso';
@@ -31,9 +47,120 @@ const setClient = (
 
 describe('MatrixClientService', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedMatrixClient.initRustCrypto.mockResolvedValue(undefined);
 		vi.stubGlobal('localStorage', {
 			getItem: vi.fn(() => null)
 		});
+	});
+
+	it('initializes Rust crypto before registering sync and starting the client', async () => {
+		const callOrder: string[] = [];
+		mockedMatrixClient.initRustCrypto.mockImplementation(async () => {
+			callOrder.push('crypto');
+		});
+		mockedMatrixClient.on.mockImplementation(() => {
+			callOrder.push('listener');
+		});
+		mockedMatrixClient.startClient.mockImplementation(() => {
+			callOrder.push('start');
+		});
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+
+		expect(callOrder).toEqual(['crypto', 'listener', 'start']);
+		expect(mockedMatrixClient.initRustCrypto).toHaveBeenCalledWith({
+			useIndexedDB: true,
+			cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+				'@alice:matrix.localhost',
+				'DEVICE_ONE'
+			)
+		});
+	});
+
+	it('surfaces Rust crypto failures without leaving a client running', async () => {
+		mockedMatrixClient.initRustCrypto.mockRejectedValueOnce(
+			new Error('crypto store unavailable')
+		);
+		const service = new MatrixClientService();
+
+		await expect(
+			service.initializeClient({
+				userId: '@alice:matrix.localhost',
+				accessToken: 'access-token',
+				deviceId: 'DEVICE_ONE',
+				homeserverUrl: 'http://matrix.localhost:18008'
+			})
+		).rejects.toThrow('crypto store unavailable');
+
+		expect(mockedMatrixClient.on).not.toHaveBeenCalled();
+		expect(mockedMatrixClient.startClient).not.toHaveBeenCalled();
+		expect(service.getClient()).toBeNull();
+	});
+
+	it('waits for replacement-client crypto initialization during token refresh', async () => {
+		let resolveCrypto: (() => void) | undefined;
+		mockedMatrixClient.initRustCrypto.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolveCrypto = resolve;
+			})
+		);
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'replacement-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const service = new MatrixClientService();
+
+		let refreshCompleted = false;
+		const refresh = service.refreshMatrixToken().then(() => {
+			refreshCompleted = true;
+		});
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+		expect(refreshCompleted).toBe(false);
+		expect(mockedMatrixClient.startClient).not.toHaveBeenCalled();
+		resolveCrypto?.();
+		await refresh;
+		expect(mockedMatrixClient.startClient).toHaveBeenCalledOnce();
+	});
+
+	it('contains a failed fire-and-forget refresh from the sync listener', async () => {
+		let syncListener:
+			| ((
+					state: string,
+					previous: string | null,
+					error?: unknown
+			  ) => void)
+			| undefined;
+		mockedMatrixClient.on.mockImplementation((_event, listener) => {
+			syncListener = listener;
+		});
+		vi.mocked(getMatrixAccessToken).mockRejectedValueOnce(
+			new Error('refresh failed')
+		);
+		const service = new MatrixClientService();
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'expired-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+
+		syncListener?.('ERROR', null, {
+			httpStatus: 401,
+			message: 'Access token has expired'
+		});
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
 	});
 
 	it('sends Matrix messages in migration rooms without native Matrix encryption state', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -6,6 +6,7 @@ import {
 	persistMatrixLoginData
 } from '../components/sessionCookie/getMatrixAccessToken';
 import { matrixCallService } from './matrixCallService';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import { matrixLiveEventBridge } from './matrixLiveEventBridge';
 import { encryptMatrixAttachment } from '../utils/matrixEncryptedAttachment';
 import { buildMatrixRoomEncryptionInitialState } from '../utils/matrixRoomEncryption';
@@ -94,7 +95,7 @@ export class MatrixClientService {
 	private syncStateListeners = new Set<(state: string | null) => void>();
 
 	// Initialize client with login data
-	public initializeClient(loginData: MatrixLoginData): void {
+	public async initializeClient(loginData: MatrixLoginData): Promise<void> {
 		this.stopCurrentClient();
 		this.loginData = loginData;
 		this.client = createMatrixClient(loginData);
@@ -108,6 +109,18 @@ export class MatrixClientService {
 		// console.log('🔧 Matrix client will fetch TURN/STUN servers from homeserver');
 
 		const client = this.client;
+		try {
+			await client.initRustCrypto({
+				useIndexedDB: true,
+				cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+					loginData.userId,
+					loginData.deviceId
+				)
+			});
+		} catch (error) {
+			this.stopCurrentClient();
+			throw error;
+		}
 
 		(client as any).on(
 			'sync',
@@ -121,7 +134,7 @@ export class MatrixClientService {
 				}
 
 				if (state === 'ERROR' && isMatrixExpiredTokenError(syncError)) {
-					void this.refreshMatrixToken();
+					this.refreshMatrixTokenSafely();
 				}
 			}
 		);
@@ -161,15 +174,19 @@ export class MatrixClientService {
 		}
 
 		this.refreshingToken = getMatrixAccessToken()
-			.then((loginData) => {
+			.then(async (loginData) => {
 				persistMatrixLoginData(loginData);
-				this.initializeClient(loginData);
+				await this.initializeClient(loginData);
 			})
 			.finally(() => {
 				this.refreshingToken = null;
 			});
 
 		return this.refreshingToken;
+	}
+
+	private refreshMatrixTokenSafely(): void {
+		void this.refreshMatrixToken().catch(() => undefined);
 	}
 
 	public async ensureFreshToken(): Promise<void> {
@@ -368,7 +385,7 @@ export class MatrixClientService {
 		);
 
 		this.refreshTimer = window.setTimeout(() => {
-			void this.refreshMatrixToken();
+			this.refreshMatrixTokenSafely();
 		}, refreshInMs);
 	}
 

--- a/src/services/matrixCrypto.test.ts
+++ b/src/services/matrixCrypto.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
+
+describe('buildMatrixCryptoStorePrefix', () => {
+	it('returns a deterministic and storage-safe prefix per Matrix device', () => {
+		const first = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE/ONE'
+		);
+		const repeated = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE/ONE'
+		);
+		const secondDevice = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE:TWO'
+		);
+
+		expect(first).toBe(repeated);
+		expect(first).not.toBe(secondDevice);
+		expect(first).toMatch(/^oriso-matrix-[a-f0-9]+-[a-f0-9]+$/);
+	});
+
+	it.each([
+		['', 'DEVICE_ONE'],
+		['@alice:matrix.localhost', ''],
+		[' @alice:matrix.localhost', 'DEVICE_ONE'],
+		['@alice:matrix.localhost ', 'DEVICE_ONE'],
+		['@alice:matrix.localhost', ' DEVICE_ONE'],
+		['@alice:matrix.localhost', 'DEVICE_ONE ']
+	])(
+		'rejects a missing or padded Matrix user or device identity',
+		(userId, deviceId) => {
+			expect(() =>
+				buildMatrixCryptoStorePrefix(userId, deviceId)
+			).toThrow(
+				'Matrix user ID and device ID are required for the crypto store'
+			);
+		}
+	);
+});

--- a/src/services/matrixCrypto.ts
+++ b/src/services/matrixCrypto.ts
@@ -1,0 +1,24 @@
+const encodeStorageSegment = (value: string): string =>
+	Array.from(new TextEncoder().encode(value), (byte) =>
+		byte.toString(16).padStart(2, '0')
+	).join('');
+
+export const buildMatrixCryptoStorePrefix = (
+	userId: string,
+	deviceId: string
+): string => {
+	if (
+		!userId.trim() ||
+		!deviceId.trim() ||
+		userId !== userId.trim() ||
+		deviceId !== deviceId.trim()
+	) {
+		throw new Error(
+			'Matrix user ID and device ID are required for the crypto store'
+		);
+	}
+
+	return `oriso-matrix-${encodeStorageSegment(userId)}-${encodeStorageSegment(
+		deviceId
+	)}`;
+};

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -64,7 +64,7 @@ type Listener = (...args: any[]) => void;
  */
 const createFakeMatrixClient = (userId = MY_USER_ID) => {
 	const listeners = new Map<string, Set<Listener>>();
-	return {
+	const event = {
 		on: (event: string, listener: Listener) => {
 			if (!listeners.has(event)) {
 				listeners.set(event, new Set());
@@ -80,6 +80,7 @@ const createFakeMatrixClient = (userId = MY_USER_ID) => {
 			listeners.get(event)?.forEach((listener) => listener(...args));
 		}
 	};
+	return event;
 };
 
 const makeEvent = (overrides: Record<string, any> = {}) => {
@@ -90,13 +91,36 @@ const makeEvent = (overrides: Record<string, any> = {}) => {
 		ts = Date.now(),
 		id = '$evt:matrix.oriso.org'
 	} = overrides;
-	return {
-		getType: () => type,
-		getContent: () => content,
+	let currentType = type;
+	let currentContent = content;
+	const listeners = new Map<string, Set<Listener>>();
+	const event = {
+		getType: () => currentType,
+		getContent: () => currentContent,
 		getSender: () => sender,
 		getTs: () => ts,
-		getId: () => id
+		getId: () => id,
+		on: (event: string, listener: Listener) => {
+			if (!listeners.has(event)) listeners.set(event, new Set());
+			listeners.get(event)!.add(listener);
+		},
+		off: (event: string, listener: Listener) => {
+			listeners.get(event)?.delete(listener);
+		},
+		emitDecrypted: (
+			clearEvent?: { type: string; content: Record<string, any> },
+			error?: Error
+		) => {
+			if (clearEvent && !error) {
+				currentType = clearEvent.type;
+				currentContent = clearEvent.content;
+			}
+			listeners
+				.get('Event.decrypted')
+				?.forEach((listener) => listener(event, error));
+		}
 	};
+	return event;
 };
 
 const room = { roomId: ROOM_ID };
@@ -246,6 +270,45 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		expect(args[1]).toBe(true); // isVideo
 		expect(args[2]).toBe('call-group'); // callId
 		expect(args[4]).toBe(true); // isGroupCall
+	});
+
+	it('routes an encrypted group-call invite after a later successful decryption', () => {
+		const event = makeEvent({ type: 'm.room.encrypted' });
+
+		client.emit('Room.timeline', event, room, false);
+		expect(receiveCall).not.toHaveBeenCalled();
+
+		// A missing room key can fail the first attempt. The bridge must remain
+		// subscribed so the Rust-Crypto retry can deliver the clear event later.
+		event.emitDecrypted(undefined, new Error('missing room key'));
+		expect(receiveCall).not.toHaveBeenCalled();
+
+		event.emitDecrypted({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'call-encrypted',
+				is_group_call: true,
+				is_element_call: true,
+				is_video: true,
+				call_room_id: '!element:matrix.oriso.org'
+			}
+		});
+
+		expect(receiveCall).toHaveBeenCalledTimes(1);
+		expect(receiveCall).toHaveBeenCalledWith(
+			'!element:matrix.oriso.org',
+			true,
+			'call-encrypted',
+			OTHER_USER_ID,
+			true,
+			ROOM_ID,
+			true
+		);
+
+		// Further SDK notifications for the same MatrixEvent must not dispatch it
+		// again after the bridge has consumed the successful decryption.
+		event.emitDecrypted();
+		expect(receiveCall).toHaveBeenCalledTimes(1);
 	});
 
 	it('ignores stale hangups but ends the call for a fresh hangup', () => {

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -186,6 +186,21 @@ describe('MatrixLiveEventBridge initialize / timeline binding', () => {
 		// Bodies never cross into the bridged event (Matrix privacy boundary).
 		expect(JSON.stringify(payload)).not.toContain('secret body');
 	});
+
+	it('refreshes metadata only once when an encrypted message decrypts later', () => {
+		bridge.initialize(client as any);
+		const callback = vi.fn();
+		bridge.on('directMessage', callback);
+		const event = makeEvent({ type: 'm.room.encrypted' });
+
+		client.emit('Room.timeline', event, room, false);
+		event.emitDecrypted({
+			type: 'm.room.message',
+			content: { msgtype: 'm.text', body: 'secret body' }
+		});
+
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
@@ -273,7 +288,10 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 	});
 
 	it('routes an encrypted group-call invite after a later successful decryption', () => {
-		const event = makeEvent({ type: 'm.room.encrypted' });
+		const event = makeEvent({
+			type: 'm.room.encrypted',
+			ts: Date.now() - 11_000
+		});
 
 		client.emit('Room.timeline', event, room, false);
 		expect(receiveCall).not.toHaveBeenCalled();

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -91,10 +91,16 @@ export class MatrixLiveEventBridge {
 		);
 	}
 
-	private dispatchTimelineEvent(event: MatrixEvent, room: Room): void {
+	private dispatchTimelineEvent(
+		event: MatrixEvent,
+		room: Room,
+		fromDecryptionRetry = false
+	): void {
 		switch (event.getType()) {
 			case 'm.room.message':
-				this.handleRoomMessage(event, room);
+				if (!fromDecryptionRetry) {
+					this.handleRoomMessage(event, room);
+				}
 				break;
 
 			case 'm.room.encrypted':
@@ -107,7 +113,7 @@ export class MatrixLiveEventBridge {
 
 			case 'm.call.invite':
 			case 'org.oriso.call.invite':
-				this.handleCallInvite(event, room);
+				this.handleCallInvite(event, room, fromDecryptionRetry);
 				break;
 
 			case 'm.call.hangup':
@@ -143,7 +149,7 @@ export class MatrixLiveEventBridge {
 
 			completed = true;
 			cleanup();
-			this.dispatchTimelineEvent(decryptedEvent, room);
+			this.dispatchTimelineEvent(decryptedEvent, room, true);
 		};
 
 		event.on('Event.decrypted' as any, listener as any);
@@ -199,7 +205,11 @@ export class MatrixLiveEventBridge {
 	/**
 	 * Handle m.call.invite events (incoming calls).
 	 */
-	private handleCallInvite(event: MatrixEvent, room: Room): void {
+	private handleCallInvite(
+		event: MatrixEvent,
+		room: Room,
+		fromDecryptionRetry = false
+	): void {
 		const sender = event.getSender();
 		const content = event.getContent();
 		const callId = content.call_id;
@@ -220,7 +230,7 @@ export class MatrixLiveEventBridge {
 
 		// CRITICAL: Ignore old call invites (> 10 seconds = from history/replay!)
 		// This prevents phantom notifications on login/reload
-		if (ageSeconds > 10) {
+		if (!fromDecryptionRetry && ageSeconds > 10) {
 			// console.log("🚫 IGNORING OLD CALL INVITE (from history, not a new call!)");
 			// console.log("═══════════════════════════════════════════════");
 			this.processedCallInvites.add(callId);

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -25,6 +25,13 @@ export class MatrixLiveEventBridge {
 	private eventCallbacks: Map<string, Set<(event: any) => void>> = new Map();
 	private initialized: boolean = false;
 	private processedCallInvites: Set<string> = new Set(); // Track processed call IDs
+	private pendingEncryptedEvents = new Map<
+		MatrixEvent,
+		{
+			listener: (event: MatrixEvent, error?: Error) => void;
+			timeout: ReturnType<typeof setTimeout>;
+		}
+	>();
 
 	/**
 	 * Initialize the bridge with a Matrix client.
@@ -43,6 +50,7 @@ export class MatrixLiveEventBridge {
 		if (this.client && this.client !== client) {
 			this.client.removeAllListeners('Room.timeline' as any);
 			this.client.removeAllListeners('sync' as any);
+			this.clearPendingEncryptedEvents();
 		}
 
 		this.client = client;
@@ -70,36 +78,7 @@ export class MatrixLiveEventBridge {
 					return;
 				}
 
-				const eventType = event.getType();
-
-				// console.log("📩 Matrix event:", {
-				// type: eventType,
-				// roomId: room.roomId,
-				// sender: event.getSender(),
-				// timestamp: event.getTs()
-				// });
-
-				// Handle different event types
-				switch (eventType) {
-					case 'm.room.message':
-					case 'm.room.encrypted':
-						this.handleRoomMessage(event, room);
-						break;
-
-					case 'm.call.invite':
-					case 'org.oriso.call.invite':
-						this.handleCallInvite(event, room);
-						break;
-
-					case 'm.call.hangup':
-					case 'org.oriso.call.hangup':
-						this.handleCallHangup(event, room);
-						break;
-
-					default:
-						// Ignore other events
-						break;
-				}
+				this.dispatchTimelineEvent(event, room);
 			}
 		);
 
@@ -110,6 +89,86 @@ export class MatrixLiveEventBridge {
 				// console.log("🔄 Matrix sync state:", state, "(previous:", prevState, ")");
 			}
 		);
+	}
+
+	private dispatchTimelineEvent(event: MatrixEvent, room: Room): void {
+		switch (event.getType()) {
+			case 'm.room.message':
+				this.handleRoomMessage(event, room);
+				break;
+
+			case 'm.room.encrypted':
+				// Room.timeline can fire before Rust-Crypto has the Megolm key.
+				// Keep the existing metadata refresh, but also redispatch the clear
+				// event when a later decryption retry succeeds.
+				this.handleRoomMessage(event, room);
+				this.waitForSuccessfulDecryption(event, room);
+				break;
+
+			case 'm.call.invite':
+			case 'org.oriso.call.invite':
+				this.handleCallInvite(event, room);
+				break;
+
+			case 'm.call.hangup':
+			case 'org.oriso.call.hangup':
+				this.handleCallHangup(event, room);
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	private waitForSuccessfulDecryption(event: MatrixEvent, room: Room): void {
+		if (this.pendingEncryptedEvents.has(event)) return;
+
+		let completed = false;
+		let timeout: ReturnType<typeof setTimeout>;
+		const cleanup = () => {
+			event.off('Event.decrypted' as any, listener as any);
+			clearTimeout(timeout);
+			this.pendingEncryptedEvents.delete(event);
+		};
+		const listener = (decryptedEvent: MatrixEvent, error?: Error) => {
+			// Rust-Crypto emits Event.decrypted for a failed attempt too. Keep
+			// listening so receipt of a delayed room key can retry successfully.
+			if (
+				completed ||
+				error ||
+				decryptedEvent.getType() === 'm.room.encrypted'
+			) {
+				return;
+			}
+
+			completed = true;
+			cleanup();
+			this.dispatchTimelineEvent(decryptedEvent, room);
+		};
+
+		event.on('Event.decrypted' as any, listener as any);
+		timeout = setTimeout(
+			() => {
+				completed = true;
+				cleanup();
+			},
+			5 * 60 * 1000
+		);
+		this.pendingEncryptedEvents.set(event, { listener, timeout });
+
+		// Close the small race where decryption finishes between the initial
+		// type check and listener registration.
+		if (event.getType() !== 'm.room.encrypted') {
+			listener(event);
+		}
+	}
+
+	private clearPendingEncryptedEvents(): void {
+		this.pendingEncryptedEvents.forEach(({ listener, timeout }, event) => {
+			event.off('Event.decrypted' as any, listener as any);
+			clearTimeout(timeout);
+		});
+		this.pendingEncryptedEvents.clear();
 	}
 
 	/**
@@ -340,6 +399,7 @@ export class MatrixLiveEventBridge {
 			this.client.removeAllListeners('Room.timeline' as any);
 			this.client.removeAllListeners('sync' as any);
 		}
+		this.clearPendingEncryptedEvents();
 		this.processedCallInvites.clear();
 		this.initialized = false;
 		this.client = null;

--- a/src/services/matrixRegistrationService.ts
+++ b/src/services/matrixRegistrationService.ts
@@ -1,5 +1,6 @@
 import { createClient } from 'matrix-js-sdk';
 import { getMatrixHomeserverUrl } from '../resources/scripts/runtimeConfig';
+import { getMatrixClientLogger } from '../utils/matrixLogging';
 
 export interface MatrixRegistrationData {
 	username: string;
@@ -31,7 +32,8 @@ export const registerMatrixUser = async (
 
 		// Create Matrix client
 		const client = createClient({
-			baseUrl: homeserverUrl
+			baseUrl: homeserverUrl,
+			logger: getMatrixClientLogger()
 		});
 
 		// Register user with proper type casting
@@ -99,7 +101,8 @@ export const loginMatrixUser = async (
 
 		// Create Matrix client
 		const client = createClient({
-			baseUrl: homeserverUrl
+			baseUrl: homeserverUrl,
+			logger: getMatrixClientLogger()
 		});
 
 		// Login user

--- a/src/utils/matrixLogging.test.ts
+++ b/src/utils/matrixLogging.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { childSetLevel, rootSetLevel, originalGetChild, mockLogger } =
+	vi.hoisted(() => {
+		const childSetLevel = vi.fn();
+		const rootSetLevel = vi.fn();
+		const originalGetChild = vi.fn(() => ({
+			setLevel: childSetLevel
+		}));
+
+		const mockLogger = {
+			setLevel: rootSetLevel,
+			getChild: originalGetChild
+		};
+
+		return { childSetLevel, rootSetLevel, originalGetChild, mockLogger };
+	});
+
+vi.mock('matrix-js-sdk/lib/logger', () => ({
+	logger: mockLogger
+}));
+
+// eslint-disable-next-line import/first -- must load after vi.mock
+import {
+	configureMatrixLogging,
+	getMatrixClientLogger,
+	resetMatrixLoggingForTests
+} from './matrixLogging';
+
+describe('matrixLogging', () => {
+	beforeEach(() => {
+		resetMatrixLoggingForTests();
+		rootSetLevel.mockClear();
+		childSetLevel.mockClear();
+		originalGetChild.mockClear();
+		mockLogger.getChild = originalGetChild;
+	});
+
+	it('does not change log level when verbose logging is enabled', () => {
+		configureMatrixLogging('true');
+
+		expect(rootSetLevel).not.toHaveBeenCalled();
+	});
+
+	it('sets error log level by default', () => {
+		configureMatrixLogging();
+
+		expect(rootSetLevel).toHaveBeenCalledWith('error');
+	});
+
+	it('sets error log level when verbose logging is disabled', () => {
+		configureMatrixLogging('false');
+
+		expect(rootSetLevel).toHaveBeenCalledWith('error');
+	});
+
+	it('keeps child loggers at error level in production', () => {
+		configureMatrixLogging();
+
+		const child = getMatrixClientLogger().getChild('sync');
+
+		expect(originalGetChild).toHaveBeenCalledWith('sync');
+		expect(childSetLevel).toHaveBeenCalledWith('error');
+		expect(child).toBeDefined();
+	});
+
+	it('runs configuration only once', () => {
+		configureMatrixLogging();
+		configureMatrixLogging();
+
+		expect(rootSetLevel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/matrixLogging.ts
+++ b/src/utils/matrixLogging.ts
@@ -1,0 +1,68 @@
+import type { Logger } from 'matrix-js-sdk/lib/logger';
+import { logger } from 'matrix-js-sdk/lib/logger';
+
+type MatrixLogger = typeof logger;
+
+type LogLevelDesc = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+type LevelSettableLogger = Logger & {
+	setLevel(level: LogLevelDesc, persist?: boolean): void;
+};
+
+const isLevelSettable = (target: Logger): target is LevelSettableLogger =>
+	typeof (target as LevelSettableLogger).setLevel === 'function';
+
+const setLoggerLevel = (target: Logger, level: LogLevelDesc): void => {
+	if (isLevelSettable(target)) {
+		target.setLevel(level);
+	}
+};
+
+const PRODUCTION_LOG_LEVEL: LogLevelDesc = 'error';
+
+let configured = false;
+
+const isMatrixVerboseLoggingEnabled = (
+	verboseLogging: string | undefined = process.env
+		.REACT_APP_MATRIX_VERBOSE_LOGGING
+): boolean => verboseLogging === 'true';
+
+const applyProductionLogLevel = (rootLogger: MatrixLogger): void => {
+	setLoggerLevel(rootLogger, PRODUCTION_LOG_LEVEL);
+
+	const originalGetChild = rootLogger.getChild?.bind(rootLogger);
+	if (!originalGetChild) {
+		return;
+	}
+
+	rootLogger.getChild = (namespace: string) => {
+		const child = originalGetChild(namespace);
+		setLoggerLevel(child, PRODUCTION_LOG_LEVEL);
+		return child;
+	};
+};
+
+/**
+ * Suppresses verbose matrix-js-sdk logging (e.g. FetchHttpApi sync traffic).
+ * Set REACT_APP_MATRIX_VERBOSE_LOGGING=true to keep SDK debug output.
+ * Safe to call multiple times; runs once.
+ */
+export const configureMatrixLogging = (
+	verboseLogging: string | undefined = process.env
+		.REACT_APP_MATRIX_VERBOSE_LOGGING
+): void => {
+	if (configured || isMatrixVerboseLoggingEnabled(verboseLogging)) {
+		return;
+	}
+
+	configured = true;
+	applyProductionLogLevel(logger);
+};
+
+/** Logger instance passed to Matrix client construction. */
+export const getMatrixClientLogger = (): MatrixLogger => logger;
+
+/** @internal test helper */
+export const resetMatrixLoggingForTests = (): void => {
+	configured = false;
+};

--- a/src/utils/promiseTimeout.test.ts
+++ b/src/utils/promiseTimeout.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { withTimeout } from './promiseTimeout';
+
+afterEach(() => vi.useRealTimers());
+
+describe('withTimeout', () => {
+	it('returns a value that settles before the deadline', async () => {
+		await expect(
+			withTimeout(Promise.resolve('ready'), 100, 'too slow')
+		).resolves.toBe('ready');
+	});
+
+	it('rejects a pending operation at the deadline', async () => {
+		vi.useFakeTimers();
+		const result = expect(
+			withTimeout(new Promise(() => undefined), 100, 'Matrix timed out')
+		).rejects.toThrow('Matrix timed out');
+		await vi.advanceTimersByTimeAsync(100);
+		await result;
+	});
+});

--- a/src/utils/promiseTimeout.ts
+++ b/src/utils/promiseTimeout.ts
@@ -1,0 +1,17 @@
+export const withTimeout = async <Value>(
+	promise: Promise<Value>,
+	timeoutMs: number,
+	message: string
+): Promise<Value> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<never>((_resolve, reject) => {
+		timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, timeoutPromise]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
+};

--- a/src/utils/translationFallback.test.ts
+++ b/src/utils/translationFallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { translateWithFallback } from './translationFallback';
+
+describe('translateWithFallback', () => {
+	it('uses a resolved translation', () => {
+		expect(
+			translateWithFallback(
+				vi.fn(() => 'Übersetzt'),
+				'key',
+				'Fallback'
+			)
+		).toBe('Übersetzt');
+	});
+
+	it.each(['', 'key'])(
+		'uses the fallback for an unresolved value',
+		(value) => {
+			expect(
+				translateWithFallback(
+					vi.fn(() => value),
+					'key',
+					'Fallback'
+				)
+			).toBe('Fallback');
+		}
+	);
+});

--- a/src/utils/translationFallback.ts
+++ b/src/utils/translationFallback.ts
@@ -1,0 +1,11 @@
+export const translateWithFallback = (
+	translate: (key: string, options?: Record<string, unknown>) => unknown,
+	key: string,
+	fallback: string,
+	options?: Record<string, unknown>
+): string => {
+	const value = translate(key, options);
+	return typeof value !== 'string' || !value || value === key
+		? fallback
+		: value;
+};

--- a/vite.matrix-smoke.config.ts
+++ b/vite.matrix-smoke.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vite';
+import { createReadStream } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+	plugins: [
+		{
+			name: 'matrix-smoke-wasm',
+			configureServer(server) {
+				server.middlewares.use((request, response, next) => {
+					if (
+						request.url !==
+						'/node_modules/.vite/deps/pkg/matrix_sdk_crypto_wasm_bg.wasm'
+					) {
+						next();
+						return;
+					}
+					response.setHeader('Content-Type', 'application/wasm');
+					const root = dirname(fileURLToPath(import.meta.url));
+					createReadStream(
+						resolve(
+							root,
+							'node_modules/@matrix-org/matrix-sdk-crypto-wasm/pkg/matrix_sdk_crypto_wasm_bg.wasm'
+						)
+					).pipe(response);
+				});
+			}
+		}
+	]
+});


### PR DESCRIPTION
- Fixes [#15](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/15) by suppressing verbose **matrix-js-sdk** console output (especially `FetchHttpApi` sync traffic) in normal runs.
- Adds `configureMatrixLogging()` at app startup and wires the shared Matrix logger into client construction (`getMatrixAccessToken`, `matrixRegistrationService`).
- Opt-in verbose SDK logs via `REACT_APP_MATRIX_VERBOSE_LOGGING=true`.
- Removes leftover app `console.log` noise (agency radio select, session assign) and silences the Tone.js version banner.
- Removes deprecated remarkable `linkify: true` option (URLs still handled by existing `urlifyLinksInText`) and hardens message markdown rendering with a safe fallback.
- Includes a small local-dev runtimeConfig tweak so remote service origins stay same-origin and go through the webpack proxy (avoids CORS in development).

## Test plan

- [x] Open a consultation/messaging session with DevTools Console open — Matrix sync HTTP spam (`FetchHttpApi: --> GET .../sync`) should no longer flood the console
- [x] Confirm critical Matrix errors still appear if something fails
- [x] Send/receive messages with plain text, markdown, and URLs — rendering still works
- [x] Run `npx vitest run src/utils/matrixLogging.test.ts`