### PR TITLE
fix: support legacy group chat translations

### DIFF
--- a/src/components/groupChat/groupChatAuthorContent.test.ts
+++ b/src/components/groupChat/groupChatAuthorContent.test.ts
@@ -62,6 +62,22 @@ describe('resolveGroupChatAuthorContent', () => {
 			rules: ['Legacy rule']
 		});
 	});
+
+	it('falls back to legacy fields when the API returns null translation maps', () => {
+		const legacyPayload = JSON.parse(`{
+			"language": "de",
+			"sourceLanguage": "de",
+			"hintMessageTranslations": null,
+			"groupChatRulesTranslations": null,
+			"legacyHintMessage": "Legacy welcome",
+			"legacyRules": ["Legacy rule"]
+		}`);
+
+		expect(resolveGroupChatAuthorContent(legacyPayload)).toEqual({
+			hintMessage: 'Legacy welcome',
+			rules: ['Legacy rule']
+		});
+	});
 });
 
 describe('group-chat language normalization', () => {

--- a/src/components/groupChat/groupChatAuthorContent.ts
+++ b/src/components/groupChat/groupChatAuthorContent.ts
@@ -1,7 +1,7 @@
 export interface GroupChatAuthorContent {
 	sourceLanguage?: string;
-	hintMessageTranslations?: Record<string, string>;
-	groupChatRulesTranslations?: Record<string, string[]>;
+	hintMessageTranslations?: Record<string, string> | null;
+	groupChatRulesTranslations?: Record<string, string[]> | null;
 }
 
 export interface GroupChatAuthorContentDraft {
@@ -84,15 +84,17 @@ export const resolveGroupChatAuthorContent = ({
 	legacyRules: string[];
 }) => {
 	const languages = fallbackLanguages(language, sourceLanguage);
+	const safeHintMessageTranslations = hintMessageTranslations || {};
+	const safeGroupChatRulesTranslations = groupChatRulesTranslations || {};
 	const hintMessage =
 		languages
-			.map((candidate) => hintMessageTranslations[candidate])
+			.map((candidate) => safeHintMessageTranslations[candidate])
 			.find((candidate) => !!candidate?.trim()) ||
 		legacyHintMessage ||
 		'';
 	const rules =
 		languages
-			.map((candidate) => groupChatRulesTranslations[candidate])
+			.map((candidate) => safeGroupChatRulesTranslations[candidate])
 			.find((candidate) => candidate?.some((rule) => !!rule.trim()))
 			?.filter((rule) => !!rule.trim()) || legacyRules;
 


### PR DESCRIPTION
## Summary

- accept runtime `null` for optional group-chat author translation maps
- fall back to legacy welcome/rules instead of crashing the Internal Group view
- add the exact deployed regression test

Closes #414. Part of #408 and #410.

## TDD evidence

- RED: new test failed with `Cannot read properties of null (reading 'de')`
- GREEN: focused suite 8/8
- Full unit suite: 592/592
- `npm run lint:scripts`: pass
- production build: pass (existing CRA/Autoprefixer warnings only)

## PreDev reproduction

Fresh Internal Group creation succeeded (`201`, Session 103157, Chat 1023, Matrix room and both participants), but both consultants redirected to `error.500.html` before this fix. After merge/deploy the same real-browser two-user flow will be repeated including encrypted A↔B messages and reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with legacy group chat content when translated hint messages or rules are unavailable.
  - Group chat hints and rules now fall back to legacy values instead of causing errors when translation data is null.

- **Tests**
  - Added coverage for legacy fallback behavior with null translation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->