### PR TITLE
feat: show anonymous live-chat sessions in the consultant queue

### DIFF
--- a/src/api/apiGetConsultantSessionList.test.ts
+++ b/src/api/apiGetConsultantSessionList.test.ts
@@ -28,20 +28,41 @@ vi.mock('./fetchData', () => ({
 }));
 
 describe('apiGetConsultantSessionList', () => {
-	it('loads registered enquiries for the enquiry tab', async () => {
-		vi.mocked(fetchData).mockResolvedValue({ sessions: [] });
+	it('loads both registered and anonymous enquiries for the enquiry tab', async () => {
+		vi.mocked(fetchData).mockImplementation((async ({ url }: any) =>
+			url.includes('/anonymous')
+				? { sessions: [{ session: { id: 2 } }] }
+				: { sessions: [{ session: { id: 1 } }] }) as any);
 
-		await apiGetConsultantSessionList({
+		const result = await apiGetConsultantSessionList({
 			type: SESSION_LIST_TYPES.ENQUIRY
 		});
 
-		expect(fetchData).toHaveBeenCalledWith({
-			url: `https://api.oriso-dev.site/service/conversations/consultants/enquiries/registered?count=${SESSION_COUNT}&filter=all&offset=0`,
-			method: 'GET',
-			rcValidation: true,
-			responseHandling: ['EMPTY'],
-			timeout: TIMEOUT
+		const calledUrls = vi
+			.mocked(fetchData)
+			.mock.calls.map(([arg]: any) => arg.url);
+		expect(calledUrls).toContain(
+			`https://api.oriso-dev.site/service/conversations/consultants/enquiries/registered?count=${SESSION_COUNT}&filter=all&offset=0`
+		);
+		expect(calledUrls).toContain(
+			`https://api.oriso-dev.site/service/conversations/consultants/enquiries/anonymous?count=${SESSION_COUNT}&filter=all&offset=0`
+		);
+		// Both feeds are merged so true-anonymous live-chat sessions appear alongside registered ones.
+		expect(result.sessions.map((s: any) => s.session.id).sort()).toEqual([
+			1, 2
+		]);
+	});
+
+	it('dedupes sessions present in both enquiry feeds by session id', async () => {
+		vi.mocked(fetchData).mockResolvedValue({
+			sessions: [{ session: { id: 7 } }]
 		});
+
+		const result = await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.ENQUIRY
+		});
+
+		expect(result.sessions.map((s: any) => s.session.id)).toEqual([7]);
 	});
 
 	it('loads consultant sessions with pagination', async () => {

--- a/src/api/apiGetConsultantSessionList.ts
+++ b/src/api/apiGetConsultantSessionList.ts
@@ -52,15 +52,43 @@ export const apiGetConsultantSessionList = async ({
 	}
 
 	/*
-	 * Enquiry list — always pull /enquiries/registered. The split between
-	 * "Chats" and "Live Chat" happens client-side based on whether the
-	 * session's asker-username starts with `Anonymous-` / `anon_` or uses
-	 * postcode `00000`, because invite-link and legacy anonymous flows store
-	 * sessions under registration_type=REGISTERED. The /enquiries/anonymous
-	 * endpoint only lists registration_type=ANONYMOUS rows.
+	 * Enquiry list — pull BOTH feeds and merge:
+	 *  - /enquiries/registered: registered enquiries plus legacy anonymous
+	 *    flows that store sessions under registration_type=REGISTERED.
+	 *  - /enquiries/anonymous: true registration_type=ANONYMOUS live-chat
+	 *    sessions, including topic-queue sessions created from a LIVE_CHAT
+	 *    invite link (cross-agency / cross-tenant topic queue).
+	 * The client-side "Chats" vs "Live Chat" split still applies afterwards.
 	 */
-	const registeredUrl =
-		`${endpoints.consultantEnquiriesBase}registered?` +
-		`count=${count}&filter=all&offset=${offset}`;
-	return fetchListUrl(registeredUrl, signal);
+	const query = `count=${count}&filter=all&offset=${offset}`;
+	const registeredUrl = `${endpoints.consultantEnquiriesBase}registered?${query}`;
+	const anonymousUrl = `${endpoints.consultantEnquiriesBase}anonymous?${query}`;
+
+	const [registered, anonymous] = await Promise.all([
+		fetchListUrl(registeredUrl, signal),
+		// The anonymous queue is best-effort: a failure there must not hide the
+		// registered enquiries a consultant is responsible for.
+		fetchListUrl(anonymousUrl, signal).catch(
+			() => ({ sessions: [] }) as ListItemsResponseInterface
+		)
+	]);
+
+	return mergeEnquiryFeeds(registered, anonymous);
+};
+
+/** Merge two enquiry feeds, de-duplicating by session id (registered wins on conflict). */
+const mergeEnquiryFeeds = (
+	registered: ListItemsResponseInterface,
+	anonymous: ListItemsResponseInterface
+): ListItemsResponseInterface => {
+	const registeredSessions = registered?.sessions ?? [];
+	const anonymousSessions = anonymous?.sessions ?? [];
+	const seen = new Set(
+		registeredSessions.map((item: any) => item?.session?.id)
+	);
+	const merged = [
+		...registeredSessions,
+		...anonymousSessions.filter((item: any) => !seen.has(item?.session?.id))
+	];
+	return { ...registered, sessions: merged };
 };


### PR DESCRIPTION
## Why

Part of the anonymous cross-tenant Live Chat topic queue (ORISO-UserService #413). With the backend now creating true `registration_type=ANONYMOUS` sessions when a LIVE_CHAT invite link is redeemed, those sessions live under `/enquiries/anonymous`. The consultant enquiry list only pulled `/enquiries/registered`, so anonymous topic-queue sessions never appeared for consultants.

## What

`apiGetConsultantSessionList` now fetches `/enquiries/registered` and `/enquiries/anonymous` in parallel and merges the two feeds, de-duplicating by session id (registered wins on conflict). The anonymous feed is best-effort: a failure there resolves to an empty list so it can never hide the registered enquiries a consultant is responsible for. The existing client-side "Chats" vs "Live Chat" modality split (`getModality`) is unchanged and now also classifies the merged anonymous sessions.

## Tests

- `apiGetConsultantSessionList.test.ts`: RED proved only the registered feed was fetched; GREEN proves both feeds are requested and merged, and that sessions present in both are de-duplicated by id. Existing registered/archive/pagination cases unchanged.
- Full FE unit suite: 609 tests / 106 files green; type-check clean.

Depends on ORISO-UserService #417. PreDev only; no merge or deployment to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
