### PR TITLE
feat: centralize conversation modality decisions

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -27,6 +27,7 @@ import { isAskerEnquirySubmission } from './messageEncryptionMode';
 import { resolveAsideTargetRoomId } from './asideRouting';
 import { chatTransportService } from '../../services/chatTransportService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 import {
 	AUTHORITIES,
@@ -499,12 +500,7 @@ export const MessageSubmitInterfaceComponent = ({
 	}, [location.pathname, location.search, threadRootId]);
 
 	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 
 	const draftTitle = useMemo(() => {
 		const topicName =
@@ -1096,8 +1092,7 @@ export const MessageSubmitInterfaceComponent = ({
 					apiPostError({
 						name: error?.name || 'EnquiryMessageSendError',
 						message:
-							error?.message ||
-							'Failed to send enquiry message',
+							error?.message || 'Failed to send enquiry message',
 						stack: error?.stack,
 						level: ERROR_LEVEL_WARN
 					}).then();

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -12,6 +12,7 @@ import {
 import { ResizeObserver } from '@juggle/resize-observer';
 import clsx from 'clsx';
 import { scrollToEnd, isMyMessage, SESSION_LIST_TYPES } from './sessionHelpers';
+import { getModality, Modality } from './getModality';
 import { formatToHHMM } from '../../utils/dateHelpers';
 import {
 	isMatrixRoom,
@@ -596,12 +597,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		featureThreadsSupervisionChatsEnabled = true
 	} = getTenantSettings();
 	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const chatType: 'anonymous' | 'oneOnOne' | 'group' | 'supervision' =
 		isSupervisor
 			? 'supervision'

--- a/src/components/session/getModality.test.ts
+++ b/src/components/session/getModality.test.ts
@@ -11,6 +11,24 @@ describe('getModality', () => {
 		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
 	});
 
+	it('keeps the legacy anonymous-postcode fallback during backend rollout', () => {
+		const item = asItem({
+			session: { registrationType: 'REGISTERED', postcode: 0 }
+		});
+		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('keeps the legacy anonymous-username fallback on the active-session shape', () => {
+		const activeSession = {
+			item: { registrationType: 'REGISTERED', postcode: 10115 },
+			user: { username: 'Anonymous-legacy' },
+			isGroup: false,
+			isSession: true
+		};
+
+		expect(getModality(activeSession)).toBe(Modality.LIVE_CHAT);
+	});
+
 	it('classifies a registered session as AGENCY_COUNSELLING', () => {
 		const item = asItem({ session: { registrationType: 'REGISTERED' } });
 		expect(getModality(item)).toBe(Modality.AGENCY_COUNSELLING);
@@ -49,6 +67,20 @@ describe('getModality', () => {
 			}
 		});
 		expect(getModality(item)).toBe(Modality.LIVE_CHAT);
+	});
+
+	it('prefers an explicit modality on the active-session shape over conflicting legacy fields', () => {
+		const activeSession = {
+			item: {
+				conversationType: 'LIVE_CHAT',
+				registrationType: 'REGISTERED',
+				postcode: 10115
+			},
+			isGroup: false,
+			isSession: true
+		};
+
+		expect(getModality(activeSession)).toBe(Modality.LIVE_CHAT);
 	});
 
 	it('ignores an unknown explicit conversationType and falls back to the heuristic', () => {

--- a/src/components/session/getModality.ts
+++ b/src/components/session/getModality.ts
@@ -23,6 +23,34 @@ const isModality = (value: unknown): value is Modality =>
 	typeof value === 'string' &&
 	(Object.values(Modality) as string[]).includes(value);
 
+type ConversationItem = Partial<SessionItemInterface> &
+	Partial<GroupChatItemInterface> & {
+		askerUserName?: string;
+		conversationType?: string;
+		teamSession?: boolean;
+	};
+
+type ModalityInput =
+	| ListItemInterface
+	| {
+			item?: ConversationItem | null;
+			isGroup?: boolean;
+			isSession?: boolean;
+			user?: { username?: string | null };
+	  };
+
+const isAnonymousUsername = (username?: string | null): boolean =>
+	typeof username === 'string' &&
+	(username.startsWith('Anonymous-') || username.startsWith('anon_'));
+
+const isAnonymousPostcode = (postcode?: number | string | null): boolean => {
+	if (postcode === null || postcode === undefined) {
+		return false;
+	}
+	const value = String(postcode).trim();
+	return value === '0' || value === '00000';
+};
+
 /**
  * The single source of truth for a conversation's modality on the frontend.
  *
@@ -36,16 +64,24 @@ const isModality = (value: unknown): value is Modality =>
  * significant: a group `chat` is checked before `teamSession`, which is checked before the
  * anonymous (live-chat) signal, so an internal group is never mislabelled as agency counselling.
  */
-export const getModality = (item?: ListItemInterface): Modality => {
-	const session = item?.session as
+export const getModality = (item?: ModalityInput): Modality => {
+	const activeSession = item && 'item' in item ? item : undefined;
+	const listItem =
+		item && !('item' in item) ? (item as ListItemInterface) : undefined;
+	const activeItem = activeSession?.item;
+	const user = activeSession?.user ?? listItem?.user;
+	const session = (
+		activeItem && !activeSession?.isGroup ? activeItem : listItem?.session
+	) as
 		| (SessionItemInterface & {
+				askerUserName?: string;
 				teamSession?: boolean;
 				conversationType?: string;
 		  })
 		| undefined;
-	const chat = item?.chat as
-		| (GroupChatItemInterface & { conversationType?: string })
-		| undefined;
+	const chat = (
+		activeItem && activeSession?.isGroup ? activeItem : listItem?.chat
+	) as (GroupChatItemInterface & { conversationType?: string }) | undefined;
 
 	// 1. An explicit backend modality wins once it is populated (ADR-006 target state).
 	const explicit = session?.conversationType ?? chat?.conversationType;
@@ -64,7 +100,11 @@ export const getModality = (item?: ListItemInterface): Modality => {
 			return Modality.INTERNAL_GROUP;
 		}
 		if (
-			(session.registrationType as string) === REGISTRATION_TYPE_ANONYMOUS
+			(session.registrationType as string) ===
+				REGISTRATION_TYPE_ANONYMOUS ||
+			isAnonymousPostcode(session.postcode) ||
+			isAnonymousUsername(session.askerUserName) ||
+			isAnonymousUsername(user?.username)
 		) {
 			return Modality.LIVE_CHAT;
 		}

--- a/src/components/sessionHeader/SessionHeaderComponent.tsx
+++ b/src/components/sessionHeader/SessionHeaderComponent.tsx
@@ -43,6 +43,7 @@ import {
 	SESSION_LIST_TAB,
 	SESSION_LIST_TYPES
 } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { SessionMenu } from '../sessionMenu/SessionMenu';
 import {
 	finishAnonymousChatErrorOverlayItem,
@@ -135,11 +136,7 @@ export const SessionHeaderComponent = (props: SessionHeaderProps) => {
 	);
 
 	// Check if this is an anonymous chat
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const isSupervisionEnabledForCurrentChat =
 		featureSupervisionEnabled !== false &&
 		(isAnonymousChat

--- a/src/components/sessionMenu/SessionMenu.tsx
+++ b/src/components/sessionMenu/SessionMenu.tsx
@@ -9,7 +9,6 @@ import {
 import { generatePath, Link, Navigate, useNavigate } from 'react-router-dom';
 import {
 	AUTHORITIES,
-	getContact,
 	hasUserAuthority,
 	SessionTypeContext,
 	useConsultingType,
@@ -24,6 +23,7 @@ import {
 	SESSION_LIST_TAB_ARCHIVE,
 	SESSION_LIST_TYPES
 } from '../session/sessionHelpers';
+import { getModality, Modality } from '../session/getModality';
 import { Overlay, OVERLAY_FUNCTIONS } from '../overlay/Overlay';
 import {
 	archiveSessionSuccessOverlayItem,
@@ -160,7 +160,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 
 	const handleStopGroupChat = () => {
 		stopGroupChatSecurityOverlayItem.copy =
-			activeSession.isGroup && activeSession.item.repetitive
+			getModality(activeSession) === Modality.SELF_HELP
 				? translate('groupChat.stopChat.securityOverlay.copyRepeat')
 				: translate('groupChat.stopChat.securityOverlay.copySingle');
 		setOverlayItem(stopGroupChatSecurityOverlayItem);
@@ -338,13 +338,7 @@ export const SessionMenu = (props: SessionMenuProps) => {
 		icon: <VideoCallHeaderIcon />
 	};
 
-	const contact = getContact(activeSession);
-	const isAnonymousChat =
-		activeSession.item.postcode === 0 ||
-		activeSession.item.postcode?.toString() === '00000' ||
-		(activeSession.item as any).registrationType === 'ANONYMOUS' ||
-		contact?.username?.startsWith('Anonymous-') ||
-		activeSession.user?.username?.startsWith('Anonymous-');
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const showAnonymousMobileMenu =
 		Boolean(props.showMobileEndAnonymousChatAction) ||
 		Boolean(props.showMobileDeleteAnonymousAccountAction) ||

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -14,7 +14,6 @@ import {
 	AUTHORITIES,
 	buildExtendedSession,
 	ExtendedSessionInterface,
-	getContact,
 	getExtendedSession,
 	hasUserAuthority,
 	REMOVE_SESSIONS,
@@ -33,7 +32,7 @@ import {
 } from '../../globalState/interfaces';
 import { SessionListItemComponent } from '../sessionsListItem/SessionListItemComponent';
 import { SessionsListSkeleton } from '../sessionsListItem/SessionsListItemSkeleton';
-import { isAnonymousAskerCandidate } from './sessionClassification';
+import { getModality, Modality } from '../session/getModality';
 import {
 	apiGetAskerSessionList,
 	apiGetCaseHandoverCandidates,
@@ -121,24 +120,9 @@ function buildSessionSearchHaystack(
  */
 function isAnonymousAskerSession(
 	raw: ListItemInterface,
-	extended: ExtendedSessionInterface
+	_extended: ExtendedSessionInterface
 ): boolean {
-	const registrationType =
-		(raw as any)?.session?.registrationType ??
-		(extended as any)?.item?.registrationType;
-	const postcode =
-		(raw as any)?.session?.postcode ?? (extended as any)?.item?.postcode;
-	const contact = getContact(extended as ListItemInterface);
-	return isAnonymousAskerCandidate({
-		registrationType,
-		postcode,
-		usernames: [
-			contact?.username,
-			(raw as any)?.user?.username,
-			(raw as any)?.session?.askerUserName,
-			(extended as any)?.item?.askerUserName
-		]
-	});
+	return getModality(raw) === Modality.LIVE_CHAT;
 }
 
 const getSessionIdentityValues = (
@@ -918,7 +902,11 @@ export const SessionsList = ({
 									(s) => s?.chat?.groupId === rid
 								);
 								// If repetitive group chat reload it by id because groupId has changed
-								if (loadedSession?.chat?.repetitive) {
+								if (
+									loadedSession &&
+									getModality(loadedSession) ===
+										Modality.SELF_HELP
+								) {
 									return ['reload', loadedSession.chat.id];
 								}
 								return ['removed', rid];
@@ -948,7 +936,11 @@ export const SessionsList = ({
 								(s) => s?.chat?.groupId === rid
 							);
 							// If repetitive group chat reload it by id because groupId has changed
-							if (loadedSession?.chat?.repetitive) {
+							if (
+								loadedSession &&
+								getModality(loadedSession) ===
+									Modality.SELF_HELP
+							) {
 								return ['reload', loadedSession.chat.id];
 							}
 							return ['removed', rid];
@@ -2140,14 +2132,16 @@ const useGroupWatcher = (isLoading: boolean) => {
 					dispatch({
 						type: REMOVE_SESSIONS,
 						ids: removedGroupSessions
-							.filter((s) => !s.chat.repetitive)
+							.filter(
+								(s) => getModality(s) !== Modality.SELF_HELP
+							)
 							.map((s) => s.chat.groupId)
 					});
 				}
 
 				// Update repetitive chats by id because groupId has changed
 				const repetitiveGroupSessions = removedGroupSessions.filter(
-					(s) => s.chat.repetitive
+					(s) => getModality(s) === Modality.SELF_HELP
 				);
 				if (repetitiveGroupSessions.length > 0) {
 					Promise.all(

--- a/src/components/sessionsList/sessionClassification.test.ts
+++ b/src/components/sessionsList/sessionClassification.test.ts
@@ -1,43 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import {
-	getDisplayablePostcode,
-	isAnonymousAskerCandidate,
-	isAnonymousUsername
-} from './sessionClassification';
+import { getDisplayablePostcode } from './sessionClassification';
 
 describe('sessionClassification', () => {
-	it('keeps registered enquiry sessions with real postcodes out of live chat', () => {
-		expect(
-			isAnonymousAskerCandidate({
-				registrationType: 'REGISTERED',
-				postcode: 12345,
-				usernames: ['ruhiges Yak Kim']
-			})
-		).toBe(false);
-	});
-
 	it('formats real postcodes and suppresses anonymous postcode sentinels', () => {
 		expect(getDisplayablePostcode(12345)).toBe('12345');
 		expect(getDisplayablePostcode(' 99322 ')).toBe('99322');
 		expect(getDisplayablePostcode(0)).toBeNull();
 		expect(getDisplayablePostcode('00000')).toBeNull();
 		expect(getDisplayablePostcode('')).toBeNull();
-	});
-
-	it('detects anonymous sessions from registration, username, and postcode markers', () => {
-		expect(
-			isAnonymousAskerCandidate({
-				registrationType: 'ANONYMOUS',
-				postcode: 12345
-			})
-		).toBe(true);
-		expect(isAnonymousUsername('Anonymous-abc')).toBe(true);
-		expect(isAnonymousUsername('anon_abc')).toBe(true);
-		expect(
-			isAnonymousAskerCandidate({
-				postcode: '00000',
-				usernames: ['ruhiges Yak Kim']
-			})
-		).toBe(true);
 	});
 });

--- a/src/components/sessionsList/sessionClassification.ts
+++ b/src/components/sessionsList/sessionClassification.ts
@@ -1,13 +1,3 @@
-export type SessionClassificationInput = {
-	registrationType?: string | null;
-	postcode?: number | string | null;
-	usernames?: Array<string | null | undefined>;
-};
-
-export const isAnonymousUsername = (username?: string | null): boolean =>
-	typeof username === 'string' &&
-	(username.startsWith('Anonymous-') || username.startsWith('anon_'));
-
 export const getDisplayablePostcode = (
 	postcode?: number | string | null
 ): string | null => {
@@ -21,25 +11,4 @@ export const getDisplayablePostcode = (
 	}
 
 	return value;
-};
-
-export const isAnonymousAskerCandidate = ({
-	registrationType,
-	postcode,
-	usernames = []
-}: SessionClassificationInput): boolean => {
-	if (registrationType === 'ANONYMOUS') {
-		return true;
-	}
-
-	if (usernames.some(isAnonymousUsername)) {
-		return true;
-	}
-
-	if (postcode === null || postcode === undefined || postcode === '') {
-		return false;
-	}
-
-	const value = String(postcode).trim();
-	return value === '0' || value === '00000';
 };

--- a/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
+++ b/src/components/sessionsList/sessionToolbarFilters.extra.test.ts
@@ -44,4 +44,25 @@ describe('session toolbar module helpers', () => {
 		).toBe(false);
 		expect(isInternalGroupChatSession({ isGroup: false })).toBe(false);
 	});
+
+	it('prefers explicit modality over conflicting repetitive metadata', () => {
+		expect(
+			isConversationCircleSession({
+				isGroup: true,
+				item: {
+					conversationType: 'INTERNAL_GROUP',
+					repetitive: true
+				}
+			})
+		).toBe(false);
+		expect(
+			isConversationCircleSession({
+				isGroup: true,
+				item: {
+					conversationType: 'SELF_HELP',
+					repetitive: false
+				}
+			})
+		).toBe(true);
+	});
 });

--- a/src/components/sessionsList/sessionToolbarFilters.ts
+++ b/src/components/sessionsList/sessionToolbarFilters.ts
@@ -1,3 +1,5 @@
+import { getModality, Modality } from '../session/getModality';
+
 export type SessionToolbarChipFilter =
 	| 'unread'
 	| 'drafts'
@@ -10,6 +12,7 @@ export type SessionToolbarChipFilter =
 export type SessionToolbarGroupSession = {
 	isGroup?: boolean;
 	item?: {
+		conversationType?: `${Modality}`;
 		repetitive?: boolean;
 	} | null;
 };
@@ -45,7 +48,8 @@ export const normalizeSessionToolbarChip = (
 // Group chat filters must rely on room metadata, never encrypted message bodies.
 export const isConversationCircleSession = (
 	session: SessionToolbarGroupSession
-): boolean => Boolean(session.isGroup && session.item?.repetitive);
+): boolean =>
+	Boolean(session.isGroup) && getModality(session) === Modality.SELF_HELP;
 
 export const isInternalGroupChatSession = (
 	session: SessionToolbarGroupSession

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -3,10 +3,8 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useActiveListItem } from '../../hooks/useActiveListItem';
-import {
-	getDisplayablePostcode,
-	isAnonymousAskerCandidate
-} from '../sessionsList/sessionClassification';
+import { getDisplayablePostcode } from '../sessionsList/sessionClassification';
+import { getModality, Modality } from '../session/getModality';
 import {
 	convertISO8601ToMSSinceEpoch,
 	getPrettyDateFromMessageDate,
@@ -867,14 +865,7 @@ export const SessionListItemComponent = ({
 	}
 
 	const postcodeLabel = getDisplayablePostcode(activeSession.item.postcode);
-	const isAnonymousChat = isAnonymousAskerCandidate({
-		registrationType: (activeSession.item as any).registrationType,
-		postcode: activeSession.item.postcode,
-		usernames: [
-			activeSession.user?.username,
-			(activeSession.item as any).askerUserName
-		]
-	});
+	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const shouldShowPostcode =
 		!isAsker &&
 		!autoSelectPostcode &&

--- a/src/globalState/interfaces/SessionsDataInterface.ts
+++ b/src/globalState/interfaces/SessionsDataInterface.ts
@@ -61,6 +61,11 @@ export interface TopicSessionInterface {
 }
 
 export interface SessionItemInterface {
+	conversationType?:
+		| 'AGENCY_COUNSELLING'
+		| 'LIVE_CHAT'
+		| 'INTERNAL_GROUP'
+		| 'SELF_HELP';
 	agencyId: number;
 	askerRcId: string;
 	attachment: UserService.Schemas.SessionAttachmentDTO;
@@ -80,6 +85,7 @@ export interface SessionItemInterface {
 	messageTime?: number;
 	postcode: number;
 	registrationType: registrationTypeRegistered;
+	teamSession?: boolean;
 	status:
 		| statusEmpty
 		| statusEnquiry
@@ -92,6 +98,11 @@ export interface SessionItemInterface {
 }
 
 export interface GroupChatItemInterface {
+	conversationType?:
+		| 'AGENCY_COUNSELLING'
+		| 'LIVE_CHAT'
+		| 'INTERNAL_GROUP'
+		| 'SELF_HELP';
 	active: boolean;
 	assignedAgencies: AgencyService.Schemas.AgencyResponseDTO[];
 	attachment: UserService.Schemas.SessionAttachmentDTO;

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -8,6 +8,7 @@ import { FETCH_ERRORS } from '../api';
 import { chatTransportService } from '../services/chatTransportService';
 import { apiGetChatRoomById } from '../api/apiGetChatRoomById';
 import { apiGetCaseHandoverCandidates } from '../api/apiCaseHandover';
+import { getModality, Modality } from '../components/session/getModality';
 
 export const useSession = (
 	rid: string | null,
@@ -50,9 +51,10 @@ export const useSession = (
 	);
 
 	useEffect(() => {
-		repetitiveId.current = session?.item?.repetitive
-			? session.item.id
-			: null;
+		repetitiveId.current =
+			getModality(session) === Modality.SELF_HELP
+				? session.item.id
+				: null;
 	}, [session]);
 
 	const loadSession = useCallback(() => {


### PR DESCRIPTION
## Why
ADR-006 requires one canonical frontend decision point for the four conversation modalities. Scattered legacy checks made Matrix/live-chat changes prone to cross-modality regressions.

## What changed
- routes production modality decisions through `getModality`
- gives explicit backend `conversationType` precedence
- preserves temporary anonymous and group-chat rollout fallbacks
- removes duplicate anonymous classification logic
- covers explicit-value precedence and legacy fallback behavior

## Validation
- `npm run test:unit` — 594 passed
- `npm run lint:scripts` — passed
- `npm run build` — passed (existing CRA/autoprefixer warnings)
- `npm run lint:style` — blocked by the unchanged `message.styles.scss:7` baseline violation already present on `pre-dev`

Closes OpenResilienceInitiative/ORISO-Frontend#409

🤖 Generated with [Claude Code](https://claude.com/claude-code)