### PR TITLE
feat(groupChat): cycle waiting-area netiquette rules (ADR-012)

### DIFF
--- a/src/components/groupChat/JoinGroupChatView.tsx
+++ b/src/components/groupChat/JoinGroupChatView.tsx
@@ -34,6 +34,7 @@ import { useTimeoutOverlay } from '../../hooks/useTimeoutOverlay';
 import { OVERLAY_REQUEST } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { FALLBACK_LNG } from '../../i18n';
 import { getWaitingAreaTime } from './groupChatWaitingArea';
+import { WaitingAreaRules } from './WaitingAreaRules';
 import { resolveGroupChatAuthorContent } from './groupChatAuthorContent';
 import { getGroupChatPlannedStart } from './groupChatDate';
 import { translateWithFallback } from '../../utils/translationFallback';
@@ -382,9 +383,13 @@ export const JoinGroupChatView = ({
 						</div>
 					</div>
 				)}
-				{groupChatRules.map((rule, index) => (
-					<Text text={rule} type="standard" key={index} />
-				))}
+				<WaitingAreaRules
+					rules={groupChatRules}
+					ariaLabel={tr(
+						'groupChat.join.waitingArea.rulesLabel',
+						'Chat rules'
+					)}
+				/>
 			</div>
 			<div className="joinChat__button-container">
 				{!hasUserAuthority(AUTHORITIES.CREATE_NEW_CHAT, userData) &&

--- a/src/components/groupChat/WaitingAreaRules.stories.tsx
+++ b/src/components/groupChat/WaitingAreaRules.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { WaitingAreaRules } from './WaitingAreaRules';
+import './joinChat.styles';
+
+const meta = {
+	title: 'GroupChat/WaitingAreaRules',
+	component: WaitingAreaRules,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Waiting-area netiquette rules. One rule is spotlighted at a time and the spotlight cross-fades every ~4s (useCyclingIndex). All rules stay in the DOM for screen readers, and prefers-reduced-motion shows every rule statically.'
+			}
+		}
+	},
+	decorators: [
+		(Story) => (
+			<div className="session joinChat">
+				<div className="joinChat__content">
+					<Story />
+				</div>
+			</div>
+		)
+	]
+} satisfies Meta<typeof WaitingAreaRules>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CyclingRules: Story = {
+	args: {
+		ariaLabel: 'Chat rules',
+		rules: [
+			'Wir duzen uns hier im Chat.',
+			'Achtet aufeinander und bleibt wertschätzend.',
+			'Was hier besprochen wird, bleibt hier.',
+			'Die Moderation darf auf die Regeln hinweisen.'
+		]
+	}
+};
+
+export const SingleRule: Story = {
+	args: {
+		ariaLabel: 'Chat rules',
+		rules: ['Wir duzen uns hier im Chat.']
+	}
+};
+
+export const NoRules: Story = {
+	args: {
+		ariaLabel: 'Chat rules',
+		rules: []
+	}
+};

