### PR TITLE
feat: role-based avatars and reponsive chat icon

### DIFF
--- a/src/components/message/Appointment.tsx
+++ b/src/components/message/Appointment.tsx
@@ -93,7 +93,9 @@ export const Appointment = (param: {
 			/>
 			<div className="appointmentSet">
 				<div className="appointmentSet--flex">
-					{appointmentIcon}
+					<span className="appointmentSet__titleIcon">
+						{appointmentIcon}
+					</span>
 					<Headline
 						semanticLevel="5"
 						text={appointmentTitle}

--- a/src/components/message/MessageAvatar.stories.tsx
+++ b/src/components/message/MessageAvatar.stories.tsx
@@ -16,10 +16,6 @@ const meta: Meta<typeof MessageAvatar> = {
 			control: 'boolean',
 			description: 'Whether the active session is a group chat'
 		},
-		isUserMessage: {
-			control: 'boolean',
-			description: 'Whether the message is from the client/asker'
-		},
 		isSystemNotification: {
 			control: 'boolean',
 			description: 'System notifications render no avatar here'
@@ -51,8 +47,7 @@ const baseIdentity = {
 export const ClientIn1on1Chat: Story = {
 	args: {
 		...baseIdentity,
-		isGroup: false,
-		isUserMessage: true
+		isGroup: false
 	},
 	play: async ({ canvasElement }) => {
 		await waitFor(() => {
@@ -78,8 +73,7 @@ export const ConsultantIn1on1Chat: Story = {
 		displayName: 'Dr. Müller',
 		firstName: 'Anna',
 		lastName: 'Müller',
-		isGroup: false,
-		isUserMessage: false
+		isGroup: false
 	},
 	play: async ({ canvasElement }) => {
 		await waitFor(() => {
@@ -100,8 +94,7 @@ export const InternalGroupChat: Story = {
 		displayName: 'Team Lead',
 		firstName: 'Team',
 		lastName: 'Lead',
-		isGroup: true,
-		isUserMessage: false
+		isGroup: true
 	}
 };
 
@@ -111,8 +104,7 @@ export const InternalGroupChat: Story = {
 export const ClientInGroupChat: Story = {
 	args: {
 		...baseIdentity,
-		isGroup: true,
-		isUserMessage: true
+		isGroup: true
 	}
 };
 
@@ -127,7 +119,6 @@ export const AllVariants: Story = {
 				label: 'Client 1-on-1',
 				props: {
 					isGroup: false,
-					isUserMessage: true,
 					isSystemNotification: false,
 					userId: 'user-1',
 					username: 'sanftes.alpaka',
@@ -139,7 +130,6 @@ export const AllVariants: Story = {
 				label: 'Consultant 1-on-1 (animal)',
 				props: {
 					isGroup: false,
-					isUserMessage: false,
 					isSystemNotification: false,
 					userId: 'consultant-1',
 					username: 'karina.p',
@@ -153,7 +143,6 @@ export const AllVariants: Story = {
 				label: 'Internal Group',
 				props: {
 					isGroup: true,
-					isUserMessage: false,
 					isSystemNotification: false,
 					userId: 'consultant-2',
 					username: 'angela.k',
@@ -167,7 +156,6 @@ export const AllVariants: Story = {
 				label: 'Client in Group',
 				props: {
 					isGroup: true,
-					isUserMessage: true,
 					isSystemNotification: false,
 					userId: 'user-2',
 					username: 'freundliche.katze',

--- a/src/components/message/MessageAvatar.stories.tsx
+++ b/src/components/message/MessageAvatar.stories.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
+import { MessageAvatar } from './MessageAvatar';
+import './message.styles.scss';
+
+const meta: Meta<typeof MessageAvatar> = {
+	title: 'Components/Chat/MessageAvatar',
+	component: MessageAvatar,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'centered'
+	},
+	argTypes: {
+		isGroup: {
+			control: 'boolean',
+			description: 'Whether the active session is a group chat'
+		},
+		isUserMessage: {
+			control: 'boolean',
+			description: 'Whether the message is from the client/asker'
+		},
+		isSystemNotification: {
+			control: 'boolean',
+			description: 'System notifications render no avatar here'
+		},
+		size: {
+			control: { type: 'number', min: 24, max: 64, step: 4 },
+			description: 'Avatar size in pixels'
+		}
+	}
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageAvatar>;
+
+const baseIdentity = {
+	userId: 'client-asker-1',
+	username: 'sanftes.alpaka.kala@oriso.invalid',
+	displayName: 'Sanftes Alpaka Kala',
+	firstName: 'Sanftes',
+	lastName: 'Alpaka Kala',
+	size: 32,
+	isSystemNotification: false
+};
+
+/**
+ * Client in a 1-on-1 chat — shows the generated animal pseudonym avatar.
+ * At 32px the animal SVG inner area is 20px (visible after AnimalAvatar padding fix).
+ */
+export const ClientIn1on1Chat: Story = {
+	args: {
+		...baseIdentity,
+		isGroup: false,
+		isUserMessage: true
+	},
+	play: async ({ canvasElement }) => {
+		await waitFor(() => {
+			const svg = canvasElement.querySelector('.messageItem__avatar svg');
+			expect(svg).toBeTruthy();
+			const innerHost = svg?.parentElement;
+			expect(innerHost).toBeTruthy();
+			expect(innerHost?.clientWidth).toBeGreaterThan(0);
+			expect(innerHost?.clientHeight).toBeGreaterThan(0);
+		});
+	}
+};
+
+/**
+ * Incoming message in a 1-on-1 chat (consultant view) — animal avatar;
+ * all incoming 1-on-1 messages use the animal pseudonym regardless of role.
+ */
+export const ConsultantIn1on1Chat: Story = {
+	args: {
+		...baseIdentity,
+		userId: 'consultant-1',
+		username: 'dr.mueller',
+		displayName: 'Dr. Müller',
+		firstName: 'Anna',
+		lastName: 'Müller',
+		isGroup: false,
+		isUserMessage: false
+	},
+	play: async ({ canvasElement }) => {
+		await waitFor(() => {
+			const svg = canvasElement.querySelector('.messageItem__avatar svg');
+			expect(svg).toBeTruthy();
+		});
+	}
+};
+
+/**
+ * Consultant or moderator in an internal group chat — initials avatar.
+ */
+export const InternalGroupChat: Story = {
+	args: {
+		...baseIdentity,
+		userId: 'consultant-2',
+		username: 'team.lead',
+		displayName: 'Team Lead',
+		firstName: 'Team',
+		lastName: 'Lead',
+		isGroup: true,
+		isUserMessage: false
+	}
+};
+
+/**
+ * Client in a group chat — group context overrides animal; shows initials.
+ */
+export const ClientInGroupChat: Story = {
+	args: {
+		...baseIdentity,
+		isGroup: true,
+		isUserMessage: true
+	}
+};
+
+/**
+ * All chat avatar variants side by side for quick comparison.
+ */
+export const AllVariants: Story = {
+	decorators: [],
+	render: () => {
+		const variants = [
+			{
+				label: 'Client 1-on-1',
+				props: {
+					isGroup: false,
+					isUserMessage: true,
+					isSystemNotification: false,
+					userId: 'user-1',
+					username: 'sanftes.alpaka',
+					displayName: 'Sanftes Alpaka',
+					size: 32
+				}
+			},
+			{
+				label: 'Consultant 1-on-1 (animal)',
+				props: {
+					isGroup: false,
+					isUserMessage: false,
+					isSystemNotification: false,
+					userId: 'consultant-1',
+					username: 'karina.p',
+					displayName: 'Karina P',
+					firstName: 'Karina',
+					lastName: 'P',
+					size: 32
+				}
+			},
+			{
+				label: 'Internal Group',
+				props: {
+					isGroup: true,
+					isUserMessage: false,
+					isSystemNotification: false,
+					userId: 'consultant-2',
+					username: 'angela.k',
+					displayName: 'Angela K',
+					firstName: 'Angela',
+					lastName: 'K',
+					size: 32
+				}
+			},
+			{
+				label: 'Client in Group',
+				props: {
+					isGroup: true,
+					isUserMessage: true,
+					isSystemNotification: false,
+					userId: 'user-2',
+					username: 'freundliche.katze',
+					displayName: 'Freundliche Katze',
+					size: 32
+				}
+			}
+		];
+
+		return (
+			<div
+				style={{
+					display: 'flex',
+					gap: '32px',
+					alignItems: 'flex-start',
+					padding: '24px'
+				}}
+			>
+				{variants.map((variant) => (
+					<div
+						key={variant.label}
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'center',
+							gap: '8px'
+						}}
+					>
+						<div
+							style={{
+								width: '48px',
+								height: '48px',
+								border: '10px solid #fff',
+								borderRadius: '999px',
+								background: '#ffd9d9',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								boxSizing: 'border-box'
+							}}
+						>
+							<MessageAvatar {...variant.props} />
+						</div>
+						<small style={{ fontSize: '11px', color: '#666' }}>
+							{variant.label}
+						</small>
+					</div>
+				))}
+			</div>
+		);
+	}
+};

--- a/src/components/message/MessageAvatar.tsx
+++ b/src/components/message/MessageAvatar.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+import { AnimalAvatar } from '../pseudonym/AnimalAvatar';
+import { generateAvatarForUser } from '../../utils/pseudonymGenerator';
+import { UserAvatar } from './UserAvatar';
+
+export interface MessageAvatarProps {
+	isGroup: boolean;
+	isUserMessage: boolean;
+	isSystemNotification: boolean;
+	/** Reserved for future outgoing-specific styling; 1-on-1 uses animal either way. */
+	isMyMessage?: boolean;
+	userId: string;
+	username: string;
+	displayName: string;
+	firstName?: string;
+	lastName?: string;
+	size?: number;
+}
+
+/**
+ * Chat message avatar: animal pseudonym for 1-on-1 messages, initials in groups.
+ * System notifications render no avatar here (handled in MessageItemComponent).
+ */
+export const MessageAvatar: React.FC<MessageAvatarProps> = ({
+	isGroup,
+	isSystemNotification,
+	userId,
+	username,
+	displayName,
+	firstName,
+	lastName,
+	size = 32
+}) => {
+	const clientAvatar = useMemo(() => generateAvatarForUser(userId), [userId]);
+
+	if (isSystemNotification) {
+		return null;
+	}
+
+	if (!isGroup) {
+		return <AnimalAvatar avatar={clientAvatar} size={size} />;
+	}
+
+	return (
+		<UserAvatar
+			username={username}
+			displayName={displayName}
+			firstName={firstName}
+			lastName={lastName}
+			userId={userId}
+			size={`${size}px`}
+			ring={false}
+		/>
+	);
+};

--- a/src/components/message/MessageAvatar.tsx
+++ b/src/components/message/MessageAvatar.tsx
@@ -6,10 +6,7 @@ import { UserAvatar } from './UserAvatar';
 
 export interface MessageAvatarProps {
 	isGroup: boolean;
-	isUserMessage: boolean;
 	isSystemNotification: boolean;
-	/** Reserved for future outgoing-specific styling; 1-on-1 uses animal either way. */
-	isMyMessage?: boolean;
 	userId: string;
 	username: string;
 	displayName: string;

--- a/src/components/message/MessageItemComponent.mocks.ts
+++ b/src/components/message/MessageItemComponent.mocks.ts
@@ -1,5 +1,4 @@
 import type { ComponentProps } from 'react';
-import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
 import { AUTHORITIES, type ExtendedSessionInterface } from '../../globalState';
 import {
 	REGISTRATION_TYPE_REGISTERED,

--- a/src/components/message/MessageItemComponent.mocks.ts
+++ b/src/components/message/MessageItemComponent.mocks.ts
@@ -1,0 +1,248 @@
+import type { ComponentProps } from 'react';
+import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
+import { AUTHORITIES, type ExtendedSessionInterface } from '../../globalState';
+import {
+	REGISTRATION_TYPE_REGISTERED,
+	STATUS_ACTIVE,
+	type UserDataInterface
+} from '../../globalState/interfaces';
+import {
+	CHAT_TYPE_GROUP_CHAT,
+	CHAT_TYPE_SINGLE_CHAT
+} from '../session/sessionHelpers';
+import { buildVisibleToPrefix } from './messageConstants';
+import { MessageItemComponent, type MessageItem } from './MessageItemComponent';
+
+export const MOCK_ASKER_RC_ID = '@sanftes.alpaka:oriso.invalid';
+export const MOCK_CONSULTANT_RC_ID = '@karina.p:oriso.invalid';
+export const MOCK_GROUP_MODERATOR_RC_ID = '@angela.k:oriso.invalid';
+
+const MOCK_MATRIX_ROOM_1ON1 = '!storybook-1on1:oriso.org';
+const MOCK_MATRIX_ROOM_GROUP = '!storybook-internal-group:oriso.org';
+
+export function mockActiveSession(
+	overrides: Partial<ExtendedSessionInterface> = {}
+): ExtendedSessionInterface {
+	return {
+		rid: MOCK_MATRIX_ROOM_1ON1,
+		type: CHAT_TYPE_SINGLE_CHAT,
+		isGroup: false,
+		isSession: true,
+		item: {
+			id: 3363,
+			agencyId: 101,
+			askerRcId: MOCK_ASKER_RC_ID,
+			groupId: MOCK_MATRIX_ROOM_1ON1,
+			matrixRoomId: MOCK_MATRIX_ROOM_1ON1,
+			postcode: 10115,
+			registrationType: REGISTRATION_TYPE_REGISTERED,
+			status: STATUS_ACTIVE,
+			topic: {
+				id: 2,
+				name: 'Suchtprobleme',
+				description: 'Beratung zu Sucht, Rückfall und Stabilisierung.'
+			},
+			moderators: [],
+			messageDate: Date.now(),
+			messagesRead: true
+		},
+		user: {
+			username: 'sanftes.alpaka.kala@oriso.invalid',
+			displayName: 'Sanftes Alpaka Kala',
+			sessionData: {}
+		},
+		consultant: {
+			consultantId: 'consultant-storybook',
+			id: 'consultant-storybook',
+			username: 'karina.p@oriso.invalid',
+			displayName: 'Karina P',
+			firstName: 'Karina',
+			lastName: 'P',
+			absent: false,
+			absenceMessage: ''
+		},
+		...overrides
+	};
+}
+
+export function mockActiveSession1on1(
+	overrides: Partial<ExtendedSessionInterface> = {}
+): ExtendedSessionInterface {
+	return mockActiveSession({
+		rid: MOCK_MATRIX_ROOM_1ON1,
+		type: CHAT_TYPE_SINGLE_CHAT,
+		isGroup: false,
+		isSession: true,
+		...overrides
+	});
+}
+
+export function mockActiveSessionGroup(
+	overrides: Partial<ExtendedSessionInterface> = {}
+): ExtendedSessionInterface {
+	return mockActiveSession({
+		rid: MOCK_MATRIX_ROOM_GROUP,
+		type: CHAT_TYPE_GROUP_CHAT,
+		isGroup: true,
+		isSession: false,
+		item: {
+			id: 4401,
+			agencyId: 101,
+			askerRcId: MOCK_ASKER_RC_ID,
+			groupId: MOCK_MATRIX_ROOM_GROUP,
+			matrixRoomId: MOCK_MATRIX_ROOM_GROUP,
+			postcode: 10115,
+			registrationType: REGISTRATION_TYPE_REGISTERED,
+			status: STATUS_ACTIVE,
+			topic: 'Interner Gruppenchat',
+			moderators: [MOCK_CONSULTANT_RC_ID, MOCK_GROUP_MODERATOR_RC_ID],
+			messageDate: Date.now(),
+			messagesRead: true,
+			active: true,
+			assignedAgencies: [],
+			attachment: {} as any,
+			consultingType: 1,
+			duration: 60,
+			hintMessage: '',
+			lastMessage: '',
+			e2eLastMessage: { t: '', msg: '' },
+			repetitive: false,
+			startDate: '2026-07-10',
+			startTime: '10:00',
+			subscribed: true,
+			createdAt: '2026-07-01T00:00:00.000Z'
+		},
+		...overrides
+	});
+}
+
+export function mockUserData(
+	overrides: Partial<UserDataInterface> = {}
+): UserDataInterface {
+	return {
+		userId: 'consultant-storybook',
+		userName: 'karina.p@oriso.invalid',
+		displayName: 'Karina P',
+		firstName: 'Karina',
+		lastName: 'P',
+		grantedAuthorities: [AUTHORITIES.CONSULTANT_DEFAULT],
+		agencies: [],
+		emailToggles: [],
+		e2eEncryptionEnabled: false,
+		formalLanguage: false,
+		hasArchive: true,
+		isDisplayNameEditable: true,
+		preferredLanguage: 'de',
+		userRoles: [],
+		termsAndConditionsConfirmation: '',
+		dataPrivacyConfirmation: '',
+		twoFactorAuth: {
+			isEnabled: false,
+			isActive: false,
+			isShown: false,
+			secret: '',
+			qrCode: ''
+		},
+		...overrides
+	};
+}
+
+export function mockE2EEContext() {
+	return {
+		key: null,
+		reloadPrivateKey: () => {},
+		isE2eeEnabled: false,
+		e2EEReady: true
+	};
+}
+
+export function mockServerSettingsContext() {
+	return {
+		settings: [],
+		settingsReady: true,
+		getSetting: () => ({ value: false }) as any
+	};
+}
+
+export function mockConsultantListContext() {
+	return {
+		consultantList: [],
+		setConsultantList: () => {},
+		reloadConsultantList: () => {}
+	};
+}
+
+export function mockE2eeParams() {
+	return {
+		keyID: '',
+		key: null,
+		encrypted: false,
+		subscriptionKeyLost: false
+	};
+}
+
+export function mockMessageItem(
+	overrides: Partial<MessageItem> = {}
+): MessageItem {
+	return {
+		_id: 'msg-storybook-1',
+		message:
+			'Ich habe heute wieder starkes Verlangen und brauche kurz Orientierung.',
+		messageDate: { str: 'Heute', date: null },
+		messageTime: String(new Date('2026-07-10T09:18:00').getTime()),
+		displayName: 'Sanftes Alpaka Kala',
+		username: 'sanftes.alpaka.kala@oriso.invalid',
+		askerRcId: MOCK_ASKER_RC_ID,
+		userId: MOCK_ASKER_RC_ID,
+		isNotRead: false,
+		t: null,
+		rid: MOCK_MATRIX_ROOM_1ON1,
+		...overrides
+	};
+}
+
+export type MessageItemStoryProps = ComponentProps<typeof MessageItemComponent>;
+
+export function mockMessageItemComponentProps(
+	overrides: Partial<MessageItemStoryProps> = {}
+): MessageItemStoryProps {
+	return {
+		...mockMessageItem(),
+		clientName: 'Sanftes Alpaka Kala',
+		isMyMessage: false,
+		isUserBanned: false,
+		isOnlyEnquiry: false,
+		handleDecryptionErrors: () => {},
+		handleDecryptionSuccess: () => {},
+		e2eeParams: mockE2eeParams(),
+		...overrides
+	};
+}
+
+export const mockAppointmentAliasContent = JSON.stringify({
+	title: 'Erstgespräch Suchtberatung',
+	user: 'sanftes.alpaka.kala',
+	counselor: 'karina.p',
+	date: new Date('2026-07-15T10:00:00.000Z').toISOString(),
+	duration: 45,
+	location: 'Online',
+	note: 'Bitte halten Sie die Unterlagen aus dem letzten Gespräch bereit.'
+});
+
+export const mockLongGermanMessage =
+	'Heute war es besonders schwer für mich, und ich brauche kurz Orientierung. '.repeat(
+		12
+	);
+
+export const mockVisibilityMessage = `${buildVisibleToPrefix([
+	'Sanftes Alpaka Kala',
+	'Familienberatung'
+])} Diese Nachricht ist nur für ausgewählte Empfänger sichtbar.`;
+
+export const mockSystemNotificationMessage = `[SYSTEM_NOTIFICATION]${JSON.stringify(
+	{
+		title: 'Systemhinweis',
+		description: 'Ihr Beratungstermin wurde aktualisiert.',
+		type: 'INFO'
+	}
+)}`;

--- a/src/components/message/MessageItemComponent.stories.tsx
+++ b/src/components/message/MessageItemComponent.stories.tsx
@@ -1,0 +1,306 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
+import {
+	ActiveSessionContext,
+	E2EEContext,
+	UserDataContext,
+	type ExtendedSessionInterface
+} from '../../globalState';
+import { ConsultantListContext } from '../../globalState/provider/ConsultantListProvider';
+import { ServerSettingsContext } from '../../globalState/provider/ServerSettingsProvider';
+import type { UserDataInterface } from '../../globalState/interfaces';
+import { MessageItemComponent } from './MessageItemComponent';
+import {
+	MOCK_ASKER_RC_ID,
+	MOCK_CONSULTANT_RC_ID,
+	MOCK_GROUP_MODERATOR_RC_ID,
+	mockActiveSession1on1,
+	mockActiveSessionGroup,
+	mockAppointmentAliasContent,
+	mockConsultantListContext,
+	mockE2EEContext,
+	mockE2eeParams,
+	mockLongGermanMessage,
+	mockMessageItemComponentProps,
+	mockServerSettingsContext,
+	mockSystemNotificationMessage,
+	mockUserData,
+	mockVisibilityMessage
+} from './MessageItemComponent.mocks';
+import './message.styles.scss';
+
+type MessageItemStoryParameters = {
+	activeSession?: ExtendedSessionInterface;
+	userData?: UserDataInterface;
+};
+
+function MessageItemContextDecorator({
+	activeSession,
+	userData,
+	children
+}: {
+	activeSession: ExtendedSessionInterface;
+	userData: UserDataInterface;
+	children: React.ReactNode;
+}) {
+	return (
+		<ServerSettingsContext.Provider value={mockServerSettingsContext()}>
+			<ConsultantListContext.Provider value={mockConsultantListContext()}>
+				<E2EEContext.Provider value={mockE2EEContext()}>
+					<UserDataContext.Provider
+						value={{
+							userData,
+							setUserData: () => {},
+							reloadUserData: async () => null as any
+						}}
+					>
+						<ActiveSessionContext.Provider
+							value={{
+								activeSession,
+								reloadActiveSession: () => {},
+								readActiveSession: () => {}
+							}}
+						>
+							<div
+								style={{
+									maxWidth: 720,
+									padding: '32px 40px',
+									background: '#ffffff'
+								}}
+							>
+								{children}
+							</div>
+						</ActiveSessionContext.Provider>
+					</UserDataContext.Provider>
+				</E2EEContext.Provider>
+			</ConsultantListContext.Provider>
+		</ServerSettingsContext.Provider>
+	);
+}
+
+const baseHandlers = {
+	handleDecryptionErrors: () => {},
+	handleDecryptionSuccess: () => {},
+	e2eeParams: mockE2eeParams()
+};
+
+const meta = {
+	title: 'Components/Chat/MessageItem',
+	component: MessageItemComponent,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps(),
+		...baseHandlers
+	},
+	decorators: [
+		(Story, { parameters }) => (
+			<MessageItemContextDecorator
+				activeSession={
+					(parameters as MessageItemStoryParameters).activeSession ??
+					mockActiveSession1on1()
+				}
+				userData={
+					(parameters as MessageItemStoryParameters).userData ??
+					mockUserData()
+				}
+			>
+				<Story />
+			</MessageItemContextDecorator>
+		)
+	]
+} satisfies Meta<typeof MessageItemComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ClientIn1on1Incoming: Story = {
+	name: 'Client 1-on-1 incoming (animal avatar)',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_ASKER_RC_ID,
+			askerRcId: MOCK_ASKER_RC_ID,
+			displayName: 'Sanftes Alpaka Kala',
+			username: 'sanftes.alpaka.kala@oriso.invalid'
+		}),
+		...baseHandlers
+	}
+};
+
+export const ClientIn1on1Outgoing: Story = {
+	name: 'Client 1-on-1 outgoing (animal avatar)',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: true,
+			userId: MOCK_CONSULTANT_RC_ID,
+			displayName: 'Karina P',
+			username: 'karina.p@oriso.invalid',
+			message:
+				'Danke, dass du dich meldest. Lass uns zuerst die nächsten 10 Minuten strukturieren.'
+		}),
+		...baseHandlers
+	}
+};
+
+export const GroupIncoming: Story = {
+	name: 'Group incoming (initials avatar)',
+	parameters: {
+		activeSession: mockActiveSessionGroup(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_GROUP_MODERATOR_RC_ID,
+			rid: mockActiveSessionGroup().rid,
+			displayName: 'Angela K',
+			username: 'angela.k@oriso.invalid',
+			message:
+				'Kurzes Update für das Team: Der Fall bleibt heute bei mir.'
+		}),
+		...baseHandlers
+	}
+};
+
+export const GroupOutgoing: Story = {
+	name: 'Group outgoing (initials avatar)',
+	parameters: {
+		activeSession: mockActiveSessionGroup(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: true,
+			userId: MOCK_CONSULTANT_RC_ID,
+			rid: mockActiveSessionGroup().rid,
+			displayName: 'Karina P',
+			username: 'karina.p@oriso.invalid',
+			message:
+				'Verstanden, ich übernehme die Rückmeldung an die Klientin.'
+		}),
+		...baseHandlers
+	}
+};
+
+export const NormalMessage: Story = {
+	name: 'Normal text message',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_ASKER_RC_ID,
+			askerRcId: MOCK_ASKER_RC_ID
+		}),
+		...baseHandlers
+	}
+};
+
+export const SystemNotification: Story = {
+	name: 'System notification',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: 'system',
+			displayName: 'system',
+			username: 'system',
+			message: mockSystemNotificationMessage
+		}),
+		...baseHandlers
+	}
+};
+
+export const AppointmentSet: Story = {
+	name: 'Appointment set',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_CONSULTANT_RC_ID,
+			displayName: 'Karina P',
+			username: 'karina.p@oriso.invalid',
+			message: '',
+			alias: {
+				messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET,
+				content: mockAppointmentAliasContent
+			}
+		}),
+		...baseHandlers
+	}
+};
+
+export const DeletedMessage: Story = {
+	name: 'Deleted message',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_ASKER_RC_ID,
+			askerRcId: MOCK_ASKER_RC_ID,
+			t: 'rm',
+			message: 'Diese Nachricht wurde gelöscht.'
+		}),
+		...baseHandlers
+	}
+};
+
+export const LongMessage: Story = {
+	name: 'Long message with show more',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_ASKER_RC_ID,
+			askerRcId: MOCK_ASKER_RC_ID,
+			message: mockLongGermanMessage
+		}),
+		...baseHandlers
+	}
+};
+
+export const OutgoingWithVisibility: Story = {
+	name: 'Outgoing with visibility chip',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: true,
+			userId: MOCK_CONSULTANT_RC_ID,
+			displayName: 'Karina P',
+			username: 'karina.p@oriso.invalid',
+			message: mockVisibilityMessage
+		}),
+		...baseHandlers
+	}
+};

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -1769,7 +1769,6 @@ export const MessageItemComponent = ({
 							<div className="messageItem__avatar">
 								<MessageAvatar
 									isGroup={!!activeSession?.isGroup}
-									isUserMessage={isUserMessage()}
 									isSystemNotification={false}
 									userId={userId}
 									username={username}
@@ -1888,9 +1887,7 @@ export const MessageItemComponent = ({
 							<div className="messageItem__avatar">
 								<MessageAvatar
 									isGroup={!!activeSession?.isGroup}
-									isUserMessage={isUserMessage()}
 									isSystemNotification={false}
-									isMyMessage={true}
 									userId={userId}
 									username={username}
 									displayName={displayName}

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -64,7 +64,7 @@ import { FlyoutMenu } from '../flyoutMenu/FlyoutMenu';
 import { BanUser, BanUserOverlay } from '../banUser/BanUser';
 import { getValueFromCookie } from '../sessionCookie/accessSessionCookie';
 import { VideoChatDetails, VideoChatDetailsAlias } from './VideoChatDetails';
-import { UserAvatar } from './UserAvatar';
+import { MessageAvatar } from './MessageAvatar';
 import clsx from 'clsx';
 import {
 	parseMessagePrefixes,
@@ -1192,6 +1192,17 @@ export const MessageItemComponent = ({
 		videoCallMessage?.eventType === 'IGNORED_CALL' &&
 		activeSession?.isGroup;
 
+	const messageTimeInBubble = messageTime ? (
+		<span
+			className={clsx(
+				'messageItem__messageTime',
+				isMyMessage && 'messageItem__messageTime--outgoing'
+			)}
+		>
+			{formatToHHMM(messageTime)}
+		</span>
+	) : null;
+
 	const messageContent = (): React.ReactElement => {
 		switch (true) {
 			case isMasterKeyLostMessage:
@@ -1284,22 +1295,25 @@ export const MessageItemComponent = ({
 				);
 			case isDeleteMessage:
 				return (
-					<div className="messageItem__message messageItem__message--deleted flex flex--ai-c">
-						<div className="mr--1">
-							<DeletedIcon
-								width={14}
-								height={14}
-								aria-hidden="true"
-								focusable="false"
-							/>
+					<div className="messageItem__message messageItem__message--deleted">
+						<div className="flex flex--ai-c">
+							<div className="mr--1">
+								<DeletedIcon
+									width={14}
+									height={14}
+									aria-hidden="true"
+									focusable="false"
+								/>
+							</div>
+							<div>
+								{translate(
+									isMyMessage
+										? 'message.delete.deleted.own'
+										: 'message.delete.deleted.other'
+								)}
+							</div>
 						</div>
-						<div>
-							{translate(
-								isMyMessage
-									? 'message.delete.deleted.own'
-									: 'message.delete.deleted.other'
-							)}
-						</div>
+						{messageTimeInBubble}
 					</div>
 				);
 			default:
@@ -1321,11 +1335,6 @@ export const MessageItemComponent = ({
 										resolvedIncomingNameParts.lastName
 									}
 								/>
-								{messageTime ? (
-									<span className="messageItem__headerTime">
-										{formatToHHMM(messageTime)}
-									</span>
-								) : null}
 								{/* MATRIX MIGRATION: Temporarily hide message menu */}
 								{false && (
 									<MessageFlyoutMenu
@@ -1625,6 +1634,7 @@ export const MessageItemComponent = ({
 										hasRenderedMessage={hasRenderedMessage}
 									/>
 								))}
+							{!isSystemNotification && messageTimeInBubble}
 						</div>
 						{showVisibleAudience && !isMyMessage && (
 							<div className="messageItem__visibleOnly">
@@ -1743,7 +1753,7 @@ export const MessageItemComponent = ({
 			<div
 				className={`
 					messageItem__messageWrap
-					${isMyMessage ? 'messageItem__messageWrap--right' : ''}
+					${isMyMessage ? 'messageItem__messageWrap--right' : 'messageItem__messageWrap--left'}
 					${isFurtherStepsMessage ? 'messageItem__messageWrap--furtherSteps' : ''}
 					${
 						isE2EEActivatedMessage
@@ -1755,9 +1765,13 @@ export const MessageItemComponent = ({
 				{!alias?.messageType &&
 					!isMyMessage &&
 					!isSystemNotification && (
-						<div className="messageItem__sideColumn">
+						<div className="messageItem__sideColumn messageItem__sideColumn--left">
 							<div className="messageItem__avatar">
-								<UserAvatar
+								<MessageAvatar
+									isGroup={!!activeSession?.isGroup}
+									isUserMessage={isUserMessage()}
+									isSystemNotification={false}
+									userId={userId}
 									username={username}
 									displayName={resolvedIncomingDisplayName}
 									firstName={
@@ -1766,11 +1780,23 @@ export const MessageItemComponent = ({
 									lastName={
 										resolvedIncomingNameParts.lastName
 									}
-									userId={userId}
-									size="32px"
-									ring={false}
+									size={32}
 								/>
 							</div>
+							<button
+								type="button"
+								className="messageItem__kebabButton messageItem__kebabButton--left"
+								aria-label="More"
+								onClick={(event) =>
+									toggleActionMenu(event, 'left')
+								}
+							>
+								{isActionMenuOpen ? (
+									<ActiveKebabIcon />
+								) : (
+									<StackVerticalIcon className="messageItem__kebabIconDefault" />
+								)}
+							</button>
 							{showVisibleAudience && (
 								<button
 									type="button"
@@ -1800,20 +1826,6 @@ export const MessageItemComponent = ({
 									</span>
 								</button>
 							)}
-							<button
-								type="button"
-								className="messageItem__kebabButton messageItem__kebabButton--left"
-								aria-label="More"
-								onClick={(event) =>
-									toggleActionMenu(event, 'left')
-								}
-							>
-								{isActionMenuOpen ? (
-									<ActiveKebabIcon />
-								) : (
-									<StackVerticalIcon className="messageItem__kebabIconDefault" />
-								)}
-							</button>
 						</div>
 					)}
 				{!alias?.messageType &&
@@ -1874,14 +1886,17 @@ export const MessageItemComponent = ({
 								)}
 							</button>
 							<div className="messageItem__avatar">
-								<UserAvatar
+								<MessageAvatar
+									isGroup={!!activeSession?.isGroup}
+									isUserMessage={isUserMessage()}
+									isSystemNotification={false}
+									isMyMessage={true}
+									userId={userId}
 									username={username}
 									displayName={displayName}
 									firstName={userData?.firstName}
 									lastName={userData?.lastName}
-									userId={userId}
-									size="32px"
-									ring={false}
+									size={32}
 								/>
 							</div>
 						</div>
@@ -1892,11 +1907,6 @@ export const MessageItemComponent = ({
 					{isMyMessage && formattedName && !alias?.messageType && (
 						<div className="messageItem__senderInfo">
 							<div className="messageItem__senderInfoPrimary">
-								{messageTime ? (
-									<span className="messageItem__headerTime">
-										{formatToHHMM(messageTime)}
-									</span>
-								) : null}
 								<div className="messageItem__senderInfoName">
 									{formattedName}
 								</div>

--- a/src/components/message/appointment.styles.scss
+++ b/src/components/message/appointment.styles.scss
@@ -70,8 +70,25 @@
 			width: 18px;
 			height: 18px;
 
+			@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+				width: 22px;
+				height: 22px;
+			}
+
 			path {
 				fill: var(--m3-primary, $primary);
+			}
+		}
+	}
+
+	&__titleIcon {
+		svg {
+			width: 24px;
+			height: 23px;
+
+			@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+				width: 28px;
+				height: 27px;
 			}
 		}
 	}

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -141,15 +141,10 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 			position: relative;
 		}
 
-		&--left {
-			// padding-left: 64px;
-		}
-
 		&--right {
 			flex-direction: row-reverse;
 			align-self: flex-end;
 			margin-left: auto;
-			// padding-right: 32px;
 		}
 
 		&--furtherSteps {
@@ -213,7 +208,6 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 	}
 
 	&__sideColumn--left {
-		// position: absolute;
 		left: 4px;
 		top: -18px;
 		z-index: 5;

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -134,14 +134,22 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 		max-width: min(71%, 600px);
 		position: relative;
 
+		&--left,
 		&--right {
-			flex-direction: row-reverse;
-			align-self: center;
-			margin-left: auto;
-			align-items: center;
+			align-items: start;
 			gap: 4px;
 			position: relative;
-			padding-right: 32px;
+		}
+
+		&--left {
+			// padding-left: 64px;
+		}
+
+		&--right {
+			flex-direction: row-reverse;
+			align-self: flex-end;
+			margin-left: auto;
+			// padding-right: 32px;
 		}
 
 		&--furtherSteps {
@@ -162,9 +170,9 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 		height: 48px;
 		min-width: 48px;
 		min-height: 48px;
-		border: 10px solid #fff;
+		border: 8px solid #fff;
 		border-radius: 999px;
-		background: #ffd9d9;
+		background: #fff;
 		overflow: hidden;
 		display: inline-flex;
 		align-items: center;
@@ -197,13 +205,24 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 		z-index: 6;
 	}
 
+	&__sideColumn--left,
 	&__sideColumn--right {
 		align-items: center;
 		justify-content: center;
 		margin-bottom: 0;
+	}
+
+	&__sideColumn--left {
+		// position: absolute;
+		left: 4px;
+		top: -18px;
+		z-index: 5;
+	}
+
+	&__sideColumn--right {
 		position: absolute;
-		right: -4px;
-		bottom: 40px;
+		right: -32px;
+		bottom: -18px;
 		z-index: 5;
 	}
 
@@ -597,11 +616,17 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
+		z-index: 5;
 	}
 
 	&__systemAvatarIcon {
 		width: 15px;
 		height: 15px;
+
+		@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+			width: 19px;
+			height: 19px;
+		}
 
 		* {
 			fill: #e53952;
@@ -769,8 +794,23 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 			text-align: right;
 		}
 
-		span:not(.messageItem__highlight) {
+		span:not(.messageItem__highlight, .messageItem__messageTime) {
 			display: inline;
+		}
+
+		.messageItem__messageTime {
+			display: block;
+			width: 100%;
+			margin-top: 4px;
+			line-height: 1;
+			font-size: $font-size-secondary;
+			color: var(--m3-on-surface-variant, $tertiary);
+			white-space: nowrap;
+			text-align: right;
+
+			&--outgoing {
+				text-align: left;
+			}
 		}
 
 		&__attachment {

--- a/src/components/pseudonym/AnimalAvatar.tsx
+++ b/src/components/pseudonym/AnimalAvatar.tsx
@@ -17,7 +17,8 @@ export const AnimalAvatar: React.FC<AnimalAvatarProps> = ({
 }) => {
 	const [avatarHtml, setAvatarHtml] = useState<string | null>(null);
 	const borderWidth = 2;
-	const padding = Math.max(14, Math.round(size * 0.18));
+	const minPadding = size >= 60 ? 8 : 2;
+	const padding = Math.max(minPadding, Math.round(size * 0.12));
 	const innerSize = Math.max(0, size - padding * 2 - borderWidth * 2);
 
 	useEffect(() => {

--- a/src/components/pseudonym/PseudonymCard.styles.scss
+++ b/src/components/pseudonym/PseudonymCard.styles.scss
@@ -59,6 +59,11 @@
 		display: block;
 		width: 25px;
 		height: 25px;
+
+		@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+			width: 29px;
+			height: 29px;
+		}
 	}
 }
 

--- a/src/utils/anonName/engine.test.ts
+++ b/src/utils/anonName/engine.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LANGUAGE_DATA } from './data';
-import { generatePassword, generatePseudonym } from './engine';
+import {
+	generateAvatarForUser,
+	generatePassword,
+	generatePseudonym
+} from './engine';
 import { allPasswordCriteriaPass } from '../../components/registration/accountData/passwordRules';
 
 describe('anonymous name engine', () => {
@@ -53,5 +57,17 @@ describe('anonymous name engine', () => {
 			expect(encodeURIComponent(password)).toBe(password);
 			expect(allPasswordCriteriaPass(password)).toBe(true);
 		}
+	});
+
+	it('generates a stable avatar for the same user id', () => {
+		const first = generateAvatarForUser('client-asker-1');
+		const second = generateAvatarForUser('client-asker-1');
+		const other = generateAvatarForUser('consultant-2');
+
+		expect(second).toEqual(first);
+		expect(other).not.toEqual(first);
+		expect(first.file).toBeTruthy();
+		expect(first.bg).toMatch(/^#[0-9A-Fa-f]{6}$/);
+		expect(['#ffffff', '#1a1a1a']).toContain(first.iconColor);
 	});
 });

--- a/src/utils/anonName/engine.ts
+++ b/src/utils/anonName/engine.ts
@@ -154,6 +154,36 @@ export function generateAvatar(lang = 'de'): Avatar {
 	return avatarFor(pick(pick(dataFor(lang).groups).animals).svg);
 }
 
+const ALL_ANIMAL_FILES = [
+	...new Set(
+		Object.values(LANGUAGE_DATA)
+			.flatMap((lang) => lang.groups)
+			.flatMap((group) => group.animals)
+			.map((animal) => animal.svg)
+	)
+];
+
+function hashUserId(userId: string): number {
+	let hash = 0;
+	for (let i = 0; i < userId.length; i++) {
+		hash = (hash << 5) - hash + userId.charCodeAt(i);
+		hash |= 0;
+	}
+	return Math.abs(hash);
+}
+
+/** Deterministic avatar derived from a stable user identifier. */
+export function generateAvatarForUser(userId: string): Avatar {
+	const absHash = hashUserId(userId);
+	const bg = PASTEL_COLORS[absHash % PASTEL_COLORS.length];
+	const iconColor = luminance(bg) < 0.5 ? '#ffffff' : '#1a1a1a';
+	const animalFile =
+		ALL_ANIMAL_FILES[absHash % ALL_ANIMAL_FILES.length] ??
+		ALL_ANIMAL_FILES[0];
+
+	return { file: animalFile, bg, iconColor };
+}
+
 /** A 16-char password guaranteed to contain a digit, an upper- and a lowercase
  *  letter, and a special character. No ambiguous look-alikes. Keep special
  *  characters URI-safe: registration currently sends the password through an


### PR DESCRIPTION
## What
Closes #398

Implements role-based avatars and responsive icon sizing 
in chat messages.

### Avatar behavior
- **1-on-1 chat** — both incoming and outgoing messages show 
  animal avatar, deterministic per userId (same user always 
  gets same animal)
- **Group/internal chat** — initials avatar unchanged
- **System notifications** — bell icon unchanged

### Responsive icon sizing
At ~150% screen size (min-resolution: 1.5dppx or min-width: 1920px),
chat icons increase by 4px:
- Notification bell: 15px → 19px
- Appointment note icon: 18px → 22px
- Carimat robot icon: 25px → 29px

### New components
- `MessageAvatar` — avatar decision facade, replaces direct 
  `UserAvatar` usage in `MessageItemComponent`
- `generateAvatarForUser(userId)` — deterministic avatar 
  generator based on userId hash

### Storybook
- `MessageAvatar.stories.tsx` — 5 stories covering all avatar 
  variants
- `MessageItemComponent.stories.tsx` — 10 stories covering 
  all message types

## Why
Figma design requires different avatar per chat type and 
consistent animal avatar per user in 1-on-1 chat.

## Verification
Tested in app:
- ✅ 1-on-1 client chat: incoming and outgoing show animal avatar
- ✅ Same user always gets same animal avatar
- ✅ Group/internal chat: initials unchanged
- ✅ System notifications: bell icon unchanged
- ✅ Outgoing messages: unchanged in group
- ✅ Icons scale at 150% zoom

## Notes
- No backend changes
- Animal avatar layout overlap (Figma) deferred to follow-up PR
- Primary color background for counsellor avatar deferred