### PR TITLE
feat: complete self-help group chat experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /playwright-report
 /test-results
 /playwright/.cache
+/.playwright-cli/
+/output/playwright/
 
 # production
 /build

--- a/package.json
+++ b/package.json
@@ -223,6 +223,8 @@
 		"test": "cross-env NODE_ENV=development FAST_REFRESH=false BROWSER=none REACT_APP_API_URL=http://127.0.0.1:9001 HTTPS=0 PORT=9001 WDS_SOCKET_PORT=9001 concurrently --kill-others --success first \"npm run dev\" \"wait-on http://127.0.0.1:9001 && cypress run\"",
 		"test:unit": "vitest run --maxWorkers=2 --minWorkers=1",
 		"test:smoke": "playwright test",
+		"test:matrix-megolm": "node scripts/matrixMegolmSmoke.mjs",
+		"test:matrix-browser-reload": "concurrently --kill-others --success first \"vite --config vite.matrix-smoke.config.ts --host 127.0.0.1 --port 9010\" \"wait-on http://127.0.0.1:9010/playwright/matrix-crypto-browser-harness.html && PLAYWRIGHT_BASE_URL=http://127.0.0.1:9010 playwright test playwright/matrix-crypto-reload.smoke.spec.ts --project=chromium --reporter=list\"",
 		"test:smoke:baseline": "playwright test playwright/registration-baseline.smoke.spec.ts",
 		"test:components": "NODE_ENV=development cypress run --component --headed",
 		"test:build": "cross-env NODE_ENV=production FAST_REFRESH=false BROWSER=none PORT=9001 CYPRESS_WS_URL=http://127.0.0.1:9002 REACT_APP_API_URL=http://127.0.0.1:9001 concurrently --kill-others --success first \"npm run start\" \"wait-on http://127.0.0.1:9001 && cypress run\"",

--- a/playwright/matrix-crypto-browser-harness.html
+++ b/playwright/matrix-crypto-browser-harness.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Matrix crypto reload harness</title>
+	</head>
+	<body>
+		<main>
+			<p data-testid="matrix-crypto-status">starting</p>
+		</main>
+		<script type="module" src="/playwright/matrix-crypto-browser-harness.ts"></script>
+	</body>
+</html>

