### PR TITLE
feat: enhance video call widget resizing and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ graphify-out/*
 
 # chromatic build log
 build-storybook.log
+docs/*
+*.pem

--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -1,0 +1,9 @@
+# Learnings
+
+## 2026-07-10 — JS-driven widget size vs CSS min-height
+
+When a call (or other) widget sets `width`/`height` via inline styles for resize/auto-fit, a stylesheet `min-height` on the same element can silently win and break aspect ratio. Prefer `min-height: 0` (or matching the JS min) when size is state-driven.
+
+## 2026-07-11 — CallManager.endCall reentrancy
+
+`matrixCall.hangup()` can synchronously emit `state: ended`, which calls `endCall()` again. Clearing `currentCall` only at the end lets the outer frame read `null.matrixCall`. Snapshot the call, set `currentCall = null` first, then hang up / tear down using the snapshot.

--- a/src/components/call/FloatingCallWidget.scss
+++ b/src/components/call/FloatingCallWidget.scss
@@ -21,10 +21,16 @@
 	}
 
 	&.normal {
-		width: 460px;
-		min-height: 560px;
+		width: min(460px, calc(100vw - 32px));
+		/* Height is driven by inline stageSize; avoid min-height fighting auto-fit/resize */
+		min-height: 0;
+		height: auto;
 		display: flex;
 		flex-direction: column;
+	}
+
+	&.resizing {
+		transition: none;
 	}
 
 	&.fullscreen {
@@ -67,7 +73,14 @@
 		}
 	}
 
