### PR TITLE
fix: refresh delayed Matrix decryption

### DIFF
--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -51,6 +51,60 @@ const createFakeMatrixClient = (room: any = null) => {
 	};
 };
 
+describe('chatTransportService Matrix timeline', () => {
+	let fakeClient: ReturnType<typeof createFakeMatrixClient>;
+
+	beforeEach(() => {
+		fakeClient = createFakeMatrixClient();
+		setMatrixClientServiceRef({
+			getClient: () => fakeClient
+		} as any);
+	});
+
+	afterEach(() => {
+		setMatrixClientServiceRef(null);
+	});
+
+	it('notifies again when a live encrypted event decrypts after first delivery', () => {
+		const decryptionListeners = new Set<Listener>();
+		let eventType = 'm.room.encrypted';
+		const event = {
+			getType: () => eventType,
+			on: (name: string, listener: Listener) => {
+				if (name === 'Event.decrypted')
+					decryptionListeners.add(listener);
+			},
+			off: (name: string, listener: Listener) => {
+				if (name === 'Event.decrypted')
+					decryptionListeners.delete(listener);
+			},
+			emitDecrypted: (error?: Error) => {
+				if (!error) eventType = 'm.room.message';
+				decryptionListeners.forEach((listener) =>
+					listener(event, error)
+				);
+			}
+		};
+		const room = { roomId: ROOM_ID };
+		const listener = vi.fn();
+		const detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenLastCalledWith(event, room, false);
+
+		event.emitDecrypted(new Error('room key not available yet'));
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(2);
+		expect(listener).toHaveBeenLastCalledWith(event, room, false);
+
+		detach?.();
+		expect(decryptionListeners.size).toBe(0);
+	});
+});
+
 describe('chatTransportService Matrix room lifecycle', () => {
 	let fakeClient: ReturnType<typeof createFakeMatrixClient>;
 

--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -51,6 +51,26 @@ const createFakeMatrixClient = (room: any = null) => {
 	};
 };
 
+const createFakeEncryptedMatrixEvent = () => {
+	const decryptionListeners = new Set<Listener>();
+	let eventType = 'm.room.encrypted';
+	const event = {
+		getType: () => eventType,
+		on: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted') decryptionListeners.add(listener);
+		},
+		off: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted')
+				decryptionListeners.delete(listener);
+		},
+		emitDecrypted: (error?: Error) => {
+			if (!error) eventType = 'm.room.message';
+			decryptionListeners.forEach((listener) => listener(event, error));
+		}
+	};
+	return { decryptionListeners, event };
+};
+
 describe('chatTransportService Matrix timeline', () => {
 	let fakeClient: ReturnType<typeof createFakeMatrixClient>;
 
@@ -66,25 +86,7 @@ describe('chatTransportService Matrix timeline', () => {
 	});
 
 	it('notifies again when a live encrypted event decrypts after first delivery', () => {
-		const decryptionListeners = new Set<Listener>();
-		let eventType = 'm.room.encrypted';
-		const event = {
-			getType: () => eventType,
-			on: (name: string, listener: Listener) => {
-				if (name === 'Event.decrypted')
-					decryptionListeners.add(listener);
-			},
-			off: (name: string, listener: Listener) => {
-				if (name === 'Event.decrypted')
-					decryptionListeners.delete(listener);
-			},
-			emitDecrypted: (error?: Error) => {
-				if (!error) eventType = 'm.room.message';
-				decryptionListeners.forEach((listener) =>
-					listener(event, error)
-				);
-			}
-		};
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
 		const room = { roomId: ROOM_ID };
 		const listener = vi.fn();
 		const detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
@@ -102,6 +104,60 @@ describe('chatTransportService Matrix timeline', () => {
 
 		detach?.();
 		expect(decryptionListeners.size).toBe(0);
+	});
+
+	it('does not register a decryption listener after synchronous detach', () => {
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
+		const room = { roomId: ROOM_ID };
+		let detach: (() => void) | null = null;
+		const listener = vi.fn(() => detach?.());
+		detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(decryptionListeners.size).toBe(0);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('removes a pending decryption listener on detach', () => {
+		const { decryptionListeners, event } = createFakeEncryptedMatrixEvent();
+		const room = { roomId: ROOM_ID };
+		const listener = vi.fn();
+		const detach = chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+		fakeClient.emit('Room.timeline', event, room, false);
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(decryptionListeners.size).toBe(1);
+
+		detach?.();
+		expect(decryptionListeners.size).toBe(0);
+
+		event.emitDecrypted();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('expires a pending decryption listener after five minutes', () => {
+		vi.useFakeTimers();
+		try {
+			const { decryptionListeners, event } =
+				createFakeEncryptedMatrixEvent();
+			const room = { roomId: ROOM_ID };
+			const listener = vi.fn();
+			chatTransportService.onMatrixTimeline(ROOM_ID, listener);
+
+			fakeClient.emit('Room.timeline', event, room, false);
+			expect(decryptionListeners.size).toBe(1);
+
+			vi.advanceTimersByTime(5 * 60 * 1000);
+			expect(decryptionListeners.size).toBe(0);
+
+			event.emitDecrypted();
+			expect(listener).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -52,6 +52,7 @@ type TimelineListener = (
 	room: Room,
 	toStartOfTimeline: boolean
 ) => void;
+type DecryptionListener = (event: MatrixEvent, error?: Error) => void;
 
 export type MatrixRoomLifecycleChange =
 	| {
@@ -177,6 +178,7 @@ class ChatTransportService {
 		if (!matrixClient) {
 			return null;
 		}
+		const pendingDecryptions = new Map<MatrixEvent, DecryptionListener>();
 
 		const handleTimeline = (
 			event: MatrixEvent,
@@ -187,12 +189,42 @@ class ChatTransportService {
 				return;
 			}
 			listener(event, room, toStartOfTimeline);
+
+			if (
+				toStartOfTimeline ||
+				event.getType() !== 'm.room.encrypted' ||
+				pendingDecryptions.has(event)
+			) {
+				return;
+			}
+
+			const handleDecrypted = (
+				decryptedEvent: MatrixEvent,
+				error?: Error
+			) => {
+				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
+					return;
+				}
+				event.off('Event.decrypted' as any, handleDecrypted as any);
+				pendingDecryptions.delete(event);
+				listener(decryptedEvent, room, false);
+			};
+
+			pendingDecryptions.set(event, handleDecrypted);
+			event.on('Event.decrypted' as any, handleDecrypted as any);
+			if (event.getType() !== 'm.room.encrypted') {
+				handleDecrypted(event);
+			}
 		};
 
 		(matrixClient as any).on('Room.timeline', handleTimeline);
 
 		return () => {
 			(matrixClient as any).off('Room.timeline', handleTimeline);
+			pendingDecryptions.forEach((decryptionListener, event) => {
+				event.off('Event.decrypted' as any, decryptionListener as any);
+			});
+			pendingDecryptions.clear();
 		};
 	}
 

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -53,6 +53,10 @@ type TimelineListener = (
 	toStartOfTimeline: boolean
 ) => void;
 type DecryptionListener = (event: MatrixEvent, error?: Error) => void;
+type PendingDecryption = {
+	listener: DecryptionListener;
+	timeout: ReturnType<typeof setTimeout>;
+};
 
 export type MatrixRoomLifecycleChange =
 	| {
@@ -178,19 +182,28 @@ class ChatTransportService {
 		if (!matrixClient) {
 			return null;
 		}
-		const pendingDecryptions = new Map<MatrixEvent, DecryptionListener>();
+		const pendingDecryptions = new Map<MatrixEvent, PendingDecryption>();
+		let detached = false;
+		const clearPendingDecryption = (event: MatrixEvent) => {
+			const pending = pendingDecryptions.get(event);
+			if (!pending) return;
+			clearTimeout(pending.timeout);
+			event.off('Event.decrypted' as any, pending.listener as any);
+			pendingDecryptions.delete(event);
+		};
 
 		const handleTimeline = (
 			event: MatrixEvent,
 			room: Room,
 			toStartOfTimeline: boolean
 		) => {
-			if (room?.roomId !== matrixRoomId) {
+			if (detached || room?.roomId !== matrixRoomId) {
 				return;
 			}
 			listener(event, room, toStartOfTimeline);
 
 			if (
+				detached ||
 				toStartOfTimeline ||
 				event.getType() !== 'm.room.encrypted' ||
 				pendingDecryptions.has(event)
@@ -205,12 +218,18 @@ class ChatTransportService {
 				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
 					return;
 				}
-				event.off('Event.decrypted' as any, handleDecrypted as any);
-				pendingDecryptions.delete(event);
+				clearPendingDecryption(event);
 				listener(decryptedEvent, room, false);
 			};
 
-			pendingDecryptions.set(event, handleDecrypted);
+			const timeout = setTimeout(
+				() => clearPendingDecryption(event),
+				5 * 60 * 1000
+			);
+			pendingDecryptions.set(event, {
+				listener: handleDecrypted,
+				timeout
+			});
 			event.on('Event.decrypted' as any, handleDecrypted as any);
 			if (event.getType() !== 'm.room.encrypted') {
 				handleDecrypted(event);
@@ -220,11 +239,11 @@ class ChatTransportService {
 		(matrixClient as any).on('Room.timeline', handleTimeline);
 
 		return () => {
+			detached = true;
 			(matrixClient as any).off('Room.timeline', handleTimeline);
-			pendingDecryptions.forEach((decryptionListener, event) => {
-				event.off('Event.decrypted' as any, decryptionListener as any);
-			});
-			pendingDecryptions.clear();
+			Array.from(pendingDecryptions.keys()).forEach(
+				clearPendingDecryption
+			);
 		};
 	}
 


### PR DESCRIPTION
## Problem

A live Matrix event can enter the open conversation as `m.room.encrypted` before Rust-Crypto receives its Megolm room key. The receiver later decrypts the event, but `SessionStream` was never notified again and kept rendering `Nachricht verschlüsselt`.

## Solution

`chatTransportService.onMatrixTimeline` now observes successful `Event.decrypted` transitions for live encrypted events and surfaces the resulting `m.room.message` through its existing public listener. Failed/incomplete attempts remain ignored, and cleanup removes the per-event listeners.

## Validation

- TDD red: delayed-decryption behavior test failed with one listener call instead of two.
- Focused transport suite: 20/20 passed.
- Full unit suite: 587/587 passed.
- ESLint + TypeScript: passed.
- Production build: passed with existing Autoprefixer warnings.
- Full Stylelint remains blocked by the existing unrelated empty-line violation in `src/components/message/message.styles.scss`.
- Final two-browser PreDev A-to-B, B-to-A, and reload proof follows after merge/deploy.

## Risk

The change is limited to the Matrix timeline subscription boundary. It does not move plaintext outside Matrix, change message persistence, or alter UI components.

Closes #411
Related: #408, #410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live chat timeline updates for encrypted messages after successful decryption.
  - Prevented duplicate or irrelevant timeline notifications during decryption.
  - Ensured decryption listeners are properly removed when timeline monitoring is stopped.

- **Tests**
  - Added coverage for encrypted event re-notification, decryption failures, duplicate events, and listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->