--- a/playwright/matrix-crypto-browser-harness.ts
+++ b/playwright/matrix-crypto-browser-harness.ts
@@ -1,0 +1,191 @@
+import { ClientEvent, createClient, MatrixClient } from 'matrix-js-sdk';
+import { buildMatrixCryptoStorePrefix } from '../src/services/matrixCrypto';
+
+const baseUrl = 'http://localhost:18008';
+const stateKey = 'oriso-matrix-browser-reload-smoke';
+const status = document.querySelector<HTMLElement>(
+	'[data-testid="matrix-crypto-status"]'
+)!;
+
+interface ReloadState {
+	accessToken: string;
+	deviceId: string;
+	eventId: string;
+	expectedBody: string;
+	roomId: string;
+	userId: string;
+}
+
+const withTimeout = async <T>(
+	promise: Promise<T>,
+	label: string
+): Promise<T> => {
+	let timeout: ReturnType<typeof setTimeout>;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${label}`)),
+					20_000
+				);
+			})
+		]);
+	} finally {
+		clearTimeout(timeout!);
+	}
+};
+
+const startClient = async (state: {
+	accessToken: string;
+	deviceId: string;
+	userId: string;
+}): Promise<MatrixClient> => {
+	const client = createClient({
+		baseUrl,
+		accessToken: state.accessToken,
+		deviceId: state.deviceId,
+		userId: state.userId
+	});
+	await client.initRustCrypto({
+		useIndexedDB: true,
+		cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+			state.userId,
+			state.deviceId
+		)
+	});
+	const prepared = new Promise<void>((resolve, reject) => {
+		const onSync = (
+			syncState: string,
+			_previous: string | null,
+			data?: any
+		) => {
+			if (syncState === 'PREPARED') {
+				client.off(ClientEvent.Sync, onSync);
+				resolve();
+			} else if (syncState === 'ERROR') {
+				client.off(ClientEvent.Sync, onSync);
+				reject(data?.error ?? new Error('Matrix sync failed'));
+			}
+		};
+		client.on(ClientEvent.Sync, onSync);
+	});
+	client.startClient({ initialSyncLimit: 20 });
+	await withTimeout(prepared, 'Matrix PREPARED state');
+	return client;
+};
+
+const register = async () => {
+	const suffix = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+	const localpart = `browser_reload_${suffix}`;
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/register`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			auth: { type: 'm.login.dummy' },
+			username: localpart,
+			password: `local-only-${localpart}`,
+			initial_device_display_name: 'Browser reload smoke'
+		})
+	});
+	if (!response.ok)
+		throw new Error(`Registration failed: ${response.status}`);
+	return response.json();
+};
+
+const waitForHistoricEvent = (client: MatrixClient, state: ReloadState) =>
+	withTimeout(
+		new Promise<void>((resolve) => {
+			const inspect = () => {
+				const event = client
+					.getRoom(state.roomId)
+					?.getLiveTimeline()
+					.getEvents()
+					.find((candidate) => candidate.getId() === state.eventId);
+				if (
+					event?.getWireType() === 'm.room.encrypted' &&
+					event.getType() === 'm.room.message' &&
+					event.getContent()?.body === state.expectedBody
+				) {
+					clearInterval(interval);
+					resolve();
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'historic browser event decryption'
+	);
+
+const waitForEncryptedRoom = (client: MatrixClient, roomId: string) =>
+	withTimeout(
+		new Promise<void>((resolve) => {
+			const inspect = () => {
+				const encryption = client
+					.getRoom(roomId)
+					?.currentState.getStateEvents('m.room.encryption', '');
+				if (
+					encryption?.getContent()?.algorithm ===
+					'm.megolm.v1.aes-sha2'
+				) {
+					clearInterval(interval);
+					resolve();
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'encrypted room state'
+	);
+
+const run = async () => {
+	const previous = localStorage.getItem(stateKey);
+	if (previous) {
+		const state = JSON.parse(previous) as ReloadState;
+		const client = await startClient(state);
+		await waitForHistoricEvent(client, state);
+		status.textContent = 'recovered';
+		return;
+	}
+
+	const registration = await register();
+	const client = await startClient({
+		accessToken: registration.access_token,
+		deviceId: registration.device_id,
+		userId: registration.user_id
+	});
+	const room = await client.createRoom({
+		name: 'Browser reload crypto smoke',
+		preset: 'private_chat',
+		initial_state: [
+			{
+				type: 'm.room.encryption',
+				state_key: '',
+				content: { algorithm: 'm.megolm.v1.aes-sha2' }
+			}
+		]
+	});
+	await waitForEncryptedRoom(client, room.room_id);
+	const expectedBody = `IndexedDB reload proof ${Date.now()}`;
+	const sent = await client.sendMessage(room.room_id, {
+		msgtype: 'm.text',
+		body: expectedBody
+	});
+	const state: ReloadState = {
+		accessToken: registration.access_token,
+		deviceId: registration.device_id,
+		eventId: sent.event_id,
+		expectedBody,
+		roomId: room.room_id,
+		userId: registration.user_id
+	};
+	// Wait for the encrypted remote echo to be decrypted and committed to the
+	// IndexedDB-backed Rust store before the browser is reloaded.
+	await waitForHistoricEvent(client, state);
+	localStorage.setItem(stateKey, JSON.stringify(state));
+	status.textContent = 'prepared';
+};
+
+run().catch((error) => {
+	status.textContent = `error: ${error instanceof Error ? error.message : String(error)}`;
+});

--- a/playwright/matrix-crypto-reload.smoke.spec.ts
+++ b/playwright/matrix-crypto-reload.smoke.spec.ts
@@ -1,0 +1,39 @@
+import { expect, Page, test } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const artifactPath = (name: string) =>
+	resolve(process.cwd(), '../../_e2e-artifacts/self-help-group', name);
+
+const proveReload = async (page: Page) => {
+	await page.goto('/playwright/matrix-crypto-browser-harness.html');
+	await expect(
+		page.locator('[data-testid="matrix-crypto-status"]')
+	).toHaveText('prepared', { timeout: 30_000 });
+
+	await page.reload();
+
+	await expect(
+		page.locator('[data-testid="matrix-crypto-status"]')
+	).toHaveText('recovered', { timeout: 30_000 });
+};
+
+test('keeps Megolm history decryptable after a desktop browser reload', async ({
+	page
+}) => {
+	await proveReload(page);
+	await page.screenshot({
+		path: artifactPath('matrix-crypto-reload-desktop.png'),
+		fullPage: true
+	});
+});
+
+test('keeps Megolm history decryptable after a mobile browser reload', async ({
+	page
+}) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await proveReload(page);
+	await page.screenshot({
+		path: artifactPath('matrix-crypto-reload-mobile.png'),
+		fullPage: true
+	});
+});

--- a/scripts/matrixMegolmSmoke.mjs
+++ b/scripts/matrixMegolmSmoke.mjs
@@ -1,0 +1,369 @@
+import {
+	createClient,
+	ClientEvent,
+	MatrixEventEvent,
+	RoomEvent
+} from 'matrix-js-sdk';
+import { logger } from 'matrix-js-sdk/lib/logger.js';
+import { decodeRecoveryKey } from 'matrix-js-sdk/lib/crypto-api/recovery-key.js';
+
+const baseUrl = process.env.MATRIX_SMOKE_BASE_URL ?? 'http://localhost:18008';
+const timeoutMs = 30_000;
+
+logger.setLevel('silent', false);
+
+const withTimeout = async (promise, label) => {
+	let timeout;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${label}`)),
+					timeoutMs
+				);
+			})
+		]);
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const silentLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error(...args) {
+		console.error(...args);
+	},
+	getChild() {
+		return this;
+	}
+};
+
+const registerDevice = async (localpart, displayName) => {
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/register`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			auth: { type: 'm.login.dummy' },
+			username: localpart,
+			password: `local-only-${localpart}`,
+			initial_device_display_name: displayName
+		})
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Matrix registration failed with HTTP ${response.status}`
+		);
+	}
+
+	const registration = await response.json();
+	if (
+		!registration.user_id ||
+		!registration.device_id ||
+		!registration.access_token
+	) {
+		throw new Error('Matrix registration response is incomplete');
+	}
+
+	return registration;
+};
+
+const loginDevice = async (localpart, password, displayName) => {
+	const response = await fetch(`${baseUrl}/_matrix/client/v3/login`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			type: 'm.login.password',
+			identifier: { type: 'm.id.user', user: localpart },
+			password,
+			initial_device_display_name: displayName
+		})
+	});
+	if (!response.ok) {
+		throw new Error(`Matrix login failed with HTTP ${response.status}`);
+	}
+	return response.json();
+};
+
+const createSecretStorageCallbacks = (seededPrivateKey = null) => {
+	let keyId = null;
+	let privateKey = seededPrivateKey;
+	return {
+		cacheSecretStorageKey(id, _keyInfo, key) {
+			keyId = id;
+			privateKey = new Uint8Array(key);
+		},
+		async getSecretStorageKey({ keys }) {
+			const requestedKeyId =
+				(keyId && keys[keyId] && keyId) || Object.keys(keys)[0];
+			return requestedKeyId && privateKey
+				? [requestedKeyId, privateKey]
+				: null;
+		}
+	};
+};
+
+const passwordUiAuth = (userId, password) => async (makeRequest) => {
+	try {
+		return await makeRequest(null);
+	} catch (error) {
+		return makeRequest({
+			type: 'm.login.password',
+			identifier: { type: 'm.id.user', user: userId },
+			password,
+			session: error?.data?.session
+		});
+	}
+};
+
+const startEncryptedClient = async (registration, cryptoCallbacks = {}) => {
+	const client = createClient({
+		baseUrl,
+		userId: registration.user_id,
+		deviceId: registration.device_id,
+		accessToken: registration.access_token,
+		logger: silentLogger,
+		cryptoCallbacks
+	});
+
+	await client.initRustCrypto({ useIndexedDB: false });
+	const prepared = new Promise((resolve, reject) => {
+		const onSync = (state, _previousState, error) => {
+			if (state === 'PREPARED') {
+				client.off(ClientEvent.Sync, onSync);
+				resolve();
+			} else if (state === 'ERROR') {
+				client.off(ClientEvent.Sync, onSync);
+				reject(error ?? new Error('Matrix sync failed'));
+			}
+		};
+		client.on(ClientEvent.Sync, onSync);
+	});
+	client.startClient({ initialSyncLimit: 20 });
+	await withTimeout(prepared, `initial sync for ${registration.user_id}`);
+	return client;
+};
+
+const waitForKeyBackup = (registration) =>
+	withTimeout(
+		(async () => {
+			for (;;) {
+				const response = await fetch(
+					`${baseUrl}/_matrix/client/v3/room_keys/version`,
+					{
+						headers: {
+							Authorization: `Bearer ${registration.access_token}`
+						}
+					}
+				);
+				if (response.ok) {
+					const info = await response.json();
+					if (Number(info.count) > 0) return info;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 200));
+			}
+		})(),
+		'uploaded Matrix key backup'
+	);
+
+const waitForRoom = (client, roomId) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const existing = client.getRoom(roomId);
+			if (existing) {
+				resolve(existing);
+				return;
+			}
+
+			const onRoom = (room) => {
+				if (room.roomId === roomId) {
+					client.off(ClientEvent.Room, onRoom);
+					resolve(room);
+				}
+			};
+			client.on(ClientEvent.Room, onRoom);
+		}),
+		`room ${roomId}`
+	);
+
+const waitForEncryptedMessage = (client, roomId, expectedBody) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const finishIfDecrypted = (event) => {
+				if (
+					event.getWireType() === 'm.room.encrypted' &&
+					event.getType() === 'm.room.message' &&
+					event.getContent()?.body === expectedBody
+				) {
+					client.off(RoomEvent.Timeline, inspect);
+					resolve(event);
+				}
+			};
+
+			const inspect = (event, room) => {
+				if (
+					room?.roomId !== roomId ||
+					event.getWireType() !== 'm.room.encrypted'
+				) {
+					return;
+				}
+
+				finishIfDecrypted(event);
+				event.once(MatrixEventEvent.Decrypted, () =>
+					finishIfDecrypted(event)
+				);
+			};
+			client.on(RoomEvent.Timeline, inspect);
+		}),
+		'encrypted and decrypted Matrix message'
+	);
+
+const waitForHistoricDecryption = (client, roomId, expectedBody) =>
+	withTimeout(
+		new Promise((resolve) => {
+			const inspect = () => {
+				const event = client
+					.getRoom(roomId)
+					?.getLiveTimeline()
+					.getEvents()
+					.find(
+						(candidate) =>
+							candidate.getWireType() === 'm.room.encrypted' &&
+							candidate.getType() === 'm.room.message' &&
+							candidate.getContent()?.body === expectedBody
+					);
+				if (event) {
+					clearInterval(interval);
+					resolve(event);
+				}
+			};
+			const interval = setInterval(inspect, 100);
+			inspect();
+		}),
+		'historic decryption on a fresh device'
+	);
+
+const suffix = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+let alice;
+let bob;
+let bobSecondDevice;
+
+try {
+	const aliceRegistration = await registerDevice(
+		`megolm_alice_${suffix}`,
+		'Megolm smoke Alice'
+	);
+	const bobLocalpart = `megolm_bob_${suffix}`;
+	const bobPassword = `local-only-${bobLocalpart}`;
+	const bobRegistration = await registerDevice(
+		bobLocalpart,
+		'Megolm smoke Bob'
+	);
+	const bobSecretStorageCallbacks = createSecretStorageCallbacks();
+	alice = await startEncryptedClient(aliceRegistration);
+	bob = await startEncryptedClient(
+		bobRegistration,
+		bobSecretStorageCallbacks
+	);
+
+	const { room_id: roomId } = await alice.createRoom({
+		name: `Megolm smoke ${suffix}`,
+		preset: 'private_chat',
+		invite: [bobRegistration.user_id],
+		initial_state: [
+			{
+				type: 'm.room.encryption',
+				state_key: '',
+				content: { algorithm: 'm.megolm.v1.aes-sha2' }
+			}
+		]
+	});
+
+	await waitForRoom(bob, roomId);
+	await bob.joinRoom(roomId);
+	const body = `Megolm transport proof ${suffix}`;
+	const received = waitForEncryptedMessage(bob, roomId, body);
+	await alice.sendMessage(roomId, { msgtype: 'm.text', body });
+	await received;
+
+	const bobCrypto = bob.getCrypto();
+	await bobCrypto.bootstrapCrossSigning({
+		setupNewCrossSigning: true,
+		authUploadDeviceSigningKeys: passwordUiAuth(
+			bobRegistration.user_id,
+			bobPassword
+		)
+	});
+	if (!(await bobCrypto.isCrossSigningReady())) {
+		throw new Error(
+			'Cross-signing did not become ready on the first device'
+		);
+	}
+	let recoveryKey;
+	await bobCrypto.bootstrapSecretStorage({
+		setupNewSecretStorage: true,
+		setupNewKeyBackup: true,
+		createSecretStorageKey: async () => {
+			recoveryKey = await bobCrypto.createRecoveryKeyFromPassphrase(
+				`recovery-${suffix}`
+			);
+			return recoveryKey;
+		}
+	});
+	await waitForKeyBackup(bobRegistration);
+	if (!recoveryKey?.encodedPrivateKey) {
+		throw new Error('SDK did not create an encoded recovery key');
+	}
+
+	const secondRegistration = await loginDevice(
+		bobLocalpart,
+		bobPassword,
+		'Megolm smoke Bob recovery device'
+	);
+	const recoveredPrivateKey = decodeRecoveryKey(
+		recoveryKey.encodedPrivateKey
+	);
+	bobSecondDevice = await startEncryptedClient(
+		secondRegistration,
+		createSecretStorageCallbacks(recoveredPrivateKey)
+	);
+	await waitForRoom(bobSecondDevice, roomId);
+	const secondCrypto = bobSecondDevice.getCrypto();
+	await secondCrypto.loadSessionBackupPrivateKeyFromSecretStorage();
+	const restoreResult = await secondCrypto.restoreKeyBackup();
+	if (restoreResult.imported < 1) {
+		throw new Error('Fresh device restored no Megolm sessions');
+	}
+	await bobCrypto.getUserDeviceInfo([bobRegistration.user_id], true);
+	await bobCrypto.crossSignDevice(secondRegistration.device_id);
+	await secondCrypto.bootstrapCrossSigning({ setupNewCrossSigning: false });
+	if (!(await secondCrypto.isCrossSigningReady())) {
+		throw new Error('Cross-signing recovery did not become ready');
+	}
+	await waitForHistoricDecryption(bobSecondDevice, roomId, body);
+
+	const encryptionState = alice
+		.getRoom(roomId)
+		?.currentState.getStateEvents('m.room.encryption', '');
+	if (
+		!encryptionState ||
+		encryptionState.getContent()?.algorithm !== 'm.megolm.v1.aes-sha2'
+	) {
+		throw new Error('Room is missing the Megolm encryption state');
+	}
+
+	console.log('Matrix Megolm smoke: PASS');
+} finally {
+	for (const client of [alice, bob, bobSecondDevice]) {
+		client?.stopClient();
+		client?.removeAllListeners();
+	}
+}
+
+// The SDK's aborted long-poll fetches can retain Node handles after the clients
+// and Rust crypto machines have been stopped. This is a one-shot smoke command.
+process.exit(0);

--- a/src/api/apiChatOccurrenceCommands.test.ts
+++ b/src/api/apiChatOccurrenceCommands.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchData } from './fetchData';
+import { apiSkipChatOccurrence } from './apiGetChatOccurrences';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { chatSeriesBase: '/service/users/chat-series/' }
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST' },
+	fetchData: vi.fn(() => Promise.resolve())
+}));
+
+describe('chat occurrence commands', () => {
+	it('skips exactly the original occurrence instant', async () => {
+		await apiSkipChatOccurrence(42, '2026-09-21T17:30:00Z');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/users/chat-series/42/occurrences/skip?originalStartUtc=2026-09-21T17%3A30%3A00Z',
+			method: 'POST'
+		});
+	});
+});

--- a/src/api/apiEventNotifications.ts
+++ b/src/api/apiEventNotifications.ts
@@ -10,6 +10,7 @@ export interface EventNotificationFeedItem {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: number;
+	params?: string | Record<string, unknown>;
 	createdAt: string | null;
 	readAt: string | null;
 }
@@ -49,4 +50,3 @@ export const apiClearEventNotifications = async (): Promise<any> =>
 		url: endpoints.eventNotifications,
 		method: FETCH_METHODS.DELETE
 	});
-

--- a/src/api/apiGetAgencyConsultantList.ts
+++ b/src/api/apiGetAgencyConsultantList.ts
@@ -25,3 +25,15 @@ export const apiGetAgencyConsultantList = async (
 		return [];
 	}
 };
+
+export const apiGetTenantConsultantList = async (): Promise<Consultant[]> => {
+	try {
+		return await fetchData({
+			url: `${endpoints.chatSeriesBase}consultants`,
+			method: FETCH_METHODS.GET,
+			responseHandling: [FETCH_ERRORS.CATCH_ALL]
+		});
+	} catch {
+		return [];
+	}
+};

--- a/src/api/apiGetChatOccurrences.ts
+++ b/src/api/apiGetChatOccurrences.ts
@@ -1,0 +1,40 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS } from './fetchData';
+
+export interface ChatOccurrence {
+	seriesId: number;
+	occurrenceIndex: number;
+	originalStart: string;
+	start: string;
+	duration: number;
+	capacity?: number;
+	modality: 'TEXT' | 'AUDIO' | 'VIDEO';
+}
+
+export const apiGetChatOccurrences = (
+	seriesId: number,
+	from: string,
+	to: string,
+	limit = 50
+): Promise<ChatOccurrence[]> => {
+	const query = new URLSearchParams({
+		from,
+		to,
+		limit: String(limit)
+	});
+	return fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/occurrences?${query}`,
+		method: FETCH_METHODS.GET
+	});
+};
+
+export const apiSkipChatOccurrence = (
+	seriesId: number,
+	originalStartUtc: string
+): Promise<void> => {
+	const query = new URLSearchParams({ originalStartUtc });
+	return fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/occurrences/skip?${query}`,
+		method: FETCH_METHODS.POST
+	});
+};

--- a/src/api/apiGetConsultantAppointments.test.ts
+++ b/src/api/apiGetConsultantAppointments.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BookingsStatus } from '../utils/consultant';
+import { fetchData } from './fetchData';
+import { apiGetConsultantAppointments } from './apiGetConsultantAppointments';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		appointmentsServiceConsultantBookings: () =>
+			'/service/appointservice/consultants/consultant-1/bookings?status=ACTIVE'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn(() => Promise.resolve([]))
+}));
+
+describe('apiGetConsultantAppointments', () => {
+	it('handles an unavailable optional appointment service without global navigation', async () => {
+		await apiGetConsultantAppointments(
+			'consultant-1',
+			BookingsStatus.ACTIVE
+		);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/appointservice/consultants/consultant-1/bookings?status=ACTIVE',
+			method: 'GET',
+			responseHandling: ['CATCH_ALL']
+		});
+	});
+});

--- a/src/api/apiGetConsultantAppointments.ts
+++ b/src/api/apiGetConsultantAppointments.ts
@@ -1,7 +1,7 @@
 import { BookingEventsInterface } from '../globalState/interfaces';
 import { endpoints } from '../resources/scripts/endpoints';
 import { BookingsStatus } from '../utils/consultant';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
 
 export const apiGetConsultantAppointments = async (
 	userId: string,
@@ -11,6 +11,7 @@ export const apiGetConsultantAppointments = async (
 
 	return fetchData({
 		url,
-		method: FETCH_METHODS.GET
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
 	});
 };

--- a/src/api/apiGetTenantConsultantList.test.ts
+++ b/src/api/apiGetTenantConsultantList.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiGetTenantConsultantList } from './apiGetAgencyConsultantList';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		chatSeriesBase: 'https://api.example/service/users/chat-series/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn(() => Promise.resolve([]))
+}));
+
+describe('apiGetTenantConsultantList', () => {
+	it('loads the tenant-scoped Series invitation directory', async () => {
+		await apiGetTenantConsultantList();
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/consultants',
+			method: 'GET',
+			responseHandling: ['CATCH_ALL']
+		});
+	});
+});

--- a/src/api/apiGroupChatAuthorTranslation.test.ts
+++ b/src/api/apiGroupChatAuthorTranslation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiTranslateGroupChatAuthorContent } from './apiGroupChatAuthorTranslation';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { tenantServiceBase: 'https://tenant/service/tenant' }
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { POST: 'POST' },
+	FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+	fetchData: vi.fn()
+}));
+
+describe('apiTranslateGroupChatAuthorContent', () => {
+	it('uses the consultant-scoped translation endpoint', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			translations: { en: { welcome: 'Welcome' } }
+		});
+
+		await apiTranslateGroupChatAuthorContent({
+			sourceLang: 'de',
+			targetLangs: ['en'],
+			texts: { welcome: 'Willkommen' }
+		});
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://tenant/service/tenant/translate/group-chat-author-content',
+			method: 'POST',
+			bodyData: JSON.stringify({
+				sourceLang: 'de',
+				targetLangs: ['en'],
+				texts: { welcome: 'Willkommen' }
+			}),
+			responseHandling: ['CONTENT']
+		});
+	});
+});

--- a/src/api/apiGroupChatAuthorTranslation.ts
+++ b/src/api/apiGroupChatAuthorTranslation.ts
@@ -1,0 +1,24 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+
+export interface GroupChatAuthorTranslationRequest {
+	sourceLang: string;
+	targetLangs: string[];
+	texts: Record<string, string>;
+}
+
+export interface GroupChatAuthorTranslationResponse {
+	translations: Record<string, Record<string, string>>;
+	provider?: string;
+	model?: string;
+}
+
+export const apiTranslateGroupChatAuthorContent = async (
+	request: GroupChatAuthorTranslationRequest
+): Promise<GroupChatAuthorTranslationResponse> =>
+	fetchData({
+		url: `${endpoints.tenantServiceBase}/translate/group-chat-author-content`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify(request),
+		responseHandling: [FETCH_SUCCESS.CONTENT]
+	});

--- a/src/api/apiGroupChatRoles.test.ts
+++ b/src/api/apiGroupChatRoles.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchData } from './fetchData';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership
+} from './apiGroupChatRoles';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		chatSeriesBase: 'https://api.example/service/users/chat-series/'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { DELETE: 'DELETE', POST: 'POST', PUT: 'PUT' },
+	fetchData: vi.fn(() => Promise.resolve())
+}));
+
+describe('group-chat role API helpers', () => {
+	it('changes a participant role through the stable Series identity', async () => {
+		await apiChangeGroupChatParticipantRole(
+			42,
+			'consultant-7',
+			'CO_MODERATOR'
+		);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/participants/consultant-7/role',
+			method: 'PUT',
+			bodyData: JSON.stringify({ role: 'CO_MODERATOR' })
+		});
+	});
+
+	it('transfers primary ownership without display-name routing', async () => {
+		await apiTransferGroupChatOwnership(42, 'consultant-9');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/transfer-ownership',
+			method: 'POST',
+			bodyData: JSON.stringify({ consultantId: 'consultant-9' })
+		});
+	});
+
+	it('removes a participant through the stable Series identity', async () => {
+		await apiRemoveGroupChatParticipant(42, 'consultant-9');
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: 'https://api.example/service/users/chat-series/42/participants/consultant-9',
+			method: 'DELETE'
+		});
+	});
+});

--- a/src/api/apiGroupChatRoles.ts
+++ b/src/api/apiGroupChatRoles.ts
@@ -1,0 +1,38 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS } from './fetchData';
+
+export type GroupChatParticipantRole = 'OWNER' | 'CO_MODERATOR' | 'PARTICIPANT';
+
+export const apiChangeGroupChatParticipantRole = (
+	seriesId: number,
+	consultantId: string,
+	role: GroupChatParticipantRole
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/participants/${encodeURIComponent(
+			consultantId
+		)}/role`,
+		method: FETCH_METHODS.PUT,
+		bodyData: JSON.stringify({ role })
+	});
+
+export const apiTransferGroupChatOwnership = (
+	seriesId: number,
+	consultantId: string
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/transfer-ownership`,
+		method: FETCH_METHODS.POST,
+		bodyData: JSON.stringify({ consultantId })
+	});
+
+export const apiRemoveGroupChatParticipant = (
+	seriesId: number,
+	consultantId: string
+): Promise<void> =>
+	fetchData({
+		url: `${endpoints.chatSeriesBase}${seriesId}/participants/${encodeURIComponent(
+			consultantId
+		)}`,
+		method: FETCH_METHODS.DELETE
+	});

--- a/src/api/apiGroupChatSettings.test.ts
+++ b/src/api/apiGroupChatSettings.test.ts
@@ -56,6 +56,33 @@ describe('group chat API helpers', () => {
 		);
 	});
 
+	it('sends finite Series settings without leaking the client feature flag', async () => {
+		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-series' });
+
+		await apiCreateGroupChat({
+			...groupChat,
+			featureGroupChatV2Enabled: true,
+			repeatCount: 4,
+			chatInterval: 'BIWEEKLY',
+			modality: 'VIDEO',
+			timezone: 'Europe/Berlin',
+			consultantIds: ['co-mod-1']
+		});
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				bodyData: JSON.stringify({
+					...groupChat,
+					repeatCount: 4,
+					chatInterval: 'BIWEEKLY',
+					modality: 'VIDEO',
+					timezone: 'Europe/Berlin',
+					consultantIds: ['co-mod-1']
+				})
+			})
+		);
+	});
+
 	it('updates an existing chat room', async () => {
 		vi.mocked(fetchData).mockResolvedValue({ groupId: 'group-123' });
 

--- a/src/api/apiGroupChatSettings.ts
+++ b/src/api/apiGroupChatSettings.ts
@@ -9,13 +9,32 @@ export interface groupChatSettings {
 	duration: number;
 	agencyId: number;
 	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
 	repetitive: boolean;
+	repeatCount?: number;
+	chatInterval?:
+		| 'DAILY'
+		| 'WEEKLY'
+		| 'BIWEEKLY'
+		| 'MONTHLY'
+		| 'QUARTERLY'
+		| 'YEARLY';
+	modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+	timezone?: string;
+	consultantIds?: string[];
 	featureGroupChatV2Enabled?: boolean;
 }
 
 export interface chatLinkData {
 	groupId: string;
 }
+
+const groupChatPayload = ({
+	featureGroupChatV2Enabled: _clientRoutingFlag,
+	...payload
+}: groupChatSettings) => payload;
 
 export const apiCreateGroupChat = async (
 	createChatItem: groupChatSettings
@@ -25,7 +44,7 @@ export const apiCreateGroupChat = async (
 		(createChatItem.featureGroupChatV2Enabled
 			? GROUP_CHAT_API.CREATEV2
 			: GROUP_CHAT_API.CREATE);
-	const chatData = JSON.stringify({ ...createChatItem });
+	const chatData = JSON.stringify(groupChatPayload(createChatItem));
 
 	return fetchData({
 		url: url,
@@ -40,7 +59,7 @@ export const apiUpdateGroupChat = async (
 	createChatItem: groupChatSettings
 ): Promise<chatLinkData> => {
 	const url = endpoints.groupChatBase + groupChatId + GROUP_CHAT_API.UPDATE;
-	const chatData = JSON.stringify({ ...createChatItem });
+	const chatData = JSON.stringify(groupChatPayload(createChatItem));
 
 	return fetchData({
 		url: url,

--- a/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
+++ b/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
@@ -983,6 +983,7 @@ function SessionListPanel() {
 						)
 					}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip
 					showLiveChatChip
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -121,56 +121,42 @@ export const AuthenticatedApp = ({
 						})
 						.then(async (userProfileData) => {
 							// 🔷 CRITICAL: Initialize Matrix client for all authenticated users
-							try {
-								const matrixLoginData =
-									await getMatrixAccessToken();
-								persistMatrixLoginData(matrixLoginData);
-								try {
-									const { MatrixClientService } =
-										await import(
-											'../../services/matrixClientService'
-										);
-									const matrixClientService =
-										new MatrixClientService();
+							const matrixLoginData =
+								await getMatrixAccessToken();
+							persistMatrixLoginData(matrixLoginData);
+							const { MatrixClientService } = await import(
+								'../../services/matrixClientService'
+							);
+							const matrixClientService =
+								new MatrixClientService();
 
-									const homeserverUrl =
-										getMatrixHomeserverUrl();
-									if (!homeserverUrl) {
-										// console.warn('⚠️ REACT_APP_MATRIX_HOMESERVER_URL is not set; skipping Matrix client init');
-									} else {
-										matrixClientService.initializeClient({
-											userId: matrixLoginData.userId,
-											accessToken:
-												matrixLoginData.accessToken,
-											deviceId: matrixLoginData.deviceId,
-											homeserverUrl: homeserverUrl
-										});
+							const homeserverUrl = getMatrixHomeserverUrl();
+							if (homeserverUrl) {
+								await matrixClientService.initializeClient({
+									userId: matrixLoginData.userId,
+									accessToken: matrixLoginData.accessToken,
+									deviceId: matrixLoginData.deviceId,
+									homeserverUrl
+								});
 
-										setMatrixClientService(
-											matrixClientService
-										);
-										(window as any).callContext =
-											callContext;
+								setMatrixClientService(matrixClientService);
+								(window as any).callContext = callContext;
 
-										const { matrixLiveEventBridge } =
-											await import(
-												'../../services/matrixLiveEventBridge'
-											);
-										matrixLiveEventBridge.initialize(
-											matrixClientService.getClient()!
-										);
-									}
-								} catch (error) {
-									// console.warn('⚠️ Matrix client initialization failed:', error);
-									// Don't fail app startup if Matrix fails
-								}
-							} catch {
-								// console.warn('⚠️ No Matrix credentials found in localStorage');
+								const { matrixLiveEventBridge } = await import(
+									'../../services/matrixLiveEventBridge'
+								);
+								matrixLiveEventBridge.initialize(
+									matrixClientService.getClient()!
+								);
 							}
 
 							setAppReady(true);
 						})
-						.catch(() => {
+						.catch((error) => {
+							console.error(
+								'Authenticated app bootstrap failed',
+								error
+							);
 							setLoading(false);
 						});
 				})

--- a/src/components/groupChat/CreateChatView.tsx
+++ b/src/components/groupChat/CreateChatView.tsx
@@ -7,7 +7,7 @@ import {
 	useMemo,
 	useRef
 } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import {
 	desktopView,
 	mobileDetailView,
@@ -16,11 +16,23 @@ import {
 import {
 	SessionsDataContext,
 	UPDATE_SESSIONS,
-	UserDataContext
+	UserDataContext,
+	useTenant
 } from '../../globalState';
 import { InputField, InputFieldItem } from '../inputField/InputField';
 import { OrisoSelect } from '../form/OrisoSelect';
-import { TOPIC_LENGTHS } from './createChatHelpers';
+import {
+	buildGroupChatSeriesRequest,
+	buildOneOffDuplicateFields,
+	getValidDateFormatForSelectedDate,
+	getValidTimeFormatForSelectedTime,
+	isGroupChatFeatureEnabled,
+	TOPIC_LENGTHS
+} from './createChatHelpers';
+import {
+	GroupChatSeriesFields,
+	GroupChatSeriesFieldsValue
+} from './GroupChatSeriesFields';
 import { ReactComponent as CheckIcon } from '../../resources/img/illustrations/check.svg';
 import { ReactComponent as XIcon } from '../../resources/img/illustrations/x.svg';
 import { ButtonItem, BUTTON_TYPES, Button } from '../button/Button';
@@ -31,11 +43,13 @@ import { useResponsive } from '../../hooks/useResponsive';
 import { apiGetSessionRoomsByGroupIds } from '../../api/apiGetSessionRooms';
 import { useTranslation } from 'react-i18next';
 import {
-	apiGetAgencyConsultantList,
+	apiGetTenantConsultantList,
 	Consultant
 } from '../../api/apiGetAgencyConsultantList';
 import { apiCreateGroupChat } from '../../api/apiGroupChatSettings';
 import { SelectChangeEvent } from '@mui/material/Select';
+import { GroupChatAuthorContentFields } from './GroupChatAuthorContentFields';
+import { GroupChatAuthorContentDraft } from './groupChatAuthorContent';
 
 const IconPlusCircle = ({ open }: { open: boolean }) => (
 	<svg
@@ -128,17 +142,72 @@ const IconUnselected = () => (
 	</svg>
 );
 
-export const CreateGroupChatView = () => {
-	const { t: translate } = useTranslation();
+const CreateGroupChatForm = () => {
+	const { t: translate, i18n } = useTranslation();
+	const tenantData = useTenant();
+	const activeLanguages = useMemo(
+		() =>
+			Array.from(
+				new Set(
+					(tenantData?.settings?.activeLanguages?.length
+						? tenantData.settings.activeLanguages
+						: [i18n.resolvedLanguage || i18n.language || 'de']
+					).map((language) => language.split('-')[0])
+				)
+			),
+		[
+			i18n.language,
+			i18n.resolvedLanguage,
+			tenantData?.settings?.activeLanguages
+		]
+	);
+	const initialAuthorLanguage = activeLanguages[0] || 'de';
+	const [authorContent, setAuthorContent] =
+		useState<GroupChatAuthorContentDraft>({
+			sourceLanguage: initialAuthorLanguage,
+			hintMessageTranslations: { [initialAuthorLanguage]: '' },
+			groupChatRulesTranslations: { [initialAuthorLanguage]: [''] }
+		});
 	const navigate = useNavigate();
+	const location = useLocation();
+	const duplicateOccurrence = (
+		location.state as {
+			duplicateOccurrence?: {
+				topic: string;
+				start: string;
+				duration: number;
+				modality: GroupChatSeriesFieldsValue['modality'];
+			};
+		} | null
+	)?.duplicateOccurrence;
 	const {
 		userData,
 		userData: { agencies = [] }
 	} = useContext(UserDataContext);
 
 	const { dispatch } = useContext(SessionsDataContext);
-	const [selectedChatTopic, setSelectedChatTopic] = useState('');
+	const [selectedChatTopic, setSelectedChatTopic] = useState(
+		() => duplicateOccurrence?.topic || ''
+	);
 	const [selectedAgency, setSelectedAgency] = useState<number | null>(null);
+	const [seriesFields, setSeriesFields] =
+		useState<GroupChatSeriesFieldsValue>(() =>
+			duplicateOccurrence
+				? buildOneOffDuplicateFields(duplicateOccurrence)
+				: {
+						startDate: getValidDateFormatForSelectedDate(
+							new Date()
+						),
+						startTime: getValidTimeFormatForSelectedTime(
+							new Date()
+						),
+						duration: 60,
+						repeatCount: 1,
+						interval: 'WEEKLY',
+						modality: 'TEXT'
+					}
+		);
+	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 	const [selectedConsultants, setSelectedConsultants] = useState<string[]>(
 		[]
 	);
@@ -215,7 +284,7 @@ export const CreateGroupChatView = () => {
 	// Fetch consultants when agency changes
 	useEffect(() => {
 		if (selectedAgency) {
-			apiGetAgencyConsultantList(selectedAgency.toString())
+			apiGetTenantConsultantList()
 				.then((consultants) => {
 					// ✅ FIX 1: Filter out current user from consultant list
 					// ✅ FIX 2: Remove duplicates using consultantId as unique key
@@ -284,13 +353,22 @@ export const CreateGroupChatView = () => {
 		if (
 			isChatTopicValid &&
 			selectedAgency &&
-			selectedConsultants.length > 0
+			seriesFields.startDate &&
+			seriesFields.startTime &&
+			seriesFields.repeatCount >= 1 &&
+			seriesFields.repeatCount <= 365
 		) {
 			setIsCreateButtonDisabled(false);
 		} else {
 			setIsCreateButtonDisabled(true);
 		}
-	}, [selectedChatTopic, selectedAgency, selectedConsultants]);
+	}, [
+		selectedChatTopic,
+		selectedAgency,
+		seriesFields.startDate,
+		seriesFields.startTime,
+		seriesFields.repeatCount
+	]);
 
 	const handleBackButton = () => {
 		navigate('/sessions/consultant/sessionView');
@@ -437,23 +515,34 @@ export const CreateGroupChatView = () => {
 	);
 
 	const handleCreateButton = useCallback(() => {
-		if (isRequestInProgress) {
+		if (isRequestInProgress || selectedAgency === null) {
 			return;
 		}
 		setIsRequestInProgress(true);
 
 		// Use the proper API function
-		apiCreateGroupChat({
-			topic: selectedChatTopic,
-			startDate: new Date().toISOString().split('T')[0],
-			startTime: '00:00',
-			duration: 60,
-			agencyId: selectedAgency,
-			hintMessage: '',
-			repetitive: false,
-			featureGroupChatV2Enabled: true,
-			consultantIds: selectedConsultants
-		} as any)
+		apiCreateGroupChat(
+			buildGroupChatSeriesRequest({
+				topic: selectedChatTopic,
+				startDate: seriesFields.startDate,
+				startTime: seriesFields.startTime,
+				duration: seriesFields.duration,
+				agencyId: selectedAgency,
+				hintMessage:
+					authorContent.hintMessageTranslations[
+						authorContent.sourceLanguage
+					] || '',
+				sourceLanguage: authorContent.sourceLanguage,
+				hintMessageTranslations: authorContent.hintMessageTranslations,
+				groupChatRulesTranslations:
+					authorContent.groupChatRulesTranslations,
+				repeatCount: seriesFields.repeatCount,
+				chatInterval: seriesFields.interval,
+				modality: seriesFields.modality,
+				timezone,
+				consultantIds: selectedConsultants
+			})
+		)
 			.then((response) => {
 				// Refresh session list
 				return apiGetSessionRoomsByGroupIds([response.groupId])
@@ -482,7 +571,10 @@ export const CreateGroupChatView = () => {
 		isRequestInProgress,
 		selectedChatTopic,
 		selectedAgency,
+		seriesFields,
+		timezone,
 		selectedConsultants,
+		authorContent,
 		dispatch,
 		navigate,
 		createChatErrorOverlayItem
@@ -538,6 +630,16 @@ export const CreateGroupChatView = () => {
 					options={agencyOptions}
 					value={selectedAgency?.toString() || ''}
 					onChange={handleAgencySelect}
+				/>
+
+				<GroupChatSeriesFields
+					value={seriesFields}
+					onChange={setSeriesFields}
+				/>
+				<GroupChatAuthorContentFields
+					activeLanguages={activeLanguages}
+					value={authorContent}
+					onChange={setAuthorContent}
 				/>
 				<div
 					className="createChat__participantsPicker"
@@ -713,4 +815,14 @@ export const CreateGroupChatView = () => {
 			)}
 		</div>
 	);
+};
+
+export const CreateGroupChatView = () => {
+	const tenantData = useTenant();
+
+	if (!isGroupChatFeatureEnabled(tenantData)) {
+		return <Navigate to="/sessions/consultant/sessionView" replace />;
+	}
+
+	return <CreateGroupChatForm />;
 };

--- a/src/components/groupChat/GroupChatAuthorContentFields.tsx
+++ b/src/components/groupChat/GroupChatAuthorContentFields.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiTranslateGroupChatAuthorContent } from '../../api/apiGroupChatAuthorTranslation';
+import {
+	applyGroupChatAuthorTranslations,
+	buildGroupChatAuthorTranslationRequest,
+	GroupChatAuthorContentDraft
+} from './groupChatAuthorContent';
+
+interface GroupChatAuthorContentFieldsProps {
+	activeLanguages: string[];
+	value: GroupChatAuthorContentDraft;
+	onChange: (value: GroupChatAuthorContentDraft) => void;
+}
+
+export const GroupChatAuthorContentFields = ({
+	activeLanguages,
+	value,
+	onChange
+}: GroupChatAuthorContentFieldsProps) => {
+	const { t } = useTranslation();
+	const languages = useMemo(
+		() =>
+			Array.from(
+				new Set(
+					activeLanguages.map((language) => language.split('-')[0])
+				)
+			),
+		[activeLanguages]
+	);
+	const [selectedLanguage, setSelectedLanguage] = useState(
+		languages.includes(value.sourceLanguage)
+			? value.sourceLanguage
+			: languages[0] || value.sourceLanguage
+	);
+	const [isTranslating, setIsTranslating] = useState(false);
+	const [translationError, setTranslationError] = useState(false);
+	const rules = value.groupChatRulesTranslations[selectedLanguage] || [''];
+
+	const updateHint = (hintMessage: string) =>
+		onChange({
+			...value,
+			hintMessageTranslations: {
+				...value.hintMessageTranslations,
+				[selectedLanguage]: hintMessage
+			}
+		});
+
+	const updateRules = (nextRules: string[]) =>
+		onChange({
+			...value,
+			groupChatRulesTranslations: {
+				...value.groupChatRulesTranslations,
+				[selectedLanguage]: nextRules
+			}
+		});
+
+	const translateContent = async () => {
+		const request = buildGroupChatAuthorTranslationRequest({
+			...value,
+			activeLanguages: languages
+		});
+		if (
+			request.targetLangs.length === 0 ||
+			Object.values(request.texts).every((text) => !text.trim())
+		) {
+			return;
+		}
+		setIsTranslating(true);
+		setTranslationError(false);
+		try {
+			const response = await apiTranslateGroupChatAuthorContent(request);
+			onChange(
+				applyGroupChatAuthorTranslations(value, response.translations)
+			);
+		} catch {
+			setTranslationError(true);
+		} finally {
+			setIsTranslating(false);
+		}
+	};
+
+	return (
+		<fieldset className="createChat__authorContent">
+			<legend>{t('groupChat.create.authorContent.title')}</legend>
+			<div className="createChat__languageTabs" role="tablist">
+				{languages.map((language) => (
+					<button
+						type="button"
+						role="tab"
+						aria-selected={language === selectedLanguage}
+						key={language}
+						onClick={() => setSelectedLanguage(language)}
+					>
+						{language.toUpperCase()}
+					</button>
+				))}
+			</div>
+			<label>
+				{t('groupChat.create.authorContent.sourceLanguage')}
+				<select
+					value={value.sourceLanguage}
+					onChange={(event) =>
+						onChange({
+							...value,
+							sourceLanguage: event.target.value
+						})
+					}
+				>
+					{languages.map((language) => (
+						<option key={language} value={language}>
+							{language.toUpperCase()}
+						</option>
+					))}
+				</select>
+			</label>
+			<label>
+				{t('groupChat.create.authorContent.welcome')}
+				<textarea
+					maxLength={120}
+					value={
+						value.hintMessageTranslations[selectedLanguage] || ''
+					}
+					onChange={(event) => updateHint(event.target.value)}
+				/>
+			</label>
+			<div className="createChat__rules">
+				<span>{t('groupChat.create.authorContent.rules')}</span>
+				{rules.map((rule, index) => (
+					<div key={`${selectedLanguage}-rule-${index}`}>
+						<textarea
+							aria-label={`${t(
+								'groupChat.create.authorContent.rule'
+							)} ${index + 1}`}
+							maxLength={120}
+							value={rule}
+							onChange={(event) =>
+								updateRules(
+									rules.map((current, ruleIndex) =>
+										ruleIndex === index
+											? event.target.value
+											: current
+									)
+								)
+							}
+						/>
+						<button
+							type="button"
+							onClick={() =>
+								updateRules(
+									rules.filter(
+										(_, ruleIndex) => ruleIndex !== index
+									)
+								)
+							}
+						>
+							{t('groupChat.create.authorContent.removeRule')}
+						</button>
+					</div>
+				))}
+				{rules.length < 10 && (
+					<button
+						type="button"
+						onClick={() => updateRules([...rules, ''])}
+					>
+						{t('groupChat.create.authorContent.addRule')}
+					</button>
+				)}
+			</div>
+			<button
+				type="button"
+				disabled={isTranslating}
+				onClick={translateContent}
+			>
+				{isTranslating
+					? t('groupChat.create.authorContent.translating')
+					: t('groupChat.create.authorContent.translate')}
+			</button>
+			{translationError && (
+				<p role="alert">
+					{t('groupChat.create.authorContent.translationError')}
+				</p>
+			)}
+		</fieldset>
+	);
+};

--- a/src/components/groupChat/GroupChatCalendarMenu.test.tsx
+++ b/src/components/groupChat/GroupChatCalendarMenu.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GroupChatCalendarMenu } from './GroupChatCalendarMenu';
+
+const translations: Record<string, string> = {
+	'groupChat.calendar.add': 'Add to calendar',
+	'groupChat.calendar.defaultTitle': 'Online appointment',
+	'groupChat.calendar.download': 'Download ICS',
+	'groupChat.calendar.google': 'Google Calendar',
+	'groupChat.calendar.outlook': 'Outlook Calendar',
+	'groupChat.calendar.titleLabel': 'Neutral calendar title'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key
+	})
+}));
+
+describe('GroupChatCalendarMenu', () => {
+	it('opens translated, confidentiality-neutral calendar actions', async () => {
+		render(
+			<GroupChatCalendarMenu
+				start={new Date('2026-08-04T18:00:00Z')}
+				durationMinutes={60}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Add to calendar' })
+		);
+
+		const titleInput = await screen.findByRole('textbox', {
+			name: 'Neutral calendar title'
+		});
+		expect((titleInput as HTMLInputElement).value).toBe(
+			'Online appointment'
+		);
+		expect(screen.getByText('Download ICS')).toBeTruthy();
+		const googleLink = screen.getByRole('menuitem', {
+			name: 'Google Calendar'
+		});
+		expect(googleLink.getAttribute('href')).toContain(
+			'calendar.google.com'
+		);
+		expect(googleLink.getAttribute('href')).not.toMatch(
+			/oriso|support|sucht/i
+		);
+	});
+});

--- a/src/components/groupChat/GroupChatCalendarMenu.tsx
+++ b/src/components/groupChat/GroupChatCalendarMenu.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useState } from 'react';
+import { Button, Menu, MenuItem, TextField } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import {
+	buildNeutralGroupChatCalendar,
+	downloadNeutralGroupChatIcs
+} from './groupChatCalendar';
+
+interface GroupChatCalendarMenuProps {
+	start: Date;
+	durationMinutes: number;
+}
+
+export const GroupChatCalendarMenu = ({
+	start,
+	durationMinutes
+}: GroupChatCalendarMenuProps) => {
+	const { t: translate } = useTranslation();
+	const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+	const [title, setTitle] = useState(() =>
+		translate('groupChat.calendar.defaultTitle')
+	);
+	const calendar = useMemo(
+		() =>
+			buildNeutralGroupChatCalendar({
+				start,
+				durationMinutes,
+				title
+			}),
+		[durationMinutes, start, title]
+	);
+
+	return (
+		<>
+			<Button
+				variant="outlined"
+				onClick={(event) => setAnchor(event.currentTarget)}
+			>
+				{translate('groupChat.calendar.add')}
+			</Button>
+			<Menu
+				anchorEl={anchor}
+				open={Boolean(anchor)}
+				onClose={() => setAnchor(null)}
+			>
+				<MenuItem disableRipple>
+					<TextField
+						label={translate('groupChat.calendar.titleLabel')}
+						value={title}
+						onChange={(event) => setTitle(event.target.value)}
+						size="small"
+					/>
+				</MenuItem>
+				<MenuItem
+					onClick={() => downloadNeutralGroupChatIcs(calendar.ics)}
+				>
+					{translate('groupChat.calendar.download')}
+				</MenuItem>
+				<MenuItem
+					component="a"
+					href={calendar.googleUrl}
+					target="_blank"
+					rel="noreferrer"
+				>
+					{translate('groupChat.calendar.google')}
+				</MenuItem>
+				<MenuItem
+					component="a"
+					href={calendar.outlookUrl}
+					target="_blank"
+					rel="noreferrer"
+				>
+					{translate('groupChat.calendar.outlook')}
+				</MenuItem>
+			</Menu>
+		</>
+	);
+};

--- a/src/components/groupChat/GroupChatInfo.tsx
+++ b/src/components/groupChat/GroupChatInfo.tsx
@@ -18,7 +18,7 @@ import {
 	apiPutGroupChat,
 	GROUP_CHAT_API
 } from '../../api';
-import { isGroupChatOwner } from './groupChatHelpers';
+import { canModerateGroupChat, isGroupChatOwner } from './groupChatHelpers';
 import { getGroupChatDate } from '../session/sessionDateHelpers';
 import { durationSelectOptionsSet } from './createChatHelpers';
 import {
@@ -49,6 +49,8 @@ import { useAppConfig } from '../../hooks/useAppConfig';
 import { useTranslation } from 'react-i18next';
 import { getPrettyDateFromMessageDate } from '../../utils/dateHelpers';
 import { useMatrixRoomUsers } from '../../hooks/useMatrixRoomUsers';
+import { GroupChatCalendarMenu } from './GroupChatCalendarMenu';
+import { GroupChatRoleManager } from './GroupChatRoleManager';
 
 export const GroupChatInfo = () => {
 	const settings = useAppConfig();
@@ -173,7 +175,10 @@ export const GroupChatInfo = () => {
 	if (redirectToSessionsList) {
 		return <Navigate to={listPath + getSessionListTab()} replace />;
 	}
-
+	const calendarStart = new Date(
+		activeSession.item.startDateWithTime ||
+			`${activeSession.item.startDate}T${activeSession.item.startTime}`
+	);
 	const showCreator =
 		settings.groupChat?.info?.showCreator &&
 		activeSession?.consultant?.displayName;
@@ -181,10 +186,12 @@ export const GroupChatInfo = () => {
 		settings.groupChat?.info?.showCreationDate &&
 		activeSession?.item?.createdAt;
 
-	const isCurrentUserModerator = isUserModerator({
-		chatItem: activeSession.item,
-		rcUserId: getValueFromCookie('rc_uid')
-	});
+	const isCurrentUserModerator =
+		canModerateGroupChat(activeSession, userData) ||
+		isUserModerator({
+			chatItem: activeSession.item,
+			rcUserId: getValueFromCookie('rc_uid')
+		});
 
 	const preparedSettings: Array<{ label: string; value: string }> = [
 		{
@@ -277,7 +284,8 @@ export const GroupChatInfo = () => {
 								: activeSession.item.topic?.name || ''}
 						</h2>
 					</div>
-					{activeSession.item.active &&
+					{canModerateGroupChat(activeSession, userData) &&
+					activeSession.item.active &&
 					activeSession.item.subscribed ? (
 						<div className="groupChatInfo__innerWrapper__stopButton">
 							<Button
@@ -286,6 +294,12 @@ export const GroupChatInfo = () => {
 							/>
 						</div>
 					) : null}
+					<div className="groupChatInfo__calendar">
+						<GroupChatCalendarMenu
+							start={calendarStart}
+							durationMinutes={activeSession.item.duration}
+						/>
+					</div>
 					<div className="groupChatInfo__content">
 						<div className="groupChatInfo__content__item groupChatInfo__data">
 							<Text
@@ -306,6 +320,15 @@ export const GroupChatInfo = () => {
 							<SubscriberList
 								isCurrentUserModerator={isCurrentUserModerator}
 							/>
+							{activeSession.item.participants?.length ? (
+								<GroupChatRoleManager
+									seriesId={activeSession.item.id}
+									currentUserId={userData.userId}
+									participants={
+										activeSession.item.participants
+									}
+								/>
+							) : null}
 						</div>
 
 						<div className="groupChatInfo__content__item groupChatInfo__data">

--- a/src/components/groupChat/GroupChatRoleManager.test.tsx
+++ b/src/components/groupChat/GroupChatRoleManager.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership
+} from '../../api/apiGroupChatRoles';
+import { GroupChatRoleManager } from './GroupChatRoleManager';
+
+vi.mock('../../api/apiGroupChatRoles', () => ({
+	apiChangeGroupChatParticipantRole: vi.fn(() => Promise.resolve()),
+	apiRemoveGroupChatParticipant: vi.fn(() => Promise.resolve()),
+	apiTransferGroupChatOwnership: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+const participants: UserService.Schemas.GroupChatParticipantDTO[] = [
+	{ consultantId: 'owner', displayName: 'Alice', role: 'OWNER' },
+	{ consultantId: 'target', displayName: 'Bob', role: 'PARTICIPANT' }
+];
+
+describe('GroupChatRoleManager', () => {
+	beforeEach(() => vi.clearAllMocks());
+	afterEach(cleanup);
+
+	it('lets an owner assign explicit Series roles', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText('Role for Bob'), {
+			target: { value: 'CO_MODERATOR' }
+		});
+
+		await waitFor(() =>
+			expect(apiChangeGroupChatParticipantRole).toHaveBeenCalledWith(
+				42,
+				'target',
+				'CO_MODERATOR'
+			)
+		);
+	});
+
+	it('transfers primary ownership through a stable consultant id', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.roles.transfer Bob'
+			})
+		);
+
+		await waitFor(() =>
+			expect(apiTransferGroupChatOwnership).toHaveBeenCalledWith(
+				42,
+				'target'
+			)
+		);
+	});
+
+	it('keeps role controls read-only for non-owners', () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="target"
+				participants={participants}
+			/>
+		);
+
+		expect(screen.queryByLabelText('Role for Alice')).toBeNull();
+		expect(screen.getByText('Alice')).toBeTruthy();
+	});
+
+	it('lets an owner remove a non-owner participant', async () => {
+		render(
+			<GroupChatRoleManager
+				seriesId={42}
+				currentUserId="owner"
+				participants={participants}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'groupChat.roles.remove Bob'
+			})
+		);
+
+		await waitFor(() =>
+			expect(apiRemoveGroupChatParticipant).toHaveBeenCalledWith(
+				42,
+				'target'
+			)
+		);
+		expect(screen.queryByText('Bob')).toBeNull();
+	});
+});

--- a/src/components/groupChat/GroupChatRoleManager.tsx
+++ b/src/components/groupChat/GroupChatRoleManager.tsx
@@ -1,0 +1,196 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	apiChangeGroupChatParticipantRole,
+	apiRemoveGroupChatParticipant,
+	apiTransferGroupChatOwnership,
+	GroupChatParticipantRole
+} from '../../api/apiGroupChatRoles';
+
+interface GroupChatRoleManagerProps {
+	seriesId: number;
+	currentUserId: string;
+	participants: UserService.Schemas.GroupChatParticipantDTO[];
+}
+
+const ROLES: GroupChatParticipantRole[] = [
+	'OWNER',
+	'CO_MODERATOR',
+	'PARTICIPANT'
+];
+
+export const GroupChatRoleManager = ({
+	seriesId,
+	currentUserId,
+	participants
+}: GroupChatRoleManagerProps) => {
+	const { t: translate } = useTranslation();
+	const [items, setItems] = React.useState(participants);
+	const [pendingId, setPendingId] = React.useState<string | null>(null);
+	const [error, setError] = React.useState(false);
+
+	React.useEffect(() => setItems(participants), [participants]);
+
+	const currentUserIsOwner = items.some(
+		(item) => item.consultantId === currentUserId && item.role === 'OWNER'
+	);
+
+	const updateRole = async (
+		consultantId: string,
+		role: GroupChatParticipantRole
+	) => {
+		setPendingId(consultantId);
+		setError(false);
+		try {
+			await apiChangeGroupChatParticipantRole(
+				seriesId,
+				consultantId,
+				role
+			);
+			setItems((current) =>
+				current.map((item) =>
+					item.consultantId === consultantId
+						? { ...item, role }
+						: item
+				)
+			);
+		} catch {
+			setError(true);
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const transferOwnership = async (consultantId: string) => {
+		setPendingId(consultantId);
+		setError(false);
+		try {
+			await apiTransferGroupChatOwnership(seriesId, consultantId);
+			setItems((current) =>
+				current.map((item) => {
+					if (item.consultantId === currentUserId) {
+						return { ...item, role: 'CO_MODERATOR' };
+					}
+					if (item.consultantId === consultantId) {
+						return { ...item, role: 'OWNER' };
+					}
+					return item;
+				})
+			);
+		} catch {
+			setError(true);
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const removeParticipant = async (consultantId: string) => {
+		setPendingId(consultantId);
+		setError(false);
+		try {
+			await apiRemoveGroupChatParticipant(seriesId, consultantId);
+			setItems((current) =>
+				current.filter((item) => item.consultantId !== consultantId)
+			);
+		} catch {
+			setError(true);
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	if (items.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="groupChatInfo__roles">
+			<h4>{translate('groupChat.roles.headline')}</h4>
+			{items.map((participant) => {
+				const isSelf = participant.consultantId === currentUserId;
+				const canRemove =
+					currentUserIsOwner &&
+					!isSelf &&
+					participant.role !== 'OWNER';
+				return (
+					<div
+						className="groupChatInfo__roleRow"
+						key={participant.consultantId}
+					>
+						<span>{participant.displayName}</span>
+						{currentUserIsOwner && !isSelf ? (
+							<>
+								<select
+									aria-label={`Role for ${participant.displayName}`}
+									value={participant.role}
+									disabled={
+										pendingId === participant.consultantId
+									}
+									onChange={(event) =>
+										void updateRole(
+											participant.consultantId,
+											event.target
+												.value as GroupChatParticipantRole
+										)
+									}
+								>
+									{ROLES.map((role) => (
+										<option value={role} key={role}>
+											{translate(
+												`groupChat.roles.${role}`
+											)}
+										</option>
+									))}
+								</select>
+								<button
+									type="button"
+									disabled={
+										pendingId === participant.consultantId
+									}
+									onClick={() =>
+										void transferOwnership(
+											participant.consultantId
+										)
+									}
+									aria-label={`${translate(
+										'groupChat.roles.transfer'
+									)} ${participant.displayName}`}
+								>
+									{translate('groupChat.roles.transfer')}
+								</button>
+								{canRemove && (
+									<button
+										type="button"
+										disabled={
+											pendingId ===
+											participant.consultantId
+										}
+										onClick={() =>
+											void removeParticipant(
+												participant.consultantId
+											)
+										}
+										aria-label={`${translate(
+											'groupChat.roles.remove'
+										)} ${participant.displayName}`}
+									>
+										{translate('groupChat.roles.remove')}
+									</button>
+								)}
+							</>
+						) : (
+							<span>
+								{translate(
+									`groupChat.roles.${participant.role}`
+								)}
+							</span>
+						)}
+					</div>
+				);
+			})}
+			{error && (
+				<p role="alert">{translate('groupChat.roles.updateError')}</p>
+			)}
+		</div>
+	);
+};

--- a/src/components/groupChat/GroupChatSeriesFields.test.tsx
+++ b/src/components/groupChat/GroupChatSeriesFields.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GroupChatSeriesFields } from './GroupChatSeriesFields';
+
+const translations: Record<string, string> = {
+	'groupChat.create.schedule': 'Schedule',
+	'groupChat.create.startDate': 'Start date',
+	'groupChat.create.startTime': 'Start time',
+	'groupChat.create.duration': 'Duration',
+	'groupChat.create.repeatCount': 'Occurrences',
+	'groupChat.create.interval.label': 'Interval',
+	'groupChat.create.modality.label': 'Format',
+	'groupChat.create.interval.options.daily': 'Daily',
+	'groupChat.create.interval.options.weekly': 'Weekly',
+	'groupChat.create.interval.options.biweekly': 'Every two weeks',
+	'groupChat.create.interval.options.monthly': 'Monthly',
+	'groupChat.create.interval.options.quarterly': 'Quarterly',
+	'groupChat.create.interval.options.yearly': 'Yearly',
+	'groupChat.create.modality.options.text': 'Text',
+	'groupChat.create.modality.options.audio': 'Audio',
+	'groupChat.create.modality.options.video': 'Video',
+	'groupChat.create.durationSelect.option1': '30 minutes',
+	'groupChat.create.durationSelect.option2': '1 hour',
+	'groupChat.create.durationSelect.option3': '1.5 hours',
+	'groupChat.create.durationSelect.option4': '2 hours',
+	'groupChat.create.durationSelect.option5': '2.5 hours',
+	'groupChat.create.durationSelect.option6': '3 hours'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key
+	})
+}));
+
+describe('GroupChatSeriesFields', () => {
+	it('uses translated controls and keeps interval disabled for one occurrence', () => {
+		const onChange = vi.fn();
+		render(
+			<GroupChatSeriesFields
+				value={{
+					startDate: '2026-08-04',
+					startTime: '18:00',
+					duration: 60,
+					repeatCount: 1,
+					interval: 'WEEKLY',
+					modality: 'TEXT'
+				}}
+				onChange={onChange}
+			/>
+		);
+
+		const interval = screen.getByRole('combobox', { name: 'Interval' });
+		expect(interval.getAttribute('aria-disabled')).toBe('true');
+
+		fireEvent.change(screen.getByLabelText('Start date'), {
+			target: { value: '2026-08-05' }
+		});
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({ startDate: '2026-08-05' })
+		);
+	});
+});

--- a/src/components/groupChat/GroupChatSeriesFields.tsx
+++ b/src/components/groupChat/GroupChatSeriesFields.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { OrisoSelect } from '../form/OrisoSelect';
+import {
+	durationSelectOptionsSet,
+	GroupChatInterval,
+	GroupChatModality
+} from './createChatHelpers';
+
+export interface GroupChatSeriesFieldsValue {
+	startDate: string;
+	startTime: string;
+	duration: number;
+	repeatCount: number;
+	interval: GroupChatInterval;
+	modality: GroupChatModality;
+}
+
+interface GroupChatSeriesFieldsProps {
+	value: GroupChatSeriesFieldsValue;
+	onChange: (value: GroupChatSeriesFieldsValue) => void;
+}
+
+const INTERVALS: GroupChatInterval[] = [
+	'DAILY',
+	'WEEKLY',
+	'BIWEEKLY',
+	'MONTHLY',
+	'QUARTERLY',
+	'YEARLY'
+];
+
+const MODALITIES: GroupChatModality[] = ['TEXT', 'AUDIO', 'VIDEO'];
+
+export const GroupChatSeriesFields = ({
+	value,
+	onChange
+}: GroupChatSeriesFieldsProps) => {
+	const { t: translate } = useTranslation();
+	const update = <Key extends keyof GroupChatSeriesFieldsValue>(
+		key: Key,
+		fieldValue: GroupChatSeriesFieldsValue[Key]
+	) => onChange({ ...value, [key]: fieldValue });
+
+	return (
+		<fieldset className="createChat__seriesFields">
+			<legend>{translate('groupChat.create.schedule')}</legend>
+			<label>
+				{translate('groupChat.create.startDate')}
+				<input
+					type="date"
+					value={value.startDate}
+					onChange={(event) =>
+						update('startDate', event.target.value)
+					}
+					required
+				/>
+			</label>
+			<label>
+				{translate('groupChat.create.startTime')}
+				<input
+					type="time"
+					value={value.startTime}
+					onChange={(event) =>
+						update('startTime', event.target.value)
+					}
+					required
+				/>
+			</label>
+			<OrisoSelect
+				id="group-chat-duration"
+				label={translate('groupChat.create.duration')}
+				value={String(value.duration)}
+				options={durationSelectOptionsSet.map((option) => ({
+					value: option.value,
+					label: translate(option.label)
+				}))}
+				onChange={(event) =>
+					update('duration', Number(event.target.value))
+				}
+			/>
+			<label>
+				{translate('groupChat.create.repeatCount')}
+				<input
+					type="number"
+					min="1"
+					max="365"
+					value={value.repeatCount}
+					onChange={(event) =>
+						update('repeatCount', Number(event.target.value))
+					}
+				/>
+			</label>
+			<OrisoSelect
+				id="group-chat-interval"
+				label={translate('groupChat.create.interval.label')}
+				value={value.interval}
+				disabled={value.repeatCount === 1}
+				options={INTERVALS.map((interval) => ({
+					value: interval,
+					label: translate(
+						`groupChat.create.interval.options.${interval.toLowerCase()}`
+					)
+				}))}
+				onChange={(event) =>
+					update('interval', event.target.value as GroupChatInterval)
+				}
+			/>
+			<OrisoSelect
+				id="group-chat-modality"
+				label={translate('groupChat.create.modality.label')}
+				value={value.modality}
+				options={MODALITIES.map((modality) => ({
+					value: modality,
+					label: translate(
+						`groupChat.create.modality.options.${modality.toLowerCase()}`
+					)
+				}))}
+				onChange={(event) =>
+					update('modality', event.target.value as GroupChatModality)
+				}
+			/>
+		</fieldset>
+	);
+};

--- a/src/components/groupChat/JoinGroupChatView.tsx
+++ b/src/components/groupChat/JoinGroupChatView.tsx
@@ -33,6 +33,8 @@ import { useTranslation } from 'react-i18next';
 import { useTimeoutOverlay } from '../../hooks/useTimeoutOverlay';
 import { OVERLAY_REQUEST } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { FALLBACK_LNG } from '../../i18n';
+import { getWaitingAreaTime } from './groupChatWaitingArea';
+import { resolveGroupChatAuthorContent } from './groupChatAuthorContent';
 
 interface JoinGroupChatViewProps {
 	forceBannedOverlay?: boolean;
@@ -43,7 +45,17 @@ export const JoinGroupChatView = ({
 	forceBannedOverlay = false,
 	bannedUsers = []
 }: JoinGroupChatViewProps) => {
-	const { t: translate } = useTranslation(['common', 'consultingTypes']);
+	const { t: translate, i18n } = useTranslation([
+		'common',
+		'consultingTypes'
+	]);
+	const tr = useCallback(
+		(key: string, fallback: string) => {
+			const value = translate(key);
+			return !value || value === key ? fallback : value;
+		},
+		[translate]
+	);
 	const { activeSession, reloadActiveSession } =
 		useContext(ActiveSessionContext);
 	const { userData } = useContext(UserDataContext);
@@ -55,6 +67,8 @@ export const JoinGroupChatView = ({
 
 	const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
+	const [now, setNow] = useState(() => new Date());
+	const [visibleRuleIndex, setVisibleRuleIndex] = useState(0);
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
 	const getSessionListTab = () =>
 		`${sessionListTab ? `?sessionListTab=${sessionListTab}` : ''}`;
@@ -251,7 +265,7 @@ export const JoinGroupChatView = ({
 		}
 	}, [forceBannedOverlay, bannedUserOverlay]);
 
-	const groupChatRules = useMemo(() => {
+	const legacyGroupChatRules = useMemo(() => {
 		const transKeys = [
 			`consultingType.${topic?.id ?? 'noConsultingType'}.groupChatRules`,
 			`consultingType.fallback.groupChatRules`
@@ -277,6 +291,62 @@ export const JoinGroupChatView = ({
 		);
 	}, [consultingType?.groupChat?.groupChatRules, topic?.id, translate]);
 
+	const authorContent = useMemo(
+		() =>
+			resolveGroupChatAuthorContent({
+				language: i18n.resolvedLanguage || i18n.language,
+				sourceLanguage: activeSession.item.sourceLanguage,
+				hintMessageTranslations:
+					activeSession.item.hintMessageTranslations,
+				groupChatRulesTranslations:
+					activeSession.item.groupChatRulesTranslations,
+				legacyHintMessage: activeSession.item.hintMessage,
+				legacyRules: legacyGroupChatRules
+			}),
+		[
+			activeSession.item.groupChatRulesTranslations,
+			activeSession.item.hintMessage,
+			activeSession.item.hintMessageTranslations,
+			activeSession.item.sourceLanguage,
+			i18n.language,
+			i18n.resolvedLanguage,
+			legacyGroupChatRules
+		]
+	);
+	const groupChatRules = authorContent.rules;
+
+	useEffect(() => {
+		const timer = window.setInterval(() => setNow(new Date()), 1000);
+		return () => window.clearInterval(timer);
+	}, []);
+
+	useEffect(() => {
+		if (groupChatRules.length < 2) return;
+		const timer = window.setInterval(
+			() =>
+				setVisibleRuleIndex(
+					(current) => (current + 1) % groupChatRules.length
+				),
+			4000
+		);
+		return () => window.clearInterval(timer);
+	}, [groupChatRules.length]);
+
+	const plannedStart = useMemo(() => {
+		const value =
+			activeSession.item.startDateWithTime ||
+			`${activeSession.item.startDate}T${activeSession.item.startTime}`;
+		const parsed = new Date(value);
+		return Number.isNaN(parsed.getTime()) ? null : parsed;
+	}, [
+		activeSession.item.startDate,
+		activeSession.item.startDateWithTime,
+		activeSession.item.startTime
+	]);
+	const waitingTime = plannedStart
+		? getWaitingAreaTime(now, plannedStart)
+		: null;
+
 	if (redirectToSessionsList) {
 		mobileListView();
 		return <Navigate to={listPath + getSessionListTab()} replace />;
@@ -293,9 +363,38 @@ export const JoinGroupChatView = ({
 					text={translate('groupChat.join.content.headline')}
 					semanticLevel="4"
 				/>
-				{groupChatRules.map((groupChatRuleText, i) => (
-					<Text text={groupChatRuleText} type="standard" key={i} />
-				))}
+				{!!authorContent.hintMessage && (
+					<Text text={authorContent.hintMessage} type="standard" />
+				)}
+				{waitingTime && (
+					<div className="joinChat__countdown" aria-live="polite">
+						<span className="joinChat__countdownValue">
+							{waitingTime.label} {waitingTime.discomfortEmoji}
+						</span>
+						<div
+							className="joinChat__timePills"
+							aria-label={tr(
+								'groupChat.join.timeConversions',
+								'Playful time conversions'
+							)}
+						>
+							{waitingTime.pills.map((pill) => (
+								<span key={pill.kind}>
+									{translate(
+										`groupChat.join.waitingArea.${pill.kind}Minutes`,
+										{ value: pill.value }
+									)}
+								</span>
+							))}
+						</div>
+					</div>
+				)}
+				{!!groupChatRules.length && (
+					<Text
+						text={groupChatRules[visibleRuleIndex]}
+						type="standard"
+					/>
+				)}
 			</div>
 			<div className="joinChat__button-container">
 				{!hasUserAuthority(AUTHORITIES.CREATE_NEW_CHAT, userData) &&

--- a/src/components/groupChat/createChat.styles.scss
+++ b/src/components/groupChat/createChat.styles.scss
@@ -135,6 +135,42 @@ $inputSpacing: 32px;
 		margin: 0 0 $inputSpacing 0;
 	}
 
+	&__seriesFields {
+		width: $chat-input-width;
+		margin: 0 0 $inputSpacing;
+		padding: 16px;
+		border: 1px solid var(--m3-outline-variant, #c8c5ca);
+		border-radius: 8px;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 16px;
+
+		legend {
+			padding: 0 6px;
+		}
+
+		label {
+			display: flex;
+			flex-direction: column;
+			gap: 6px;
+			font-size: 14px;
+		}
+
+		input,
+		select {
+			min-height: 44px;
+			padding: 8px;
+			border: 1px solid #8c878c;
+			border-radius: 5px;
+			background: #fff;
+			font: inherit;
+		}
+
+		@media (width <= 480px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
 	&__participantsRow {
 		display: flex;
 		align-items: center;
@@ -394,6 +430,39 @@ $inputSpacing: 32px;
 	&__explanation {
 		font-size: 12px;
 		margin: 0 0 $grid-base-four;
+	}
+
+	&__authorContent {
+		width: $chat-input-width;
+		margin: 0 0 $inputSpacing;
+		padding: $grid-base-three;
+		border: 1px solid #d8dcdf;
+		border-radius: 8px;
+
+		label,
+		.createChat__rules {
+			display: grid;
+			gap: $grid-base;
+			margin-top: $grid-base-two;
+		}
+
+		textarea,
+		select {
+			box-sizing: border-box;
+			width: 100%;
+			padding: $grid-base-two;
+		}
+	}
+
+	&__languageTabs {
+		display: flex;
+		gap: $grid-base;
+		margin-top: $grid-base-two;
+
+		button[aria-selected='true'] {
+			border-color: #a5000a;
+			color: #a5000a;
+		}
 	}
 }
 

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildGroupChatSeriesRequest,
+	buildOneOffDuplicateFields,
+	isGroupChatFeatureEnabled
+} from './createChatHelpers';
+
+describe('isGroupChatFeatureEnabled', () => {
+	it('fails closed unless the tenant explicitly enables group chat v2', () => {
+		expect(isGroupChatFeatureEnabled(undefined)).toBe(false);
+		expect(isGroupChatFeatureEnabled({ settings: undefined })).toBe(false);
+		expect(
+			isGroupChatFeatureEnabled({
+				settings: { featureGroupChatV2Enabled: false }
+			})
+		).toBe(false);
+		expect(
+			isGroupChatFeatureEnabled({
+				settings: { featureGroupChatV2Enabled: true }
+			})
+		).toBe(true);
+	});
+});
+
+describe('buildGroupChatSeriesRequest', () => {
+	it('builds an explicit finite text-only one-off Series', () => {
+		expect(
+			buildGroupChatSeriesRequest({
+				topic: 'Peer support',
+				agencyId: 17,
+				startDate: '2026-08-04',
+				startTime: '18:30',
+				duration: 90,
+				repeatCount: 1,
+				chatInterval: 'WEEKLY',
+				modality: 'TEXT',
+				timezone: 'Europe/Berlin',
+				hintMessage: 'Welcome',
+				consultantIds: []
+			})
+		).toEqual({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 90,
+			repetitive: false,
+			repeatCount: 1,
+			modality: 'TEXT',
+			timezone: 'Europe/Berlin',
+			hintMessage: 'Welcome',
+			consultantIds: [],
+			featureGroupChatV2Enabled: true
+		});
+	});
+});
+
+describe('buildOneOffDuplicateFields', () => {
+	it('prefills a skipped virtual occurrence as a standalone one-off Series', () => {
+		expect(
+			buildOneOffDuplicateFields({
+				topic: 'Peer support',
+				start: '2026-09-21T18:30:00',
+				duration: 90,
+				modality: 'VIDEO'
+			})
+		).toEqual({
+			topic: 'Peer support',
+			startDate: '2026-09-21',
+			startTime: '18:30',
+			duration: 90,
+			repeatCount: 1,
+			interval: 'WEEKLY',
+			modality: 'VIDEO'
+		});
+	});
+});

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -1,3 +1,66 @@
+import { groupChatSettings } from '../../api/apiGroupChatSettings';
+
+export type GroupChatInterval = NonNullable<groupChatSettings['chatInterval']>;
+export type GroupChatModality = NonNullable<groupChatSettings['modality']>;
+
+export interface GroupChatSeriesFormValue {
+	topic: string;
+	agencyId: number;
+	startDate: string;
+	startTime: string;
+	duration: number;
+	repeatCount: number;
+	chatInterval: GroupChatInterval;
+	modality: GroupChatModality;
+	timezone: string;
+	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
+	consultantIds: string[];
+}
+
+export const isGroupChatFeatureEnabled = (
+	tenant?: {
+		settings?: { featureGroupChatV2Enabled?: boolean };
+	} | null
+) => tenant?.settings?.featureGroupChatV2Enabled === true;
+
+export const buildGroupChatSeriesRequest = ({
+	repeatCount,
+	chatInterval,
+	...form
+}: GroupChatSeriesFormValue): groupChatSettings => ({
+	...form,
+	repetitive: repeatCount > 1,
+	repeatCount,
+	...(repeatCount > 1 ? { chatInterval } : {}),
+	featureGroupChatV2Enabled: true
+});
+
+export const buildOneOffDuplicateFields = ({
+	topic,
+	start,
+	duration,
+	modality
+}: {
+	topic: string;
+	start: string;
+	duration: number;
+	modality: GroupChatModality;
+}) => {
+	const plannedStart = new Date(start);
+	return {
+		topic,
+		startDate: getValidDateFormatForSelectedDate(plannedStart),
+		startTime: getValidTimeFormatForSelectedTime(plannedStart),
+		duration,
+		repeatCount: 1,
+		interval: 'WEEKLY' as GroupChatInterval,
+		modality
+	};
+};
+
 export const TOPIC_LENGTHS = {
 	MIN: 3,
 	MAX: 50

--- a/src/components/groupChat/groupChatAuthorContent.test.ts
+++ b/src/components/groupChat/groupChatAuthorContent.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyGroupChatAuthorTranslations,
+	buildGroupChatAuthorTranslationRequest,
+	resolveGroupChatAuthorContent
+} from './groupChatAuthorContent';
+
+describe('resolveGroupChatAuthorContent', () => {
+	it('prefers the requested language', () => {
+		expect(
+			resolveGroupChatAuthorContent({
+				language: 'fr-FR',
+				sourceLanguage: 'de',
+				hintMessageTranslations: {
+					fr: 'Bienvenue',
+					en: 'Welcome',
+					de: 'Willkommen'
+				},
+				groupChatRulesTranslations: {
+					fr: ['Respectez-vous'],
+					en: ['Be respectful'],
+					de: ['Respektvoll bleiben']
+				},
+				legacyHintMessage: 'Legacy',
+				legacyRules: ['Legacy rule']
+			})
+		).toEqual({ hintMessage: 'Bienvenue', rules: ['Respectez-vous'] });
+	});
+
+	it('falls back independently through English, source language, then legacy', () => {
+		expect(
+			resolveGroupChatAuthorContent({
+				language: 'it',
+				sourceLanguage: 'de',
+				hintMessageTranslations: { en: 'Welcome' },
+				groupChatRulesTranslations: {
+					de: ['Respektvoll bleiben']
+				},
+				legacyHintMessage: 'Legacy',
+				legacyRules: ['Legacy rule']
+			})
+		).toEqual({
+			hintMessage: 'Welcome',
+			rules: ['Respektvoll bleiben']
+		});
+	});
+});
+
+describe('group-chat author translation draft', () => {
+	it('maps welcome and rules to stable translation keys', () => {
+		expect(
+			buildGroupChatAuthorTranslationRequest({
+				sourceLanguage: 'de',
+				activeLanguages: ['de', 'en', 'fr'],
+				hintMessageTranslations: { de: 'Willkommen' },
+				groupChatRulesTranslations: {
+					de: ['Respektvoll bleiben', 'Keine Werbung']
+				}
+			})
+		).toEqual({
+			sourceLang: 'de',
+			targetLangs: ['en', 'fr'],
+			texts: {
+				'welcome': 'Willkommen',
+				'rule-0': 'Respektvoll bleiben',
+				'rule-1': 'Keine Werbung'
+			}
+		});
+	});
+
+	it('merges translated fields into editable per-language content', () => {
+		expect(
+			applyGroupChatAuthorTranslations(
+				{
+					sourceLanguage: 'de',
+					hintMessageTranslations: { de: 'Willkommen' },
+					groupChatRulesTranslations: {
+						de: ['Respektvoll bleiben']
+					}
+				},
+				{
+					en: {
+						'welcome': 'Welcome',
+						'rule-0': 'Be respectful'
+					}
+				}
+			)
+		).toMatchObject({
+			hintMessageTranslations: { de: 'Willkommen', en: 'Welcome' },
+			groupChatRulesTranslations: {
+				de: ['Respektvoll bleiben'],
+				en: ['Be respectful']
+			}
+		});
+	});
+});

--- a/src/components/groupChat/groupChatAuthorContent.ts
+++ b/src/components/groupChat/groupChatAuthorContent.ts
@@ -1,0 +1,100 @@
+export interface GroupChatAuthorContent {
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
+}
+
+export interface GroupChatAuthorContentDraft {
+	sourceLanguage: string;
+	hintMessageTranslations: Record<string, string>;
+	groupChatRulesTranslations: Record<string, string[]>;
+}
+
+const normalizeLanguage = (language?: string) =>
+	language?.trim().toLowerCase().split('-')[0];
+
+const fallbackLanguages = (language?: string, sourceLanguage?: string) =>
+	Array.from(
+		new Set(
+			[
+				normalizeLanguage(language),
+				'en',
+				normalizeLanguage(sourceLanguage)
+			].filter((value): value is string => !!value)
+		)
+	);
+
+export const resolveGroupChatAuthorContent = ({
+	language,
+	sourceLanguage,
+	hintMessageTranslations = {},
+	groupChatRulesTranslations = {},
+	legacyHintMessage,
+	legacyRules
+}: GroupChatAuthorContent & {
+	language?: string;
+	legacyHintMessage?: string;
+	legacyRules: string[];
+}) => {
+	const languages = fallbackLanguages(language, sourceLanguage);
+	const hintMessage =
+		languages
+			.map((candidate) => hintMessageTranslations[candidate])
+			.find((candidate) => !!candidate?.trim()) ||
+		legacyHintMessage ||
+		'';
+	const rules =
+		languages
+			.map((candidate) => groupChatRulesTranslations[candidate])
+			.find((candidate) => candidate?.some((rule) => !!rule.trim()))
+			?.filter((rule) => !!rule.trim()) || legacyRules;
+
+	return { hintMessage, rules };
+};
+
+export const buildGroupChatAuthorTranslationRequest = ({
+	sourceLanguage,
+	activeLanguages,
+	hintMessageTranslations,
+	groupChatRulesTranslations
+}: GroupChatAuthorContentDraft & { activeLanguages: string[] }) => ({
+	sourceLang: sourceLanguage,
+	targetLangs: activeLanguages.filter(
+		(language) =>
+			normalizeLanguage(language) !== normalizeLanguage(sourceLanguage)
+	),
+	texts: {
+		welcome: hintMessageTranslations[sourceLanguage] || '',
+		...Object.fromEntries(
+			(groupChatRulesTranslations[sourceLanguage] || []).map(
+				(rule, index) => [`rule-${index}`, rule]
+			)
+		)
+	}
+});
+
+export const applyGroupChatAuthorTranslations = (
+	draft: GroupChatAuthorContentDraft,
+	translations: Record<string, Record<string, string>>
+): GroupChatAuthorContentDraft => {
+	const nextHints = { ...draft.hintMessageTranslations };
+	const nextRules = { ...draft.groupChatRulesTranslations };
+
+	Object.entries(translations).forEach(([language, fields]) => {
+		nextHints[language] = fields.welcome || '';
+		nextRules[language] = Object.entries(fields)
+			.filter(([key]) => key.startsWith('rule-'))
+			.sort(
+				([left], [right]) =>
+					Number(left.slice('rule-'.length)) -
+					Number(right.slice('rule-'.length))
+			)
+			.map(([, value]) => value);
+	});
+
+	return {
+		...draft,
+		hintMessageTranslations: nextHints,
+		groupChatRulesTranslations: nextRules
+	};
+};

--- a/src/components/groupChat/groupChatCalendar.test.ts
+++ b/src/components/groupChat/groupChatCalendar.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildNeutralGroupChatCalendar } from './groupChatCalendar';
+
+describe('buildNeutralGroupChatCalendar', () => {
+	it('creates content-neutral ICS and provider URLs', () => {
+		const calendar = buildNeutralGroupChatCalendar({
+			start: new Date('2026-08-04T18:00:00Z'),
+			durationMinutes: 60,
+			title: 'Online appointment'
+		});
+
+		expect(calendar.ics).toContain('SUMMARY:Online appointment');
+		expect(calendar.ics).not.toMatch(/support|oriso|sucht/i);
+		expect(calendar.googleUrl).toContain('calendar.google.com');
+		expect(calendar.outlookUrl).toContain('outlook.live.com');
+	});
+});

--- a/src/components/groupChat/groupChatCalendar.ts
+++ b/src/components/groupChat/groupChatCalendar.ts
@@ -1,0 +1,64 @@
+interface GroupChatCalendarInput {
+	start: Date;
+	durationMinutes: number;
+	title: string;
+}
+
+const compactUtc = (date: Date) =>
+	date
+		.toISOString()
+		.replace(/[-:]/g, '')
+		.replace(/\.\d{3}/, '');
+
+const escapeIcs = (value: string) =>
+	value.replace(/\\/g, '\\\\').replace(/[,;]/g, '\\$&').replace(/\n/g, '\\n');
+
+export const buildNeutralGroupChatCalendar = ({
+	start,
+	durationMinutes,
+	title
+}: GroupChatCalendarInput) => {
+	const end = new Date(start.getTime() + durationMinutes * 60_000);
+	const startUtc = compactUtc(start);
+	const endUtc = compactUtc(end);
+	const safeTitle = title.trim() || 'Online appointment';
+	const ics = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//Online Appointment//Calendar//EN',
+		'BEGIN:VEVENT',
+		`UID:${start.getTime()}-online-appointment@localhost`,
+		`DTSTAMP:${compactUtc(new Date())}`,
+		`DTSTART:${startUtc}`,
+		`DTEND:${endUtc}`,
+		`SUMMARY:${escapeIcs(safeTitle)}`,
+		'END:VEVENT',
+		'END:VCALENDAR'
+	].join('\r\n');
+	const common = new URLSearchParams({
+		text: safeTitle,
+		dates: `${startUtc}/${endUtc}`
+	});
+	const outlook = new URLSearchParams({
+		path: '/calendar/action/compose',
+		rru: 'addevent',
+		subject: safeTitle,
+		startdt: start.toISOString(),
+		enddt: end.toISOString()
+	});
+
+	return {
+		ics,
+		googleUrl: `https://calendar.google.com/calendar/render?action=TEMPLATE&${common}`,
+		outlookUrl: `https://outlook.live.com/calendar/0/deeplink/compose?${outlook}`
+	};
+};
+
+export const downloadNeutralGroupChatIcs = (ics: string): void => {
+	const url = URL.createObjectURL(new Blob([ics], { type: 'text/calendar' }));
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = 'online-appointment.ics';
+	anchor.click();
+	URL.revokeObjectURL(url);
+};

--- a/src/components/groupChat/groupChatHelpers.test.ts
+++ b/src/components/groupChat/groupChatHelpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+	canModerateGroupChat,
+	shouldShowGroupChatJoinView
+} from './groupChatHelpers';
+
+describe('canModerateGroupChat', () => {
+	it('allows the primary owner and explicitly invited Series moderators only', () => {
+		const activeSession = {
+			consultant: { id: 'owner' },
+			item: { moderators: ['owner', 'co-mod'] }
+		};
+
+		expect(canModerateGroupChat(activeSession, { userId: 'owner' })).toBe(
+			true
+		);
+		expect(canModerateGroupChat(activeSession, { userId: 'co-mod' })).toBe(
+			true
+		);
+		expect(
+			canModerateGroupChat(activeSession, { userId: 'participant' })
+		).toBe(false);
+		expect(canModerateGroupChat(activeSession, undefined)).toBe(false);
+	});
+});
+
+describe('shouldShowGroupChatJoinView', () => {
+	it('keeps a subscribed moderator on the start view while the chat is inactive', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: true,
+				active: false,
+				subscribed: true,
+				isBanned: false
+			})
+		).toBe(true);
+	});
+
+	it('opens the stream only for an active subscribed non-banned member', () => {
+		expect(
+			shouldShowGroupChatJoinView({
+				isGroup: true,
+				active: true,
+				subscribed: true,
+				isBanned: false
+			})
+		).toBe(false);
+	});
+});