-	.fullscreen-toggle {
+	.call-stage-controls {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.fullscreen-toggle,
+	.auto-fit-toggle {
 		background: transparent;
 		border: none;
 		color: #b8b8b8;
@@ -86,8 +99,8 @@
 		position: relative;
 		width: 100%;
 		flex: 1;
-		min-height: 380px;
-		background: #e8e8e8; // Light gray background
+		min-height: 0;
+		background: #1a1a1a; // Letterbox bars for contain
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -95,7 +108,8 @@
 		.remote-video {
 			width: 100%;
 			height: 100%;
-			object-fit: cover;
+			object-fit: contain;
+			background: #1a1a1a;
 		}
 
 		// Off-screen but playing — used for audio-only WebRTC playback
@@ -252,6 +266,121 @@
 		.call-btn {
 			padding: 8px 16px;
 			font-size: 12px;
+		}
+	}
+
+	.call-resize-handle {
+		position: absolute;
+		z-index: 6;
+		touch-action: none;
+
+		&--n,
+		&--s {
+			left: 12px;
+			right: 12px;
+			height: 10px;
+			cursor: ns-resize;
+		}
+
+		&--n {
+			top: 0;
+		}
+
+		&--s {
+			bottom: 0;
+		}
+
+		&--e,
+		&--w {
+			top: 12px;
+			bottom: 12px;
+			width: 10px;
+			cursor: ew-resize;
+		}
+
+		&--e {
+			right: 0;
+		}
+
+		&--w {
+			left: 0;
+		}
+
+		&--ne,
+		&--nw,
+		&--se,
+		&--sw {
+			width: 16px;
+			height: 16px;
+		}
+
+		&--ne {
+			top: 0;
+			right: 0;
+			cursor: nesw-resize;
+		}
+
+		&--nw {
+			top: 0;
+			left: 0;
+			cursor: nwse-resize;
+		}
+
+		&--se {
+			right: 0;
+			bottom: 0;
+			cursor: nwse-resize;
+
+			&::after {
+				content: '';
+				position: absolute;
+				right: 4px;
+				bottom: 4px;
+				width: 10px;
+				height: 10px;
+				border-right: 2px solid rgba(255, 255, 255, 0.65);
+				border-bottom: 2px solid rgba(255, 255, 255, 0.65);
+			}
+		}
+
+		&--sw {
+			left: 0;
+			bottom: 0;
+			cursor: nesw-resize;
+		}
+	}
+}
+
+@media (max-width: 480px) {
+	.floating-call-widget.normal {
+		width: calc(100vw - 16px) !important;
+		max-width: calc(100vw - 16px);
+		/* Keep JS-driven height; only constrain width on narrow screens */
+
+		.call-video-area {
+			min-height: 220px;
+
+			.local-video {
+				width: 72px;
+				height: 72px;
+				bottom: 12px;
+				right: 12px;
+			}
+		}
+
+		.call-controls {
+			padding: 12px;
+			gap: 10px;
+			min-height: 80px;
+		}
+
+		.call-btn {
+			width: 44px;
+			height: 44px;
+		}
+
+		.call-resize-handle {
+			display: none;
 		}
 	}
 }

--- a/src/components/call/FloatingCallWidget.tsx
+++ b/src/components/call/FloatingCallWidget.tsx
@@ -7,7 +7,21 @@ import React, { useEffect, useRef, useState } from 'react';
 import { callManager, CallData } from '../../services/CallManager';
 import { matrixCallService } from '../../services/matrixCallService';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
+import {
+	getAutoFitStageSize,
+	normalizeAspectRatio,
+	RESIZE_EDGES,
+	resizeCursorForEdge,
+	resizeStageFromPointer,
+	type ResizeEdge,
+	type Size
+} from '../../utils/videoTileSizing';
 import './FloatingCallWidget.scss';
+
+const FLOATING_DEFAULT_WIDTH = 460;
+const FLOATING_DEFAULT_HEIGHT = 560;
+const FLOATING_MIN = { width: 300, height: 400 };
+const DEFAULT_VIDEO_ASPECT = 16 / 9;
 
 export const FloatingCallWidget: React.FC = () => {
 	const { matrixClientService } = useMatrixClient();
@@ -20,34 +34,108 @@ export const FloatingCallWidget: React.FC = () => {
 	const [, forceUpdate] = useState(0); // 🔥 Force re-render trigger
 
 	const [isDragging, setIsDragging] = useState(false);
+	const [isResizing, setIsResizing] = useState(false);
+	const [stageSize, setStageSize] = useState<Size>({
+		width: FLOATING_DEFAULT_WIDTH,
+		height: FLOATING_DEFAULT_HEIGHT
+	});
+	const [videoAspect, setVideoAspect] = useState(DEFAULT_VIDEO_ASPECT);
 	const [position, setPosition] = useState(() => {
 		// Center the popup initially
-		const popupWidth = 460;
-		const popupHeight = 560;
+		const popupWidth = FLOATING_DEFAULT_WIDTH;
+		const popupHeight = FLOATING_DEFAULT_HEIGHT;
 		return {
 			x: (window.innerWidth - popupWidth) / 2,
 			y: (window.innerHeight - popupHeight) / 2
 		};
 	});
 	const dragStartPos = useRef({ x: 0, y: 0 });
+	const resizeStartRef = useRef<{
+		edge: ResizeEdge;
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		posX: number;
+		posY: number;
+	} | null>(null);
+	const [resizeCursor, setResizeCursor] = useState('nwse-resize');
 
 	const localVideoRef = useRef<HTMLVideoElement>(null);
 	const remoteVideoRef = useRef<HTMLVideoElement>(null);
 	const callInitiatedRef = useRef(false);
 	const widgetRef = useRef<HTMLDivElement>(null);
 
-	// Re-center the modal whenever a new call starts
+	const getFloatingBounds = () => ({
+		minWidth: FLOATING_MIN.width,
+		minHeight: FLOATING_MIN.height,
+		maxWidth: Math.max(FLOATING_MIN.width, window.innerWidth - 32),
+		maxHeight: Math.max(FLOATING_MIN.height, window.innerHeight - 32)
+	});
+
+	const applyAutoFit = (aspect: number = videoAspect) => {
+		const bounds = getFloatingBounds();
+		const next = getAutoFitStageSize({
+			aspectRatio: aspect,
+			maxWidth: bounds.maxWidth,
+			maxHeight: bounds.maxHeight,
+			preferredWidth: FLOATING_DEFAULT_WIDTH,
+			preferredHeight: FLOATING_DEFAULT_HEIGHT,
+			minWidth: bounds.minWidth,
+			minHeight: bounds.minHeight
+		});
+		setStageSize(next);
+		setPosition({
+			x: Math.max(16, (window.innerWidth - next.width) / 2),
+			y: Math.max(16, (window.innerHeight - next.height) / 2)
+		});
+	};
+
+	// Re-center / auto-fit whenever a new call starts
 	useEffect(() => {
 		if (!callData?.callId) return;
-		const popupWidth = 460;
-		const popupHeight = 560;
-		setPosition({
-			x: Math.max(16, (window.innerWidth - popupWidth) / 2),
-			y: Math.max(16, (window.innerHeight - popupHeight) / 2)
-		});
+		setVideoAspect(DEFAULT_VIDEO_ASPECT);
 		setIsFullscreen(false);
 		setIsMinimized(false);
+		applyAutoFit(DEFAULT_VIDEO_ASPECT);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [callData?.callId]);
+
+	// Track remote video intrinsic aspect for letterbox / resize
+	useEffect(() => {
+		const video = remoteVideoRef.current;
+		if (!video || !callData?.isVideo) return;
+
+		const syncAspect = () => {
+			const next = normalizeAspectRatio(
+				video.videoWidth,
+				video.videoHeight,
+				DEFAULT_VIDEO_ASPECT
+			);
+			setVideoAspect((prev) => {
+				if (Math.abs(prev - next) <= 0.01) return prev;
+				return next;
+			});
+		};
+
+		syncAspect();
+		video.addEventListener('loadedmetadata', syncAspect);
+		video.addEventListener('resize', syncAspect);
+		return () => {
+			video.removeEventListener('loadedmetadata', syncAspect);
+			video.removeEventListener('resize', syncAspect);
+		};
+	}, [callData?.matrixCall, callData?.state, callData?.isVideo]);
+
+	// When remote track aspect becomes known/changes, re-fit the stage once
+	const lastFittedAspectRef = useRef(DEFAULT_VIDEO_ASPECT);
+	useEffect(() => {
+		if (!callData?.isVideo || isFullscreen || isMinimized) return;
+		if (Math.abs(lastFittedAspectRef.current - videoAspect) <= 0.01) return;
+		lastFittedAspectRef.current = videoAspect;
+		applyAutoFit(videoAspect);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [videoAspect, callData?.isVideo, isFullscreen, isMinimized]);
 
 	// Subscribe to CallManager
 	useEffect(() => {
@@ -172,9 +260,12 @@ export const FloatingCallWidget: React.FC = () => {
 
 	// Dragging
 	const handleMouseDown = (e: React.MouseEvent) => {
+		if (isResizing) return;
 		if (
 			(e.target as HTMLElement).closest('.call-controls') ||
-			(e.target as HTMLElement).closest('.window-controls')
+			(e.target as HTMLElement).closest('.window-controls') ||
+			(e.target as HTMLElement).closest('.call-resize-handle') ||
+			(e.target as HTMLElement).closest('.call-stage-controls')
 		)
 			return;
 		setIsDragging(true);
@@ -184,24 +275,73 @@ export const FloatingCallWidget: React.FC = () => {
 		};
 	};
 
+	const handleResizePointerDown = (
+		e: React.PointerEvent,
+		edge: ResizeEdge
+	) => {
+		if (e.button !== 0) return;
+		e.preventDefault();
+		e.stopPropagation();
+		if (isFullscreen || isMinimized) return;
+		(e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+		setIsResizing(true);
+		setResizeCursor(resizeCursorForEdge(edge));
+		resizeStartRef.current = {
+			edge,
+			x: e.clientX,
+			y: e.clientY,
+			width: stageSize.width,
+			height: stageSize.height,
+			posX: position.x,
+			posY: position.y
+		};
+	};
+
 	useEffect(() => {
-		const handleMouseMove = (e: MouseEvent) => {
+		const handlePointerMove = (e: PointerEvent) => {
+			if (isResizing && resizeStartRef.current) {
+				const start = resizeStartRef.current;
+				const widgetAspect =
+					start.width / start.height || DEFAULT_VIDEO_ASPECT;
+				const next = resizeStageFromPointer({
+					edge: start.edge,
+					startSize: { width: start.width, height: start.height },
+					startPosition: { x: start.posX, y: start.posY },
+					dx: e.clientX - start.x,
+					dy: e.clientY - start.y,
+					aspectRatio: widgetAspect,
+					bounds: getFloatingBounds()
+				});
+				setStageSize(next.size);
+				setPosition(next.position);
+				return;
+			}
 			if (!isDragging) return;
 			setPosition({
 				x: e.clientX - dragStartPos.current.x,
 				y: e.clientY - dragStartPos.current.y
 			});
 		};
-		const handleMouseUp = () => isDragging && setIsDragging(false);
-		if (isDragging) {
-			window.addEventListener('mousemove', handleMouseMove);
-			window.addEventListener('mouseup', handleMouseUp);
+		const handlePointerUp = () => {
+			if (isDragging) setIsDragging(false);
+			if (isResizing) {
+				setIsResizing(false);
+				resizeStartRef.current = null;
+			}
+		};
+		if (isDragging || isResizing) {
+			window.addEventListener('pointermove', handlePointerMove);
+			window.addEventListener('pointerup', handlePointerUp);
+			window.addEventListener('pointercancel', handlePointerUp);
+			document.body.style.userSelect = 'none';
 		}
 		return () => {
-			window.removeEventListener('mousemove', handleMouseMove);
-			window.removeEventListener('mouseup', handleMouseUp);
+			window.removeEventListener('pointermove', handlePointerMove);
+			window.removeEventListener('pointerup', handlePointerUp);
+			window.removeEventListener('pointercancel', handlePointerUp);
+			document.body.style.userSelect = '';
 		};
-	}, [isDragging, position]);
+	}, [isDragging, isResizing]);
 
 	// Cleanup
 	useEffect(() => {
@@ -289,7 +429,14 @@ export const FloatingCallWidget: React.FC = () => {
 	// Group calls are handled by GroupCallWidget
 	if (!callData || callData.usesElementCall || callData.isGroup) return null;
 
-	const widgetClass = `floating-call-widget ${isFullscreen ? 'fullscreen' : isMinimized ? 'minimized' : 'normal'}`;
+	const showStageControls =
+		callData.isVideo &&
+		!isFullscreen &&
+		!isMinimized &&
+		callData.state !== 'ringing' &&
+		!!callData.matrixCall;
+
+	const widgetClass = `floating-call-widget ${isFullscreen ? 'fullscreen' : isMinimized ? 'minimized' : 'normal'}${isResizing ? ' resizing' : ''}`;
 
 	return (
 		<>
@@ -303,7 +450,18 @@ export const FloatingCallWidget: React.FC = () => {
 					position: 'fixed',
 					left: isFullscreen ? 0 : `${position.x}px`,
 					top: isFullscreen ? 0 : `${position.y}px`,
-					cursor: isDragging ? 'grabbing' : 'default'
+					cursor: isDragging
+						? 'grabbing'
+						: isResizing
+							? resizeCursor
+							: 'default',
+					...(isFullscreen || isMinimized
+						? {}
+						: {
+								width: `${stageSize.width}px`,
+								height: `${stageSize.height}px`,
+								minHeight: undefined
+							})
 				}}
 				onMouseDown={handleMouseDown}
 			>
@@ -326,23 +484,47 @@ export const FloatingCallWidget: React.FC = () => {
 						</span>
 					</div>
 
-					<button
-						className="fullscreen-toggle"
-						onClick={(e) => {
-							e.stopPropagation();
-							toggleFullscreen();
-						}}
-						title="Fullscreen"
-					>
-						<svg
-							width="18"
-							height="18"
-							viewBox="0 0 24 24"
-							fill="currentColor"
+					<div className="call-stage-controls">
+						{showStageControls && (
+							<button
+								type="button"
+								className="auto-fit-toggle"
+								onClick={(e) => {
+									e.stopPropagation();
+									applyAutoFit(videoAspect);
+								}}
+								title="Auto-fit video"
+								aria-label="Auto-fit video to window"
+							>
+								<svg
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="currentColor"
+									aria-hidden="true"
+								>
+									<path d="M3 5v4h2V7h2V5H3zm12 0v2h2v2h2V5h-4zM5 15H3v4h4v-2H5v-2zm14 2h-2v2h4v-4h-2v2zM7 9h10v6H7V9z" />
+								</svg>
+							</button>
+						)}
+						<button
+							className="fullscreen-toggle"
+							onClick={(e) => {
+								e.stopPropagation();
+								toggleFullscreen();
+							}}
+							title="Fullscreen"
 						>
-							<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
-						</svg>
-					</button>
+							<svg
+								width="18"
+								height="18"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+							>
+								<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+							</svg>
+						</button>
+					</div>
 				</div>
 
 				{/* Video area */}
@@ -516,6 +698,24 @@ export const FloatingCallWidget: React.FC = () => {
 						</>
 					)}
 				</div>
+
+				{showStageControls &&
+					RESIZE_EDGES.map((edge) => (
+						<div
+							key={edge}
+							className={`call-resize-handle call-resize-handle--${edge}`}
+							role="separator"
+							aria-orientation={
+								edge === 'n' || edge === 's'
+									? 'horizontal'
+									: 'vertical'
+							}
+							aria-label={`Resize video call window (${edge})`}
+							onPointerDown={(e) =>
+								handleResizePointerDown(e, edge)
+							}
+						/>
+					))}
 			</div>
 		</>
 	);

--- a/src/components/call/GroupCallWidget.scss
+++ b/src/components/call/GroupCallWidget.scss
@@ -20,6 +20,14 @@
 		opacity: 0.9;
 	}
 
+	&.resizing {
+		opacity: 1;
+
+		.element-call-iframe {
+			pointer-events: none;
+		}
+	}
+
 	&.group-call-widget--mobile {
 		left: 0 !important;
 		top: 0 !important;
@@ -115,6 +123,109 @@
 
 	&:hover {
 		background: rgba(0, 0, 0, 0.8);
+	}
+}
+
+.element-call-autofit {
+	position: absolute;
+	top: 10px;
+	right: 90px;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	border: none;
+	background: rgba(0, 0, 0, 0.6);
+	color: #fff;
+	font-size: 14px;
+	cursor: pointer;
+	z-index: 5;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background: rgba(0, 0, 0, 0.8);
+	}
+}
+
+.element-call-container .call-resize-handle {
+	position: absolute;
+	z-index: 6;
+	touch-action: none;
+
+	&--n,
+	&--s {
+		left: 12px;
+		right: 12px;
+		height: 10px;
+		cursor: ns-resize;
+	}
+
+	&--n {
+		top: 0;
+	}
+
+	&--s {
+		bottom: 0;
+	}
+
+	&--e,
+	&--w {
+		top: 12px;
+		bottom: 12px;
+		width: 10px;
+		cursor: ew-resize;
+	}
+
+	&--e {
+		right: 0;
+	}
+
+	&--w {
+		left: 0;
+	}
+
+	&--ne,
+	&--nw,
+	&--se,
+	&--sw {
+		width: 16px;
+		height: 16px;
+	}
+
+	&--ne {
+		top: 0;
+		right: 0;
+		cursor: nesw-resize;
+	}
+
+	&--nw {
+		top: 0;
+		left: 0;
+		cursor: nwse-resize;
+	}
+
+	&--se {
+		right: 0;
+		bottom: 0;
+		cursor: nwse-resize;
+
+		&::after {
+			content: '';
+			position: absolute;
+			right: 4px;
+			bottom: 4px;
+			width: 10px;
+			height: 10px;
+			border-right: 2px solid rgba(255, 255, 255, 0.65);
+			border-bottom: 2px solid rgba(255, 255, 255, 0.65);
+		}
+	}
+
+	&--sw {
+		left: 0;
+		bottom: 0;
+		cursor: nesw-resize;
 	}
 }
 

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -12,7 +12,20 @@ import {
 } from '../../resources/scripts/runtimeConfig';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
 import { getElementCallAccessToken } from '../sessionCookie/getMatrixAccessToken';
+import {
+	getAutoFitStageSize,
+	RESIZE_EDGES,
+	resizeCursorForEdge,
+	resizeStageFromPointer,
+	type ResizeEdge,
+	type Size
+} from '../../utils/videoTileSizing';
 import './GroupCallWidget.scss';
+
+const GROUP_DEFAULT_WIDTH = 520;
+const GROUP_DEFAULT_HEIGHT = 320;
+const GROUP_ASPECT = GROUP_DEFAULT_WIDTH / GROUP_DEFAULT_HEIGHT;
+const GROUP_MIN = { width: 280, height: 180 };
 
 export const GroupCallWidget: React.FC = () => {
 	const { matrixClientService } = useMatrixClient();
@@ -21,8 +34,13 @@ export const GroupCallWidget: React.FC = () => {
 	const [elementCallUrl, setElementCallUrl] = useState<string>('');
 	const [isDismissed, setIsDismissed] = useState(false);
 
-	// Dragging state
+	// Dragging / resize state
 	const [isDragging, setIsDragging] = useState(false);
+	const [isResizing, setIsResizing] = useState(false);
+	const [stageSize, setStageSize] = useState<Size>({
+		width: GROUP_DEFAULT_WIDTH,
+		height: GROUP_DEFAULT_HEIGHT
+	});
 	const [position, setPosition] = useState({ x: 100, y: 100 });
 	const [isMobileView, setIsMobileView] = useState(false);
 	const [isMobileCompact, setIsMobileCompact] = useState(false);
@@ -32,10 +50,45 @@ export const GroupCallWidget: React.FC = () => {
 		elemX: number;
 		elemY: number;
 	} | null>(null);
+	const resizeStartRef = useRef<{
+		edge: ResizeEdge;
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		posX: number;
+		posY: number;
+	} | null>(null);
+	const [resizeCursor, setResizeCursor] = useState('nwse-resize');
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const setupInProgressRef = useRef(false);
 	const [isFullscreen, setIsFullscreen] = useState(false);
+
+	const getGroupBounds = () => ({
+		minWidth: GROUP_MIN.width,
+		minHeight: GROUP_MIN.height,
+		maxWidth: Math.max(GROUP_MIN.width, window.innerWidth - 32),
+		maxHeight: Math.max(GROUP_MIN.height, window.innerHeight - 32)
+	});
+
+	const applyAutoFit = () => {
+		const bounds = getGroupBounds();
+		const next = getAutoFitStageSize({
+			aspectRatio: GROUP_ASPECT,
+			maxWidth: bounds.maxWidth,
+			maxHeight: bounds.maxHeight,
+			preferredWidth: GROUP_DEFAULT_WIDTH,
+			preferredHeight: GROUP_DEFAULT_HEIGHT,
+			minWidth: bounds.minWidth,
+			minHeight: bounds.minHeight
+		});
+		setStageSize(next);
+		setPosition({
+			x: Math.max(16, (window.innerWidth - next.width) / 2),
+			y: Math.max(16, (window.innerHeight - next.height) / 2)
+		});
+	};
 
 	// Subscribe to CallManager
 	useEffect(() => {
@@ -75,21 +128,12 @@ export const GroupCallWidget: React.FC = () => {
 	useEffect(() => {
 		if (!callData || !callData.usesElementCall) return;
 
-		const padding = 16;
-		const maxWidth = 520;
-		const maxHeight = 320;
-		const width = Math.min(maxWidth, window.innerWidth - padding * 2);
-		const height = Math.min(maxHeight, window.innerHeight - padding * 2);
-
 		if (window.innerWidth <= 640) {
 			setPosition({ x: 0, y: 0 });
 			return;
 		}
 
-		setPosition({
-			x: Math.max(padding, (window.innerWidth - width) / 2),
-			y: Math.max(padding, (window.innerHeight - height) / 2)
-		});
+		applyAutoFit();
 		// Re-center only when a new call starts or the url changes; the full
 		// callData object gets a new identity on every call-state update.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -113,12 +157,13 @@ export const GroupCallWidget: React.FC = () => {
 			const data = event.data;
 			if (!data || typeof data !== 'object') return;
 			if (data.type !== 'oriso-call-ended') return;
-			// console.log('📴 Element Call ended (message from iframe)');
 			setElementCallUrl('');
 			setCallData(null);
 			setCallState(null);
 			setIsDismissed(true);
-			callManager.endCall();
+			if (callManager.hasActiveCall()) {
+				callManager.endCall();
+			}
 		};
 		window.addEventListener('message', handleMessage);
 		return () => window.removeEventListener('message', handleMessage);
@@ -334,13 +379,13 @@ export const GroupCallWidget: React.FC = () => {
 
 	// Dragging handlers (mouse + touch)
 	const handleMouseDown = (e: React.MouseEvent) => {
-		if (isMobileView) return;
+		if (isMobileView || isResizing) return;
 		const target = e.target as HTMLElement;
 		const isDragHandle = !!target.closest('.element-call-drag-handle');
 		if (elementCallUrl && !isDragHandle) return;
 		if (
 			target.closest(
-				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close'
+				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close, .element-call-fullscreen, .element-call-autofit, .call-resize-handle'
 			)
 		)
 			return;
@@ -354,13 +399,13 @@ export const GroupCallWidget: React.FC = () => {
 	};
 
 	const handleTouchStart = (e: React.TouchEvent) => {
-		if (isMobileView) return;
+		if (isMobileView || isResizing) return;
 		const target = e.target as HTMLElement;
 		const isDragHandle = !!target.closest('.element-call-drag-handle');
 		if (elementCallUrl && !isDragHandle) return;
 		if (
 			target.closest(
-				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close'
+				'.btn-end-call, .btn-answer, .btn-decline, iframe, .element-call-close, .element-call-fullscreen, .element-call-autofit, .call-resize-handle'
 			)
 		)
 			return;
@@ -374,7 +419,45 @@ export const GroupCallWidget: React.FC = () => {
 		};
 	};
 
-	const handleMouseMove = (e: MouseEvent) => {
+	const handleResizePointerDown = (
+		e: React.PointerEvent,
+		edge: ResizeEdge
+	) => {
+		if (e.button !== 0) return;
+		e.preventDefault();
+		e.stopPropagation();
+		if (isMobileView || isFullscreen || isMobileCompact) return;
+		(e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+		setIsResizing(true);
+		setResizeCursor(resizeCursorForEdge(edge));
+		resizeStartRef.current = {
+			edge,
+			x: e.clientX,
+			y: e.clientY,
+			width: stageSize.width,
+			height: stageSize.height,
+			posX: position.x,
+			posY: position.y
+		};
+	};
+
+	const handlePointerMove = (e: PointerEvent) => {
+		if (isResizing && resizeStartRef.current) {
+			const start = resizeStartRef.current;
+			const widgetAspect = start.width / start.height || GROUP_ASPECT;
+			const next = resizeStageFromPointer({
+				edge: start.edge,
+				startSize: { width: start.width, height: start.height },
+				startPosition: { x: start.posX, y: start.posY },
+				dx: e.clientX - start.x,
+				dy: e.clientY - start.y,
+				aspectRatio: widgetAspect,
+				bounds: getGroupBounds()
+			});
+			setStageSize(next.size);
+			setPosition(next.position);
+			return;
+		}
 		if (!isDragging || !dragRef.current) return;
 		const dx = e.clientX - dragRef.current.startX;
 		const dy = e.clientY - dragRef.current.startY;
@@ -395,9 +478,11 @@ export const GroupCallWidget: React.FC = () => {
 		});
 	};
 
-	const handleMouseUp = () => {
+	const handlePointerUp = () => {
 		setIsDragging(false);
+		setIsResizing(false);
 		dragRef.current = null;
+		resizeStartRef.current = null;
 	};
 
 	const handleTouchEnd = () => {
@@ -406,22 +491,26 @@ export const GroupCallWidget: React.FC = () => {
 	};
 
 	useEffect(() => {
-		if (isDragging) {
-			window.addEventListener('mousemove', handleMouseMove);
-			window.addEventListener('mouseup', handleMouseUp);
+		if (isDragging || isResizing) {
+			window.addEventListener('pointermove', handlePointerMove);
+			window.addEventListener('pointerup', handlePointerUp);
+			window.addEventListener('pointercancel', handlePointerUp);
 			window.addEventListener('touchmove', handleTouchMove);
 			window.addEventListener('touchend', handleTouchEnd);
+			document.body.style.userSelect = 'none';
 			return () => {
-				window.removeEventListener('mousemove', handleMouseMove);
-				window.removeEventListener('mouseup', handleMouseUp);
+				window.removeEventListener('pointermove', handlePointerMove);
+				window.removeEventListener('pointerup', handlePointerUp);
+				window.removeEventListener('pointercancel', handlePointerUp);
 				window.removeEventListener('touchmove', handleTouchMove);
 				window.removeEventListener('touchend', handleTouchEnd);
+				document.body.style.userSelect = '';
 			};
 		}
 		// The drag handlers are re-created every render; subscribing on
-		// isDragging transitions only is intentional.
+		// isDragging / isResizing transitions only is intentional.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isDragging]);
+	}, [isDragging, isResizing]);
 
 	// Only render for group calls
 	if (isDismissed || !callData || !callData.usesElementCall) return null;
@@ -432,8 +521,12 @@ export const GroupCallWidget: React.FC = () => {
 				<div className="call-modal-backdrop" aria-hidden="true" />
 			)}
 			<div
-				className={`group-call-widget ${isDragging ? 'dragging' : ''} ${isMobileView ? 'group-call-widget--mobile' : ''} ${isMobileCompact ? 'group-call-widget--mobile-compact' : ''} ${isFullscreen ? 'group-call-widget--fullscreen' : ''}`}
-				style={{ left: `${position.x}px`, top: `${position.y}px` }}
+				className={`group-call-widget ${isDragging ? 'dragging' : ''} ${isResizing ? 'resizing' : ''} ${isMobileView ? 'group-call-widget--mobile' : ''} ${isMobileCompact ? 'group-call-widget--mobile-compact' : ''} ${isFullscreen ? 'group-call-widget--fullscreen' : ''}`}
+				style={{
+					left: `${position.x}px`,
+					top: `${position.y}px`,
+					...(isResizing ? { cursor: resizeCursor } : {})
+				}}
 				onMouseDown={handleMouseDown}
 				onTouchStart={handleTouchStart}
 			>
@@ -469,7 +562,18 @@ export const GroupCallWidget: React.FC = () => {
 					</div>
 				) : elementCallUrl ? (
 					/* Active call - show Element Call iframe */
-					<div className="element-call-container" ref={containerRef}>
+					<div
+						className="element-call-container"
+						ref={containerRef}
+						style={
+							isMobileView || isFullscreen
+								? undefined
+								: {
+										width: `${stageSize.width}px`,
+										height: `${stageSize.height}px`
+									}
+						}
+					>
 						<div className="element-call-drag-handle" />
 						<button
 							className="element-call-close"
@@ -478,6 +582,20 @@ export const GroupCallWidget: React.FC = () => {
 						>
 							×
 						</button>
+						{!isMobileView && !isFullscreen && (
+							<button
+								type="button"
+								className="element-call-autofit"
+								onClick={(e) => {
+									e.stopPropagation();
+									applyAutoFit();
+								}}
+								aria-label="Auto-fit call window"
+								title="Auto-fit"
+							>
+								⛶
+							</button>
+						)}
 						<button
 							className="element-call-fullscreen"
 							onClick={handleToggleFullscreen}
@@ -516,6 +634,24 @@ export const GroupCallWidget: React.FC = () => {
 							allowFullScreen
 							title="Group video call"
 						/>
+						{!isMobileView &&
+							!isFullscreen &&
+							RESIZE_EDGES.map((edge) => (
+								<div
+									key={edge}
+									className={`call-resize-handle call-resize-handle--${edge}`}
+									role="separator"
+									aria-orientation={
+										edge === 'n' || edge === 's'
+											? 'horizontal'
+											: 'vertical'
+									}
+									aria-label={`Resize video call window (${edge})`}
+									onPointerDown={(e) =>
+										handleResizePointerDown(e, edge)
+									}
+								/>
+							))}
 					</div>
 				) : (
 					/* Connecting state */

--- a/src/components/matrixCall/MatrixCallView.styles.scss
+++ b/src/components/matrixCall/MatrixCallView.styles.scss
@@ -78,9 +78,10 @@
 	&__video {
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
+		object-fit: contain; // letterbox remote / mismatched aspect
 
 		&--local {
+			object-fit: cover;
 			transform: scaleX(-1); // Mirror local video
 		}
 	}

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -544,46 +544,35 @@ class CallManager {
 	 * End the current call
 	 */
 	public endCall(notifyRemote: boolean = true): void {
-		// console.log("═══════════════════════════════════════════════");
-		// console.log("📴 CallManager.endCall()");
-		// console.log("═══════════════════════════════════════════════");
-
-		if (!this.currentCall) {
-			// console.log("ℹ️  No active call to end");
+		// Snapshot + clear first so nested hangup → state:ended → endCall()
+		// (and late oriso-call-ended messages) cannot read null.matrixCall.
+		const call = this.currentCall;
+		if (!call) {
 			return;
 		}
+		this.currentCall = null;
 
-		if (notifyRemote && this.currentCall.usesElementCall) {
-			this.sendElementCallHangup(this.currentCall);
+		if (notifyRemote && call.usesElementCall) {
+			this.sendElementCallHangup(call);
 		}
 
 		// Hangup Matrix call (this will send m.call.hangup event to other side)
-		if (this.currentCall.matrixCall) {
-			// console.log("📞 Hanging up Matrix call object...");
+		if (call.matrixCall) {
 			try {
-				(this.currentCall.matrixCall as any).hangup();
-				// console.log("✅ Matrix call hangup sent (other side will receive it)");
-			} catch (err) {
-				// console.error("❌ Error hanging up Matrix call:", err);
+				(call.matrixCall as any).hangup();
+			} catch {
+				// Hangup can throw if the call is already tearing down
 			}
 		}
 
 		// Stop local media streams
 		const stream = (window as any).__activeMediaStream;
 		if (stream) {
-			// console.log("🧹 Stopping local media stream...");
 			stream.getTracks().forEach((track: any) => {
 				track.stop();
-				// console.log(`   Stopped ${track.kind} track`);
 			});
 			delete (window as any).__activeMediaStream;
-			// console.log("✅ Local media stream stopped");
 		}
-
-		this.currentCall = null;
-
-		// console.log("✅ Call ended and cleared");
-		// console.log("═══════════════════════════════════════════════");
 
 		this.notifyListeners();
 	}

--- a/src/utils/videoTileSizing.test.ts
+++ b/src/utils/videoTileSizing.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import {
+	normalizeAspectRatio,
+	computeContainFit,
+	clampStageSize,
+	getAutoFitStageSize,
+	sizeFromWidth,
+	resizeStageFromPointer
+} from './videoTileSizing';
+
+describe('videoTileSizing', () => {
+	describe('normalizeAspectRatio', () => {
+		it('returns width/height for valid dimensions', () => {
+			expect(normalizeAspectRatio(1080, 1920)).toBeCloseTo(1080 / 1920);
+			expect(normalizeAspectRatio(1920, 1080)).toBeCloseTo(16 / 9);
+		});
+
+		it('falls back when dimensions are missing', () => {
+			expect(normalizeAspectRatio(0, 1080)).toBeCloseTo(16 / 9);
+			expect(normalizeAspectRatio(1920, 0)).toBeCloseTo(16 / 9);
+			expect(normalizeAspectRatio(NaN, 100, 4 / 3)).toBeCloseTo(4 / 3);
+		});
+	});
+
+	describe('computeContainFit', () => {
+		it('letterboxes a portrait stream in a landscape container', () => {
+			const fit = computeContainFit(1080, 1920, 520, 320);
+			expect(fit.width).toBeLessThanOrEqual(520);
+			expect(fit.height).toBeLessThanOrEqual(320);
+			expect(fit.width / fit.height).toBeCloseTo(1080 / 1920, 5);
+			expect(fit.x).toBeGreaterThan(0);
+			expect(fit.y).toBe(0);
+		});
+
+		it('pillarboxes a landscape stream in a portrait container', () => {
+			const fit = computeContainFit(1920, 1080, 300, 500);
+			expect(fit.width).toBeLessThanOrEqual(300);
+			expect(fit.height).toBeLessThanOrEqual(500);
+			expect(fit.width / fit.height).toBeCloseTo(16 / 9, 5);
+			expect(fit.y).toBeGreaterThan(0);
+		});
+
+		it('returns zeros for invalid input', () => {
+			expect(computeContainFit(0, 100, 200, 200)).toEqual({
+				width: 0,
+				height: 0,
+				x: 0,
+				y: 0
+			});
+		});
+	});
+
+	describe('clampStageSize', () => {
+		const bounds = {
+			minWidth: 280,
+			minHeight: 200,
+			maxWidth: 800,
+			maxHeight: 600
+		};
+
+		it('preserves aspect while clamping to max', () => {
+			const result = clampStageSize(
+				{ width: 2000, height: 1125 },
+				bounds,
+				16 / 9
+			);
+			expect(result.width).toBeLessThanOrEqual(800);
+			expect(result.height).toBeLessThanOrEqual(600);
+			expect(result.width / result.height).toBeCloseTo(16 / 9, 1);
+		});
+
+		it('preserves aspect while clamping to min', () => {
+			const result = clampStageSize(
+				{ width: 50, height: 50 },
+				bounds,
+				16 / 9
+			);
+			expect(result.width).toBeGreaterThanOrEqual(280);
+			expect(result.height).toBeGreaterThanOrEqual(200);
+		});
+	});
+
+	describe('getAutoFitStageSize', () => {
+		it('fits preferred landscape stage into available space', () => {
+			const size = getAutoFitStageSize({
+				aspectRatio: 16 / 9,
+				maxWidth: 1000,
+				maxHeight: 400,
+				preferredWidth: 520,
+				preferredHeight: 292.5,
+				minWidth: 280,
+				minHeight: 180
+			});
+			expect(size.width).toBeLessThanOrEqual(1000);
+			expect(size.height).toBeLessThanOrEqual(400);
+			expect(size.width / size.height).toBeCloseTo(16 / 9, 1);
+		});
+
+		it('fits portrait preferred stage without exceeding viewport', () => {
+			const size = getAutoFitStageSize({
+				aspectRatio: 9 / 16,
+				maxWidth: 400,
+				maxHeight: 700,
+				preferredWidth: 360,
+				preferredHeight: 640,
+				minWidth: 200,
+				minHeight: 280
+			});
+			expect(size.width).toBeLessThanOrEqual(400);
+			expect(size.height).toBeLessThanOrEqual(700);
+			expect(size.width / size.height).toBeCloseTo(9 / 16, 1);
+		});
+	});
+
+	describe('sizeFromWidth', () => {
+		it('derives height from width and aspect', () => {
+			expect(sizeFromWidth(320, 16 / 9)).toEqual({
+				width: 320,
+				height: 320 / (16 / 9)
+			});
+		});
+	});
+
+	describe('resizeStageFromPointer', () => {
+		const bounds = {
+			minWidth: 200,
+			minHeight: 100,
+			maxWidth: 800,
+			maxHeight: 600
+		};
+		const startSize = { width: 400, height: 225 };
+		const startPosition = { x: 100, y: 80 };
+		const aspect = 16 / 9;
+
+		it('grows SE without moving position', () => {
+			const result = resizeStageFromPointer({
+				edge: 'se',
+				startSize,
+				startPosition,
+				dx: 80,
+				dy: 45,
+				aspectRatio: aspect,
+				bounds
+			});
+			expect(result.size.width).toBeGreaterThan(startSize.width);
+			expect(result.size.width / result.size.height).toBeCloseTo(
+				aspect,
+				1
+			);
+			expect(result.position).toEqual(startPosition);
+		});
+
+		it('grows SW while anchoring the east edge', () => {
+			const result = resizeStageFromPointer({
+				edge: 'sw',
+				startSize,
+				startPosition,
+				dx: -80,
+				dy: 45,
+				aspectRatio: aspect,
+				bounds
+			});
+			expect(result.size.width).toBeGreaterThan(startSize.width);
+			expect(result.position.x + result.size.width).toBeCloseTo(
+				startPosition.x + startSize.width,
+				0
+			);
+			expect(result.position.y).toBe(startPosition.y);
+		});
+
+		it('grows NW while anchoring the SE corner', () => {
+			const result = resizeStageFromPointer({
+				edge: 'nw',
+				startSize,
+				startPosition,
+				dx: -80,
+				dy: -45,
+				aspectRatio: aspect,
+				bounds
+			});
+			expect(result.size.width).toBeGreaterThan(startSize.width);
+			expect(result.position.x + result.size.width).toBeCloseTo(
+				startPosition.x + startSize.width,
+				0
+			);
+			expect(result.position.y + result.size.height).toBeCloseTo(
+				startPosition.y + startSize.height,
+				0
+			);
+		});
+
+		it('resizes from east edge using dx only', () => {
+			const result = resizeStageFromPointer({
+				edge: 'e',
+				startSize,
+				startPosition,
+				dx: 100,
+				dy: 999,
+				aspectRatio: aspect,
+				bounds
+			});
+			expect(result.size.width).toBeGreaterThan(startSize.width);
+			expect(result.position).toEqual(startPosition);
+		});
+	});
+});

--- a/src/utils/videoTileSizing.ts
+++ b/src/utils/videoTileSizing.ts
@@ -1,0 +1,284 @@
+/**
+ * Pure layout helpers for video call stage sizing.
+ * Used by FloatingCallWidget / GroupCallWidget — no DOM dependency.
+ */
+
+export type Size = { width: number; height: number };
+
+export type StageBounds = {
+	minWidth: number;
+	minHeight: number;
+	maxWidth: number;
+	maxHeight: number;
+};
+
+const DEFAULT_ASPECT = 16 / 9;
+
+/** Prefer intrinsic track ratio; fall back when metadata is missing. */
+export function normalizeAspectRatio(
+	videoWidth: number,
+	videoHeight: number,
+	fallback: number = DEFAULT_ASPECT
+): number {
+	if (
+		!Number.isFinite(videoWidth) ||
+		!Number.isFinite(videoHeight) ||
+		videoWidth <= 0 ||
+		videoHeight <= 0
+	) {
+		return fallback;
+	}
+	return videoWidth / videoHeight;
+}
+
+/**
+ * Letterbox a content box inside a container (object-fit: contain math).
+ * Returns the drawn size and top-left offset within the container.
+ */
+export function computeContainFit(
+	contentWidth: number,
+	contentHeight: number,
+	containerWidth: number,
+	containerHeight: number
+): Size & { x: number; y: number } {
+	if (
+		contentWidth <= 0 ||
+		contentHeight <= 0 ||
+		containerWidth <= 0 ||
+		containerHeight <= 0
+	) {
+		return { width: 0, height: 0, x: 0, y: 0 };
+	}
+
+	const contentAspect = contentWidth / contentHeight;
+	const containerAspect = containerWidth / containerHeight;
+
+	let width: number;
+	let height: number;
+	if (contentAspect > containerAspect) {
+		width = containerWidth;
+		height = containerWidth / contentAspect;
+	} else {
+		height = containerHeight;
+		width = containerHeight * contentAspect;
+	}
+
+	return {
+		width,
+		height,
+		x: (containerWidth - width) / 2,
+		y: (containerHeight - height) / 2
+	};
+}
+
+/**
+ * Clamp a stage size to bounds while preserving aspect ratio.
+ * Prefers the proposed width when both axes would clamp.
+ */
+export function clampStageSize(
+	proposed: Size,
+	bounds: StageBounds,
+	aspectRatio: number
+): Size {
+	const aspect =
+		Number.isFinite(aspectRatio) && aspectRatio > 0
+			? aspectRatio
+			: DEFAULT_ASPECT;
+
+	let width = Math.max(
+		bounds.minWidth,
+		Math.min(bounds.maxWidth, proposed.width)
+	);
+	let height = width / aspect;
+
+	if (height > bounds.maxHeight) {
+		height = bounds.maxHeight;
+		width = height * aspect;
+	}
+	if (height < bounds.minHeight) {
+		height = bounds.minHeight;
+		width = height * aspect;
+	}
+
+	// Re-clamp width after height-driven adjustments
+	if (width > bounds.maxWidth) {
+		width = bounds.maxWidth;
+		height = width / aspect;
+	}
+	if (width < bounds.minWidth) {
+		width = bounds.minWidth;
+		height = width / aspect;
+	}
+
+	// Final hard clamp if aspect cannot satisfy both mins (degenerate bounds)
+	width = Math.max(bounds.minWidth, Math.min(bounds.maxWidth, width));
+	height = Math.max(bounds.minHeight, Math.min(bounds.maxHeight, height));
+
+	return { width: Math.round(width), height: Math.round(height) };
+}
+
+/**
+ * Optimal stage size: fit preferred box inside available space, keep aspect.
+ * If preferred is omitted, uses the largest box that fits max bounds.
+ */
+export function getAutoFitStageSize(options: {
+	aspectRatio: number;
+	maxWidth: number;
+	maxHeight: number;
+	preferredWidth?: number;
+	preferredHeight?: number;
+	minWidth?: number;
+	minHeight?: number;
+}): Size {
+	const aspect =
+		Number.isFinite(options.aspectRatio) && options.aspectRatio > 0
+			? options.aspectRatio
+			: DEFAULT_ASPECT;
+
+	const preferredWidth =
+		options.preferredWidth ??
+		Math.min(options.maxWidth, options.maxHeight * aspect);
+	const preferredHeight = options.preferredHeight ?? preferredWidth / aspect;
+
+	const fitted = computeContainFit(
+		preferredWidth,
+		preferredHeight,
+		options.maxWidth,
+		options.maxHeight
+	);
+
+	return clampStageSize(
+		{ width: fitted.width, height: fitted.height },
+		{
+			minWidth: options.minWidth ?? 1,
+			minHeight: options.minHeight ?? 1,
+			maxWidth: options.maxWidth,
+			maxHeight: options.maxHeight
+		},
+		aspect
+	);
+}
+
+/** Derive height from width at a fixed aspect (for SE-corner resize). */
+export function sizeFromWidth(width: number, aspectRatio: number): Size {
+	const aspect =
+		Number.isFinite(aspectRatio) && aspectRatio > 0
+			? aspectRatio
+			: DEFAULT_ASPECT;
+	return { width, height: width / aspect };
+}
+
+export type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+export type Point = { x: number; y: number };
+
+const ANCHORS_WEST = new Set<ResizeEdge>(['w', 'nw', 'sw']);
+const ANCHORS_NORTH = new Set<ResizeEdge>(['n', 'ne', 'nw']);
+
+/**
+ * Aspect-preserving resize from a pointer delta on a given edge/corner.
+ * Keeps the opposite edge(s) fixed by adjusting position.
+ */
+export function resizeStageFromPointer(options: {
+	edge: ResizeEdge;
+	startSize: Size;
+	startPosition: Point;
+	dx: number;
+	dy: number;
+	aspectRatio: number;
+	bounds: StageBounds;
+}): { size: Size; position: Point } {
+	const aspect =
+		Number.isFinite(options.aspectRatio) && options.aspectRatio > 0
+			? options.aspectRatio
+			: DEFAULT_ASPECT;
+
+	const { edge, startSize, startPosition, dx, dy, bounds } = options;
+
+	let proposed: Size;
+	switch (edge) {
+		case 'e':
+			proposed = sizeFromWidth(startSize.width + dx, aspect);
+			break;
+		case 'w':
+			proposed = sizeFromWidth(startSize.width - dx, aspect);
+			break;
+		case 's':
+			proposed = {
+				width: (startSize.height + dy) * aspect,
+				height: startSize.height + dy
+			};
+			break;
+		case 'n':
+			proposed = {
+				width: (startSize.height - dy) * aspect,
+				height: startSize.height - dy
+			};
+			break;
+		case 'se':
+		case 'ne':
+		case 'sw':
+		case 'nw': {
+			const widthDelta =
+				edge === 'se' || edge === 'ne'
+					? startSize.width + dx
+					: startSize.width - dx;
+			const heightDelta =
+				edge === 'se' || edge === 'sw'
+					? startSize.height + dy
+					: startSize.height - dy;
+			const fromW = sizeFromWidth(widthDelta, aspect);
+			const fromH = {
+				width: heightDelta * aspect,
+				height: heightDelta
+			};
+			// Prefer the axis with larger pointer travel for smoother corners
+			proposed = Math.abs(dx) >= Math.abs(dy) ? fromW : fromH;
+			break;
+		}
+		default:
+			proposed = { ...startSize };
+	}
+
+	const size = clampStageSize(proposed, bounds, aspect);
+
+	let x = startPosition.x;
+	let y = startPosition.y;
+	if (ANCHORS_WEST.has(edge)) {
+		x = startPosition.x + startSize.width - size.width;
+	}
+	if (ANCHORS_NORTH.has(edge)) {
+		y = startPosition.y + startSize.height - size.height;
+	}
+
+	return { size, position: { x, y } };
+}
+
+export const RESIZE_EDGES: ResizeEdge[] = [
+	'n',
+	's',
+	'e',
+	'w',
+	'ne',
+	'nw',
+	'se',
+	'sw'
+];
+
+export function resizeCursorForEdge(edge: ResizeEdge): string {
+	switch (edge) {
+		case 'n':
+		case 's':
+			return 'ns-resize';
+		case 'e':
+		case 'w':
+			return 'ew-resize';
+		case 'ne':
+		case 'sw':
+			return 'nesw-resize';
+		case 'nw':
+		case 'se':
+		default:
+			return 'nwse-resize';
+	}
+}


### PR DESCRIPTION
Closes #35

## What changed

### Bug fix — hangup crash
`CallManager.endCall` previously cleared `currentCall` at the end of teardown.
When `matrixCall.hangup()` synchronously fired `state: ended`, the listener
called `endCall()` again and hit `null.matrixCall` — producing the
"Cannot read properties of null (reading 'matrixCall')" runtime error.

Fix: snapshot and clear `currentCall` **before** calling hangup so any
re-entrant call finds `null` and returns early. Late `oriso-call-ended`
iframe messages are also guarded with `hasActiveCall()`.

### UX — multi-edge / corner resize
Both `FloatingCallWidget` (native 1:1) and `GroupCallWidget` (Element Call)
previously had a single bottom-right resize grip only, which was hard to reach
and didn't feel smooth.

Now:
- **8 handles** — all 4 edges (N/S/E/W) and all 4 corners (NE/NW/SE/SW)
- Pointer capture so the resize tracks across the iframe without losing the event
- Opposite edge/corner stays **anchored** as you drag (correct resize physics)
- `transition: none` + iframe `pointer-events: none` while resizing — no lag
- SE corner retains the visual grip indicator for discoverability
- Resize handles are hidden on narrow viewports (≤ 480 px) where touch drag is the primary gesture

### Sizing helpers
`resizeStageFromPointer` added to `videoTileSizing.ts` with 4 new unit tests
covering SE, SW, NW (opposite-edge anchor) and E (axis isolation).

Total: **14/14 unit tests pass**, `npm run lint:scripts` (eslint + tsc) **exit 0**.

## Video

[[See attached screen recording]
](https://cap.dreambau.com/s/n823tj4ym8qwjw2)

## Test checklist

- [x] Hang up call — no runtime overlay / crash
- [x] Resize from any edge or corner — opposite side stays put
- [x] Aspect ratio preserved throughout drag
- [x] Auto-fit button resets to optimal stage size
- [x] Element Call fullscreen + mobile compact unaffected
- [x] Narrow viewport: floating widget controls usable; resize grips hidden