--- a/src/components/groupChat/WaitingAreaRules.test.tsx
+++ b/src/components/groupChat/WaitingAreaRules.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WaitingAreaRules } from './WaitingAreaRules';
+
+const ACTIVE = 'joinChat__rule--active';
+
+describe('WaitingAreaRules', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('renders nothing when there are no rules', () => {
+		const { container } = render(<WaitingAreaRules rules={[]} />);
+		expect(container.querySelector('.joinChat__rules')).toBeNull();
+	});
+
+	it('renders every rule so assistive tech always has the full list', () => {
+		const rules = ['Be kind', 'Stay on topic', 'No ads'];
+		const { container } = render(<WaitingAreaRules rules={rules} />);
+		const items = container.querySelectorAll('.joinChat__rule');
+		expect(items).toHaveLength(3);
+		expect(Array.from(items, (el) => el.textContent)).toEqual(rules);
+	});
+
+	it('marks exactly the first rule active initially', () => {
+		const { container } = render(
+			<WaitingAreaRules rules={['a', 'b', 'c']} />
+		);
+		const active = container.querySelectorAll(`.${ACTIVE}`);
+		expect(active).toHaveLength(1);
+		expect(active[0].textContent).toBe('a');
+	});
+
+	it('advances the active rule after ~4 seconds', () => {
+		const { container } = render(
+			<WaitingAreaRules rules={['a', 'b', 'c']} />
+		);
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+		const active = container.querySelector(`.${ACTIVE}`);
+		expect(active?.textContent).toBe('b');
+	});
+
+	it('does not cycle a single rule (it stays active)', () => {
+		const { container } = render(<WaitingAreaRules rules={['only']} />);
+		act(() => {
+			vi.advanceTimersByTime(20000);
+		});
+		const active = container.querySelectorAll(`.${ACTIVE}`);
+		expect(active).toHaveLength(1);
+		expect(active[0].textContent).toBe('only');
+	});
+
+	it('exposes the list with the provided aria-label', () => {
+		const { container } = render(
+			<WaitingAreaRules rules={['a']} ariaLabel="Chat rules" />
+		);
+		expect(
+			container.querySelector('.joinChat__rules')?.getAttribute('aria-label')
+		).toBe('Chat rules');
+	});
+});

--- a/src/components/groupChat/WaitingAreaRules.test.tsx
+++ b/src/components/groupChat/WaitingAreaRules.test.tsx
@@ -61,4 +61,26 @@ describe('WaitingAreaRules', () => {
 			container.querySelector('.joinChat__rules')?.getAttribute('aria-label')
 		).toBe('Chat rules');
 	});
+
+	it('does not cycle when the user prefers reduced motion', () => {
+		const mql = {
+			matches: true,
+			media: '(prefers-reduced-motion: reduce)',
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn()
+		};
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn().mockReturnValue(mql as unknown as MediaQueryList)
+		);
+		const { container } = render(
+			<WaitingAreaRules rules={['a', 'b', 'c']} />
+		);
+		act(() => {
+			vi.advanceTimersByTime(8000);
+		});
+		const active = container.querySelector(`.${ACTIVE}`);
+		expect(active?.textContent).toBe('a');
+		vi.unstubAllGlobals();
+	});
 });

--- a/src/components/groupChat/WaitingAreaRules.tsx
+++ b/src/components/groupChat/WaitingAreaRules.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion';
 import { useCyclingIndex } from './useCyclingIndex';
 
 const RULE_CYCLE_INTERVAL_MS = 4000;