--- a/src/components/groupChat/groupChatHelpers.ts
+++ b/src/components/groupChat/groupChatHelpers.ts
@@ -1,7 +1,44 @@
-export const isGroupChatOwner = (activeSession, userData) => {
+interface GroupChatAuthorizationSession {
+	consultant?: { id?: string };
+	item?: { moderators?: string[] };
+}
+
+interface GroupChatAuthorizationUser {
+	userId?: string;
+}
+
+export const isGroupChatOwner = (
+	activeSession: GroupChatAuthorizationSession,
+	userData?: GroupChatAuthorizationUser
+) => {
 	if (activeSession.consultant && userData) {
 		return activeSession.consultant.id === userData.userId;
 	} else {
 		return false;
 	}
 };
+
+export const canModerateGroupChat = (
+	activeSession: GroupChatAuthorizationSession,
+	userData?: GroupChatAuthorizationUser
+): boolean =>
+	Boolean(
+		userData?.userId &&
+			(isGroupChatOwner(activeSession, userData) ||
+				activeSession.item?.moderators?.includes(userData.userId))
+	);
+
+interface GroupChatJoinViewOptions {
+	isGroup: boolean;
+	active?: boolean;
+	subscribed?: boolean;
+	isBanned: boolean;
+}
+
+export const shouldShowGroupChatJoinView = ({
+	isGroup,
+	active,
+	subscribed,
+	isBanned
+}: GroupChatJoinViewOptions): boolean =>
+	isGroup && (!active || !subscribed || isBanned);

--- a/src/components/groupChat/groupChatInfo.styles.scss
+++ b/src/components/groupChat/groupChatInfo.styles.scss
@@ -275,3 +275,22 @@ $inputMaxWidth: 500px;
 		}
 	}
 }
