### PR TITLE
fix: retain decrypted Matrix refreshes

### DIFF
--- a/src/components/session/SessionStream.test.tsx
+++ b/src/components/session/SessionStream.test.tsx
@@ -24,7 +24,13 @@ const mocks = vi.hoisted(() => {
 		navigate: vi.fn(),
 		logout: vi.fn(),
 		lifecycleListeners: [] as ((change: any) => void)[],
+		timelineListeners: [] as ((
+			event: any,
+			room: any,
+			toStart: boolean
+		) => void)[],
 		detachLifecycle: vi.fn(),
+		getMatrixRoomMessages: vi.fn(() => []),
 		resolveSession: vi.fn(() => ({
 			isMatrixSession: true,
 			matrixRoomId: ROOM_ID,
@@ -64,10 +70,21 @@ vi.mock('../../services/chatTransportService', () => ({
 	chatTransportService: {
 		resolveSession: mocks.resolveSession,
 		getMatrixRoom: vi.fn(() => null),
-		getMatrixRoomMessages: vi.fn(() => []),
+		getMatrixRoomMessages: mocks.getMatrixRoomMessages,
 		sendTyping: vi.fn(() => Promise.resolve()),
 		markRoomAsRead: vi.fn(() => Promise.resolve()),
-		onMatrixTimeline: vi.fn(() => () => {}),
+		onMatrixTimeline: vi.fn(
+			(
+				_roomId: string,
+				listener: (event: any, room: any, toStart: boolean) => void
+			) => {
+				mocks.timelineListeners.push(listener);
+				return () => {
+					const index = mocks.timelineListeners.indexOf(listener);
+					if (index >= 0) mocks.timelineListeners.splice(index, 1);
+				};
+			}
+		),
 		onMatrixRoomLifecycle: vi.fn(
 			(_roomId: string, listener: (change: any) => void) => {
 				mocks.lifecycleListeners.push(listener);
@@ -197,6 +214,7 @@ describe('SessionStream Matrix room lifecycle', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.lifecycleListeners.length = 0;
+		mocks.timelineListeners.length = 0;
 		mocks.sessionItemProps = null;
 	});
 
@@ -279,5 +297,34 @@ describe('SessionStream Matrix room lifecycle', () => {
 
 		unmount();
 		expect(mocks.detachLifecycle).toHaveBeenCalled();
+	});
+
+	it('refreshes a clear message when delayed decryption lands inside the coalescing window', async () => {
+		renderSessionStream({ isGroup: true });
+
+		await waitFor(() => {
+			expect(mocks.timelineListeners.length).toBe(1);
+		});
+		const callsBeforeTimelineEvents =
+			mocks.getMatrixRoomMessages.mock.calls.length;
+		const encryptedEvent = { getType: () => 'm.room.encrypted' };
+		const decryptedEvent = { getType: () => 'm.room.message' };
+		const room = { roomId: ROOM_ID };
+
+		act(() => {
+			mocks.timelineListeners.forEach((listener) => {
+				listener(encryptedEvent, room, false);
+				listener(decryptedEvent, room, false);
+			});
+		});
+
+		await waitFor(
+			() => {
+				expect(mocks.getMatrixRoomMessages).toHaveBeenCalledTimes(
+					callsBeforeTimelineEvents + 2
+				);
+			},
+			{ timeout: 500 }
+		);
 	});
 });

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -401,6 +401,12 @@ export const SessionStream = ({
 		let retryTimer: number | null = null;
 		let detachTimelineListeners: Array<() => void> = [];
 		let lastRefreshAt = 0;
+		const refreshMessages = () => {
+			lastRefreshAt = Date.now();
+			fetchSessionMessages().catch(() => {
+				// keep UI stable if a timeline event races with navigation
+			});
+		};
 
 		const attachTimelineListeners = () => {
 			const handleMatrixTimeline = (
@@ -423,16 +429,14 @@ export const SessionStream = ({
 					return;
 				}
 
-				// Coalesce bursts (decrypt + relation updates) into one fetch.
+				// Coalesce encrypted/metadata bursts, but never drop a clear message:
+				// delayed Matrix decryption mutates the event after its fallback rendered.
 				const now = Date.now();
-				if (now - lastRefreshAt < 120) {
+				const elapsed = now - lastRefreshAt;
+				if (eventType !== 'm.room.message' && elapsed < 120) {
 					return;
 				}
-				lastRefreshAt = now;
-
-				fetchSessionMessages().catch(() => {
-					// keep UI stable if a timeline event races with navigation
-				});
+				refreshMessages();
 			};
 
 			const detachers = watchedRoomIds


### PR DESCRIPTION
## Problem

The deployed delayed-decryption transport fix correctly re-emits a clear Matrix event, but `SessionStream` can still discard it when it arrives within 120 ms of the encrypted event. The UI then keeps rendering `Nachricht verschlüsselt` even though Rust-Crypto received the Megolm room key.

## Solution

Keep coalescing encrypted/metadata bursts, but never discard a clear `m.room.message`. A component test drives encrypted and decrypted callbacks through one active timeline subscription inside the coalescing window and requires two timeline reads.

## TDD evidence

- Corrected the timeline mock so detach removes stale callbacks.
- Red: expected three total room reads (initial plus encrypted plus decrypted), received two.
- Rejected a trailing-timer implementation because the immediate refresh re-renders and tears down the effect, cancelling the timer.
- Green: clear message events bypass coalescing; focused SessionStream suite 5/5.

## Validation

- Full unit suite: 591/591 passed.
- ESLint + TypeScript: passed.
- Production build: passed with the existing Autoprefixer warnings.
- Final two-browser PreDev A-to-B, B-to-A, and reload proof follows after merge/deploy.

## Scope

Two Frontend files only. No message content leaves the Matrix privacy boundary.

Related bug: #411
Related gate: #408