@@ -15,7 +16,10 @@ interface WaitingAreaRulesProps {
  * all statically (handled in joinChat.styles.scss) — motion is never required to read a rule.
  */
 export const WaitingAreaRules = ({ rules, ariaLabel }: WaitingAreaRulesProps) => {
-	const activeIndex = useCyclingIndex(rules.length, RULE_CYCLE_INTERVAL_MS);
+	const prefersReducedMotion = usePrefersReducedMotion();
+	const activeIndex = useCyclingIndex(rules.length, RULE_CYCLE_INTERVAL_MS, {
+		enabled: !prefersReducedMotion
+	});
 
 	if (rules.length === 0) {
 		return null;

--- a/src/components/groupChat/WaitingAreaRules.tsx
+++ b/src/components/groupChat/WaitingAreaRules.tsx
@@ -29,7 +29,10 @@ export const WaitingAreaRules = ({ rules, ariaLabel }: WaitingAreaRulesProps) =>
 		<ul className="joinChat__rules" aria-label={ariaLabel}>
 			{rules.map((rule, index) => (
 				<li
-					key={index}
+					// Rules have no id; a composite key stays unique even for two
+					// identical rule strings and survives the list changing between
+					// occurrences (unlike a bare array index).
+					key={`${index}-${rule}`}
 					className={
 						index === activeIndex
 							? 'joinChat__rule joinChat__rule--active'

--- a/src/components/groupChat/WaitingAreaRules.tsx
+++ b/src/components/groupChat/WaitingAreaRules.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { useCyclingIndex } from './useCyclingIndex';
+
+const RULE_CYCLE_INTERVAL_MS = 4000;
+
+interface WaitingAreaRulesProps {
+	rules: string[];
+	ariaLabel?: string;
+}
+
+/**
+ * The waiting-area netiquette rules. One rule is visually spotlighted at a time and
+ * the spotlight advances every ~4s (ADR-012). All rules are always present in the DOM
+ * so screen readers get the whole list at once, and `prefers-reduced-motion` shows them
+ * all statically (handled in joinChat.styles.scss) — motion is never required to read a rule.
+ */
+export const WaitingAreaRules = ({ rules, ariaLabel }: WaitingAreaRulesProps) => {
+	const activeIndex = useCyclingIndex(rules.length, RULE_CYCLE_INTERVAL_MS);
+
+	if (rules.length === 0) {
+		return null;
+	}
+
+	return (
+		<ul className="joinChat__rules" aria-label={ariaLabel}>
+			{rules.map((rule, index) => (
+				<li
+					key={index}
+					className={
+						index === activeIndex
+							? 'joinChat__rule joinChat__rule--active'
+							: 'joinChat__rule'
+					}
+				>
+					{rule}
+				</li>
+			))}
+		</ul>
+	);
+};

--- a/src/components/groupChat/joinChat.styles.scss
+++ b/src/components/groupChat/joinChat.styles.scss
@@ -69,6 +69,49 @@
 		}
 	}
 
+	// Netiquette rules: one spotlighted at a time, cross-fading every ~4s
+	// (WaitingAreaRules + useCyclingIndex). Inactive rules keep opacity:0 only —
+	// never display:none/visibility:hidden — so screen readers still get the whole
+	// list. prefers-reduced-motion shows every rule statically in normal flow.
+	&__rules {
+		list-style: none;
+		margin: $grid-base-two 0 0;
+		padding: 0;
+		display: grid;
+		justify-items: center;
+		text-align: center;
+		min-height: $grid-base-six;
+	}
+
+	&__rule {
+		grid-area: 1 / 1;
+		margin: 0;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.4s ease;
+
+		&--active {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		&__rules {
+			display: block;
+		}
+
+		&__rule {
+			opacity: 1;
+			pointer-events: auto;
+			transition: none;
+
+			& + & {
+				margin-top: $grid-base;
+			}
+		}
+	}
+
 	&__button-container {
 		text-align: center;
 		padding: $grid-base-six $grid-base-four;

--- a/src/components/groupChat/useCyclingIndex.test.ts
+++ b/src/components/groupChat/useCyclingIndex.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCyclingIndex } from './useCyclingIndex';
+
+describe('useCyclingIndex', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('starts at 0', () => {
+		const { result } = renderHook(() => useCyclingIndex(3, 4000));
+		expect(result.current).toBe(0);
+	});
+
+	it('advances to the next index after the interval elapses', () => {
+		const { result } = renderHook(() => useCyclingIndex(3, 4000));
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+		expect(result.current).toBe(1);
+	});
+
+	it('wraps back to 0 after the last index', () => {
+		const { result } = renderHook(() => useCyclingIndex(2, 4000));
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+		expect(result.current).toBe(1);
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+		expect(result.current).toBe(0);
+	});
+
+	it('does not cycle when there is a single item', () => {
+		const { result } = renderHook(() => useCyclingIndex(1, 4000));
+		act(() => {
+			vi.advanceTimersByTime(40000);
+		});
+		expect(result.current).toBe(0);
+	});
+
+	it('does not cycle when there are no items', () => {
+		const { result } = renderHook(() => useCyclingIndex(0, 4000));
+		act(() => {
+			vi.advanceTimersByTime(40000);
+		});
+		expect(result.current).toBe(0);
+	});
+
+	it('does not cycle when disabled (e.g. reduced motion)', () => {
+		const { result } = renderHook(() =>
+			useCyclingIndex(3, 4000, { enabled: false })
+		);
+		act(() => {
+			vi.advanceTimersByTime(40000);
+		});
+		expect(result.current).toBe(0);
+	});
+
+	it('clears its timer on unmount', () => {
+		const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+		const { unmount } = renderHook(() => useCyclingIndex(3, 4000));
+		unmount();
+		expect(clearSpy).toHaveBeenCalled();
+	});
+
+	it('keeps the index in range when the item count shrinks', () => {
+		const { result, rerender } = renderHook(
+			({ count }) => useCyclingIndex(count, 4000),
+			{ initialProps: { count: 5 } }
+		);
+		act(() => {
+			vi.advanceTimersByTime(4000 * 4);
+		});
+		expect(result.current).toBe(4);
+		rerender({ count: 2 });
+		expect(result.current).toBeLessThan(2);
+	});
+});

--- a/src/components/groupChat/useCyclingIndex.ts
+++ b/src/components/groupChat/useCyclingIndex.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Cycles through `0..count-1`, advancing one step every `intervalMs`.
+ *
+ * Pauses (stays at 0) when there is at most one item or when `enabled` is false —
+ * the latter lets callers honour `prefers-reduced-motion` and keep the waiting-area
+ * netiquette rules static for motion-sensitive users. The returned value is always
+ * kept in range, so a shrinking `count` never points past the end.
+ */
+export const useCyclingIndex = (
+	count: number,
+	intervalMs: number,
+	options: { enabled?: boolean } = {}
+): number => {
+	const { enabled = true } = options;
+	const [index, setIndex] = useState(0);
+
+	useEffect(() => {
+		if (!enabled || count <= 1) {
+			return;
+		}
+		const timer = setInterval(() => {
+			setIndex((current) => (current + 1) % count);
+		}, intervalMs);
+		return () => clearInterval(timer);
+	}, [enabled, count, intervalMs]);
+
+	if (count <= 0) {
+		return 0;
+	}
+	return index % count;
+};

--- a/src/hooks/usePrefersReducedMotion.test.ts
+++ b/src/hooks/usePrefersReducedMotion.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+
+type ChangeListener = (event: MediaQueryListEvent) => void;
+
+const installMatchMedia = (initialMatches: boolean) => {
+	const listeners = new Set<ChangeListener>();
+	const mql = {
+		matches: initialMatches,
+		media: '(prefers-reduced-motion: reduce)',
+		addEventListener: (_: 'change', cb: ChangeListener) => listeners.add(cb),
+		removeEventListener: (_: 'change', cb: ChangeListener) =>
+			listeners.delete(cb),
+		emit(matches: boolean) {
+			mql.matches = matches;
+			listeners.forEach((cb) => cb({ matches } as MediaQueryListEvent));
+		},
+		listenerCount: () => listeners.size
+	};
+	vi.stubGlobal(
+		'matchMedia',
+		vi.fn().mockReturnValue(mql as unknown as MediaQueryList)
+	);
+	return mql;
+};
+
+describe('usePrefersReducedMotion', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns false when the user has not requested reduced motion', () => {
+		installMatchMedia(false);
+		const { result } = renderHook(() => usePrefersReducedMotion());
+		expect(result.current).toBe(false);
+	});
+
+	it('returns true when the user has requested reduced motion', () => {
+		installMatchMedia(true);
+		const { result } = renderHook(() => usePrefersReducedMotion());
+		expect(result.current).toBe(true);
+	});
+
+	it('reacts when the preference changes at runtime', () => {
+		const mql = installMatchMedia(false);
+		const { result } = renderHook(() => usePrefersReducedMotion());
+		expect(result.current).toBe(false);
+		act(() => mql.emit(true));
+		expect(result.current).toBe(true);
+	});
+
+	it('removes its listener on unmount', () => {
+		const mql = installMatchMedia(true);
+		const { unmount } = renderHook(() => usePrefersReducedMotion());
+		expect(mql.listenerCount()).toBe(1);
+		unmount();
+		expect(mql.listenerCount()).toBe(0);
+	});
+
+	it('falls back to false when matchMedia is unavailable', () => {
+		vi.stubGlobal('matchMedia', undefined);
+		const { result } = renderHook(() => usePrefersReducedMotion());
+		expect(result.current).toBe(false);
+	});
+});

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * True when the user has asked the OS to reduce motion, kept in sync with the
+ * media query at runtime. Callers can use it to pause animations/cycling. Safe
+ * where `matchMedia` is unavailable (older environments, SSR): returns false.
+ */
+export const usePrefersReducedMotion = (): boolean => {
+	const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+	useEffect(() => {
+		if (
+			typeof window === 'undefined' ||
+			typeof window.matchMedia !== 'function'
+		) {
+			return;
+		}
+		const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+		setPrefersReducedMotion(mediaQueryList.matches);
+		const listener = (event: MediaQueryListEvent) =>
+			setPrefersReducedMotion(event.matches);
+		mediaQueryList.addEventListener('change', listener);
+		return () => mediaQueryList.removeEventListener('change', listener);
+	}, []);
+
+	return prefersReducedMotion;
+};

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -803,7 +803,8 @@
 					"veryLate": "stark verspätet"
 				},
 				"dogMinutes": "{{value}} Hundeminuten",
-				"romanMinutes": "{{value}} Minuten"
+				"romanMinutes": "{{value}} Minuten",
+				"rulesLabel": "Chat-Regeln"
 			},
 			"button": {
 				"label": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -789,7 +789,8 @@
 					"veryLate": "very late"
 				},
 				"dogMinutes": "{{value}} dog minutes",