+
+.groupChatInfo__roles {
+	margin-top: 24px;
+	display: grid;
+	gap: 12px;
+}
+
+.groupChatInfo__roleRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+
+	select,
+	button {
+		min-height: 40px;
+	}
+}

--- a/src/components/groupChat/groupChatWaitingArea.test.ts
+++ b/src/components/groupChat/groupChatWaitingArea.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getWaitingAreaTime } from './groupChatWaitingArea';
+
+describe('getWaitingAreaTime', () => {
+	it('keeps counting negatively after the planned start', () => {
+		const result = getWaitingAreaTime(
+			new Date('2026-08-04T18:07:00Z'),
+			new Date('2026-08-04T18:00:00Z')
+		);
+
+		expect(result.signedMinutes).toBe(-7);
+		expect(result.label).toBe('-00:07');
+		expect(result.discomfortEmoji).toBe('😬');
+		expect(result.pills).toEqual([
+			{ kind: 'dog', value: 49 },
+			{ kind: 'cat', value: 32 },
+			{ kind: 'roman', value: 'VII' }
+		]);
+	});
+});

--- a/src/components/groupChat/groupChatWaitingArea.ts
+++ b/src/components/groupChat/groupChatWaitingArea.ts
@@ -1,0 +1,70 @@
+export interface WaitingAreaTime {
+	signedMinutes: number;
+	label: string;
+	discomfortEmoji: string;
+	pills: Array<{
+		kind: 'dog' | 'cat' | 'roman';
+		value: number | string;
+	}>;
+}
+
+const roman = (value: number): string => {
+	if (value <= 0) return '0';
+	const numerals: Array<[number, string]> = [
+		[100, 'C'],
+		[90, 'XC'],
+		[50, 'L'],
+		[40, 'XL'],
+		[10, 'X'],
+		[9, 'IX'],
+		[5, 'V'],
+		[4, 'IV'],
+		[1, 'I']
+	];
+	let remaining = Math.min(value, 399);
+	let result = '';
+	for (const [amount, symbol] of numerals) {
+		while (remaining >= amount) {
+			result += symbol;
+			remaining -= amount;
+		}
+	}
+	return result;
+};
+
+export const getWaitingAreaTime = (
+	now: Date,
+	plannedStart: Date
+): WaitingAreaTime => {
+	const signedMinutes = Math.ceil(
+		(plannedStart.getTime() - now.getTime()) / 60_000
+	);
+	const absoluteMinutes = Math.abs(signedMinutes);
+	const hours = Math.floor(absoluteMinutes / 60)
+		.toString()
+		.padStart(2, '0');
+	const minutes = (absoluteMinutes % 60).toString().padStart(2, '0');
+	const label = `${signedMinutes < 0 ? '-' : ''}${hours}:${minutes}`;
+	const discomfortEmoji =
+		signedMinutes <= -15
+			? '😵'
+			: signedMinutes <= -5
+				? '😬'
+				: signedMinutes < 0
+					? '😅'
+					: '🙂';
+
+	return {
+		signedMinutes,
+		label,
+		discomfortEmoji,
+		pills: [
+			{ kind: 'dog', value: absoluteMinutes * 7 },
+			{
+				kind: 'cat',
+				value: Math.max(1, Math.round(absoluteMinutes * 4.5))
+			},
+			{ kind: 'roman', value: roman(absoluteMinutes) }
+		]
+	};
+};

