### PR TITLE
fix: finalize self-help group PreDev E2E

### DIFF
--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -11,6 +11,7 @@ import {
 	getMatrixHomeserverUrl
 } from '../../resources/scripts/runtimeConfig';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
+import { getElementCallAccessToken } from '../sessionCookie/getMatrixAccessToken';
 import './GroupCallWidget.scss';
 
 export const GroupCallWidget: React.FC = () => {
@@ -33,6 +34,7 @@ export const GroupCallWidget: React.FC = () => {
 	} | null>(null);
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const setupInProgressRef = useRef(false);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 
 	// Subscribe to CallManager
@@ -46,6 +48,7 @@ export const GroupCallWidget: React.FC = () => {
 			}
 			if (!newCallData) {
 				setElementCallUrl('');
+				setupInProgressRef.current = false;
 			}
 		});
 		const currentCall = callManager.getCurrentCall();
@@ -130,7 +133,7 @@ export const GroupCallWidget: React.FC = () => {
 		if (callState !== 'connecting' && callState !== 'in_call') return;
 
 		// console.log('✅ Incoming group call moving to state', callState, '- setting up Element Call for receiver...');
-		setupElementCall();
+		void setupElementCall();
 		// setupElementCall is re-created every render; including it would make
 		// this effect run on each render instead of on call-state changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -143,15 +146,16 @@ export const GroupCallWidget: React.FC = () => {
 		if (elementCallUrl) return; // Already set up
 
 		// console.log('📞 Starting outgoing call, setting up Element Call...');
-		setupElementCall();
+		void setupElementCall();
 		// setupElementCall is re-created every render and elementCallUrl is only
 		// used as an "already set up" guard; adding them would re-run this
 		// effect on every render.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [callData, matrixClientService]);
 
-	const setupElementCall = () => {
-		if (!callData) return;
+	const setupElementCall = async () => {
+		if (!callData || setupInProgressRef.current) return;
+		setupInProgressRef.current = true;
 
 		try {
 			const client = matrixClientService?.getClient();
@@ -160,26 +164,27 @@ export const GroupCallWidget: React.FC = () => {
 			// For group calls we use the dedicated Element Call room if present.
 			const roomId =
 				(callData as any).elementCallRoomId || callData.roomId;
+			const elementCallLogin = await getElementCallAccessToken();
 			const homeserverUrl =
-				client.getHomeserverUrl() || getMatrixHomeserverUrl();
+				elementCallLogin.homeserverUrl ||
+				client.getHomeserverUrl() ||
+				getMatrixHomeserverUrl();
 			if (!homeserverUrl) {
 				throw new Error(
 					'Matrix homeserver URL is missing. Set REACT_APP_MATRIX_HOMESERVER_URL or ensure the client reports a homeserver URL.'
 				);
 			}
 
-			// Get Matrix credentials
-			const accessToken =
-				(client as any).accessToken ||
-				localStorage.getItem('matrix_access_token');
-			const userId =
-				client.getUserId() || localStorage.getItem('matrix_user_id');
-			const deviceId =
-				(client as any).deviceId ||
-				localStorage.getItem('matrix_device_id');
+			// Element Call runs on a different origin and therefore must own a
+			// separate Matrix device/crypto store. Reusing the ORISO app device
+			// causes the two clients to overwrite each other's device keys.
+			const { accessToken, userId, deviceId } = elementCallLogin;
 
-			if (!accessToken || !userId) {
+			if (!accessToken || !userId || !deviceId) {
 				throw new Error('Matrix authentication not available');
+			}
+			if (client.getUserId() && client.getUserId() !== userId) {
+				throw new Error('Element Call Matrix identity mismatch');
 			}
 
 			// Element Call - open the specific Matrix room directly.
@@ -251,6 +256,7 @@ export const GroupCallWidget: React.FC = () => {
 				iframeRef.current.onload = sendCredentials;
 			}
 		} catch (err) {
+			setupInProgressRef.current = false;
 			// console.error('❌ Failed to setup Element Call:', err);
 			alert(`Failed to start call: ${(err as Error).message}`);
 			callManager.endCall();
@@ -267,7 +273,7 @@ export const GroupCallWidget: React.FC = () => {
 		// directly in the call UI without any extra "Join" step.
 		if (!elementCallUrl) {
 			// console.log('📞 Answer clicked, setting up Element Call immediately for receiver...');
-			setupElementCall();
+			void setupElementCall();
 		}
 	};
 

--- a/src/components/groupChat/GroupChatCopyLinks.tsx
+++ b/src/components/groupChat/GroupChatCopyLinks.tsx
@@ -10,18 +10,15 @@ import { GenerateQrCode } from '../generateQrCode/GenerateQrCode';
 import './groupChatCopyLinks.scss';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
+import { buildGroupChatInviteLink } from './groupChatInviteLink';
 
 type GroupChatCopyLinksProps = {
-	id: string;
-	groupChatId: string;
+	seriesId: number;
 };
 
-export const GroupChatCopyLinks = ({
-	id,
-	groupChatId
-}: GroupChatCopyLinksProps) => {
+export const GroupChatCopyLinks = ({ seriesId }: GroupChatCopyLinksProps) => {
 	const settings = useAppConfig();
-	const url = `${settings.urls.toLogin}?gcid=${id}`;
+	const url = buildGroupChatInviteLink(settings.urls.toLogin, seriesId);
 	const { addNotification } = useContext(NotificationsContext);
 	const { t: translate } = useTranslation();
 
@@ -43,7 +40,7 @@ export const GroupChatCopyLinks = ({
 					url={url}
 					headline={translate('groupChat.qrCode.headline')}
 					text={translate('groupChat.qrCode.text')}
-					filename={`group-chat-${groupChatId}`}
+					filename={`group-chat-${seriesId}`}
 				/>
 			</div>
 			<div className="GroupChatCopyLinks_copyLink">

--- a/src/components/groupChat/GroupChatInfo.tsx
+++ b/src/components/groupChat/GroupChatInfo.tsx
@@ -18,7 +18,11 @@ import {
 	apiPutGroupChat,
 	GROUP_CHAT_API
 } from '../../api';
-import { canModerateGroupChat, isGroupChatOwner } from './groupChatHelpers';
+import {
+	canModerateGroupChat,
+	isGroupChatOwner,
+	isV2GroupChatSession
+} from './groupChatHelpers';
 import { getGroupChatDate } from '../session/sessionDateHelpers';
 import { durationSelectOptionsSet } from './createChatHelpers';
 import {
@@ -108,9 +112,7 @@ export const GroupChatInfo = () => {
 			return;
 		}
 
-		if (activeSession.isGroup && !activeSession.item.consultingType) {
-			setIsV2GroupChat(true);
-		}
+		setIsV2GroupChat(isV2GroupChatSession(activeSession));
 	}, [activeSession, navigate, listPath, ready, sessionListTab]);
 
 	const handleStopGroupChatButton = () => {
@@ -313,8 +315,7 @@ export const GroupChatInfo = () => {
 							{featureGroupChatV2Enabled && isV2GroupChat && (
 								<div className="groupChatInfo__groupChatContainer">
 									<GroupChatCopyLinks
-										id={activeSession.item.groupId}
-										groupChatId={activeSession.item.id.toString()}
+										seriesId={activeSession.item.id}
 									/>
 								</div>
 							)}

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -89,13 +89,32 @@ describe('buildGroupChatSeriesRequest', () => {
 			modality: 'AUDIO',
 			timezone: 'Europe/Berlin',
 			hintMessage: '',
-			groupChatRulesTranslations: { de: ['', '  ', 'Respect'] },
+			groupChatRulesTranslations: { de: ['', '  ', '  Respect  '] },
 			consultantIds: []
 		});
 
 		expect(request.groupChatRulesTranslations).toEqual({
 			de: ['Respect']
 		});
+	});
+
+	it('omits group rules when every locale contains only blanks', () => {
+		const request = buildGroupChatSeriesRequest({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 60,
+			repeatCount: 1,
+			chatInterval: 'WEEKLY',
+			modality: 'TEXT',
+			timezone: 'Europe/Berlin',
+			hintMessage: '',
+			groupChatRulesTranslations: { de: ['', '  '] },
+			consultantIds: []
+		});
+
+		expect(request.groupChatRulesTranslations).toBeUndefined();
 	});
 });
 

--- a/src/components/groupChat/createChatHelpers.test.ts
+++ b/src/components/groupChat/createChatHelpers.test.ts
@@ -76,6 +76,27 @@ describe('buildGroupChatSeriesRequest', () => {
 			modality: 'VIDEO'
 		});
 	});
+
+	it('does not submit blank group rules that the API rejects', () => {
+		const request = buildGroupChatSeriesRequest({
+			topic: 'Peer support',
+			agencyId: 17,
+			startDate: '2026-08-04',
+			startTime: '18:30',
+			duration: 60,
+			repeatCount: 1,
+			chatInterval: 'WEEKLY',
+			modality: 'AUDIO',
+			timezone: 'Europe/Berlin',
+			hintMessage: '',
+			groupChatRulesTranslations: { de: ['', '  ', 'Respect'] },
+			consultantIds: []
+		});
+
+		expect(request.groupChatRulesTranslations).toEqual({
+			de: ['Respect']
+		});
+	});
 });
 
 describe('buildOneOffDuplicateFields', () => {

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -29,14 +29,31 @@ export const isGroupChatFeatureEnabled = (
 export const buildGroupChatSeriesRequest = ({
 	repeatCount,
 	chatInterval,
+	groupChatRulesTranslations,
 	...form
-}: GroupChatSeriesFormValue): groupChatSettings => ({
-	...form,
-	repetitive: repeatCount > 1,
-	repeatCount,
-	...(repeatCount > 1 ? { chatInterval } : {}),
-	featureGroupChatV2Enabled: true
-});
+}: GroupChatSeriesFormValue): groupChatSettings => {
+	const normalizedRules = groupChatRulesTranslations
+		? Object.fromEntries(
+				Object.entries(groupChatRulesTranslations).map(
+					([language, rules]) => [
+						language,
+						rules.map((rule) => rule.trim()).filter(Boolean)
+					]
+				)
+			)
+		: undefined;
+
+	return {
+		...form,
+		...(normalizedRules
+			? { groupChatRulesTranslations: normalizedRules }
+			: {}),
+		repetitive: repeatCount > 1,
+		repeatCount,
+		...(repeatCount > 1 ? { chatInterval } : {}),
+		featureGroupChatV2Enabled: true
+	};
+};
 
 export const buildOneOffDuplicateFields = ({
 	topic,

--- a/src/components/groupChat/createChatHelpers.ts
+++ b/src/components/groupChat/createChatHelpers.ts
@@ -34,18 +34,22 @@ export const buildGroupChatSeriesRequest = ({
 }: GroupChatSeriesFormValue): groupChatSettings => {
 	const normalizedRules = groupChatRulesTranslations
 		? Object.fromEntries(
-				Object.entries(groupChatRulesTranslations).map(
-					([language, rules]) => [
-						language,
-						rules.map((rule) => rule.trim()).filter(Boolean)
-					]
+				Object.entries(groupChatRulesTranslations).flatMap(
+					([language, rules]) => {
+						const normalized = rules
+							.map((rule) => rule.trim())
+							.filter(Boolean);
+						return normalized.length
+							? [[language, normalized]]
+							: [];
+					}
 				)
 			)
 		: undefined;
 
 	return {
 		...form,
-		...(normalizedRules
+		...(normalizedRules && Object.keys(normalizedRules).length
 			? { groupChatRulesTranslations: normalizedRules }
 			: {}),
 		repetitive: repeatCount > 1,

--- a/src/components/groupChat/groupChatHelpers.test.ts
+++ b/src/components/groupChat/groupChatHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	canModerateGroupChat,
+	isV2GroupChatSession,
 	shouldShowGroupChatJoinView
 } from './groupChatHelpers';
 
@@ -76,5 +77,16 @@ describe('shouldShowGroupChatJoinView', () => {
 				isBanned: true
 			})
 		).toBe(false);
+	});
+});
+
+describe('isV2GroupChatSession', () => {
+	it('recognizes a self-help Series even when consultingType is present', () => {
+		expect(
+			isV2GroupChatSession({
+				isGroup: true,
+				item: { modality: 'TEXT', consultingType: 1 }
+			})
+		).toBe(true);
 	});
 });

--- a/src/components/groupChat/groupChatHelpers.ts
+++ b/src/components/groupChat/groupChatHelpers.ts
@@ -7,6 +7,22 @@ interface GroupChatAuthorizationUser {
 	userId?: string;
 }
 
+interface V2GroupChatSession {
+	isGroup?: boolean;
+	item?: {
+		modality?: string;
+		consultingType?: number;
+	};
+}
+
+export const isV2GroupChatSession = ({
+	isGroup,
+	item
+}: V2GroupChatSession): boolean =>
+	Boolean(
+		isGroup && ['TEXT', 'AUDIO', 'VIDEO'].includes(item?.modality || '')
+	);
+
 export const isGroupChatOwner = (
 	activeSession: GroupChatAuthorizationSession,
 	userData?: GroupChatAuthorizationUser

--- a/src/components/groupChat/groupChatInviteLink.test.ts
+++ b/src/components/groupChat/groupChatInviteLink.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { buildGroupChatInviteLink } from './groupChatInviteLink';
+
+describe('buildGroupChatInviteLink', () => {
+	it('uses the stable numeric Series id as gcid', () => {
+		expect(
+			buildGroupChatInviteLink('https://app.oriso-dev.site/login', 1013)
+		).toBe('https://app.oriso-dev.site/login?gcid=1013');
+	});
+});

--- a/src/components/groupChat/groupChatInviteLink.ts
+++ b/src/components/groupChat/groupChatInviteLink.ts
@@ -1,0 +1,8 @@
+export const buildGroupChatInviteLink = (
+	loginUrl: string,
+	seriesId: number
+) => {
+	const url = new URL(loginUrl);
+	url.searchParams.set('gcid', String(seriesId));
+	return url.toString();
+};

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -37,6 +37,7 @@ import '../../resources/styles/styles';
 import './login.styles';
 import useIsFirstVisit from '../../utils/useIsFirstVisit';
 import { VALIDITY_INVALID } from '../registration/registrationHelpers';
+import { buildRegistrationLink } from './groupChatRegistrationLink';
 import { TwoFactorAuthResendMail } from '../twoFactorAuth/TwoFactorAuthResendMail';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
@@ -717,7 +718,11 @@ export const Login = () => {
 									<button
 										onClick={() =>
 											window.open(
-												settings.urls.toRegistration,
+												buildRegistrationLink(
+													settings.urls
+														.toRegistration,
+													gcid
+												),
 												'_self'
 											)
 										}

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -72,6 +72,10 @@ export const Login = () => {
 	const { userData, reloadUserData } = useContext(UserDataContext);
 	const { Stage } = useContext(GlobalComponentContext);
 	const gcid = useSearchParam<string>('gcid');
+	const registrationUrl = buildRegistrationLink(
+		settings.urls.toRegistration,
+		gcid
+	);
 	const magicToken = useSearchParam<string>('magicToken');
 	const isFirstVisit = useIsFirstVisit();
 
@@ -389,6 +393,7 @@ export const Login = () => {
 				stage={<Stage hasAnimation={isFirstVisit} isReady={isReady} />}
 				showLegalLinks
 				showRegistrationLink={hasTenant}
+				registrationUrl={registrationUrl}
 			>
 				<div className="loginForm">
 					<div className="loginForm__inner">
@@ -718,11 +723,7 @@ export const Login = () => {
 									<button
 										onClick={() =>
 											window.open(
-												buildRegistrationLink(
-													settings.urls
-														.toRegistration,
-													gcid
-												),
+												registrationUrl,
 												'_self'
 											)
 										}

--- a/src/components/login/groupChatRegistrationLink.test.ts
+++ b/src/components/login/groupChatRegistrationLink.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildRegistrationLink } from './groupChatRegistrationLink';
+
+describe('buildRegistrationLink', () => {
+	it('preserves the Series invitation when login continues to registration', () => {
+		expect(
+			buildRegistrationLink(
+				'https://app.oriso-dev.site/registration',
+				'1013'
+			)
+		).toBe('https://app.oriso-dev.site/registration?gcid=1013');
+	});
+
+	it('keeps the normal registration URL without an invitation', () => {
+		expect(
+			buildRegistrationLink(
+				'https://app.oriso-dev.site/registration',
+				null
+			)
+		).toBe('https://app.oriso-dev.site/registration');
+	});
+});

--- a/src/components/login/groupChatRegistrationLink.ts
+++ b/src/components/login/groupChatRegistrationLink.ts
@@ -1,0 +1,9 @@
+export const buildRegistrationLink = (
+	registrationUrl: string,
+	gcid?: string | null
+): string => {
+	if (!gcid?.trim()) return registrationUrl;
+	const url = new URL(registrationUrl);
+	url.searchParams.set('gcid', gcid.trim());
+	return url.toString();
+};

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createMatrixClient,
+	getElementCallAccessToken,
 	getMatrixAccessToken,
 	persistMatrixLoginData
 } from './getMatrixAccessToken';
@@ -50,6 +51,9 @@ beforeEach(() => {
 		configurable: true
 	});
 	vi.clearAllMocks();
+	vi.mocked(getMatrixHomeserverUrl).mockReturnValue(
+		'https://matrix.example.test'
+	);
 });
 
 afterEach(() => {
@@ -220,5 +224,35 @@ describe('getMatrixAccessToken', () => {
 				fallbackICEServerAllowed: true
 			}
 		});
+	});
+});
+
+describe('getElementCallAccessToken', () => {
+	it('uses a dedicated stable device instead of the ORISO app device', async () => {
+		localStorage.setItem('matrix_device_id', 'ORISO_WEB_MAIN_DEVICE');
+		Object.defineProperty(globalThis, 'crypto', {
+			value: { randomUUID: () => '12345678-90ab-cdef-1234-567890abcdef' },
+			configurable: true
+		});
+		vi.mocked(fetchData).mockResolvedValue({
+			accessToken: 'element-call-token',
+			deviceId: 'ORISO_CALL_1234567890ABCDEF12345678',
+			userId: '@user:matrix.example.test'
+		});
+
+		const result = await getElementCallAccessToken();
+
+		expect(result.deviceId).toBe('ORISO_CALL_1234567890ABCDEF12345678');
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://api.example.test/service/matrix/me/token?deviceId=ORISO_CALL_1234567890ABCDEF12345678'
+			})
+		);
+		expect(localStorage.getItem('matrix_device_id')).toBe(
+			'ORISO_WEB_MAIN_DEVICE'
+		);
+		expect(localStorage.getItem('matrix_call_device_id')).toBe(
+			'ORISO_CALL_1234567890ABCDEF12345678'
+		);
 	});
 });

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -12,9 +12,13 @@ export interface MatrixLoginData {
 }
 
 const MATRIX_DEVICE_ID_STORAGE_KEY = 'matrix_device_id';