-				"romanMinutes": "{{value}} roman minutes"
+				"romanMinutes": "{{value}} roman minutes",
+				"rulesLabel": "Chat rules"
 			},
 			"button": {
 				"label": {


### PR DESCRIPTION
## Waiting-area netiquette rules now cycle (~4s), instead of a static list

Audit against **ADR-012** found the self-help group chat is ~90–95 % built on `pre-dev`. The one concrete waiting-area gap: the netiquette rules were rendered as a **static list** (`groupChatRules.map`), but ADR-012 specifies one rule spotlighted at a time, cross-fading every ~4s (the "Anzeigedauer erstmal 4 Sek" from the design session). This closes it.

### What
- **`useCyclingIndex(count, intervalMs, {enabled})`** — pure hook: advances an index on an interval, pauses for ≤1 item or when disabled, always kept in range on shrink.
- **`WaitingAreaRules`** — renders **every** rule (so screen readers always get the full list; inactive rules use `opacity:0` only — never `display:none`/`visibility:hidden`) and marks one active via the hook. `prefers-reduced-motion` shows all rules statically (CSS).
- Wired into `JoinGroupChatView` (replaces the static map). i18n `rulesLabel` added (de/en) for the list aria-label.
- Storybook story with cycling / single / empty states.

### Accessibility
The visible spotlight is motion; the content never is. All rules stay in the DOM and are exposed to AT at once, and reduced-motion users get the plain static list. Deliberately more accessible than a carousel that hides inactive slides.

### Verification (evidence)
- **TDD, red-green**: 8 hook + 6 component tests. Proven to have teeth — a deliberately-static stub failed the cycling assertions before the real implementation passed them.
- `vitest` all **69 groupChat tests green**; `tsc --noEmit` clean on touched files; `eslint --max-warnings=0` clean.
- **`npm run build-storybook` exit 0** (real production pipeline) — SCSS + TSX compile and the story is registered in the built output.

### Scope note
The remaining ADR-012 item — **editing a whole series** (`apiUpdateGroupChat` exists but is unwired) — is intentionally **not** in this PR: changing a running series' schedule (interval / start / repeatCount) touches materialised occurrences and already-fired reminders, which is exactly the complexity ADR-012 flagged. That needs a "which fields are safely editable" decision first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group chat waiting areas now display participation rules with one rule highlighted at a time.
  - Rules automatically cycle every few seconds when multiple rules are available.
  - Improved accessibility with a translated label for the rules list.
  - Reduced-motion settings display all rules without animation.

- **Bug Fixes**
  - Empty or single-rule lists now behave appropriately without unnecessary cycling.

- **Tests**
  - Added coverage for rule display, cycling behavior, accessibility labels, and reduced-motion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->