--- a/src/components/groupChat/joinChat.styles.scss
+++ b/src/components/groupChat/joinChat.styles.scss
@@ -40,6 +40,35 @@
 		}
 	}
 
+	&__countdown {
+		width: min(100%, $grid-base * 56);
+		text-align: center;
+		margin: $grid-base-two 0;
+	}
+
+	&__countdownValue {
+		display: block;
+		font-size: clamp(2.5rem, 10vw, 5rem);
+		font-variant-numeric: tabular-nums;
+		line-height: 1;
+	}
+
+	&__timePills {
+		display: flex;
+		gap: $grid-base;
+		overflow-x: auto;
+		padding: $grid-base-two 0;
+		scroll-snap-type: x proximity;
+
+		span {
+			flex: 0 0 auto;
+			padding: $grid-base $grid-base-two;
+			border-radius: 999px;
+			background: var(--m3-secondary-container, #e0e7ef);
+			scroll-snap-align: start;
+		}
+	}
+
 	&__button-container {
 		text-align: center;
 		padding: $grid-base-six $grid-base-four;

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -20,6 +20,7 @@ import {
 	isKnownEventType
 } from './eventDescriptors';
 import { EventFamily } from './eventDescriptors/types';
+import { resolveNotificationActionPath } from './notificationActionTarget';
 import { useActiveListItem } from '../../hooks/useActiveListItem';
 import { pickActiveItemKey } from '../../utils/listItemSelection';
 import {
@@ -120,8 +121,14 @@ const describeItem = (
 };
 
 const resolveSessionId = (item: any): string | null => {
-	if (item?.sourceSessionId) {
+	if (item?.sourceSessionId != null) {
 		return String(item.sourceSessionId);
+	}
+	if (item?.params?.sourceSessionId != null) {
+		return String(item.params.sourceSessionId);
+	}
+	if (item?.params?.seriesId != null) {
+		return String(item.params.seriesId);
 	}
 	const path = item?.actionPath;
 	if (!path) {
@@ -351,6 +358,13 @@ export const NotificationsCenter = () => {
 				: '/sessions/user/view',
 		[userData]
 	);
+	const getNotificationActionPath = useCallback(
+		(item: (typeof notificationFeed)[number]) =>
+			toNonEmbeddedPath(
+				resolveNotificationActionPath(item, getDefaultSessionsPath())
+			),
+		[getDefaultSessionsPath]
+	);
 	const embeddedChatPath = useMemo(() => {
 		if (!canShowChatPreview) {
 			return null;
@@ -406,7 +420,7 @@ export const NotificationsCenter = () => {
 	const openNotification = (item: (typeof notificationFeed)[number]) => {
 		markNotificationAsRead(item.id);
 		if (untilL) {
-			const directPath = toNonEmbeddedPath(item.actionPath);
+			const directPath = getNotificationActionPath(item);
 			if (directPath) {
 				navigate(directPath);
 				return;
@@ -427,7 +441,7 @@ export const NotificationsCenter = () => {
 		if (nextUnreadId && nextUnreadId !== selectedNotification.id) {
 			setSelectedNotificationId(nextUnreadId);
 		}
-		const directPath = toNonEmbeddedPath(selectedNotification.actionPath);
+		const directPath = getNotificationActionPath(selectedNotification);
 		if (directPath) {
 			navigate(directPath);
 			return;
@@ -804,7 +818,16 @@ export const NotificationsCenter = () => {
 						}}
 					>
 						{selectedNotification?.actionLabel ||
-							translate('notifications.center.open', 'Open chat')}
+							translate(
+								selectedNotification?.eventType ===
+									'group_chat.opened'
+									? 'notifications.center.join'
+									: 'notifications.center.open',
+								selectedNotification?.eventType ===
+									'group_chat.opened'
+									? 'Join'
+									: 'Open chat'
+							)}
 					</MenuItem>
 					<MenuItem
 						onClick={() => {

--- a/src/components/notificationsCenter/eventDescriptors/icons.tsx
+++ b/src/components/notificationsCenter/eventDescriptors/icons.tsx
@@ -22,6 +22,7 @@ import { ReactComponent as CallMissedIcon } from '../../../resources/img/icons/c
 import { ReactComponent as SupervisorIcon } from '../../../resources/img/icons/shield.svg';
 import { ReactComponent as RenameIcon } from '../../../resources/img/icons/pen.svg';
 import { ReactComponent as SystemIcon } from '../../../resources/img/icons/notification_bell.svg';
+import { ReactComponent as AppointmentIcon } from '../../../resources/img/icons/chat-booking.svg';
 import { EventIconId } from './types';
 
 type SvgIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
@@ -39,6 +40,7 @@ export const EVENT_ICONS: Record<EventIconId, SvgIcon> = {
 	callMissed: CallMissedIcon,
 	supervisor: SupervisorIcon,
 	rename: RenameIcon,
+	appointment: AppointmentIcon,
 	system: SystemIcon
 };
 

--- a/src/components/notificationsCenter/eventDescriptors/registry.test.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.test.ts
@@ -61,6 +61,7 @@ const KNOWN_ICON_IDS: EventIconId[] = [
 	'callMissed',
 	'supervisor',
 	'rename',
+	'appointment',
 	'system'
 ];
 
@@ -85,7 +86,10 @@ const EXPECTED_TARGET_KIND: Record<string, string> = {
 	'case.handover.consent.declined': 'conversation',
 	'call.started': 'join',
 	'call.ended': 'conversation',
-	'call.missed': 'conversation'
+	'call.missed': 'conversation',
+	'group_chat.reminder': 'conversation',
+	'group_chat.opened': 'groupChatJoin',
+	'group_chat.cancelled': 'conversation'
 };
 
 // Resolve a dotted i18n key against a loaded common.json object.
@@ -102,9 +106,9 @@ describe('WP-06 event-descriptor registry', () => {
 		});
 	});
 
-	it('seeds every designed family (Appointments deferred) — 20 types total', () => {
+	it('seeds group-chat lifecycle events in the appointments family', () => {
 		// 7 existing + request.new + draft.created + 8 handover + 3 call = 20.
-		expect(KNOWN_EVENT_TYPES.length).toBe(20);
+		expect(KNOWN_EVENT_TYPES.length).toBe(23);
 		[
 			'request.new',
 			'draft.created',
@@ -118,7 +122,10 @@ describe('WP-06 event-descriptor registry', () => {
 			'case.handover.consent.declined',
 			'call.started',
 			'call.ended',
-			'call.missed'
+			'call.missed',
+			'group_chat.reminder',
+			'group_chat.opened',
+			'group_chat.cancelled'
 		].forEach((type) => expect(isKnownEventType(type)).toBe(true));
 	});
 
@@ -158,8 +165,7 @@ describe('WP-06 event-descriptor registry', () => {
 				'system'
 			] as EventFamily[]
 		).forEach((fam) => expect(seededFamilies.has(fam)).toBe(true));
-		// Appointments family is declared but intentionally not seeded yet.
-		expect(seededFamilies.has('appointments')).toBe(false);
+		expect(seededFamilies.has('appointments')).toBe(true);
 	});
 
 	it('returns the fallback descriptor for unknown / empty types', () => {
@@ -202,6 +208,20 @@ describe('WP-06 event-descriptor registry', () => {
 			expect(target).toEqual({
 				kind: 'conversation',
 				path: '/sessions/user/view/session/7'
+			});
+		});
+
+		it('opens a group-chat occurrence through its stable series conversation', () => {
+			const target = getEventDescriptor(
+				'group_chat.opened'
+			).resolveActionTarget({
+				seriesId: 42,
+				sessionsBasePath: '/sessions/consultant/sessionView'
+			});
+
+			expect(target).toEqual({
+				kind: 'groupChatJoin',
+				path: '/sessions/consultant/sessionView/session/42'
 			});
 		});
 

--- a/src/components/notificationsCenter/eventDescriptors/registry.ts
+++ b/src/components/notificationsCenter/eventDescriptors/registry.ts
@@ -38,11 +38,20 @@ const buildConversationPath = (params: EventActionParams): string | null => {
 		const base = params.sessionsBasePath || DEFAULT_SESSIONS_BASE_PATH;
 		return `${base}/session/${params.sourceSessionId}`;
 	}
+	if (params.seriesId != null && params.seriesId !== '') {
+		const base = params.sessionsBasePath || DEFAULT_SESSIONS_BASE_PATH;
+		return `${base}/session/${params.seriesId}`;
+	}
 	return null;
 };
 
 const conversationTarget = (params: EventActionParams): EventActionTarget => ({
 	kind: 'conversation',
+	path: buildConversationPath(params)
+});
+
+const groupChatJoinTarget = (params: EventActionParams): EventActionTarget => ({
+	kind: 'groupChatJoin',
 	path: buildConversationPath(params)
 });
 
@@ -258,6 +267,29 @@ const seeds: EventDescriptor[] = [
 		category: 'system',
 		icon: 'callMissed',
 		i18nKey: 'callMissed',
+		resolveActionTarget: conversationTarget
+	}),
+
+	// ----- Self-help group occurrence lifecycle -----
+	descriptor('group_chat.reminder', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatReminder',
+		resolveActionTarget: conversationTarget
+	}),
+	descriptor('group_chat.opened', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatOpened',
+		resolveActionTarget: groupChatJoinTarget
+	}),
+	descriptor('group_chat.cancelled', {
+		family: 'appointments',
+		category: 'system',
+		icon: 'appointment',
+		i18nKey: 'groupChatCancelled',
 		resolveActionTarget: conversationTarget
 	})
 ];

--- a/src/components/notificationsCenter/eventDescriptors/types.ts
+++ b/src/components/notificationsCenter/eventDescriptors/types.ts
@@ -57,6 +57,7 @@ export type EventIconId =
 	| 'callMissed'
 	| 'supervisor'
 	| 'rename'
+	| 'appointment'
 	| 'system';
 
 /**
@@ -71,6 +72,8 @@ export interface EventActionParams {
 	actionPath?: string | null;
 	/** Session id the event belongs to, when known. */
 	sourceSessionId?: string | number | null;
+	/** Stable self-help group Series id, used when no materialized Session id exists. */
+	seriesId?: string | number | null;
 	/** Matrix room id / RC group id, when known. */
 	roomRef?: string | null;
 	/** Draft resume scope key (`forcedScopeKey`) for draft events. */
@@ -102,6 +105,7 @@ export interface EventActionParams {
  */
 export type EventActionTarget =
 	| { kind: 'conversation'; path: string | null }
+	| { kind: 'groupChatJoin'; path: string | null }
 	| { kind: 'request'; path: string | null }
 	| { kind: 'draft'; forcedScopeKey: string | null; path: string | null }
 	| { kind: 'join'; callRoomId: string | null; isVideo: boolean }

--- a/src/components/notificationsCenter/notificationActionTarget.test.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+	parseEventActionParams,
+	resolveNotificationActionPath
+} from './notificationActionTarget';
+
+describe('notification action targets', () => {
+	it('opens a group-chat lifecycle event at its stable Series conversation', () => {
+		const params = parseEventActionParams(
+			'{"seriesId":42,"occurrenceIndex":3,"roomRef":"!room:matrix.example"}'
+		);
+
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'group_chat.opened',
+					params
+				},
+				'/sessions/consultant/sessionView'
+			)
+		).toBe('/sessions/consultant/sessionView/session/42');
+	});
+
+	it('keeps a direct action path authoritative', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'message.new',
+					actionPath: '/sessions/user/view/session/7',
+					params: { seriesId: 42 }
+				},
+				'/sessions/consultant/sessionView'
+			)
+		).toBe('/sessions/user/view/session/7');
+	});
+
+	it('treats malformed params as absent instead of breaking the timeline', () => {
+		expect(parseEventActionParams('{not-json')).toEqual({});
+	});
+});

--- a/src/components/notificationsCenter/notificationActionTarget.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.ts
@@ -1,0 +1,70 @@
+import { getEventDescriptor } from './eventDescriptors';
+import { EventActionParams } from './eventDescriptors/types';
+
+type Identifier = string | number | null;
+
+interface NotificationActionInput {
+	eventType?: string | null;
+	actionPath?: string | null;
+	sourceSessionId?: Identifier;
+	params?: EventActionParams;
+}
+
+const isIdentifier = (value: unknown): value is Identifier =>
+	value === null || typeof value === 'string' || typeof value === 'number';
+
+const asNullableString = (value: unknown): string | null | undefined =>
+	value === null || typeof value === 'string'
+		? (value as string | null)
+		: undefined;
+
+/** Parse only the known, non-content fields accepted by action-target resolvers. */
+export const parseEventActionParams = (raw: unknown): EventActionParams => {
+	let value: unknown = raw;
+	if (typeof raw === 'string') {
+		try {
+			value = JSON.parse(raw);
+		} catch {
+			return {};
+		}
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return {};
+	}
+
+	const source = value as Record<string, unknown>;
+	const params: EventActionParams = {};
+	if (isIdentifier(source.sourceSessionId)) {
+		params.sourceSessionId = source.sourceSessionId;
+	}
+	if (isIdentifier(source.seriesId)) {
+		params.seriesId = source.seriesId;
+	}
+	params.roomRef = asNullableString(source.roomRef);
+	params.forcedScopeKey = asNullableString(source.forcedScopeKey);
+	params.threadRootId = asNullableString(source.threadRootId);
+	params.callRoomId = asNullableString(source.callRoomId);
+	if (typeof source.isVideo === 'boolean' || source.isVideo === null) {
+		params.isVideo = source.isVideo as boolean | null;
+	}
+	return params;
+};
+
+export const resolveNotificationActionPath = (
+	item: NotificationActionInput,
+	sessionsBasePath: string
+): string | null => {
+	const target = getEventDescriptor(item.eventType).resolveActionTarget({
+		...(item.params || {}),
+		actionPath: item.actionPath,
+		sourceSessionId: item.sourceSessionId,
+		sessionsBasePath
+	});
+
+	return target.kind === 'conversation' ||
+		target.kind === 'groupChatJoin' ||
+		target.kind === 'request' ||
+		target.kind === 'draft'
+		? target.path
+		: null;
+};

--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -31,6 +31,7 @@ import {
 import { GlobalComponentContext } from '../../globalState/provider/GlobalComponentContext';
 import {
 	redirectToApp,
+	getPostRegistrationGroupChatId,
 	POST_REGISTRATION_LOADER_KEY
 } from '../../components/registration/autoLogin';
 import { PreselectionBox } from './preselectionBox/PreselectionBox';
@@ -296,7 +297,9 @@ export const Registration = () => {
 			.filter((missingStep) => missingStep < currStepIndex);
 
 		if (missingPreviousSteps.length > 0) {
-			navigate(makeStepUrl(availableSteps[missingPreviousSteps[0]]?.name));
+			navigate(
+				makeStepUrl(availableSteps[missingPreviousSteps[0]]?.name)
+			);
 		}
 	}, [
 		availableSteps,
@@ -356,7 +359,9 @@ export const Registration = () => {
 						POST_REGISTRATION_LOADER_KEY,
 						'true'
 					);
-					redirectToApp();
+					redirectToApp(
+						getPostRegistrationGroupChatId(location.search)
+					);
 				})
 				.catch((error) => {
 					// console.error('Registration failed:', error);
@@ -387,7 +392,8 @@ export const Registration = () => {
 		addNotification,
 		t,
 		locale,
-		isRegistering
+		isRegistering,
+		location.search
 	]);
 
 	const handleSubmit = useCallback(
@@ -463,7 +469,8 @@ export const Registration = () => {
 										}}
 									>
 										{(() => {
-											const StepComponent = activeStep.component;
+											const StepComponent =
+												activeStep.component;
 											return (
 												<StepComponent
 													key={`${activeStep.name}-${clearSelectionVersion}`}

--- a/src/components/registration/autoLogin.test.ts
+++ b/src/components/registration/autoLogin.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { autoLogin } from './autoLogin';
+import { autoLogin, getPostRegistrationGroupChatId } from './autoLogin';
 import { getKeycloakAccessToken } from '../sessionCookie/getKeycloakAccessToken';
 import {
 	getMatrixAccessToken,
@@ -239,5 +239,19 @@ describe('autoLogin', () => {
 			'secret!',
 			{ featureToolsEnabled: true }
 		);
+	});
+});
+
+describe('getPostRegistrationGroupChatId', () => {
+	it('preserves the group chat deep link through registration', () => {
+		expect(
+			getPostRegistrationGroupChatId('?gcid=%21room%3Amatrix.localhost')
+		).toBe('!room:matrix.localhost');
+	});
+
+	it('returns undefined without a group chat deep link', () => {
+		expect(
+			getPostRegistrationGroupChatId('?topic=counseling')
+		).toBeUndefined();
 	});
 });

--- a/src/components/registration/autoLogin.ts
+++ b/src/components/registration/autoLogin.ts
@@ -157,6 +157,9 @@ export const autoLogin = async ({
 export const POST_REGISTRATION_LOADER_KEY =
 	'onlineBeratung_postRegistrationLoader';
 
+export const getPostRegistrationGroupChatId = (search: string) =>
+	new URLSearchParams(search).get('gcid') || undefined;
+
 export const redirectToApp = (gcid?: string) => {
 	const params = gcid ? `?gcid=${gcid}` : '';
 	window.location.href = appConfig.urls.redirectToApp + params;

--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -24,6 +24,7 @@ import { useSession } from '../../hooks/useSession';
 import { SessionStream } from './SessionStream';
 import { useSetAtom } from 'jotai';
 import { agencyLogoAtom } from '../../store/agencyLogoAtom';
+import { shouldShowGroupChatJoinView } from '../groupChat/groupChatHelpers';
 
 export const SessionView = () => {
 	const { rcGroupId: groupIdFromParam, sessionId: sessionIdFromParam } =
@@ -205,9 +206,12 @@ export const SessionView = () => {
 	// });
 
 	if (
-		activeSession.isGroup &&
-		(!activeSession.item.subscribed ||
-			bannedUsers.includes(userData.userName))
+		shouldShowGroupChatJoinView({
+			isGroup: activeSession.isGroup,
+			active: activeSession.item.active,
+			subscribed: activeSession.item.subscribed,
+			isBanned: bannedUsers.includes(userData.userName)
+		})
 	) {
 		// console.log('🔥 Showing JoinGroupChatView');
 		return (

--- a/src/components/session/getModality.test.ts
+++ b/src/components/session/getModality.test.ts
@@ -33,6 +33,13 @@ describe('getModality', () => {
 		expect(getModality(item)).toBe(Modality.SELF_HELP);
 	});
 
+	it('classifies a one-occurrence Series as SELF_HELP', () => {
+		const item = asItem({
+			chat: { repetitive: false, repeatCount: 1 }
+		});
+		expect(getModality(item)).toBe(Modality.SELF_HELP);
+	});
+
 	it('prefers an explicit backend conversationType over the heuristic', () => {
 		// looks like AGENCY_COUNSELLING by heuristic, but the backend says LIVE_CHAT
 		const item = asItem({

--- a/src/components/session/getModality.ts
+++ b/src/components/session/getModality.ts
@@ -55,7 +55,9 @@ export const getModality = (item?: ListItemInterface): Modality => {
 
 	// 2. Fallback heuristic (centralised here, deleted once the column is populated everywhere).
 	if (chat) {
-		return chat.repetitive ? Modality.SELF_HELP : Modality.INTERNAL_GROUP;
+		return chat.repeatCount !== undefined || chat.repetitive
+			? Modality.SELF_HELP
+			: Modality.INTERNAL_GROUP;
 	}
 	if (session) {
 		if (session.teamSession === true) {

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -92,6 +92,7 @@ describe('persistMatrixLoginData', () => {
 
 describe('getMatrixAccessToken', () => {
 	it('loads Matrix credentials from the API and uses the response device id', async () => {
+		localStorage.setItem('matrix_device_id', 'ORISO_WEB_EXISTING_DEVICE');
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
 			deviceId: 'RESPONSE_DEVICE',
@@ -108,14 +109,34 @@ describe('getMatrixAccessToken', () => {
 		});
 
 		expect(fetchData).toHaveBeenCalledWith({
-			url: 'https://api.example.test/service/matrix/me/token',
+			url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_WEB_EXISTING_DEVICE',
 			method: 'GET',
 			responseHandling: ['CATCH_ALL'],
 			recoverOnPublicAuthRoute: false
 		});
 	});
 
-	it('reuses a stored browser device id when the API omits one', async () => {
+	it('creates and sends a stable browser device id before requesting a token', async () => {
+		Object.defineProperty(globalThis, 'crypto', {
+			value: { randomUUID: () => '12345678-90ab-cdef-1234-567890abcdef' },
+			configurable: true
+		});
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_1234567890ABCDEF12345678',
+			userId: '@new-user:matrix.example.test'
+		});
+
+		await getMatrixAccessToken();
+
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_WEB_1234567890ABCDEF12345678'
+			})
+		);
+	});
+
+	it('rejects a token response without a device-bound identity', async () => {
 		localStorage.setItem(
 			'matrix_device_id:@user:matrix.example.test',
 			'STORED_DEVICE'
@@ -125,9 +146,9 @@ describe('getMatrixAccessToken', () => {
 			userId: '@user:matrix.example.test'
 		});
 
-		await expect(getMatrixAccessToken()).resolves.toMatchObject({
-			deviceId: 'STORED_DEVICE'
-		});
+		await expect(getMatrixAccessToken()).rejects.toThrow(
+			'Matrix login did not return a device-bound access token'
+		);
 	});
 
 	it('creates a browser device id when neither API nor storage has one', async () => {
@@ -137,6 +158,7 @@ describe('getMatrixAccessToken', () => {
 		});
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_1234567890ABCDEF12345678',
 			userId: '@new-user:matrix.example.test'
 		});
 
@@ -153,6 +175,7 @@ describe('getMatrixAccessToken', () => {
 	it('throws when Matrix homeserver URL is missing', async () => {
 		vi.mocked(fetchData).mockResolvedValue({
 			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
 			userId: '@user:matrix.example.test'
 		});
 		vi.mocked(getMatrixHomeserverUrl).mockReturnValue('');

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -31,11 +31,12 @@ const getOrCreateMatrixDeviceId = (
 	userId: string,
 	responseDeviceId?: string
 ): string => {
+	const userStorageKey = `${MATRIX_DEVICE_ID_STORAGE_KEY}:${userId}`;
 	if (responseDeviceId) {
+		localStorage.setItem(userStorageKey, responseDeviceId);
 		return responseDeviceId;
 	}
 
-	const userStorageKey = `${MATRIX_DEVICE_ID_STORAGE_KEY}:${userId}`;
 	const storedDeviceId = localStorage.getItem(userStorageKey);
 	if (storedDeviceId) {
 		return storedDeviceId;
@@ -46,11 +47,28 @@ const getOrCreateMatrixDeviceId = (
 	return deviceId;
 };
 
+const getOrCreateRequestedDeviceId = (): string => {
+	const storedDeviceId = localStorage.getItem(MATRIX_DEVICE_ID_STORAGE_KEY);
+	if (storedDeviceId) {
+		return storedDeviceId;
+	}
+
+	const deviceId = createBrowserDeviceId();
+	localStorage.setItem(MATRIX_DEVICE_ID_STORAGE_KEY, deviceId);
+	return deviceId;
+};
+
 export const getMatrixAccessToken = (
 	_username?: string,
 	_password?: string
 ): Promise<MatrixLoginData> => {
-	const tokenUrl = endpoints.matrixAccessToken;
+	const requestedDeviceId = getOrCreateRequestedDeviceId();
+	const querySeparator = endpoints.matrixAccessToken.includes('?')
+		? '&'
+		: '?';
+	const tokenUrl = `${endpoints.matrixAccessToken}${querySeparator}deviceId=${encodeURIComponent(
+		requestedDeviceId
+	)}`;
 	return fetchData({
 		url: tokenUrl,
 		method: FETCH_METHODS.GET,
@@ -61,6 +79,11 @@ export const getMatrixAccessToken = (
 		if (!homeserverUrl) {
 			throw new Error(
 				'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			);
+		}
+		if (!response.accessToken || !response.userId || !response.deviceId) {
+			throw new Error(
+				'Matrix login did not return a device-bound access token'
 			);
 		}
 

--- a/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.test.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { groupChatCallCapabilities } from './groupChatCallCapabilities';
+
+describe('groupChatCallCapabilities', () => {
+	it.each([
+		['TEXT', false, false],
+		['AUDIO', true, false],
+		['VIDEO', true, true]
+	] as const)(
+		'%s modality exposes the intended controls',
+		(modality, audio, video) => {
+			expect(groupChatCallCapabilities(modality)).toEqual({
+				audio,
+				video
+			});
+		}
+	);
+});

--- a/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatCallCapabilities.ts
@@ -1,0 +1,9 @@
+export const groupChatCallCapabilities = (
+	modality?: 'TEXT' | 'AUDIO' | 'VIDEO'
+): { audio: boolean; video: boolean } => {
+	if (!modality) return { audio: true, video: true };
+	return {
+		audio: modality === 'AUDIO' || modality === 'VIDEO',
+		video: modality === 'VIDEO'
+	};
+};

--- a/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.test.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowGroupChatMenu } from './groupChatHeaderMenu';
+
+describe('shouldShowGroupChatMenu', () => {
+	it('shows the menu to consultants in an active joined group chat', () => {
+		expect(
+			shouldShowGroupChatMenu({
+				isActive: true,
+				isJoinGroupChatView: false
+			})
+		).toBe(true);
+	});
+
+	it('shows the menu to askers in an active joined group chat', () => {
+		expect(
+			shouldShowGroupChatMenu({
+				isActive: true,
+				isJoinGroupChatView: false
+			})
+		).toBe(true);
+	});
+
+	it.each([
+		{ isActive: false, isJoinGroupChatView: false },
+		{ isActive: true, isJoinGroupChatView: true }
+	])('hides the menu when the active joined view is unavailable', (state) => {
+		expect(shouldShowGroupChatMenu(state)).toBe(false);
+	});
+});

--- a/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.ts
+++ b/src/components/sessionHeader/GroupChatHeader/groupChatHeaderMenu.ts
@@ -1,0 +1,9 @@
+interface GroupChatMenuState {
+	isActive: boolean;
+	isJoinGroupChatView: boolean;
+}
+
+export const shouldShowGroupChatMenu = ({
+	isActive,
+	isJoinGroupChatView
+}: GroupChatMenuState) => isActive && !isJoinGroupChatView;

--- a/src/components/sessionHeader/GroupChatHeader/index.tsx
+++ b/src/components/sessionHeader/GroupChatHeader/index.tsx
@@ -19,6 +19,9 @@ import { RoomMember } from 'matrix-js-sdk';
 import { UserAvatar } from '../../message/UserAvatar';
 import { getTenantSettings } from '../../../utils/tenantSettingsHelper';
 import { ChatroomMainInteractionIcon } from '../ChatroomMainInteractionIcon';
+import { groupChatCallCapabilities } from './groupChatCallCapabilities';
+import { SessionMenu } from '../../sessionMenu/SessionMenu';
+import { shouldShowGroupChatMenu } from './groupChatHeaderMenu';
 
 interface GroupChatHeaderProps {
 	hasUserInitiatedStopOrLeaveRequest: React.MutableRefObject<boolean>;
@@ -285,12 +288,17 @@ export const GroupChatHeader = ({
 	} = getTenantSettings();
 
 	const isCallsEnabled = featureCallsEnabled !== false;
+	const modalityCalls = groupChatCallCapabilities(
+		activeSession.item.modality
+	);
 	const isAudioCallsEnabled =
 		isCallsEnabled &&
+		modalityCalls.audio &&
 		featureAudioCallsEnabled !== false &&
 		featureAudioCallsGroupChatsEnabled !== false;
 	const isVideoCallsEnabled =
 		isCallsEnabled &&
+		modalityCalls.video &&
 		featureVideoCallsEnabled !== false &&
 		featureVideoCallsGroupChatsEnabled !== false;
 
@@ -431,7 +439,19 @@ export const GroupChatHeader = ({
 						</div>
 					)}
 
-				{/* Group header uses only inline call controls; hide flyout 3-dot menu here. */}
+				{shouldShowGroupChatMenu({
+					isActive,
+					isJoinGroupChatView
+				}) && (
+					<SessionMenu
+						hasUserInitiatedStopOrLeaveRequest={
+							hasUserInitiatedStopOrLeaveRequest
+						}
+						isAskerInfoAvailable={false}
+						isJoinGroupChatView={isJoinGroupChatView}
+						bannedUsers={bannedUsers}
+					/>
+				)}
 			</div>
 			{/* <div className="sessionInfo__metaInfo">
 			{activeSession.item.active &&

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -41,7 +41,10 @@ import {
 } from '../../api';
 import { logout } from '../logout/logout';
 import { mobileListView } from '../app/navigationHandler';
-import { isGroupChatOwner } from '../groupChat/groupChatHelpers';
+import {
+	canModerateGroupChat,
+	isGroupChatOwner
+} from '../groupChat/groupChatHelpers';
 import { ReactComponent as LeaveChatIcon } from '../../resources/img/icons/out.svg';
 import { ReactComponent as GroupChatInfoIcon } from '../../resources/img/icons/i.svg';
 import { ReactComponent as StopGroupChatIcon } from '../../resources/img/icons/x.svg';
@@ -564,6 +567,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 						className="sessionMenu__icon sessionMenu__icon--desktop"
 						aria-expanded={Boolean(flyoutOpen)}
 						aria-controls="flyout"
+						aria-label={translate('app.menu')}
 					>
 						<MenuVerticalIcon
 							title={translate('app.menu')}
@@ -577,6 +581,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 						className="sessionMenu__icon sessionMenu__icon--mobile"
 						aria-expanded={Boolean(flyoutOpen)}
 						aria-controls="flyout"
+						aria-label={translate('app.menu')}
 					>
 						<MenuVerticalIcon
 							title={translate('app.menu')}
@@ -958,7 +963,8 @@ const SessionMenuFlyoutGroup = ({
 				</Link>
 			)}
 			{activeSession.item.subscribed &&
-				hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) && (
+				hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) &&
+				canModerateGroupChat(activeSession, userData) && (
 					<div
 						onClick={handleStopGroupChat}
 						className="sessionMenu__item chatMenuDropdown__item sessionMenu__button"

--- a/src/components/sessionsList/FutureTimelinePanel.component.test.tsx
+++ b/src/components/sessionsList/FutureTimelinePanel.component.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetChatOccurrences,
+	apiSkipChatOccurrence
+} from '../../api/apiGetChatOccurrences';
+import { apiGetConsultantAppointments } from '../../api/apiGetConsultantAppointments';
+import { FutureTimelinePanel } from './FutureTimelinePanel';
+
+const translations: Record<string, string> = {
+	'groupChat.futureTimeline.appointmentFallback': 'Appointment',
+	'groupChat.futureTimeline.ariaLabel': 'Future timeline',
+	'groupChat.futureTimeline.empty': 'No upcoming events.',
+	'groupChat.futureTimeline.duplicate': 'Duplicate as one-off',
+	'groupChat.futureTimeline.groupChatFallback': 'Group chat',
+	'groupChat.futureTimeline.hide': 'Hide future events',
+	'groupChat.futureTimeline.loadMore': 'Load three more months',
+	'groupChat.futureTimeline.loading': 'Loading future events…',
+	'groupChat.futureTimeline.now': 'Now',
+	'groupChat.futureTimeline.revealAriaLabel': 'Reveal future timeline',
+	'groupChat.futureTimeline.show': 'Show future events',
+	'groupChat.futureTimeline.skip': 'Skip occurrence',
+	'groupChat.create.modality.options.audio': 'Audio'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key,
+		i18n: { language: 'en' }
+	})
+}));
+
+vi.mock('../../api/apiGetChatOccurrences', () => ({
+	apiGetChatOccurrences: vi.fn(),
+	apiSkipChatOccurrence: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock('../../api/apiGetConsultantAppointments', () => ({
+	apiGetConsultantAppointments: vi.fn()
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('FutureTimelinePanel', () => {
+	it('does not mix appointments into a filtered group-chat timeline', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([]);
+		vi.mocked(apiGetConsultantAppointments).mockResolvedValue([
+			{
+				id: 1,
+				title: 'Private appointment',
+				startTime: new Date(Date.now() + 60_000).toISOString()
+			} as never
+		]);
+
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group' }]}
+				consultantId="consultant-1"
+				includeAppointments={false}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		await screen.findByText('No upcoming events.');
+		expect(apiGetConsultantAppointments).not.toHaveBeenCalled();
+		expect(screen.queryByText('Private appointment')).toBeNull();
+	});
+
+	it('keeps group occurrences visible when the optional appointment service is unavailable', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 0,
+				occurrenceIndex: 1,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T17:30:00Z',
+				duration: 120,
+				capacity: 14,
+				modality: 'AUDIO'
+			}
+		]);
+		vi.mocked(apiGetConsultantAppointments).mockRejectedValue(
+			new Error('CATCH_ALL')
+		);
+
+		const { rerender } = render(
+			<FutureTimelinePanel
+				series={[{ id: 0, topic: 'Selbsthilfegruppe E2E' }]}
+				consultantId="consultant-1"
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		expect(await screen.findByText('Selbsthilfegruppe E2E')).toBeTruthy();
+		expect(screen.getByText(/Audio/)).toBeTruthy();
+
+		await act(async () => {
+			rerender(
+				<FutureTimelinePanel
+					series={[{ id: 0, topic: 'Selbsthilfegruppe E2E' }]}
+					consultantId="consultant-1"
+				/>
+			);
+		});
+
+		expect(apiGetChatOccurrences).toHaveBeenCalledTimes(1);
+		expect(apiGetConsultantAppointments).toHaveBeenCalledTimes(1);
+	});
+
+	it('lets an authorized moderator skip exactly one virtual occurrence', async () => {
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 42,
+				occurrenceIndex: 2,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T17:30:00Z',
+				duration: 60,
+				modality: 'TEXT'
+			}
+		]);
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group', canModerate: true }]}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+
+		fireEvent.click(
+			await screen.findByRole('button', { name: 'Skip occurrence' })
+		);
+
+		await act(async () => undefined);
+		expect(apiSkipChatOccurrence).toHaveBeenCalledWith(
+			42,
+			'2026-09-21T17:30:00Z'
+		);
+		expect(screen.queryByText('Peer group')).toBeNull();
+	});
+
+	it('hands a virtual occurrence to the one-off duplication flow', async () => {
+		const onDuplicateOccurrence = vi.fn();
+		vi.mocked(apiGetChatOccurrences).mockResolvedValue([
+			{
+				seriesId: 42,
+				occurrenceIndex: 1,
+				originalStart: '2026-09-21T17:30:00Z',
+				start: '2026-09-21T18:30:00Z',
+				duration: 90,
+				modality: 'VIDEO'
+			}
+		]);
+		render(
+			<FutureTimelinePanel
+				series={[{ id: 42, topic: 'Peer group', canModerate: true }]}
+				onDuplicateOccurrence={onDuplicateOccurrence}
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Show future events' })
+		);
+		fireEvent.click(
+			await screen.findByRole('button', { name: 'Duplicate as one-off' })
+		);
+
+		expect(onDuplicateOccurrence).toHaveBeenCalledWith(
+			expect.objectContaining({ seriesId: 42, duration: 90 }),
+			'Peer group'
+		);
+	});
+});

--- a/src/components/sessionsList/FutureTimelinePanel.test.ts
+++ b/src/components/sessionsList/FutureTimelinePanel.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { toSeriesApiTimestamp } from './futureTimelineTime';
+
+describe('toSeriesApiTimestamp', () => {
+	it('keeps the UTC offset required by the chat series API', () => {
+		expect(toSeriesApiTimestamp(new Date('2026-07-20T16:00:00Z'))).toBe(
+			'2026-07-20T16:00:00.000Z'
+		);
+	});
+});

--- a/src/components/sessionsList/FutureTimelinePanel.tsx
+++ b/src/components/sessionsList/FutureTimelinePanel.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+	apiGetChatOccurrences,
+	apiSkipChatOccurrence,
+	ChatOccurrence
+} from '../../api/apiGetChatOccurrences';
+import { apiGetConsultantAppointments } from '../../api/apiGetConsultantAppointments';
+import { BookingEventsInterface } from '../../globalState/interfaces';
+import { BookingsStatus } from '../../utils/consultant';
+import { toSeriesApiTimestamp } from './futureTimelineTime';
+import './futureTimelinePanel.styles';
+
+interface FutureTimelineSeries {
+	id: number;
+	topic: string;
+	canModerate?: boolean;
+}
+
+interface FutureTimelinePanelProps {
+	series: FutureTimelineSeries[];
+	consultantId?: string;
+	includeAppointments?: boolean;
+	onDuplicateOccurrence?: (occurrence: ChatOccurrence, topic: string) => void;
+}
+
+export const FutureTimelinePanel = ({
+	series,
+	consultantId,
+	includeAppointments = true,
+	onDuplicateOccurrence
+}: FutureTimelinePanelProps) => {
+	const { t: translate, i18n } = useTranslation();
+	const [expanded, setExpanded] = useState(false);
+	const [months, setMonths] = useState(3);
+	const [occurrences, setOccurrences] = useState<ChatOccurrence[]>([]);
+	const [appointments, setAppointments] = useState<BookingEventsInterface[]>(
+		[]
+	);
+	const [loading, setLoading] = useState(false);
+	const [commandError, setCommandError] = useState(false);
+	const seriesQueryKey = JSON.stringify(
+		series.map((item) => [item.id, item.topic, item.canModerate])
+	);
+	const seriesById = useMemo(
+		() => new Map(series.map((item) => [item.id, item])),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[seriesQueryKey]
+	);
+
+	useEffect(() => {
+		if (!expanded) {
+			setOccurrences([]);
+			setAppointments([]);
+			return;
+		}
+		const from = new Date();
+		const to = new Date(from);
+		to.setMonth(to.getMonth() + months);
+		setLoading(true);
+		Promise.all([
+			Promise.all(
+				series.map((item) =>
+					apiGetChatOccurrences(
+						item.id,
+						toSeriesApiTimestamp(from),
+						toSeriesApiTimestamp(to),
+						100
+					)
+				)
+			),
+			consultantId && includeAppointments
+				? apiGetConsultantAppointments(
+						consultantId,
+						BookingsStatus.ACTIVE
+					).catch(() => [])
+				: Promise.resolve([])
+		])
+			.then(([seriesItems, appointmentItems]) => {
+				setOccurrences(
+					seriesItems
+						.flat()
+						.sort(
+							(a, b) =>
+								new Date(a.start).getTime() -
+								new Date(b.start).getTime()
+						)
+				);
+				setAppointments(
+					appointmentItems.filter((appointment) => {
+						const start = new Date(appointment.startTime);
+						return start >= from && start < to;
+					})
+				);
+			})
+			.catch(() => setOccurrences([]))
+			.finally(() => setLoading(false));
+		// Session polling rebuilds equivalent arrays. Depend on semantic series identity so the
+		// expanded timeline does not refetch on every notification/list refresh.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [consultantId, expanded, includeAppointments, months, seriesQueryKey]);
+
+	const timelineItems = useMemo(
+		() =>
+			[
+				...occurrences.map((occurrence) => ({
+					key: `series-${occurrence.seriesId}-${occurrence.originalStart}`,
+					kind: 'occurrence' as const,
+					title:
+						seriesById.get(occurrence.seriesId)?.topic ||
+						translate('groupChat.futureTimeline.groupChatFallback'),
+					start: occurrence.start,
+					modality: occurrence.modality,
+					occurrence,
+					canModerate:
+						seriesById.get(occurrence.seriesId)?.canModerate ===
+						true
+				})),
+				...appointments.map((appointment) => ({
+					key: `appointment-${appointment.id}`,
+					kind: 'appointment' as const,
+					title:
+						appointment.title ||
+						translate(
+							'groupChat.futureTimeline.appointmentFallback'
+						),
+					start: appointment.startTime,
+					modality: appointment.location
+				}))
+			].sort(
+				(a, b) =>
+					new Date(a.start).getTime() - new Date(b.start).getTime()
+			),
+		[appointments, occurrences, seriesById, translate]
+	);
+
+	const skipOccurrence = async (occurrence: ChatOccurrence) => {
+		setCommandError(false);
+		try {
+			await apiSkipChatOccurrence(
+				occurrence.seriesId,
+				occurrence.originalStart
+			);
+			setOccurrences((current) =>
+				current.filter(
+					(item) =>
+						item.seriesId !== occurrence.seriesId ||
+						item.originalStart !== occurrence.originalStart
+				)
+			);
+		} catch {
+			setCommandError(true);
+		}
+	};
+
+	return (
+		<section
+			className="futureTimeline"
+			aria-label={translate('groupChat.futureTimeline.ariaLabel')}
+		>
+			<div className="futureTimeline__divider">
+				<span>{translate('groupChat.futureTimeline.now')}</span>
+				<input
+					type="range"
+					min="0"
+					max="1"
+					value={expanded ? 1 : 0}
+					onChange={(event) =>
+						setExpanded(event.target.value === '1')
+					}
+					aria-label={translate(
+						'groupChat.futureTimeline.revealAriaLabel'
+					)}
+				/>
+				<button
+					type="button"
+					onClick={() => setExpanded((value) => !value)}
+				>
+					{translate(
+						expanded
+							? 'groupChat.futureTimeline.hide'
+							: 'groupChat.futureTimeline.show'
+					)}
+				</button>
+			</div>
+			{expanded && (
+				<div className="futureTimeline__events" aria-live="polite">
+					{commandError && (
+						<p role="alert">
+							{translate('groupChat.futureTimeline.commandError')}
+						</p>
+					)}
+					{loading && (
+						<p>{translate('groupChat.futureTimeline.loading')}</p>
+					)}
+					{!loading && !timelineItems.length && (
+						<p>{translate('groupChat.futureTimeline.empty')}</p>
+					)}
+					{timelineItems.map((item) => (
+						<article key={item.key}>
+							<strong>{item.title}</strong>
+							<span>
+								{new Date(item.start).toLocaleString(
+									i18n.language
+								)}{' '}
+								·{' '}
+								{item.kind === 'occurrence'
+									? translate(
+											`groupChat.create.modality.options.${item.modality.toLowerCase()}`
+										)
+									: item.modality}
+							</span>
+							{item.kind === 'occurrence' && item.canModerate && (
+								<div className="futureTimeline__eventActions">
+									<button
+										type="button"
+										onClick={() =>
+											void skipOccurrence(item.occurrence)
+										}
+									>
+										{translate(
+											'groupChat.futureTimeline.skip'
+										)}
+									</button>
+									{onDuplicateOccurrence && (
+										<button
+											type="button"
+											onClick={() =>
+												onDuplicateOccurrence(
+													item.occurrence,
+													item.title
+												)
+											}
+										>
+											{translate(
+												'groupChat.futureTimeline.duplicate'
+											)}
+										</button>
+									)}
+								</div>
+							)}
+						</article>
+					))}
+					<button
+						type="button"
+						onClick={() => setMonths((value) => value + 3)}
+					>
+						{translate('groupChat.futureTimeline.loadMore')}
+					</button>
+				</div>
+			)}
+		</section>
+	);
+};

--- a/src/components/sessionsList/SessionListColumn.stories.tsx
+++ b/src/components/sessionsList/SessionListColumn.stories.tsx
@@ -143,6 +143,7 @@ function FullColumnPlayground() {
 					activeChip={chip}
 					onChipToggle={(c) => setChip((p) => (p === c ? null : c))}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 					archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"
@@ -220,6 +221,7 @@ function ToolbarCreateChatColumn() {
 					activeChip={null}
 					onChipToggle={() => {}}
 					showConsultantActions
+					showCreateGroupChatAction
 					showSupervisionChip={false}
 					createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 					archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -23,6 +23,7 @@ import {
 	SET_SESSIONS,
 	UPDATE_SESSIONS,
 	UserDataContext,
+	useTenant,
 	ActiveSessionProvider
 } from '../../globalState';
 import {
@@ -81,6 +82,9 @@ import {
 	REMOTE_DRAFT_INDEX_SCOPE
 } from '../../services/draftStore';
 import { isCaseHandoverCandidate } from '../session/caseHandoverHelpers';
+import { FutureTimelinePanel } from './FutureTimelinePanel';
+import { canModerateGroupChat } from '../groupChat/groupChatHelpers';
+import { ChatOccurrence } from '../../api/apiGetChatOccurrences';
 
 function buildSessionSearchHaystack(
 	raw: ListItemInterface,
@@ -393,6 +397,7 @@ export const SessionsList = ({
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
 
 	const { userData } = useContext(UserDataContext);
+	const tenantData = useTenant();
 
 	const [isLoading, setIsLoading] = useState(true);
 	const [currentOffset, setCurrentOffset] = useState(0);
@@ -1206,6 +1211,9 @@ export const SessionsList = ({
 	const showConsultantToolbarActions =
 		type === SESSION_LIST_TYPES.MY_SESSION &&
 		!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData);
+	const showCreateGroupChatAction =
+		showConsultantToolbarActions &&
+		tenantData?.settings?.featureGroupChatV2Enabled === true;
 	const showCaseHandoverBatchUi =
 		showConsultantToolbarActions &&
 		sessionListTab !== SESSION_LIST_TAB_ARCHIVE;
@@ -1778,6 +1786,39 @@ export const SessionsList = ({
 		(session?.rid && session.rid === groupIdFromParam) ||
 		(session?.item?.id !== undefined &&
 			String(session.item.id) === String(sessionIdFromParam || ''));
+	const futureTimelineSeries = React.useMemo(
+		() =>
+			sortedSessions
+				.filter(
+					(session) =>
+						session.isGroup &&
+						session.item.repeatCount !== undefined
+				)
+				.map((session) => ({
+					id: session.item.id,
+					canModerate: canModerateGroupChat(session, userData),
+					topic:
+						typeof session.item.topic === 'string'
+							? session.item.topic
+							: session.item.topic?.name || 'Group chat'
+				})),
+		[sortedSessions, userData]
+	);
+	const handleDuplicateOccurrence = React.useCallback(
+		(occurrence: ChatOccurrence, topic: string) => {
+			navigate(buildCreateGroupChatPath(sessionListTab || undefined), {
+				state: {
+					duplicateOccurrence: {
+						topic,
+						start: occurrence.start,
+						duration: occurrence.duration,
+						modality: occurrence.modality
+					}
+				}
+			});
+		},
+		[navigate, sessionListTab]
+	);
 
 	return (
 		<div className="sessionsList__innerWrapper">
@@ -1800,6 +1841,7 @@ export const SessionsList = ({
 					activeChip={isCreateChatActive ? null : sessionToolbarChip}
 					onChipToggle={handleToolbarChipToggle}
 					showConsultantActions={showConsultantToolbarActions}
+					showCreateGroupChatAction={showCreateGroupChatAction}
 					showSupervisionChip={showSupervisionChip}
 					/* Live-Chat chip shows on Gespräch too once the sidebar
 					   availability toggle is ON — it narrows the
@@ -1815,6 +1857,14 @@ export const SessionsList = ({
 					}
 					createGroupChatActive={isCreateChatActive}
 					chipCounts={toolbarChipCounts}
+				/>
+			)}
+			{showMySessionToolbar && futureTimelineSeries.length > 0 && (
+				<FutureTimelinePanel
+					series={futureTimelineSeries}
+					consultantId={userData.userId}
+					includeAppointments={sessionToolbarChip === null}
+					onDuplicateOccurrence={handleDuplicateOccurrence}
 				/>
 			)}
 			{showCaseHandoverBatchUi && (

--- a/src/components/sessionsList/SessionsListToolbar.stories.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.stories.tsx
@@ -83,6 +83,7 @@ function SessionsListToolbarPlayground({
 					setActiveChip((prev) => (prev === chip ? null : chip))
 				}
 				showConsultantActions={showConsultantActions}
+				showCreateGroupChatAction={showConsultantActions}
 				showSupervisionChip={showSupervisionChip}
 				showLiveChatChip
 				createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
@@ -151,6 +152,7 @@ function ToolbarWithSearchPreset() {
 					setActiveChip((p) => (p === chip ? null : chip))
 				}
 				showConsultantActions
+				showCreateGroupChatAction
 				showSupervisionChip
 				createGroupChatPath="/sessions/consultant/sessionView/createGroupChat"
 				archiveTabPath="/sessions/consultant/sessionView?sessionListTab=archive"

--- a/src/components/sessionsList/SessionsListToolbar.test.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionsListToolbar } from './SessionsListToolbar';
+
+vi.mock('./SessionToolbarFilterIcons', () => {
+	const Icon = () => <span aria-hidden />;
+	return {
+		ArchiveFilterIcon: Icon,
+		CreateChatFilterIcon: Icon,
+		DraftFilterIcon: Icon,
+		GroupFilterIcon: Icon,
+		InternalGroupFilterIcon: Icon,
+		LiveChatFilterIcon: Icon,
+		NearbyFilterIcon: Icon,
+		SupervisionFilterIcon: Icon,
+		UnreadFilterIcon: Icon
+	};
+});
+
+const renderToolbar = (showCreateGroupChatAction: boolean) =>
+	render(
+		<MemoryRouter>
+			<SessionsListToolbar
+				translate={(key) => key}
+				searchValue=""
+				onSearchChange={vi.fn()}
+				activeChip={null}
+				onChipToggle={vi.fn()}
+				showConsultantActions
+				showCreateGroupChatAction={showCreateGroupChatAction}
+				showSupervisionChip={false}
+				createGroupChatPath="/sessions/create"
+				archiveTabPath="/sessions/archive"
+				archiveTabActive={false}
+				createGroupChatActive={false}
+			/>
+		</MemoryRouter>
+	);
+
+describe('SessionsListToolbar group-chat feature gate', () => {
+	it('hides Create while preserving ordinary consultant actions when disabled', () => {
+		renderToolbar(false);
+
+		expect(
+			screen.queryByRole('link', {
+				name: 'sessionList.createChat.buttonTitle'
+			})
+		).toBeNull();
+		expect(
+			screen.getByRole('link', {
+				name: 'sessionList.view.archive.tab'
+			})
+		).toBeTruthy();
+	});
+
+	it('shows Create when the tenant enables the feature', () => {
+		renderToolbar(true);
+
+		expect(
+			screen.getByRole('link', {
+				name: 'sessionList.createChat.buttonTitle'
+			})
+		).toBeTruthy();
+	});
+});

--- a/src/components/sessionsList/SessionsListToolbar.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.tsx
@@ -28,6 +28,7 @@ interface SessionsListToolbarProps {
 	activeChip: SessionToolbarChipFilter | null;
 	onChipToggle: (chip: SessionToolbarChipFilter) => void;
 	showConsultantActions: boolean;
+	showCreateGroupChatAction: boolean;
 	showSupervisionChip: boolean;
 	/** Show the "Live-Chat" filter chip (tied to the sidebar availability toggle). */
 	showLiveChatChip?: boolean;
@@ -261,6 +262,7 @@ export const SessionsListToolbar = ({
 	activeChip,
 	onChipToggle,
 	showConsultantActions,
+	showCreateGroupChatAction,
 	showSupervisionChip,
 	showLiveChatChip = false,
 	createGroupChatPath,
@@ -643,7 +645,7 @@ export const SessionsListToolbar = ({
 				style={{ display: showSearchDropdown ? 'none' : undefined }}
 			>
 				<div className="sessionsListToolbar__chipsRow">
-					{showConsultantActions && (
+					{showCreateGroupChatAction && (
 						<Link
 							className={clsx('sessionsListToolbar__chip', {
 								'sessionsListToolbar__chip--iconOnly':

--- a/src/components/sessionsList/futureTimelinePanel.styles.scss
+++ b/src/components/sessionsList/futureTimelinePanel.styles.scss
@@ -1,0 +1,44 @@
+.futureTimeline {
+	padding: 8px 16px;
+	border-bottom: 1px solid var(--m3-outline-variant, #c8c5ca);
+
+	&__divider {
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: center;
+		gap: 8px;
+
+		input {
+			width: 100%;
+		}
+
+		button {
+			border: 0;
+			background: transparent;
+			text-decoration: underline;
+			cursor: pointer;
+		}
+	}
+
+	&__events {
+		display: grid;
+		gap: 8px;
+		padding-top: 12px;
+		max-height: 320px;
+		overflow-y: auto;
+
+		article {
+			display: flex;
+			flex-direction: column;
+			padding: 10px;
+			border-radius: 8px;
+			background: var(--m3-surface-container, #f1f3f5);
+		}
+	}
+}
+
+.futureTimeline__eventActions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}

--- a/src/components/sessionsList/futureTimelineTime.ts
+++ b/src/components/sessionsList/futureTimelineTime.ts
@@ -1,0 +1,1 @@
+export const toSeriesApiTimestamp = (date: Date): string => date.toISOString();

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -26,6 +26,9 @@ import { ReactComponent as HelpIcon } from '../../resources/img/icons/i.svg';
 import { ReactComponent as ImprintIcon } from '../../resources/img/icons/imprint.svg';
 import { ReactComponent as PlusIcon } from '../../resources/img/icons/plus.svg';
 import { ReactComponent as PackageIcon } from '../../resources/img/icons/documents.svg';
+import { ReactComponent as TextModalityIcon } from '../../resources/img/icons/chat.svg';
+import { ReactComponent as AudioModalityIcon } from '../../resources/img/icons/call.svg';
+import { ReactComponent as VideoModalityIcon } from '../../resources/img/icons/video-call.svg';
 import nearbyConversationIcon from '../../resources/img/icons/chatroom/nearby_conv_type_200.svg';
 import teamImage from '../../resources/img/illustrations/Team.svg';
 import {
@@ -61,6 +64,7 @@ import { parseMessagePrefixes } from '../message/messageConstants';
 import { useE2EE } from '../../hooks/useE2EE';
 import { useSearchParam } from '../../hooks/useSearchParams';
 import { SessionListItemLastMessage } from './SessionListItemLastMessage';
+import { getSessionNavigationPath } from './sessionsListItemHelpers';
 import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
 import { useTranslation } from 'react-i18next';
 import {
@@ -121,6 +125,12 @@ export const SessionListItemComponent = ({
 	const { isE2eeEnabled } = useContext(E2EEContext);
 	const activeSessionContext = useContext(ActiveSessionContext);
 	const activeSession = activeSessionContext?.activeSession;
+	const GroupModalityIcon =
+		activeSession?.item?.modality === 'VIDEO'
+			? VideoModalityIcon
+			: activeSession?.item?.modality === 'AUDIO'
+				? AudioModalityIcon
+				: TextModalityIcon;
 	const reloadActiveSession = activeSessionContext?.reloadActiveSession;
 	const sessionItem = activeSession?.item;
 	const { dispatch: sessionsDispatch } = useContext(SessionsDataContext);
@@ -514,32 +524,22 @@ export const SessionListItemComponent = ({
 		// isAsker: hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData)
 		// });
 
-		// For sessions without groupId (Matrix migration), navigate by session ID
 		if (activeSession.item.id !== undefined) {
-			// Check if groupId looks like a Matrix room ID (starts with ! or contains :)
-			const isMatrixRoomId = isMatrixRoomIdHeuristic(
-				activeSession.item.groupId
+			navigate(
+				getSessionNavigationPath({
+					listPath,
+					sessionId: activeSession.item.id,
+					groupId: activeSession.item.groupId,
+					rid: activeSession.rid,
+					isGroup: activeSession.isGroup,
+					isAsker: hasUserAuthority(
+						AUTHORITIES.ASKER_DEFAULT,
+						userData
+					),
+					isEmptyEnquiry: activeSession.isEmptyEnquiry,
+					tabSuffix: getSessionListTab()
+				})
 			);
-
-			if (activeSession.item.groupId && !isMatrixRoomId) {
-				// Original RocketChat behavior: navigate with groupId
-				const targetPath = `${listPath}/${activeSession.item.groupId}/${activeSession.item.id}${getSessionListTab()}`;
-				// console.log('🚀 Navigating with RocketChat groupId:', targetPath);
-				navigate(targetPath);
-			} else if (
-				hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) &&
-				activeSession.isEmptyEnquiry
-			) {
-				// Empty enquiry: go to write view
-				const targetPath = `/sessions/user/view/write/${activeSession.item.id}`;
-				// console.log('🚀 Navigating to write view:', targetPath);
-				navigate(targetPath);
-			} else {
-				// MATRIX MIGRATION FIX: Navigate by session ID for Matrix rooms or sessions without groupId
-				const targetPath = `${listPath}/session/${activeSession.item.id}${getSessionListTab()}`;
-				// console.log('🚀 Navigating by session ID (Matrix or no groupId):', targetPath);
-				navigate(targetPath);
-			}
 		}
 	};
 
@@ -1426,6 +1426,15 @@ export const SessionListItemComponent = ({
 								'sessionsListItem__username--readLabel'
 						)}
 					>
+						{activeSession.isGroup &&
+							activeSession.item.modality && (
+								<GroupModalityIcon
+									className="sessionsListItem__groupModalityIcon"
+									aria-label={translate(
+										`groupChat.create.modality.options.${activeSession.item.modality.toLowerCase()}`
+									)}
+								/>
+							)}
 						{sessionTopic}
 					</div>
 				</div>

--- a/src/components/sessionsListItem/sessionNavigationPath.test.ts
+++ b/src/components/sessionsListItem/sessionNavigationPath.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { getSessionNavigationPath } from './sessionsListItemHelpers';
+
+describe('getSessionNavigationPath', () => {
+	it('keeps Matrix group chats on the group-room route', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 1,
+				groupId: '!room:matrix.localhost',
+				isGroup: true,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/!room%3Amatrix.localhost/1');
+	});
+
+	it('falls back to the resolved room id for group chats', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 1,
+				groupId: undefined,
+				rid: '!resolved-room:matrix.localhost',
+				isGroup: true,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/!resolved-room%3Amatrix.localhost/1');
+	});
+
+	it('keeps ordinary Matrix sessions on the session-id route', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 4,
+				groupId: '!session:matrix.localhost',
+				isGroup: false,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/session/4');
+	});
+});

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -25,6 +25,12 @@ $case-handover-denied-bg: var(--m3-error-container, #f7d7d7);
 $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 .sessionsListItem {
+	&__groupModalityIcon {
+		width: 18px;
+		height: 18px;
+		margin-right: 6px;
+		vertical-align: text-bottom;
+	}
 	display: flex;
 	color: $body-font-color;
 	margin-bottom: 0px;

--- a/src/components/sessionsListItem/sessionsListItemHelpers.ts
+++ b/src/components/sessionsListItem/sessionsListItemHelpers.ts
@@ -2,6 +2,7 @@ import { ReactComponent as OpenEnvelopeIcon } from '../../resources/img/icons/en
 import { ReactComponent as GroupChatIcon } from '../../resources/img/icons/speech-bubble.svg';
 import { ReactComponent as NewEnquiryIcon } from '../../resources/img/icons/plus.svg';
 import { ReactComponent as ClosedEnvelopeIcon } from '../../resources/img/icons/envelope.svg';
+import { isMatrixRoomIdHeuristic } from '../../utils/matrixRoomUtils';
 
 export const LIST_ICONS = {
 	IS_READ: 'IS_READ',
@@ -21,4 +22,42 @@ export const getSessionsListItemIcon = (variant: string) => {
 		default:
 			return ClosedEnvelopeIcon;
 	}
+};
+
+interface SessionNavigationPathOptions {
+	listPath: string;
+	sessionId: number | string;
+	groupId?: string;
+	rid?: string;
+	isGroup: boolean;
+	isAsker: boolean;
+	isEmptyEnquiry: boolean;
+	tabSuffix: string;
+}
+
+export const getSessionNavigationPath = ({
+	listPath,
+	sessionId,
+	groupId,
+	rid,
+	isGroup,
+	isAsker,
+	isEmptyEnquiry,
+	tabSuffix
+}: SessionNavigationPathOptions) => {
+	const roomId = groupId ?? rid;
+
+	if (isGroup && roomId) {
+		return `${listPath}/${encodeURIComponent(roomId)}/${sessionId}${tabSuffix}`;
+	}
+
+	if (groupId && !isMatrixRoomIdHeuristic(groupId)) {
+		return `${listPath}/${groupId}/${sessionId}${tabSuffix}`;
+	}
+
+	if (isAsker && isEmptyEnquiry) {
+		return `/sessions/user/view/write/${sessionId}`;
+	}
+
+	return `${listPath}/session/${sessionId}${tabSuffix}`;
 };

--- a/src/generated/userservice.d.ts
+++ b/src/generated/userservice.d.ts
@@ -341,11 +341,24 @@ declare namespace UserService {
 			 * false
 			 */
 			repetitive: boolean;
+			repeatCount?: number;
+			chatInterval?:
+				| 'DAILY'
+				| 'WEEKLY'
+				| 'BIWEEKLY'
+				| 'MONTHLY'
+				| 'QUARTERLY'
+				| 'YEARLY';
+			modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+			timezone?: string;
 			/**
 			 * example:
 			 * Hint
 			 */
 			hintMessage?: string;
+			sourceLanguage?: string;
+			hintMessageTranslations?: Record<string, string>;
+			groupChatRulesTranslations?: Record<string, string[]>;
 		}
 		export interface ChatInfoResponseDTO {
 			/**
@@ -1947,6 +1960,11 @@ declare namespace UserService {
 			 */
 			tenantId?: number;
 		}
+		export interface GroupChatParticipantDTO {
+			consultantId: string;
+			role: 'OWNER' | 'CO_MODERATOR' | 'PARTICIPANT';
+			displayName: string;
+		}
 		export interface UserChatDTO {
 			/**
 			 * example:
@@ -1978,6 +1996,17 @@ declare namespace UserService {
 			 * false
 			 */
 			repetitive: boolean;
+			repeatCount?: number;
+			currentOccurrenceIndex?: number;
+			chatInterval?:
+				| 'DAILY'
+				| 'WEEKLY'
+				| 'BIWEEKLY'
+				| 'MONTHLY'
+				| 'QUARTERLY'
+				| 'YEARLY';
+			modality?: 'TEXT' | 'AUDIO' | 'VIDEO';
+			timezone?: string;
 			/**
 			 * example:
 			 * false
@@ -2016,6 +2045,7 @@ declare namespace UserService {
 			 */
 			subscribed?: boolean;
 			moderators?: string[];
+			participants?: GroupChatParticipantDTO[];
 			startDateWithTime?: string; // date-time
 			/**
 			 * example:
@@ -2028,6 +2058,9 @@ declare namespace UserService {
 			 * Hint
 			 */
 			hintMessage?: string;
+			sourceLanguage?: string;
+			hintMessageTranslations?: Record<string, string>;
+			groupChatRulesTranslations?: Record<string, string[]>;
 		}
 		export interface UserDTO {
 			/**

--- a/src/globalState/interfaces/SessionsDataInterface.ts
+++ b/src/globalState/interfaces/SessionsDataInterface.ts
@@ -99,6 +99,9 @@ export interface GroupChatItemInterface {
 	duration: number;
 	groupId: string;
 	hintMessage: string;
+	sourceLanguage?: string;
+	hintMessageTranslations?: Record<string, string>;
+	groupChatRulesTranslations?: Record<string, string[]>;
 	id: number;
 	lastMessage: string;
 	lastMessageType?: string;
@@ -109,9 +112,16 @@ export interface GroupChatItemInterface {
 	messageDate: number;
 	messagesRead: boolean;
 	moderators: string[];
+	participants?: UserService.Schemas.GroupChatParticipantDTO[];
 	repetitive: boolean;
+	repeatCount?: number;
+	currentOccurrenceIndex?: number;
+	chatInterval?: UserService.Schemas.UserChatDTO['chatInterval'];
+	modality?: UserService.Schemas.UserChatDTO['modality'];
+	timezone?: string;
 	startDate: string;
 	startTime: string;
+	startDateWithTime?: string;
 	subscribed: boolean;
 	topic: string;
 	createdAt: string;

--- a/src/globalState/provider/NotificationsProvider.tsx
+++ b/src/globalState/provider/NotificationsProvider.tsx
@@ -19,6 +19,8 @@ import {
 	apiMarkEventNotificationRead
 } from '../../api/apiEventNotifications';
 import { getValueFromCookie } from '../../components/sessionCookie/accessSessionCookie';
+import { EventActionParams } from '../../components/notificationsCenter/eventDescriptors';
+import { parseEventActionParams } from '../../components/notificationsCenter/notificationActionTarget';
 
 export const NOTIFICATION_DEFAULT_TIMEOUT = 3000;
 
@@ -80,6 +82,7 @@ export type NotificationFeedItem = {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: string;
+	params?: EventActionParams;
 	category: 'system' | 'message';
 };
 
@@ -92,6 +95,7 @@ export type EventNotificationInput = {
 	actionPath?: string;
 	actionLabel?: string;
 	sourceSessionId?: string | number;
+	params?: EventActionParams;
 };
 
 const NOTIFICATION_FEED_MAX_ITEMS = 50;
@@ -154,6 +158,7 @@ export function NotificationsProvider(props) {
 					item.sourceSessionId != null
 						? String(item.sourceSessionId)
 						: undefined,
+				params: parseEventActionParams(item.params),
 				category: item.category === 'message' ? 'message' : 'system'
 			}));
 			setNotificationFeed(normalized);
@@ -224,6 +229,7 @@ export function NotificationsProvider(props) {
 					event.sourceSessionId != null
 						? String(event.sourceSessionId)
 						: undefined,
+				params: event.params,
 				category: event.category === 'message' ? 'message' : 'system'
 			};
 			setNotificationFeed((existing) =>

--- a/src/hooks/useSession.test.tsx
+++ b/src/hooks/useSession.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetSessionRoomBySessionId,
+	apiGetSessionRoomsByGroupIds
+} from '../api/apiGetSessionRooms';
+import { apiGetChatRoomById } from '../api/apiGetChatRoomById';
+import { apiGetCaseHandoverCandidates } from '../api/apiCaseHandover';
+import { buildExtendedSession } from '../globalState';
+import { useSession } from './useSession';
+
+vi.mock('../api', () => ({
+	FETCH_ERRORS: { ABORT: 'ABORT' }
+}));
+
+vi.mock('../api/apiGetSessionRooms', () => ({
+	apiGetSessionRoomBySessionId: vi.fn(),
+	apiGetSessionRoomsByGroupIds: vi.fn()
+}));
+
+vi.mock('../api/apiGetChatRoomById', () => ({
+	apiGetChatRoomById: vi.fn()
+}));
+
+vi.mock('../api/apiCaseHandover', () => ({
+	apiGetCaseHandoverCandidates: vi.fn()
+}));
+
+vi.mock('../globalState', () => ({
+	buildExtendedSession: vi.fn()
+}));
+
+vi.mock('../services/chatTransportService', () => ({
+	chatTransportService: {
+		resolveSession: vi.fn(),
+		markRoomAsRead: vi.fn()
+	}
+}));
+
+describe('useSession', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('loads a valid zero-valued session id', async () => {
+		const rawSession = { session: { id: 0 } };
+		const extendedSession = { item: { id: 0 } };
+		vi.mocked(apiGetSessionRoomBySessionId).mockResolvedValue({
+			sessions: [rawSession]
+		} as any);
+		vi.mocked(buildExtendedSession).mockReturnValue(extendedSession as any);
+
+		const { result } = renderHook(() => useSession(null, 0));
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(apiGetSessionRoomBySessionId).toHaveBeenCalledWith(
+			0,
+			expect.any(AbortSignal)
+		);
+		expect(result.current.session).toBe(extendedSession);
+		expect(apiGetSessionRoomsByGroupIds).not.toHaveBeenCalled();
+		expect(apiGetChatRoomById).not.toHaveBeenCalled();
+		expect(apiGetCaseHandoverCandidates).not.toHaveBeenCalled();
+	});
+
+	it('loads a routed group chat by room id when both route params exist', async () => {
+		const rawSession = {
+			chat: { id: 1, groupId: '!room:matrix.localhost' }
+		};
+		const extendedSession = { item: rawSession.chat, isGroup: true };
+		vi.mocked(apiGetSessionRoomsByGroupIds).mockResolvedValue({
+			sessions: [rawSession]
+		} as any);
+		vi.mocked(buildExtendedSession).mockReturnValue(extendedSession as any);
+
+		const { result } = renderHook(() =>
+			useSession('!room:matrix.localhost', 1)
+		);
+
+		await waitFor(() => expect(result.current.ready).toBe(true));
+		expect(apiGetSessionRoomsByGroupIds).toHaveBeenCalledWith(
+			['!room:matrix.localhost'],
+			expect.any(AbortSignal)
+		);
+		expect(apiGetSessionRoomBySessionId).not.toHaveBeenCalled();
+		expect(result.current.session).toBe(extendedSession);
+	});
+});

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -26,7 +26,7 @@ export const useSession = (
 
 	const loadCaseHandoverCandidateSession = useCallback(
 		async (signal?: AbortSignal): Promise<boolean> => {
-			if (!sessionId) {
+			if (sessionId === undefined || sessionId === null) {
 				return false;
 			}
 
@@ -67,26 +67,30 @@ export const useSession = (
 
 		let promise;
 
-		if (!rid && !sessionId && !chatId) {
+		if (
+			!rid &&
+			(sessionId === undefined || sessionId === null) &&
+			(chatId === undefined || chatId === null)
+		) {
 			// console.log('⚠️ useSession: No rid, sessionId, or chatId provided - returning early');
 			return;
 		}
 
-		if (chatId) {
+		if (chatId !== undefined && chatId !== null) {
 			// console.log('🔍 useSession: Loading by chatId:', chatId);
 			promise = apiGetChatRoomById(
 				chatId,
 				abortController.current.signal
 			);
-		} else if (sessionId) {
+		} else if (rid) {
+			promise = apiGetSessionRoomsByGroupIds(
+				[rid],
+				abortController.current.signal
+			);
+		} else if (sessionId !== undefined && sessionId !== null) {
 			// console.log('🔍 useSession: Loading by sessionId:', sessionId);
 			promise = apiGetSessionRoomBySessionId(
 				sessionId,
-				abortController.current.signal
-			);
-		} else {
-			promise = apiGetSessionRoomsByGroupIds(
-				[rid],
 				abortController.current.signal
 			);
 		}
@@ -101,7 +105,8 @@ export const useSession = (
 					setSession(extendedSession);
 				} else {
 					if (
-						sessionId &&
+						sessionId !== undefined &&
+						sessionId !== null &&
 						(await loadCaseHandoverCandidateSession(
 							abortController.current?.signal
 						).catch(() => false))
@@ -126,7 +131,8 @@ export const useSession = (
 					);
 				}
 				if (
-					sessionId &&
+					sessionId !== undefined &&
+					sessionId !== null &&
 					(await loadCaseHandoverCandidateSession(
 						abortController.current?.signal
 					).catch(() => false))

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -614,6 +614,38 @@
 		}
 	},
 	"groupChat": {
+		"calendar": {
+			"add": "Zum Kalender hinzufügen",
+			"defaultTitle": "Online-Termin",
+			"download": "ICS herunterladen",
+			"google": "Google Kalender",
+			"outlook": "Outlook Kalender",
+			"titleLabel": "Neutraler Kalendertitel"
+		},
+		"futureTimeline": {
+			"appointmentFallback": "Termin",
+			"ariaLabel": "Zukünftige Termine",
+			"commandError": "Der Termin konnte nicht geändert werden. Bitte erneut versuchen.",
+			"duplicate": "Als Einzeltermin duplizieren",
+			"empty": "Keine bevorstehenden Termine.",
+			"groupChatFallback": "Gruppenchat",
+			"hide": "Zukünftige Termine ausblenden",
+			"loadMore": "Drei weitere Monate laden",
+			"loading": "Zukünftige Termine werden geladen…",
+			"now": "Jetzt",
+			"revealAriaLabel": "Zukünftige Termine anzeigen",
+			"show": "Zukünftige Termine anzeigen",
+			"skip": "Termin überspringen"
+		},
+		"roles": {
+			"CO_MODERATOR": "Co-Moderation",
+			"OWNER": "Eigentümer:in",
+			"PARTICIPANT": "Teilnehmende:r",
+			"headline": "Rollen im Beratungsteam",
+			"remove": "Aus der Gruppe entfernen",
+			"transfer": "Primäre Eigentümerschaft übertragen an",
+			"updateError": "Die Rolle konnte nicht aktualisiert werden. Bitte erneut versuchen."
+		},
 		"active": {
 			"sessionInfo": {
 				"subscriber": "Teilnehmende"
@@ -635,6 +667,30 @@
 			}
 		},
 		"create": {
+			"duration": "Dauer",
+			"interval": {
+				"label": "Intervall",
+				"options": {
+					"biweekly": "Alle zwei Wochen",
+					"daily": "Täglich",
+					"monthly": "Monatlich",
+					"quarterly": "Vierteljährlich",
+					"weekly": "Wöchentlich",
+					"yearly": "Jährlich"
+				}
+			},
+			"modality": {
+				"label": "Format",
+				"options": {
+					"audio": "Audio",
+					"text": "Text",
+					"video": "Video"
+				}
+			},
+			"repeatCount": "Termine",
+			"schedule": "Terminplanung",
+			"startDate": "Startdatum",
+			"startTime": "Startzeit",
 			"agencySelect": {
 				"label": "Beratungsstelle"
 			},
@@ -662,6 +718,18 @@
 			"hintMessage": {
 				"explanation": "Hinweis: Diese Informationen sind für alle Administrator:innen des Gruppenchats sichtbar.",
 				"label": "Hinweisfeld"
+			},
+			"authorContent": {
+				"title": "Begrüßung und Gruppenregeln",
+				"sourceLanguage": "Ausgangssprache",
+				"welcome": "Begrüßung (maximal 120 Zeichen)",
+				"rules": "Gruppenregeln",
+				"rule": "Regel",
+				"addRule": "Regel hinzufügen",
+				"removeRule": "Entfernen",
+				"translate": "In aktive Sprachen übersetzen",
+				"translating": "Wird übersetzt…",
+				"translationError": "Übersetzung fehlgeschlagen. Der Text wurde beibehalten; bitte erneut versuchen."
 			},
 			"listItem": {
 				"label": "Neuer Chat"
@@ -720,6 +788,12 @@
 			}
 		},
 		"join": {
+			"timeConversions": "Spielerische Zeitangaben",
+			"waitingArea": {
+				"catMinutes": "{{value}} Katzenminuten",
+				"dogMinutes": "{{value}} Hundeminuten",
+				"romanMinutes": "{{value}} Minuten"
+			},
 			"button": {
 				"label": {
 					"join": "Teilnehmen",
@@ -1445,6 +1519,18 @@
 			"callMissed": {
 				"title": "Verpasster Anruf",
 				"text": "Sie haben einen Anruf verpasst."
+			},
+			"groupChatReminder": {
+				"title": "Erinnerung an einen Online-Termin",
+				"text": "Ein Online-Termin steht bald an."
+			},
+			"groupChatOpened": {
+				"title": "Online-Termin geöffnet",
+				"text": "Der Online-Termin ist geöffnet. Sie können jetzt beitreten."
+			},
+			"groupChatCancelled": {
+				"title": "Online-Termin abgesagt",
+				"text": "Der Online-Termin wurde abgesagt."
 			}
 		},
 		"error": "Fehlgeschlagen",
@@ -1467,6 +1553,7 @@
 			"empty": "Noch keine Benachrichtigungen.",
 			"emptyDetail": "Wählen Sie eine Benachrichtigung aus, um Details zu sehen.",
 			"open": "Chat öffnen",
+			"join": "Beitreten",
 			"systemTag": "Systembenachrichtigung",
 			"messageTag": "Nachrichtenbenachrichtigung"
 		},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -602,6 +602,38 @@
 		}
 	},
 	"groupChat": {
+		"calendar": {
+			"add": "Add to calendar",
+			"defaultTitle": "Online appointment",
+			"download": "Download ICS",
+			"google": "Google Calendar",
+			"outlook": "Outlook Calendar",
+			"titleLabel": "Neutral calendar title"
+		},
+		"futureTimeline": {
+			"appointmentFallback": "Appointment",
+			"ariaLabel": "Future timeline",
+			"commandError": "The occurrence could not be changed. Please try again.",
+			"duplicate": "Duplicate as one-off",
+			"empty": "No upcoming events.",
+			"groupChatFallback": "Group chat",
+			"hide": "Hide future events",
+			"loadMore": "Load three more months",
+			"loading": "Loading future events…",
+			"now": "Now",
+			"revealAriaLabel": "Reveal future timeline",
+			"show": "Show future events",
+			"skip": "Skip occurrence"
+		},
+		"roles": {
+			"CO_MODERATOR": "Co-moderator",
+			"OWNER": "Owner",
+			"PARTICIPANT": "Participant",
+			"headline": "Counsellor roles",
+			"remove": "Remove from group",
+			"transfer": "Transfer primary ownership to",
+			"updateError": "The role could not be updated. Please try again."
+		},
 		"active": {
 			"sessionInfo": {
 				"subscriber": "Participants"
@@ -623,6 +655,30 @@
 			}
 		},
 		"create": {
+			"duration": "Duration",
+			"interval": {
+				"label": "Interval",
+				"options": {
+					"biweekly": "Every two weeks",
+					"daily": "Daily",
+					"monthly": "Monthly",
+					"quarterly": "Quarterly",
+					"weekly": "Weekly",
+					"yearly": "Yearly"
+				}
+			},
+			"modality": {
+				"label": "Format",
+				"options": {
+					"audio": "Audio",
+					"text": "Text",
+					"video": "Video"
+				}
+			},
+			"repeatCount": "Occurrences",
+			"schedule": "Schedule",
+			"startDate": "Start date",
+			"startTime": "Start time",
 			"agencySelect": {
 				"label": "Agency"
 			},
@@ -650,6 +706,18 @@
 			"hintMessage": {
 				"explanation": "Note: This information is visible to all administrators of the group chat.",
 				"label": "Note field"
+			},
+			"authorContent": {
+				"title": "Welcome and group rules",
+				"sourceLanguage": "Source language",
+				"welcome": "Welcome message (maximum 120 characters)",
+				"rules": "Group rules",
+				"rule": "Rule",
+				"addRule": "Add rule",
+				"removeRule": "Remove",
+				"translate": "Translate into active languages",
+				"translating": "Translating…",
+				"translationError": "Translation failed. Your text was kept; please try again."
 			},
 			"listItem": {
 				"label": "New chat"
@@ -706,6 +774,12 @@
 			}
 		},
 		"join": {
+			"timeConversions": "Playful time conversions",
+			"waitingArea": {
+				"catMinutes": "{{value}} cat minutes",
+				"dogMinutes": "{{value}} dog minutes",
+				"romanMinutes": "{{value}} minutes"
+			},
 			"button": {
 				"label": {
 					"join": "Join",
@@ -1421,6 +1495,18 @@
 			"callMissed": {
 				"title": "Missed call",
 				"text": "You missed a call."
+			},
+			"groupChatReminder": {
+				"title": "Online appointment reminder",
+				"text": "An online appointment is coming up."
+			},
+			"groupChatOpened": {
+				"title": "Online appointment opened",
+				"text": "The online appointment is open. Join when you are ready."
+			},
+			"groupChatCancelled": {
+				"title": "Online appointment cancelled",
+				"text": "The online appointment was cancelled."
 			}
 		},
 		"error": "failed",
@@ -1443,6 +1529,7 @@
 			"empty": "No notifications yet.",
 			"emptyDetail": "Select a notification to see the details.",
 			"open": "Open chat",
+			"join": "Join",
 			"systemTag": "System notification",
 			"messageTag": "Message notification"
 		},

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -82,6 +82,7 @@ export const endpoints = {
 	email: userServiceOrigin + '/service/users/email',
 	error: apiUrl + '/service/logstash',
 	groupChatBase: userServiceOrigin + '/service/users/chat/',
+	chatSeriesBase: userServiceOrigin + '/service/users/chat-series/',
 	keycloakAccessToken:
 		keycloakOrigin + getKeycloakAuthPath('/protocol/openid-connect/token'),
 	keycloakLogout:

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,5 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getMatrixAccessToken } from '../components/sessionCookie/getMatrixAccessToken';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import { MatrixClientService } from './matrixClientService';
+
+const mockedMatrixClient = vi.hoisted(() => ({
+	initRustCrypto: vi.fn(),
+	on: vi.fn(),
+	removeAllListeners: vi.fn(),
+	startClient: vi.fn(),
+	stopClient: vi.fn()
+}));
+
+vi.mock('../components/sessionCookie/getMatrixAccessToken', () => ({
+	createMatrixClient: vi.fn(() => mockedMatrixClient),
+	getMatrixAccessToken: vi.fn(),
+	persistMatrixLoginData: vi.fn()
+}));
 
 vi.hoisted(() => {
 	process.env.REACT_APP_KEYCLOAK_REALM = 'oriso';
@@ -31,9 +47,88 @@ const setClient = (
 
 describe('MatrixClientService', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		vi.stubGlobal('localStorage', {
 			getItem: vi.fn(() => null)
 		});
+	});
+
+	it('initializes Rust crypto before registering sync and starting the client', async () => {
+		const callOrder: string[] = [];
+		mockedMatrixClient.initRustCrypto.mockImplementation(async () => {
+			callOrder.push('crypto');
+		});
+		mockedMatrixClient.on.mockImplementation(() => {
+			callOrder.push('listener');
+		});
+		mockedMatrixClient.startClient.mockImplementation(() => {
+			callOrder.push('start');
+		});
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+
+		expect(callOrder).toEqual(['crypto', 'listener', 'start']);
+		expect(mockedMatrixClient.initRustCrypto).toHaveBeenCalledWith({
+			useIndexedDB: true,
+			cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+				'@alice:matrix.localhost',
+				'DEVICE_ONE'
+			)
+		});
+	});
+
+	it('surfaces Rust crypto failures without leaving a client running', async () => {
+		mockedMatrixClient.initRustCrypto.mockRejectedValueOnce(
+			new Error('crypto store unavailable')
+		);
+		const service = new MatrixClientService();
+
+		await expect(
+			service.initializeClient({
+				userId: '@alice:matrix.localhost',
+				accessToken: 'access-token',
+				deviceId: 'DEVICE_ONE',
+				homeserverUrl: 'http://matrix.localhost:18008'
+			})
+		).rejects.toThrow('crypto store unavailable');
+
+		expect(mockedMatrixClient.on).not.toHaveBeenCalled();
+		expect(mockedMatrixClient.startClient).not.toHaveBeenCalled();
+		expect(service.getClient()).toBeNull();
+	});
+
+	it('waits for replacement-client crypto initialization during token refresh', async () => {
+		let resolveCrypto: (() => void) | undefined;
+		mockedMatrixClient.initRustCrypto.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolveCrypto = resolve;
+			})
+		);
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'replacement-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const service = new MatrixClientService();
+
+		let refreshCompleted = false;
+		const refresh = service.refreshMatrixToken().then(() => {
+			refreshCompleted = true;
+		});
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+		expect(refreshCompleted).toBe(false);
+		expect(mockedMatrixClient.startClient).not.toHaveBeenCalled();
+		resolveCrypto?.();
+		await refresh;
+		expect(mockedMatrixClient.startClient).toHaveBeenCalledOnce();
 	});
 
 	it('sends Matrix messages in migration rooms without native Matrix encryption state', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -6,6 +6,7 @@ import {
 	persistMatrixLoginData
 } from '../components/sessionCookie/getMatrixAccessToken';
 import { matrixCallService } from './matrixCallService';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import { matrixLiveEventBridge } from './matrixLiveEventBridge';
 import { encryptMatrixAttachment } from '../utils/matrixEncryptedAttachment';
 import { buildMatrixRoomEncryptionInitialState } from '../utils/matrixRoomEncryption';
@@ -94,7 +95,7 @@ export class MatrixClientService {
 	private syncStateListeners = new Set<(state: string | null) => void>();
 
 	// Initialize client with login data
-	public initializeClient(loginData: MatrixLoginData): void {
+	public async initializeClient(loginData: MatrixLoginData): Promise<void> {
 		this.stopCurrentClient();
 		this.loginData = loginData;
 		this.client = createMatrixClient(loginData);
@@ -108,6 +109,18 @@ export class MatrixClientService {
 		// console.log('🔧 Matrix client will fetch TURN/STUN servers from homeserver');
 
 		const client = this.client;
+		try {
+			await client.initRustCrypto({
+				useIndexedDB: true,
+				cryptoDatabasePrefix: buildMatrixCryptoStorePrefix(
+					loginData.userId,
+					loginData.deviceId
+				)
+			});
+		} catch (error) {
+			this.stopCurrentClient();
+			throw error;
+		}
 
 		(client as any).on(
 			'sync',
@@ -161,9 +174,9 @@ export class MatrixClientService {
 		}
 
 		this.refreshingToken = getMatrixAccessToken()
-			.then((loginData) => {
+			.then(async (loginData) => {
 				persistMatrixLoginData(loginData);
-				this.initializeClient(loginData);
+				await this.initializeClient(loginData);
 			})
 			.finally(() => {
 				this.refreshingToken = null;

--- a/src/services/matrixCrypto.test.ts
+++ b/src/services/matrixCrypto.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
+
+describe('buildMatrixCryptoStorePrefix', () => {
+	it('returns a deterministic and storage-safe prefix per Matrix device', () => {
+		const first = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE/ONE'
+		);
+		const repeated = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE/ONE'
+		);
+		const secondDevice = buildMatrixCryptoStorePrefix(
+			'@alice:matrix.localhost',
+			'DEVICE:TWO'
+		);
+
+		expect(first).toBe(repeated);
+		expect(first).not.toBe(secondDevice);
+		expect(first).toMatch(/^oriso-matrix-[a-f0-9]+-[a-f0-9]+$/);
+	});
+
+	it.each([
+		['', 'DEVICE_ONE'],
+		['@alice:matrix.localhost', '']
+	])(
+		'rejects a missing Matrix user or device identity',
+		(userId, deviceId) => {
+			expect(() =>
+				buildMatrixCryptoStorePrefix(userId, deviceId)
+			).toThrow(
+				'Matrix user ID and device ID are required for the crypto store'
+			);
+		}
+	);
+});

--- a/src/services/matrixCrypto.ts
+++ b/src/services/matrixCrypto.ts
@@ -1,0 +1,19 @@
+const encodeStorageSegment = (value: string): string =>
+	Array.from(new TextEncoder().encode(value), (byte) =>
+		byte.toString(16).padStart(2, '0')
+	).join('');
+
+export const buildMatrixCryptoStorePrefix = (
+	userId: string,
+	deviceId: string
+): string => {
+	if (!userId.trim() || !deviceId.trim()) {
+		throw new Error(
+			'Matrix user ID and device ID are required for the crypto store'
+		);
+	}
+
+	return `oriso-matrix-${encodeStorageSegment(userId)}-${encodeStorageSegment(
+		deviceId
+	)}`;
+};

--- a/vite.matrix-smoke.config.ts
+++ b/vite.matrix-smoke.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vite';
+import { createReadStream } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+	plugins: [
+		{
+			name: 'matrix-smoke-wasm',
+			configureServer(server) {
+				server.middlewares.use((request, response, next) => {
+					if (
+						request.url !==
+						'/node_modules/.vite/deps/pkg/matrix_sdk_crypto_wasm_bg.wasm'
+					) {
+						next();
+						return;
+					}
+					response.setHeader('Content-Type', 'application/wasm');
+					const root = dirname(fileURLToPath(import.meta.url));
+					createReadStream(
+						resolve(
+							root,
+							'node_modules/@matrix-org/matrix-sdk-crypto-wasm/pkg/matrix_sdk_crypto_wasm_bg.wasm'
+						)
+					).pipe(response);
+				});
+			}
+		}
+	]
+});


### PR DESCRIPTION
## Summary

- initialize Matrix Rust crypto before listeners and sync, including reload/token-refresh recovery
- add finite Series controls, future timeline, waiting area, roles, calendar actions, and multilingual author content
- preserve self-help deep links through pseudonymous registration and Matrix-native join
- expose permission-aware room actions for consultants and askers
- add notification action targets and consultant-initiated group-call capabilities

## Why

This is the Frontend vertical slice for #396. It extends the existing Matrix group-chat UX with the complete self-help group lifecycle instead of building a parallel chat surface.

## Verification

- 94 test files / 518 tests: green
- ESLint, TypeScript, Stylelint, and production build: green
- Matrix Megolm smoke under the pinned Node 22 runtime: green
- desktop/mobile Matrix reload smoke: 2/2 green
- real browser: two consultants and two freshly registered askers, waiting area, encrypted room, participant leave, reload persistence, and final room removal
- based on and targeting `pre-dev`

## Deployment dependency

ORISO-Helm `pre-dev` commit `9d3c4e3` provides the stable `matrix.oriso-dev.site` identity and UserService encryption rollout flag.

Refs #400
Refs #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