+const MATRIX_CALL_DEVICE_ID_STORAGE_KEY = 'matrix_call_device_id';
 const MATRIX_DEVICE_ID_PREFIX = 'ORISO_WEB_';
+const MATRIX_CALL_DEVICE_ID_PREFIX = 'ORISO_CALL_';
 
-const createBrowserDeviceId = (): string => {
+const createBrowserDeviceId = (
+	prefix: string = MATRIX_DEVICE_ID_PREFIX
+): string => {
 	const randomValue =
 		typeof crypto !== 'undefined' && crypto.randomUUID
 			? crypto.randomUUID().replace(/-/g, '')
@@ -22,9 +26,7 @@ const createBrowserDeviceId = (): string => {
 					.toString(36)
 					.slice(2)}`;
 
-	return `${MATRIX_DEVICE_ID_PREFIX}${randomValue
-		.toUpperCase()
-		.slice(0, 24)}`;
+	return `${prefix}${randomValue.toUpperCase().slice(0, 24)}`;
 };
 
 const getOrCreateMatrixDeviceId = (
@@ -47,15 +49,62 @@ const getOrCreateMatrixDeviceId = (
 	return deviceId;
 };
 
-const getOrCreateRequestedDeviceId = (): string => {
-	const storedDeviceId = localStorage.getItem(MATRIX_DEVICE_ID_STORAGE_KEY);
+const getOrCreateRequestedDeviceId = (
+	storageKey: string = MATRIX_DEVICE_ID_STORAGE_KEY,
+	prefix: string = MATRIX_DEVICE_ID_PREFIX
+): string => {
+	const storedDeviceId = localStorage.getItem(storageKey);
 	if (storedDeviceId) {
 		return storedDeviceId;
 	}
 
-	const deviceId = createBrowserDeviceId();
-	localStorage.setItem(MATRIX_DEVICE_ID_STORAGE_KEY, deviceId);
+	const deviceId = createBrowserDeviceId(prefix);
+	localStorage.setItem(storageKey, deviceId);
 	return deviceId;
+};
+
+export const getElementCallAccessToken = (): Promise<MatrixLoginData> => {
+	const requestedDeviceId = getOrCreateRequestedDeviceId(
+		MATRIX_CALL_DEVICE_ID_STORAGE_KEY,
+		MATRIX_CALL_DEVICE_ID_PREFIX
+	);
+	const querySeparator = endpoints.matrixAccessToken.includes('?')
+		? '&'
+		: '?';
+	const tokenUrl = `${endpoints.matrixAccessToken}${querySeparator}deviceId=${encodeURIComponent(
+		requestedDeviceId
+	)}`;
+
+	return fetchData({
+		url: tokenUrl,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL],
+		recoverOnPublicAuthRoute: false
+	}).then((response) => {
+		const homeserverUrl = getMatrixHomeserverUrl();
+		if (!homeserverUrl) {
+			throw new Error(
+				'REACT_APP_MATRIX_HOMESERVER_URL is not configured'
+			);
+		}
+		if (!response.accessToken || !response.userId || !response.deviceId) {
+			throw new Error(
+				'Element Call login did not return a device-bound access token'
+			);
+		}
+
+		localStorage.setItem(
+			MATRIX_CALL_DEVICE_ID_STORAGE_KEY,
+			response.deviceId
+		);
+		return {
+			accessToken: response.accessToken,
+			userId: response.userId,
+			deviceId: response.deviceId,
+			homeserverUrl,
+			expiresInMs: response.expiresInMs
+		};
+	});
 };
 
 export const getMatrixAccessToken = (

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -72,6 +72,7 @@ import {
 	ChatMenuDropdownHeader,
 	ChatMenuDropdownItemContent as SessionMenuItemContent
 } from '../chatMenuDropdown/ChatMenuDropdown';
+import { sessionMenuOwnsCallControls } from './callControlOwnership';
 
 export interface SessionMenuProps {
 	hasUserInitiatedStopOrLeaveRequest: React.MutableRefObject<boolean>;
@@ -522,7 +523,8 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 	return (
 		<div className="sessionMenu__wrapper">
-			{hasVideoCallFeatures() &&
+			{sessionMenuOwnsCallControls(activeSession.isGroup) &&
+				hasVideoCallFeatures() &&
 				!props.isSupervisor &&
 				(isAudioCallsEnabled || isVideoCallsEnabled) && (
 					<div

--- a/src/components/sessionMenu/callControlOwnership.test.ts
+++ b/src/components/sessionMenu/callControlOwnership.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { sessionMenuOwnsCallControls } from './callControlOwnership';
+
+describe('sessionMenuOwnsCallControls', () => {
+	it('leaves group-call controls exclusively to GroupChatHeader', () => {
+		expect(sessionMenuOwnsCallControls(true)).toBe(false);
+	});
+
+	it('keeps call controls for non-group sessions', () => {
+		expect(sessionMenuOwnsCallControls(false)).toBe(true);
+	});
+});

--- a/src/components/sessionMenu/callControlOwnership.ts
+++ b/src/components/sessionMenu/callControlOwnership.ts
@@ -1,0 +1,2 @@
+export const sessionMenuOwnsCallControls = (isGroup: boolean): boolean =>
+	!isGroup;

--- a/src/components/stageLayout/StageLayout.test.tsx
+++ b/src/components/stageLayout/StageLayout.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { AgencySpecificContext, LocaleContext } from '../../globalState';
+import { StageLayout } from './StageLayout';
+
+vi.mock('../../hooks/useAppConfig', () => ({
+	useAppConfig: () => ({
+		urls: {
+			toLogin: 'https://app.oriso-dev.site/login',
+			toRegistration: 'https://app.oriso-dev.site/registration'
+		}
+	})
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) =>
+			key === 'login.register.linkLabel' ? 'Register' : key
+	})
+}));
+
+vi.mock('../registration/infoDrawer/InfoDrawer', () => ({
+	InfoDrawer: () => null
+}));
+
+vi.mock('lottie-react', () => ({ default: () => null }));
+
+describe('StageLayout registration invitation continuity', () => {
+	it('uses the invitation-aware registration URL supplied by Login', () => {
+		render(
+			<MemoryRouter>
+				<LocaleContext.Provider
+					value={{ selectableLocales: [] } as any}
+				>
+					<AgencySpecificContext.Provider
+						value={{ specificAgency: null } as any}
+					>
+						<StageLayout
+							stage={<div>stage</div>}
+							showRegistrationLink
+							registrationUrl="https://app.oriso-dev.site/registration?gcid=1017"
+						>
+							<div>content</div>
+						</StageLayout>
+					</AgencySpecificContext.Provider>
+				</LocaleContext.Provider>
+			</MemoryRouter>
+		);
+
+		expect(
+			screen.getByRole('link', { name: /register/i }).getAttribute('href')
+		).toBe('https://app.oriso-dev.site/registration?gcid=1017');
+	});
+});

--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -37,6 +37,7 @@ interface StageLayoutProps {
 	showLoginLink?: boolean;
 	showRegistrationLink?: boolean;
 	loginParams?: string;
+	registrationUrl?: string;
 	showRegistrationInfoDrawer?: boolean;
 }
 
@@ -48,6 +49,7 @@ export const StageLayout = ({
 	showLoginLink,
 	showRegistrationLink,
 	loginParams,
+	registrationUrl,
 	showRegistrationInfoDrawer
 }: StageLayoutProps) => {
 	const trigger = useScrollTrigger();
@@ -63,8 +65,10 @@ export const StageLayout = ({
 		loginParams ? `?${loginParams}` : ''
 	}`;
 	const loginRoute = toSameOriginRoute(loginUrl);
-	const registrationRoute = toSameOriginRoute(settings.urls.toRegistration);
-	const registrationHref = registrationRoute || settings.urls.toRegistration;
+	const resolvedRegistrationUrl =
+		registrationUrl || settings.urls.toRegistration;
+	const registrationRoute = toSameOriginRoute(resolvedRegistrationUrl);
+	const registrationHref = registrationRoute || resolvedRegistrationUrl;
 
 	return (
 		<div className={clsx('stageLayout', className)}>

--- a/src/hooks/useJoinGroupChat.test.tsx
+++ b/src/hooks/useJoinGroupChat.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiPutGroupChat, GROUP_CHAT_API } from '../api';
+import { useJoinGroupChat } from './useJoinGroupChat';
+
+vi.mock('../api', () => ({
+	apiPutGroupChat: vi.fn(() => Promise.resolve()),
+	GROUP_CHAT_API: { ASSIGN: '/assign', JOIN: '/join' }
+}));
+
+vi.mock('../globalState', () => ({
+	useTenant: () => ({ settings: { featureGroupChatV2Enabled: true } })
+}));
+
+describe('useJoinGroupChat', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('joins a V2 Series through the canonical join endpoint', () => {
+		const { result } = renderHook(() => useJoinGroupChat());
+
+		act(() => result.current.joinGroupChat('1013'));
+
+		expect(apiPutGroupChat).toHaveBeenCalledWith(
+			'1013',
+			GROUP_CHAT_API.JOIN
+		);
+	});
+});

--- a/src/hooks/useJoinGroupChat.test.tsx
+++ b/src/hooks/useJoinGroupChat.test.tsx
@@ -17,14 +17,14 @@ vi.mock('../globalState', () => ({
 describe('useJoinGroupChat', () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it('joins a V2 Series through the canonical join endpoint', () => {
+	it('assigns an invited user before the visible join action', () => {
 		const { result } = renderHook(() => useJoinGroupChat());
 
 		act(() => result.current.joinGroupChat('1013'));
 
 		expect(apiPutGroupChat).toHaveBeenCalledWith(
 			'1013',
-			GROUP_CHAT_API.JOIN
+			GROUP_CHAT_API.ASSIGN
 		);
 	});
 });

--- a/src/hooks/useJoinGroupChat.ts
+++ b/src/hooks/useJoinGroupChat.ts
@@ -8,7 +8,7 @@ export const useJoinGroupChat = () => {
 	const joinGroupChat = useCallback(
 		(gcid: string) => {
 			if (tenantData?.settings?.featureGroupChatV2Enabled && gcid) {
-				apiPutGroupChat(gcid, GROUP_CHAT_API.ASSIGN).then();
+				apiPutGroupChat(gcid, GROUP_CHAT_API.JOIN).then();
 			}
 		},
 		[tenantData]

--- a/src/hooks/useJoinGroupChat.ts
+++ b/src/hooks/useJoinGroupChat.ts
@@ -8,7 +8,7 @@ export const useJoinGroupChat = () => {
 	const joinGroupChat = useCallback(
 		(gcid: string) => {
 			if (tenantData?.settings?.featureGroupChatV2Enabled && gcid) {
-				apiPutGroupChat(gcid, GROUP_CHAT_API.JOIN).then();
+				apiPutGroupChat(gcid, GROUP_CHAT_API.ASSIGN).then();
 			}
 		},
 		[tenantData]

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -64,7 +64,7 @@ type Listener = (...args: any[]) => void;
  */
 const createFakeMatrixClient = (userId = MY_USER_ID) => {
 	const listeners = new Map<string, Set<Listener>>();
-	return {
+	const event = {
 		on: (event: string, listener: Listener) => {
 			if (!listeners.has(event)) {
 				listeners.set(event, new Set());
@@ -80,6 +80,7 @@ const createFakeMatrixClient = (userId = MY_USER_ID) => {
 			listeners.get(event)?.forEach((listener) => listener(...args));
 		}
 	};
+	return event;
 };
 
 const makeEvent = (overrides: Record<string, any> = {}) => {
@@ -90,13 +91,36 @@ const makeEvent = (overrides: Record<string, any> = {}) => {
 		ts = Date.now(),
 		id = '$evt:matrix.oriso.org'
 	} = overrides;
-	return {
-		getType: () => type,
-		getContent: () => content,
+	let currentType = type;
+	let currentContent = content;
+	const listeners = new Map<string, Set<Listener>>();
+	const event = {
+		getType: () => currentType,
+		getContent: () => currentContent,
 		getSender: () => sender,
 		getTs: () => ts,
-		getId: () => id
+		getId: () => id,
+		on: (event: string, listener: Listener) => {
+			if (!listeners.has(event)) listeners.set(event, new Set());
+			listeners.get(event)!.add(listener);
+		},
+		off: (event: string, listener: Listener) => {
+			listeners.get(event)?.delete(listener);
+		},
+		emitDecrypted: (
+			clearEvent?: { type: string; content: Record<string, any> },
+			error?: Error
+		) => {
+			if (clearEvent && !error) {
+				currentType = clearEvent.type;
+				currentContent = clearEvent.content;
+			}
+			listeners
+				.get('Event.decrypted')
+				?.forEach((listener) => listener(event, error));
+		}
 	};
+	return event;
 };
 
 const room = { roomId: ROOM_ID };
@@ -246,6 +270,45 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		expect(args[1]).toBe(true); // isVideo
 		expect(args[2]).toBe('call-group'); // callId
 		expect(args[4]).toBe(true); // isGroupCall
+	});
+
+	it('routes an encrypted group-call invite after a later successful decryption', () => {
+		const event = makeEvent({ type: 'm.room.encrypted' });
+
+		client.emit('Room.timeline', event, room, false);
+		expect(receiveCall).not.toHaveBeenCalled();
+
+		// A missing room key can fail the first attempt. The bridge must remain
+		// subscribed so the Rust-Crypto retry can deliver the clear event later.
+		event.emitDecrypted(undefined, new Error('missing room key'));
+		expect(receiveCall).not.toHaveBeenCalled();
+
+		event.emitDecrypted({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'call-encrypted',
+				is_group_call: true,
+				is_element_call: true,
+				is_video: true,
+				call_room_id: '!element:matrix.oriso.org'
+			}
+		});
+
+		expect(receiveCall).toHaveBeenCalledTimes(1);
+		expect(receiveCall).toHaveBeenCalledWith(
+			'!element:matrix.oriso.org',
+			true,
+			'call-encrypted',
+			OTHER_USER_ID,
+			true,
+			ROOM_ID,
+			true
+		);
+
+		// Further SDK notifications for the same MatrixEvent must not dispatch it
+		// again after the bridge has consumed the successful decryption.
+		event.emitDecrypted();
+		expect(receiveCall).toHaveBeenCalledTimes(1);
 	});
 
 	it('ignores stale hangups but ends the call for a fresh hangup', () => {

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -186,6 +186,21 @@ describe('MatrixLiveEventBridge initialize / timeline binding', () => {
 		// Bodies never cross into the bridged event (Matrix privacy boundary).
 		expect(JSON.stringify(payload)).not.toContain('secret body');
 	});
+
+	it('refreshes metadata only once when an encrypted message decrypts later', () => {
+		bridge.initialize(client as any);
+		const callback = vi.fn();
+		bridge.on('directMessage', callback);
+		const event = makeEvent({ type: 'm.room.encrypted' });
+
+		client.emit('Room.timeline', event, room, false);
+		event.emitDecrypted({
+			type: 'm.room.message',
+			content: { msgtype: 'm.text', body: 'secret body' }
+		});
+
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
@@ -273,7 +288,10 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 	});
 
 	it('routes an encrypted group-call invite after a later successful decryption', () => {
-		const event = makeEvent({ type: 'm.room.encrypted' });
+		const event = makeEvent({
+			type: 'm.room.encrypted',
+			ts: Date.now() - 11_000
+		});
 
 		client.emit('Room.timeline', event, room, false);
 		expect(receiveCall).not.toHaveBeenCalled();

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -91,10 +91,16 @@ export class MatrixLiveEventBridge {
 		);
 	}
 
-	private dispatchTimelineEvent(event: MatrixEvent, room: Room): void {
+	private dispatchTimelineEvent(
+		event: MatrixEvent,
+		room: Room,
+		fromDecryptionRetry = false
+	): void {
 		switch (event.getType()) {
 			case 'm.room.message':
-				this.handleRoomMessage(event, room);
+				if (!fromDecryptionRetry) {
+					this.handleRoomMessage(event, room);
+				}
 				break;
 
 			case 'm.room.encrypted':
@@ -107,7 +113,7 @@ export class MatrixLiveEventBridge {
 
 			case 'm.call.invite':
 			case 'org.oriso.call.invite':
-				this.handleCallInvite(event, room);
+				this.handleCallInvite(event, room, fromDecryptionRetry);
 				break;
 
 			case 'm.call.hangup':
@@ -143,7 +149,7 @@ export class MatrixLiveEventBridge {
 
 			completed = true;
 			cleanup();
-			this.dispatchTimelineEvent(decryptedEvent, room);
+			this.dispatchTimelineEvent(decryptedEvent, room, true);
 		};
 
 		event.on('Event.decrypted' as any, listener as any);
@@ -199,7 +205,11 @@ export class MatrixLiveEventBridge {
 	/**
 	 * Handle m.call.invite events (incoming calls).
 	 */
-	private handleCallInvite(event: MatrixEvent, room: Room): void {
+	private handleCallInvite(
+		event: MatrixEvent,
+		room: Room,
+		fromDecryptionRetry = false
+	): void {
 		const sender = event.getSender();
 		const content = event.getContent();
 		const callId = content.call_id;
@@ -220,7 +230,7 @@ export class MatrixLiveEventBridge {
 
 		// CRITICAL: Ignore old call invites (> 10 seconds = from history/replay!)
 		// This prevents phantom notifications on login/reload
-		if (ageSeconds > 10) {
+		if (!fromDecryptionRetry && ageSeconds > 10) {
 			// console.log("🚫 IGNORING OLD CALL INVITE (from history, not a new call!)");
 			// console.log("═══════════════════════════════════════════════");
 			this.processedCallInvites.add(callId);

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -25,6 +25,13 @@ export class MatrixLiveEventBridge {
 	private eventCallbacks: Map<string, Set<(event: any) => void>> = new Map();
 	private initialized: boolean = false;
 	private processedCallInvites: Set<string> = new Set(); // Track processed call IDs
+	private pendingEncryptedEvents = new Map<
+		MatrixEvent,
+		{
+			listener: (event: MatrixEvent, error?: Error) => void;
+			timeout: ReturnType<typeof setTimeout>;
+		}
+	>();
 
 	/**
 	 * Initialize the bridge with a Matrix client.
@@ -43,6 +50,7 @@ export class MatrixLiveEventBridge {
 		if (this.client && this.client !== client) {
 			this.client.removeAllListeners('Room.timeline' as any);
 			this.client.removeAllListeners('sync' as any);
+			this.clearPendingEncryptedEvents();
 		}
 
 		this.client = client;
@@ -70,36 +78,7 @@ export class MatrixLiveEventBridge {
 					return;
 				}
 
-				const eventType = event.getType();
-
-				// console.log("📩 Matrix event:", {
-				// type: eventType,
-				// roomId: room.roomId,
-				// sender: event.getSender(),
-				// timestamp: event.getTs()
-				// });
-
-				// Handle different event types
-				switch (eventType) {
-					case 'm.room.message':
-					case 'm.room.encrypted':
-						this.handleRoomMessage(event, room);
-						break;
-
-					case 'm.call.invite':
-					case 'org.oriso.call.invite':
-						this.handleCallInvite(event, room);
-						break;
-
-					case 'm.call.hangup':
-					case 'org.oriso.call.hangup':
-						this.handleCallHangup(event, room);
-						break;
-
-					default:
-						// Ignore other events
-						break;
-				}
+				this.dispatchTimelineEvent(event, room);
 			}
 		);
 
@@ -110,6 +89,86 @@ export class MatrixLiveEventBridge {
 				// console.log("🔄 Matrix sync state:", state, "(previous:", prevState, ")");
 			}
 		);
+	}
+
+	private dispatchTimelineEvent(event: MatrixEvent, room: Room): void {
+		switch (event.getType()) {
+			case 'm.room.message':
+				this.handleRoomMessage(event, room);
+				break;
+
+			case 'm.room.encrypted':
+				// Room.timeline can fire before Rust-Crypto has the Megolm key.
+				// Keep the existing metadata refresh, but also redispatch the clear
+				// event when a later decryption retry succeeds.
+				this.handleRoomMessage(event, room);
+				this.waitForSuccessfulDecryption(event, room);
+				break;
+
+			case 'm.call.invite':
+			case 'org.oriso.call.invite':
+				this.handleCallInvite(event, room);
+				break;
+
+			case 'm.call.hangup':
+			case 'org.oriso.call.hangup':
+				this.handleCallHangup(event, room);
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	private waitForSuccessfulDecryption(event: MatrixEvent, room: Room): void {
+		if (this.pendingEncryptedEvents.has(event)) return;
+
+		let completed = false;
+		let timeout: ReturnType<typeof setTimeout>;
+		const cleanup = () => {
+			event.off('Event.decrypted' as any, listener as any);
+			clearTimeout(timeout);
+			this.pendingEncryptedEvents.delete(event);
+		};
+		const listener = (decryptedEvent: MatrixEvent, error?: Error) => {
+			// Rust-Crypto emits Event.decrypted for a failed attempt too. Keep
+			// listening so receipt of a delayed room key can retry successfully.
+			if (
+				completed ||
+				error ||
+				decryptedEvent.getType() === 'm.room.encrypted'
+			) {
+				return;
+			}
+
+			completed = true;
+			cleanup();
+			this.dispatchTimelineEvent(decryptedEvent, room);
+		};
+
+		event.on('Event.decrypted' as any, listener as any);
+		timeout = setTimeout(
+			() => {
+				completed = true;
+				cleanup();
+			},
+			5 * 60 * 1000
+		);
+		this.pendingEncryptedEvents.set(event, { listener, timeout });
+
+		// Close the small race where decryption finishes between the initial
+		// type check and listener registration.
+		if (event.getType() !== 'm.room.encrypted') {
+			listener(event);
+		}
+	}
+
+	private clearPendingEncryptedEvents(): void {
+		this.pendingEncryptedEvents.forEach(({ listener, timeout }, event) => {
+			event.off('Event.decrypted' as any, listener as any);
+			clearTimeout(timeout);
+		});
+		this.pendingEncryptedEvents.clear();
 	}
 
 	/**
@@ -340,6 +399,7 @@ export class MatrixLiveEventBridge {
 			this.client.removeAllListeners('Room.timeline' as any);
 			this.client.removeAllListeners('sync' as any);
 		}
+		this.clearPendingEncryptedEvents();
 		this.processedCallInvites.clear();
 		this.initialized = false;
 		this.client = null;


### PR DESCRIPTION
## Summary

Finalizes the Self-Help Group PreDev E2E repair delta after the merged feature PR #402.

Refs #396, #400, and #404.

## Verified behavior

- numeric invite and registration continuity
- correct assignment-before-join workflow
- dedicated Element Call device identity
- delayed encrypted call-event dispatch without duplicate metadata
- modality-correct audio/video controls
- normalized multilingual group rules

## Evidence

- 105 test files / 586 tests passed
- ESLint, TypeScript, and production build passed
- deployed and proven on PreDev as `e402528`
- encrypted text, advice-seeker join, two-party audio, and two-party video passed in a real browser

This PR promotes an already-tested hot image delta into the regular `pre-dev` image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
