### PR TITLE
fix: repoint consultant statistics tab to UserService, drop sourceless metrics

### DIFF
--- a/src/api/apiGetConsultantStatistics.ts
+++ b/src/api/apiGetConsultantStatistics.ts
@@ -5,10 +5,7 @@ export interface ConsultantStatisticsDTO {
 	startDate: string;
 	endDate: string;
 	numberOfAssignedSessions: number;
-	numberOfSentMessages: number;
-	numberOfSessionsWhereConsultantWasActive: number;
-	videoCallDuration: number;
-	numberOfAppointments: number;
+	numberOfActiveSessions: number;
 }
 
 export interface ApiGetConsultantStatisticsInterface {

--- a/src/components/profile/ConsultantStatistics.tsx
+++ b/src/components/profile/ConsultantStatistics.tsx
@@ -17,7 +17,6 @@ import dayjs from 'dayjs';
 import './statistics.styles';
 import './profile.styles';
 import { useTranslation } from 'react-i18next';
-import { getTenantSettings } from '../../utils/tenantSettingsHelper';
 import { SelectChangeEvent } from '@mui/material/Select';
 
 const statisticsPeriodOptionCurrentMonth = 'currentMonth';
@@ -73,7 +72,6 @@ export const ConsultantStatistics = () => {
 	const [selectedStatistics, setSelectedStatistics] =
 		useState<ConsultantStatisticsDTO>(null);
 	const [csvData, setCsvData] = useState([]);
-	const { featureAppointmentsEnabled } = getTenantSettings();
 
 	const csvHeaders = [
 		{
@@ -84,27 +82,11 @@ export const ConsultantStatistics = () => {
 		},
 		{
 			label: translate(
-				'profile.statistics.csvHeader.numberOfSentMessages'
-			),
-			key: 'numberOfSentMessages'
-		},
-		{
-			label: translate(
 				'profile.statistics.csvHeader.numberOfSessionsWhereConsultantWasActive'
 			),
-			key: 'numberOfSessionsWhereConsultantWasActive'
-		},
-		{
-			label: translate('profile.statistics.csvHeader.videoCallDuration'),
-			key: 'videoCallDuration'
-		},
-		featureAppointmentsEnabled && {
-			label: translate(
-				'profile.statistics.csvHeader.numberOfAppointments'
-			),
-			key: 'numberOfAppointments'
+			key: 'numberOfActiveSessions'
 		}
-	].filter(Boolean);
+	];
 
 	const statisticsPeriodOptions: {
 		value: statisticOptions;
@@ -157,25 +139,11 @@ export const ConsultantStatistics = () => {
 		setIsRequestInProgress(true);
 		apiGetConsultantStatistics({ startDate, endDate })
 			.then((response: ConsultantStatisticsDTO) => {
-				const videoCallDurationMinutes = Math.floor(
-					response.videoCallDuration / 60
-				);
-				const videoCallDurationSeconds =
-					response.videoCallDuration % 60;
 				const data = [
 					{
 						numberOfAssignedSessions:
 							response.numberOfAssignedSessions,
-						numberOfSentMessages: response.numberOfSentMessages,
-						numberOfSessionsWhereConsultantWasActive:
-							response.numberOfSessionsWhereConsultantWasActive,
-						videoCallDuration:
-							videoCallDurationMinutes +
-							':' +
-							videoCallDurationSeconds,
-						numberOfAppointments:
-							featureAppointmentsEnabled &&
-							response.numberOfAppointments
+						numberOfActiveSessions: response.numberOfActiveSessions
 					}
 				];
 
@@ -252,12 +220,13 @@ export const ConsultantStatistics = () => {
 								focusable="false"
 							/>
 							<p>
-								{selectedStatistics?.numberOfSentMessages || 0}
+								{selectedStatistics?.numberOfActiveSessions ||
+									0}
 							</p>
 						</span>
 						<Text
 							text={translate(
-								'profile.statistics.csvHeader.numberOfSentMessages'
+								'profile.statistics.csvHeader.numberOfSessionsWhereConsultantWasActive'
 							)}
 							type="standard"
 						/>

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -66,7 +66,8 @@ export const endpoints = {
 		userServiceOrigin + '/service/conversations/consultants/availability',
 	consultantSessions:
 		userServiceOrigin + '/service/users/sessions/consultants?status=2&',
-	consultantStatistics: apiUrl + '/service/statistics/consultant',
+	consultantStatistics:
+		userServiceOrigin + '/service/users/statistics/consultant',
 	consultantsLanguages:
 		userServiceOrigin + '/service/users/consultants/languages',
 	caseHandoverBatch: userServiceOrigin + '/service/users/case-handover/batch',


### PR DESCRIPTION
## Why

The consultant profile statistics tab (`profile.routes.activities.statistics`, shown when `featureStatisticsEnabled` is set **or** in non-tenant contexts) calls `/service/statistics/consultant`. That endpoint belonged to the upstream Caritas **statisticsservice, which does not exist in ORISO** — the call 404ed and the tab always showed zeros.

## What

- `endpoints.consultantStatistics` now points at the new UserService endpoint `/service/users/statistics/consultant` (OpenResilienceInitiative/ORISO-UserService#391)
- The tab shows the two metrics the app-layer DB can answer (KDG: own numbers only, computed server-side from the authenticated consultant):
  - **assigned sessions** (created in the selected period)
  - **active sessions** (in progress, touched in the period)
- **Sent messages, video call duration and appointments are dropped** from the DTO, the tiles and the CSV export — they have no app-layer data source in ORISO
- Existing i18n labels are reused (`numberOfAssignedSessions`, `numberOfSessionsWhereConsultantWasActive`), so all languages stay covered with no new keys

## Dependency

Needs OpenResilienceInitiative/ORISO-UserService#391 deployed; until then the tab keeps failing soft (zeros), exactly as today — no regression if this merges first.

## Tests

- `npx tsc --noEmit` clean
- `npm run test:unit`: 72 files / 459 tests green
- Prettier + ESLint clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)