### PR TITLE
feat: implement keyboard shortcuts settings and command palette

### DIFF
--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -7,3 +7,11 @@ When a call (or other) widget sets `width`/`height` via inline styles for resize
 ## 2026-07-11 — CallManager.endCall reentrancy
 
 `matrixCall.hangup()` can synchronously emit `state: ended`, which calls `endCall()` again. Clearing `currentCall` only at the end lets the outer frame read `null.matrixCall`. Snapshot the call, set `currentCall = null` first, then hang up / tear down using the snapshot.
+
+## 2026-07-12 — TipTap empty composer vs HTML trim
+
+TipTap empty docs are markup like `<p></p>`. Using `!composerText.trim()` for “empty” blocks edit-last and similar guards. Prefer plain-text extraction (`textContent` / shared strip helpers).
+
+## 2026-07-12 — Browser shortcut conflicts need capture phase
+
+App handlers for Cmd/Ctrl+F, Cmd/Ctrl+Shift+N, Cmd/Ctrl+K must listen in the capture phase and `preventDefault()` before the browser’s default Find / New Window / etc. Bubble-phase listeners are too late. Also set `activeInTextInput: true` when the action must work with the composer focused.

--- a/src/components/messageSubmitInterface/TipTapComposer.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.tsx
@@ -3,6 +3,7 @@ import React, {
 	useEffect,
 	useImperativeHandle,
 	useMemo,
+	useRef,
 	useState
 } from 'react';
 import { EditorContent, useEditor } from '@tiptap/react';
@@ -27,7 +28,13 @@ import {
 	Redo,
 	ChevronRight
 } from '@mui/icons-material';
+import { useChatComposerShortcuts } from '../../features/keyboard-shortcuts/hooks/useChatComposerShortcuts';
 import './TipTapComposer.styles.scss';
+
+const isMentionSuggestionOpen = (): boolean =>
+	!!document.querySelector(
+		'.mentionList__popup .mentionList, .mentionList[role="listbox"]'
+	);
 
 export interface HighlightSnippetPayload {
 	text: string;
@@ -61,6 +68,16 @@ interface TipTapComposerProps {
 	onFocusChange?: (focused: boolean) => void;
 	/** Enables Slack-like @-mentions for agency consultants when provided. */
 	mentionProvider?: MentionProvider;
+	/** Shortcut: edit the last own message (returns true if handled). */
+	onEditLast?: () => boolean;
+	/** Shortcut: cancel the current reply/edit (returns true if handled). */
+	onCancel?: () => boolean;
+	/** Shortcut: open the file attachment picker (returns true if handled). */
+	onUpload?: () => boolean;
+	/** Shortcut: open the emoji picker (returns true if handled). */
+	onOpenEmoji?: () => boolean;
+	/** True when the composer has no text and no attachment. */
+	isComposerEmpty?: boolean;
 }
 
 const getEditorPlainTextLength = (editorLike: any): number =>
@@ -139,11 +156,29 @@ export const TipTapComposer = forwardRef<
 			onSubmitShortcut,
 			onSelectionSnippet,
 			onFocusChange,
-			mentionProvider
+			mentionProvider,
+			onEditLast,
+			onCancel,
+			onUpload,
+			onOpenEmoji,
+			isComposerEmpty
 		},
 		ref
 	) => {
 		const [isSyncingFromValue, setIsSyncingFromValue] = useState(false);
+
+		const { handleComposerKeyDown } = useChatComposerShortcuts({
+			onSend: onSubmitShortcut,
+			disabled: readOnly,
+			hasOpenSuggestions: false,
+			onEditLast,
+			onCancel,
+			onUpload,
+			onOpenEmoji,
+			isComposerEmpty
+		});
+		const shortcutHandlerRef = useRef(handleComposerKeyDown);
+		shortcutHandlerRef.current = handleComposerKeyDown;
 
 		const editor = useEditor({
 			extensions: useMemo(
@@ -240,15 +275,10 @@ export const TipTapComposer = forwardRef<
 					return true;
 				},
 				handleKeyDown: (_, event) => {
-					if (
-						event.key === 'Enter' &&
-						(event.ctrlKey || event.metaKey)
-					) {
-						event.preventDefault();
-						onSubmitShortcut();
-						return true;
+					if (isMentionSuggestionOpen()) {
+						return false;
 					}
-					return false;
+					return shortcutHandlerRef.current(event);
 				}
 			},
 			onFocus: () => {

--- a/src/components/messageSubmitInterface/inputField/DefaultActionBar.tsx
+++ b/src/components/messageSubmitInterface/inputField/DefaultActionBar.tsx
@@ -92,6 +92,7 @@ export const DefaultActionBar = ({
 			onClick={onEmojiClick}
 			selected={isEmojiOpen}
 			expanded={isEmojiOpen}
+			data-emoji-picker-toggle=""
 		>
 			<AddReactionOutlinedIcon fontSize="inherit" />
 		</ToolbarButton>

--- a/src/components/messageSubmitInterface/inputField/EmojiPickerPopup.tsx
+++ b/src/components/messageSubmitInterface/inputField/EmojiPickerPopup.tsx
@@ -25,17 +25,22 @@ export const EmojiPickerPopup = ({
 
 	useEffect(() => {
 		const handlePointerDown = (event: PointerEvent) => {
-			const target = event.target as Node | null;
-			if (
-				popupRef.current &&
-				target &&
-				!popupRef.current.contains(target)
-			) {
+			const target = event.target;
+			if (!(target instanceof Element)) {
+				return;
+			}
+			// Toggle button owns open/close — don't close here or the following
+			// click will reopen the picker.
+			if (target.closest('[data-emoji-picker-toggle]')) {
+				return;
+			}
+			if (popupRef.current && !popupRef.current.contains(target)) {
 				onClose();
 			}
 		};
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.key === 'Escape') {
+				event.preventDefault();
 				onClose();
 			}
 		};

--- a/src/components/messageSubmitInterface/inputField/ToolbarButton.tsx
+++ b/src/components/messageSubmitInterface/inputField/ToolbarButton.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 
 export interface ToolbarButtonProps {
-	label: string;
-	onClick?: () => void;
-	selected?: boolean;
-	expanded?: boolean;
-	disabled?: boolean;
+	'label': string;
+	'onClick'?: () => void;
+	'selected'?: boolean;
+	'expanded'?: boolean;
+	'disabled'?: boolean;
 	/** Optional visible text next to the icon (e.g. the "Add" button). */
-	text?: string;
-	children: React.ReactNode;
+	'text'?: string;
+	'children': React.ReactNode;
+	/** Extra attrs for outside-click / toggle coordination. */
+	'data-emoji-picker-toggle'?: string;
 }
 
 /** 38×32 icon button, radius 12, per Figma Tip Tap menu buttons. */
@@ -19,7 +21,8 @@ export const ToolbarButton = ({
 	expanded,
 	disabled = false,
 	text,
-	children
+	children,
+	'data-emoji-picker-toggle': emojiPickerToggle
 }: ToolbarButtonProps) => (
 	<button
 		type="button"
@@ -30,6 +33,7 @@ export const ToolbarButton = ({
 		aria-expanded={expanded}
 		disabled={disabled}
 		onClick={onClick}
+		data-emoji-picker-toggle={emojiPickerToggle}
 		className={[
 			'composerToolbar__button',
 			text && 'composerToolbar__button--labeled',

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -526,6 +526,83 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			overflow: visible;
 		}
 
+		&__editingBanner {
+			position: absolute;
+			top: 6px;
+			left: 12px;
+			right: 72px;
+			z-index: 30;
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 0.75rem;
+			min-height: 32px;
+			padding: 0.35rem 0.65rem;
+			border-radius: 8px;
+			box-sizing: border-box;
+			background: color-mix(
+				in srgb,
+				var(--m3-primary-fixed, #ffdad5) 70%,
+				#fff
+			);
+			border: 1px solid
+				color-mix(
+					in srgb,
+					var(--m3-primary-container, #cc1e1c) 18%,
+					transparent
+				);
+			color: var(--m3-on-surface, #1d1b20);
+			font-size: 0.8125rem;
+			line-height: 1.3;
+			pointer-events: auto;
+		}
+
+		&__editingBanner__label {
+			font-weight: 600;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		&__editingBanner__cancel {
+			flex-shrink: 0;
+			border: none;
+			border-radius: 999px;
+			padding: 0.25rem 0.7rem;
+			font: inherit;
+			font-size: 0.75rem;
+			font-weight: 600;
+			cursor: pointer;
+			background: #fff;
+			color: var(--m3-primary-container, #cc1e1c);
+			box-shadow: 0 0 0 1px
+				color-mix(
+					in srgb,
+					var(--m3-primary-container, #cc1e1c) 22%,
+					transparent
+				);
+
+			&:hover,
+			&:focus-visible {
+				background: color-mix(
+					in srgb,
+					var(--m3-primary-fixed, #ffdad5) 40%,
+					#fff
+				);
+				outline: none;
+			}
+		}
+
+		&__input--editing {
+			.textarea__figmaToolbar {
+				top: 42px;
+			}
+
+			.tiptap-composer__content .ProseMirror {
+				top: 98px;
+			}
+		}
+
 		&__toolbarButton--selected svg path[stroke] {
 			stroke: var(--m3-primary-container, #cc1e1c) !important;
 		}

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -95,6 +95,18 @@ import {
 import { getIconForAttachmentType } from '../message/messageHelpers';
 import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
 import { HIGHLIGHT_SNIPPET_SELECTED_EVENT } from './highlightSnippetEvents';
+import { isMyMessage } from '../session/sessionHelpers';
+import { transportMarkupToComposerHtml } from './transportMarkupToComposerHtml';
+import type { MessageItem } from '../message/MessageItemComponent';
+import { useKeyboardShortcuts } from '../../features/keyboard-shortcuts/context/KeyboardShortcutsProvider';
+import {
+	hasOpenModalDialog,
+	resolveEffectiveBinding
+} from '../../features/keyboard-shortcuts/utils/resolveAction';
+import {
+	isImeComposing,
+	matchesShortcut
+} from '../../features/keyboard-shortcuts/utils/match';
 
 type AttachmentUploadControl = Pick<XMLHttpRequest, 'abort'>;
 const VOICE_RECORDING_MAX_DURATION_SEC = 180;
@@ -158,6 +170,14 @@ export interface MessageSubmitInterfaceComponentProps {
 	onMobileNavigateBack?: () => void;
 	onMobileNavigateDown?: () => void;
 	onMobileNavigateBottom?: () => void;
+	/** All messages in the current session — used to find the last own message for editing. */
+	messages?: MessageItem[];
+	/** Close the thread panel (for Escape shortcut). */
+	onCloseThread?: () => void;
+	/** Notify parent of a local optimistic edit (messageId → new text). */
+	onLocalMessageEdit?: (messageId: string, newText: string) => void;
+	/** Prefer Matrix-aware ownership from SessionItem when provided. */
+	isOwnMessage?: (userId: string) => boolean;
 }
 
 export const MessageSubmitInterfaceComponent = ({
@@ -178,7 +198,11 @@ export const MessageSubmitInterfaceComponent = ({
 	mobileIsScrolledToBottom = false,
 	onMobileNavigateBack,
 	onMobileNavigateDown,
-	onMobileNavigateBottom
+	onMobileNavigateBottom,
+	messages,
+	onCloseThread,
+	onLocalMessageEdit,
+	isOwnMessage
 }: MessageSubmitInterfaceComponentProps) => {
 	const ComposerMobileBackIcon = () => (
 		<svg
@@ -357,6 +381,9 @@ export const MessageSubmitInterfaceComponent = ({
 	const [isEmojiStripOpen, setIsEmojiStripOpen] = useState(false);
 	const [isCompactActionStripOpen, setIsCompactActionStripOpen] =
 		useState(true);
+	const [editingMessageId, setEditingMessageId] = useState<string | null>(
+		null
+	);
 	const [isMobileViewport, setIsMobileViewport] = useState<boolean>(() =>
 		typeof window !== 'undefined' ? window.innerWidth <= 899 : false
 	);
@@ -1368,14 +1395,40 @@ export const MessageSubmitInterfaceComponent = ({
 			return;
 		}
 
+		// Shortcut: edit an existing message via Matrix m.replace
+		if (editingMessageId) {
+			const matrixRoomId = resolvedChatSession.matrixRoomId;
+			if (matrixRoomId && matrixClientService) {
+				try {
+					await matrixClientService.editMessage(
+						matrixRoomId,
+						editingMessageId,
+						getPlainTextFromComposerValue(message) || message
+					);
+					onLocalMessageEdit?.(editingMessageId, message);
+				} catch {
+					// Editing failed silently — fall through to clear state
+				}
+			}
+			setEditingMessageId(null);
+			setIsRequestInProgress(false);
+			composerRef.current?.clear();
+			setComposerText('');
+			return;
+		}
+
 		await sendMessage(message, attachment, isEncrypted, isAside);
 	}, [
+		editingMessageId,
 		encodeAlignmentForTransport,
 		encodeHighlightColorsForTransport,
 		getTypedMarkdownMessage,
 		hasMessageContent,
 		isAskerEnquiry,
+		matrixClientService,
+		onLocalMessageEdit,
 		preselectedFile,
+		resolvedChatSession,
 		sendEnquiry,
 		sendMessage,
 		selectedAudienceValues,
@@ -2686,6 +2739,163 @@ export const MessageSubmitInterfaceComponent = ({
 		setIsCompactActionStripOpen(false);
 	}, []);
 
+	// ── Keyboard shortcut handlers ───────────────────────────────────────────
+	// TipTap stores empty docs as markup (e.g. <p></p>) — use plain text.
+	const isComposerEmpty =
+		!hasMessageContent(composerText) && !attachmentSelected;
+
+	const handleEditLast = useCallback((): boolean => {
+		if (!messages || messages.length === 0) {
+			return false;
+		}
+		const owns = isOwnMessage ?? isMyMessage;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const msg = messages[i];
+			if (!owns(msg.userId)) {
+				continue;
+			}
+			// Skip deleted (t === 'rm') and aliased (system) messages
+			if (msg.t === 'rm' || msg.alias) {
+				continue;
+			}
+			if (!msg.message?.trim()) {
+				continue;
+			}
+			const composerHtml = transportMarkupToComposerHtml(msg.message);
+			if (!hasMessageContent(composerHtml)) {
+				continue;
+			}
+			setEditingMessageId(msg._id);
+			setComposerText(composerHtml);
+			composerRef.current?.setText(composerHtml);
+			requestAnimationFrame(() => composerRef.current?.focus());
+			return true;
+		}
+		return false;
+	}, [messages, isOwnMessage, hasMessageContent]);
+
+	const handleCancelEdit = useCallback((): boolean => {
+		if (isEmojiStripOpen) {
+			setIsEmojiStripOpen(false);
+			return true;
+		}
+		if (editingMessageId) {
+			setEditingMessageId(null);
+			setComposerText('');
+			composerRef.current?.clear();
+			requestAnimationFrame(() => composerRef.current?.focus());
+			return true;
+		}
+		if (highlightedSnippet) {
+			setHighlightedSnippet(null);
+			return true;
+		}
+		if (onCloseThread) {
+			onCloseThread();
+			return true;
+		}
+		if (isExpandedComposer) {
+			setIsExpandedComposer(false);
+			return true;
+		}
+		return false;
+	}, [
+		isEmojiStripOpen,
+		editingMessageId,
+		highlightedSnippet,
+		onCloseThread,
+		isExpandedComposer
+	]);
+
+	const handleUpload = useCallback((): boolean => {
+		if (!hasUploadFunctionality || !!uploadProgress || isVoiceRecording) {
+			return false;
+		}
+		handleAttachmentSelect();
+		return true;
+	}, [
+		hasUploadFunctionality,
+		uploadProgress,
+		isVoiceRecording,
+		handleAttachmentSelect
+	]);
+
+	const handleOpenEmoji = useCallback((): boolean => {
+		if (isEmojiStripOpen) {
+			setIsEmojiStripOpen(false);
+			return true;
+		}
+		openCompactActionStrip();
+		setIsEmojiStripOpen(true);
+		return true;
+	}, [isEmojiStripOpen, openCompactActionStrip]);
+
+	const { preferences: shortcutPreferences, platform: shortcutPlatform } =
+		useKeyboardShortcuts();
+
+	// Window capture so ⌘/Ctrl+E toggles even when focus is inside the picker.
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.defaultPrevented || isImeComposing(event)) {
+				return;
+			}
+			if (hasOpenModalDialog()) {
+				return;
+			}
+			const binding = resolveEffectiveBinding(
+				shortcutPreferences,
+				'chat.openEmojiPicker',
+				shortcutPlatform
+			);
+			if (
+				!binding ||
+				!matchesShortcut(event, binding, shortcutPlatform)
+			) {
+				return;
+			}
+			event.preventDefault();
+			event.stopPropagation();
+			handleOpenEmoji();
+		};
+		window.addEventListener('keydown', onKeyDown, true);
+		return () => window.removeEventListener('keydown', onKeyDown, true);
+	}, [shortcutPreferences, shortcutPlatform, handleOpenEmoji]);
+
+	// Listen for CustomEvents dispatched from CommandPaletteDialog
+	useEffect(() => {
+		const onUploadEvent = () => {
+			if (
+				hasUploadFunctionality &&
+				!uploadProgress &&
+				!isVoiceRecording
+			) {
+				handleAttachmentSelect();
+			}
+		};
+		const onEmojiEvent = () => {
+			handleOpenEmoji();
+		};
+		window.addEventListener('oriso:shortcut:uploadFile', onUploadEvent);
+		window.addEventListener('oriso:shortcut:openEmoji', onEmojiEvent);
+		return () => {
+			window.removeEventListener(
+				'oriso:shortcut:uploadFile',
+				onUploadEvent
+			);
+			window.removeEventListener(
+				'oriso:shortcut:openEmoji',
+				onEmojiEvent
+			);
+		};
+	}, [
+		hasUploadFunctionality,
+		uploadProgress,
+		isVoiceRecording,
+		handleAttachmentSelect,
+		handleOpenEmoji
+	]);
+	// ── End shortcut handlers ────────────────────────────────────────────────
+
 	const toggleExpandedComposer = useCallback(() => {
 		setIsExpandedComposer((prev) => !prev);
 	}, []);
@@ -2739,8 +2949,8 @@ export const MessageSubmitInterfaceComponent = ({
 		if (!emoji) {
 			return;
 		}
+		// Keep the picker open so users can insert multiple emojis.
 		composerRef.current?.insertText(`${emoji} `);
-		setIsEmojiStripOpen(false);
 	}, []);
 
 	const handleMentionInsert = useCallback(() => {
@@ -3442,7 +3652,9 @@ export const MessageSubmitInterfaceComponent = ({
 								className={clsx(
 									'textarea__input',
 									attachmentSelected &&
-										'textarea__input--attachmentMode'
+										'textarea__input--attachmentMode',
+									editingMessageId &&
+										'textarea__input--editing'
 								)}
 								ref={textareaInputRef}
 								onKeyUp={(e) => {
@@ -3533,6 +3745,29 @@ export const MessageSubmitInterfaceComponent = ({
 									</div>
 								) : (
 									<>
+										{editingMessageId && (
+											<div
+												className="textarea__editingBanner"
+												role="status"
+											>
+												<span className="textarea__editingBanner__label">
+													{translate(
+														'shortcuts.editingBanner'
+													)}
+												</span>
+												<button
+													type="button"
+													className="textarea__editingBanner__cancel"
+													onClick={() => {
+														handleCancelEdit();
+													}}
+												>
+													{translate(
+														'shortcuts.editingCancel'
+													)}
+												</button>
+											</div>
+										)}
 										<div
 											className="textarea__figmaToolbar"
 											onMouseDown={handleToolbarMouseDown}
@@ -3631,6 +3866,10 @@ export const MessageSubmitInterfaceComponent = ({
 												setIsComposerSelected
 											}
 											mentionProvider={mentionProvider}
+											isComposerEmpty={isComposerEmpty}
+											onEditLast={handleEditLast}
+											onCancel={handleCancelEdit}
+											onUpload={handleUpload}
 											onSubmitShortcut={() => {
 												if (
 													!uploadProgress &&

--- a/src/components/messageSubmitInterface/transportMarkupToComposerHtml.test.ts
+++ b/src/components/messageSubmitInterface/transportMarkupToComposerHtml.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { transportMarkupToComposerHtml } from './transportMarkupToComposerHtml';
+
+describe('transportMarkupToComposerHtml', () => {
+	it('converts align tokens wrapping HTML into TipTap-compatible paragraphs', () => {
+		expect(
+			transportMarkupToComposerHtml(
+				'[[align:left]]<p>hello</p>[[/align]]'
+			)
+		).toContain('text-align: left');
+		expect(
+			transportMarkupToComposerHtml(
+				'[[align:left]]<p>hello</p>[[/align]]'
+			)
+		).toContain('hello');
+		expect(
+			transportMarkupToComposerHtml(
+				'[[align:left]]<p>hello</p>[[/align]]'
+			)
+		).not.toContain('[[align');
+	});
+
+	it('wraps plain aligned text without exposing tokens', () => {
+		const html = transportMarkupToComposerHtml(
+			'[[align:left]]\nhello\n[[/align]]'
+		);
+		expect(html).toContain('hello');
+		expect(html).not.toContain('[[align');
+		expect(html).toContain('<p');
+	});
+
+	it('rehydrates highlight tokens as mark tags', () => {
+		const html = transportMarkupToComposerHtml(
+			'[[hl:yellow]]hi[[/hl]] there'
+		);
+		expect(html).toContain('<mark');
+		expect(html).toContain('hi');
+		expect(html).not.toContain('[[hl');
+	});
+
+	it('strips visibility prefixes before decoding', () => {
+		const html = transportMarkupToComposerHtml(
+			'[VISIBLE_TO:abc][[align:left]]<p>secret</p>[[/align]]'
+		);
+		expect(html).toContain('secret');
+		expect(html).not.toContain('VISIBLE_TO');
+	});
+});

--- a/src/components/messageSubmitInterface/transportMarkupToComposerHtml.ts
+++ b/src/components/messageSubmitInterface/transportMarkupToComposerHtml.ts
@@ -1,0 +1,103 @@
+import { parseMessagePrefixes } from '../message/messageConstants';
+import { normalizeHighlightColor } from './richtextHelpers';
+
+const escapeHtml = (value: string): string =>
+	value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+
+const applyAlignToInnerHtml = (inner: string, align: string): string => {
+	const trimmed = inner.trim();
+	if (!trimmed) {
+		return '';
+	}
+
+	if (/<(p|h[1-6]|div|blockquote|li)\b/i.test(trimmed)) {
+		return trimmed.replace(
+			/<(p|h[1-6]|div|blockquote)(\b[^>]*)>/gi,
+			(_full, tag: string, attrs: string) => {
+				let nextAttrs = attrs || '';
+				if (/style\s*=/i.test(nextAttrs)) {
+					nextAttrs = nextAttrs.replace(
+						/style\s*=\s*(["'])(.*?)\1/i,
+						(_m, quote: string, style: string) => {
+							const cleaned = style
+								.replace(/text-align\s*:\s*[^;]+;?/gi, '')
+								.trim();
+							const merged = cleaned
+								? `${cleaned}; text-align: ${align}`
+								: `text-align: ${align}`;
+							return `style=${quote}${merged}${quote}`;
+						}
+					);
+				} else {
+					nextAttrs += ` style="text-align: ${align}"`;
+				}
+				if (!/data-text-align\s*=/i.test(nextAttrs)) {
+					nextAttrs += ` data-text-align="${align}"`;
+				}
+				return `<${tag}${nextAttrs}>`;
+			}
+		);
+	}
+
+	return `<p style="text-align: ${align}" data-text-align="${align}">${escapeHtml(
+		trimmed
+	).replace(/\n/g, '<br>')}</p>`;
+};
+
+/**
+ * Convert stored message transport markup into TipTap-ready HTML.
+ * Strips ORISO prefixes and rehydrates [[align:]] / [[hl:]] tokens.
+ */
+export const transportMarkupToComposerHtml = (
+	rawMessage?: string | null
+): string => {
+	const { cleanedMessage } = parseMessagePrefixes(rawMessage);
+	if (!cleanedMessage.trim()) {
+		return '';
+	}
+
+	let html = cleanedMessage;
+
+	html = html.replace(
+		/\[\[hl:([^\]]+)\]\]([\s\S]*?)\[\[\/hl\]\]|\[hl:([^\]]+)\]([\s\S]*?)\[\/hl\]/gi,
+		(
+			_match,
+			doubleColor: string,
+			doubleInner: string,
+			legacyColor: string,
+			legacyInner: string
+		) => {
+			const colorRaw = doubleColor || legacyColor;
+			const inner = doubleInner ?? legacyInner ?? '';
+			const color = normalizeHighlightColor(colorRaw);
+			if (!color) {
+				return `<mark>${inner}</mark>`;
+			}
+			return `<mark data-color="${color}" style="background-color: ${color}">${inner}</mark>`;
+		}
+	);
+
+	html = html.replace(
+		/\[\[align:(left|center|right)\]\]([\s\S]*?)\[\[\/align\]\]/gi,
+		(_match, alignRaw: string, inner: string) =>
+			applyAlignToInnerHtml(inner, alignRaw.toLowerCase())
+	);
+
+	// Drop any leftover transport tokens that are not valid editor content.
+	html = html.replace(/\[\[[^\]]*\]\]/g, '');
+
+	const trimmed = html.trim();
+	if (!trimmed) {
+		return '';
+	}
+
+	if (!/<[a-z][\s\S]*>/i.test(trimmed)) {
+		return `<p>${escapeHtml(trimmed).replace(/\n/g, '<br>')}</p>`;
+	}
+
+	return trimmed;
+};

--- a/src/components/profile/profileSettings.routes.ts
+++ b/src/components/profile/profileSettings.routes.ts
@@ -12,6 +12,7 @@ import { TwoFactorAuth } from '../twoFactorAuth/TwoFactorAuth';
 import { ConsultantNotifications } from './ConsultantNotifications';
 import { DeleteAccount } from './DeleteAccount';
 import { Locale } from './Locale';
+import { KeyboardShortcutsSettings } from '../../features/keyboard-shortcuts/components/KeyboardShortcutsSettings';
 
 export const profileRoutesSettings = (
 	selectableLocales: string[],
@@ -62,6 +63,17 @@ export const profileRoutesSettings = (
 			{
 				condition: () => selectableLocales.length > 1,
 				component: Locale,
+				column: COLUMN_RIGHT,
+				order: 1
+			}
+		]
+	},
+	{
+		title: 'profile.routes.settings.keyboardShortcuts',
+		url: '/tastatur',
+		elements: [
+			{
+				component: KeyboardShortcutsSettings,
 				column: COLUMN_RIGHT,
 				order: 1
 			}

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -105,7 +105,6 @@ import liveChatClosedIllustration from '../../resources/img/illustrations/live-c
 import NorthEastIcon from '@mui/icons-material/NorthEast';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CloseIcon from '@mui/icons-material/Close';
-
 const MessageSubmitInterfaceComponent = lazy(() =>
 	import('../messageSubmitInterface/messageSubmitInterfaceComponent').then(
 		(m) => ({ default: m.MessageSubmitInterfaceComponent })
@@ -4589,6 +4588,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 							onMobileNavigateBottom={
 								handleScrollToBottomButtonClick
 							}
+							messages={messages}
+							onCloseThread={handleCloseThread}
+							isOwnMessage={isMyMessageMatrix}
 						/>
 					</div>
 				</div>
@@ -4706,6 +4708,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 									onMobileNavigateBottom={
 										handleScrollToBottomButtonClick
 									}
+									messages={messages}
+									onCloseThread={handleCloseThread}
+									isOwnMessage={isMyMessageMatrix}
 								/>
 							</MessageSubmitErrorBoundary>
 						</Suspense>

--- a/src/features/keyboard-shortcuts/components/CommandPaletteDialog.styles.scss
+++ b/src/features/keyboard-shortcuts/components/CommandPaletteDialog.styles.scss
@@ -1,0 +1,153 @@
+.commandPaletteDialog {
+	border: none;
+	padding: 0;
+	background: transparent;
+	max-width: min(32rem, calc(100vw - 2rem));
+	width: 100%;
+	max-height: min(85vh, calc(100% - 2rem));
+	margin: auto;
+	overflow: hidden;
+
+	&::backdrop {
+		background: rgba(0, 0, 0, 0.45);
+	}
+
+	&__panel {
+		background: var(--surface-primary, #fff);
+		color: inherit;
+		border-radius: 12px;
+		box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+		padding: 1rem 1.1rem 1.15rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-height: min(85vh, calc(100vh - 2rem));
+		overflow: hidden;
+		box-sizing: border-box;
+	}
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		flex-shrink: 0;
+
+		h2 {
+			margin: 0;
+			font-size: 1.05rem;
+		}
+	}
+
+	&__close {
+		border: none;
+		background: transparent;
+		font-size: 1.4rem;
+		line-height: 1;
+		cursor: pointer;
+		padding: 0.15rem 0.4rem;
+		opacity: 0.7;
+	}
+
+	&__search {
+		width: 100%;
+		box-sizing: border-box;
+		padding: 0.55rem 0.7rem;
+		border-radius: 8px;
+		border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+		font: inherit;
+		flex-shrink: 0;
+	}
+
+	&__scroll {
+		overflow: auto;
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	&__item {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.55rem 0.65rem;
+		border: none;
+		border-radius: 8px;
+		background: transparent;
+		cursor: pointer;
+		font: inherit;
+		text-align: left;
+		color: inherit;
+
+		&:hover,
+		&:focus-visible {
+			background: color-mix(in srgb, currentColor 8%, transparent);
+			outline: none;
+		}
+
+		kbd {
+			font-family: inherit;
+			font-size: 0.75rem;
+			padding: 0.15rem 0.4rem;
+			border-radius: 4px;
+			border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+			white-space: nowrap;
+		}
+	}
+
+	&__bindings {
+		font-size: 0.8125rem;
+		opacity: 0.9;
+		border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+		padding-top: 0.5rem;
+
+		summary {
+			cursor: pointer;
+			margin-bottom: 0.4rem;
+			user-select: none;
+		}
+
+		h3 {
+			margin: 0.5rem 0 0.25rem;
+			font-size: 0.7rem;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			opacity: 0.7;
+		}
+
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		li {
+			display: flex;
+			justify-content: space-between;
+			gap: 0.5rem;
+			padding: 0.2rem 0;
+		}
+
+		kbd {
+			font-family: inherit;
+			font-size: 0.7rem;
+			padding: 0.1rem 0.3rem;
+			border-radius: 3px;
+			border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+			white-space: nowrap;
+		}
+	}
+}

--- a/src/features/keyboard-shortcuts/components/CommandPaletteDialog.tsx
+++ b/src/features/keyboard-shortcuts/components/CommandPaletteDialog.tsx
@@ -1,0 +1,240 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import {
+	getImplementedShortcuts,
+	SETTINGS_CATEGORY_ORDER
+} from '../constants/registry';
+import { formatShortcut } from '../utils/format';
+import { resolveEffectiveBinding } from '../utils/resolveAction';
+import type { ShortcutActionId, ShortcutCategory } from '../types';
+import './CommandPaletteDialog.styles.scss';
+
+type PaletteCommand = {
+	id: ShortcutActionId | 'nav.settingsShortcuts';
+	labelKey: string;
+	run: () => void;
+};
+
+export const CommandPaletteDialog = () => {
+	const { t: translate } = useTranslation();
+	const navigate = useNavigate();
+	const { isPaletteOpen, closePalette, openHelp, preferences, platform } =
+		useKeyboardShortcuts();
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const previousFocus = useRef<HTMLElement | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const titleId = useId();
+	const [query, setQuery] = useState('');
+	const keyLabels = {
+		ctrl: translate('shortcuts.keys.ctrl'),
+		cmd: translate('shortcuts.keys.cmd'),
+		alt: translate('shortcuts.keys.alt'),
+		option: translate('shortcuts.keys.option'),
+		shift: translate('shortcuts.keys.shift'),
+		enter: translate('shortcuts.keys.enter'),
+		escape: translate('shortcuts.keys.escape'),
+		arrowUp: translate('shortcuts.keys.arrowUp')
+	};
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+		if (!dialog) {
+			return;
+		}
+		if (isPaletteOpen) {
+			previousFocus.current = document.activeElement as HTMLElement;
+			setQuery('');
+			if (!dialog.open) {
+				dialog.showModal();
+			}
+			requestAnimationFrame(() => inputRef.current?.focus());
+		} else if (dialog.open) {
+			dialog.close();
+			previousFocus.current?.focus?.();
+		}
+	}, [isPaletteOpen]);
+
+	const commands = useMemo<PaletteCommand[]>(() => {
+		const runAndClose = (fn: () => void) => () => {
+			closePalette();
+			fn();
+		};
+		return [
+			{
+				id: 'app.showShortcutHelp',
+				labelKey: 'shortcuts.actions.showShortcutHelp.label',
+				run: runAndClose(() => openHelp())
+			},
+			{
+				id: 'chat.openEmojiPicker',
+				labelKey: 'shortcuts.actions.openEmojiPicker.label',
+				run: runAndClose(() => {
+					window.dispatchEvent(
+						new CustomEvent('oriso:shortcut:openEmoji')
+					);
+				})
+			},
+			{
+				id: 'chat.uploadFile',
+				labelKey: 'shortcuts.actions.uploadFile.label',
+				run: runAndClose(() => {
+					window.dispatchEvent(
+						new CustomEvent('oriso:shortcut:uploadFile')
+					);
+				})
+			},
+			{
+				id: 'nav.settingsShortcuts',
+				labelKey: 'shortcuts.title',
+				run: runAndClose(() => navigate('/profile/tastatur'))
+			}
+		];
+	}, [closePalette, navigate, openHelp]);
+
+	const filtered = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) {
+			return commands;
+		}
+		return commands.filter((cmd) =>
+			translate(cmd.labelKey).toLowerCase().includes(q)
+		);
+	}, [commands, query, translate]);
+
+	const shortcutLabel = (actionId: ShortcutActionId | string) => {
+		if (!actionId.startsWith('chat.') && !actionId.startsWith('app.')) {
+			return null;
+		}
+		const binding = resolveEffectiveBinding(
+			preferences,
+			actionId as ShortcutActionId,
+			platform
+		);
+		return binding
+			? formatShortcut(binding, platform, { labels: keyLabels })
+			: null;
+	};
+
+	const implementedByCategory = SETTINGS_CATEGORY_ORDER.map((category) => ({
+		category: category as ShortcutCategory,
+		items: getImplementedShortcuts().filter((d) => d.category === category)
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<dialog
+			ref={dialogRef}
+			className="commandPaletteDialog"
+			aria-labelledby={titleId}
+			aria-modal="true"
+			onClose={closePalette}
+			onCancel={(event) => {
+				event.preventDefault();
+				closePalette();
+			}}
+		>
+			{isPaletteOpen && (
+				<div className="commandPaletteDialog__panel">
+					<header className="commandPaletteDialog__header">
+						<h2 id={titleId}>
+							{translate('shortcuts.palette.title')}
+						</h2>
+						<button
+							type="button"
+							className="commandPaletteDialog__close"
+							onClick={closePalette}
+							aria-label={translate('shortcuts.palette.close')}
+						>
+							×
+						</button>
+					</header>
+					<input
+						ref={inputRef}
+						className="commandPaletteDialog__search"
+						type="search"
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						placeholder={translate(
+							'shortcuts.palette.searchPlaceholder'
+						)}
+						aria-label={translate(
+							'shortcuts.palette.searchPlaceholder'
+						)}
+					/>
+					<div className="commandPaletteDialog__scroll">
+						<ul
+							className="commandPaletteDialog__list"
+							role="listbox"
+						>
+							{filtered.map((cmd) => {
+								const keys = shortcutLabel(cmd.id);
+								return (
+									<li key={cmd.id}>
+										<button
+											type="button"
+											className="commandPaletteDialog__item"
+											onClick={cmd.run}
+										>
+											<span>
+												{translate(cmd.labelKey)}
+											</span>
+											{keys && <kbd>{keys}</kbd>}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+						<details className="commandPaletteDialog__bindings">
+							<summary>
+								{translate('shortcuts.palette.allShortcuts')}
+							</summary>
+							{implementedByCategory.map(
+								({ category, items }) => (
+									<section key={category}>
+										<h3>
+											{translate(
+												`shortcuts.categories.${category}`
+											)}
+										</h3>
+										<ul>
+											{items.map((def) => {
+												const binding =
+													resolveEffectiveBinding(
+														preferences,
+														def.id,
+														platform
+													);
+												if (!binding) {
+													return null;
+												}
+												return (
+													<li key={def.id}>
+														<span>
+															{translate(
+																def.labelTranslationKey
+															)}
+														</span>
+														<kbd>
+															{formatShortcut(
+																binding,
+																platform,
+																{
+																	labels: keyLabels
+																}
+															)}
+														</kbd>
+													</li>
+												);
+											})}
+										</ul>
+									</section>
+								)
+							)}
+						</details>
+					</div>
+				</div>
+			)}
+		</dialog>
+	);
+};

--- a/src/features/keyboard-shortcuts/components/KeyboardShortcutsAppShell.tsx
+++ b/src/features/keyboard-shortcuts/components/KeyboardShortcutsAppShell.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { KeyboardShortcutsProvider } from '../context/KeyboardShortcutsProvider';
+import { useGlobalShortcuts } from '../hooks/useGlobalShortcuts';
+import { ShortcutHelpDialog } from './ShortcutHelpDialog';
+import { CommandPaletteDialog } from './CommandPaletteDialog';
+
+const ShortcutHelpHost = () => {
+	useGlobalShortcuts(true);
+	return (
+		<>
+			<ShortcutHelpDialog />
+			<CommandPaletteDialog />
+		</>
+	);
+};
+
+/**
+ * Mount inside authenticated ContextProvider (after UserDataProvider).
+ */
+export const KeyboardShortcutsAppShell = ({
+	children
+}: {
+	children: React.ReactNode;
+}) => (
+	<KeyboardShortcutsProvider>
+		{children}
+		<ShortcutHelpHost />
+	</KeyboardShortcutsProvider>
+);
+
+/** Ensures dialog element exists for a11y tests without opening. */
+export const useMountHelpDialog = () => {
+	useEffect(() => undefined, []);
+};

--- a/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.styles.scss
+++ b/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.styles.scss
@@ -1,0 +1,233 @@
+.keyboardShortcutsSettings {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	max-width: 40rem;
+
+	&__live {
+		min-height: 0;
+	}
+
+	&__error,
+	&__warning {
+		margin: 0;
+		padding: 0.65rem 0.85rem;
+		border-radius: 6px;
+		border: 1px solid currentColor;
+		font-size: 0.875rem;
+		background: color-mix(in srgb, currentColor 8%, transparent);
+	}
+
+	&__warning {
+		opacity: 0.92;
+	}
+
+	&__panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		border: 1px solid color-mix(in srgb, currentColor 16%, transparent);
+		border-radius: 10px;
+		padding: 0.25rem 0.4rem 0.5rem;
+		background: color-mix(in srgb, currentColor 2%, transparent);
+	}
+
+	&__accordion {
+		box-shadow: none !important;
+		background: transparent !important;
+		border: none;
+		border-radius: 8px !important;
+
+		&::before {
+			display: none;
+		}
+
+		&.Mui-expanded {
+			margin: 0 !important;
+		}
+	}
+
+	&__summary {
+		min-height: 2.75rem !important;
+		padding: 0 0.5rem !important;
+		border-radius: 8px;
+
+		&:hover {
+			background: color-mix(in srgb, currentColor 5%, transparent);
+		}
+
+		&.Mui-focused,
+		&:focus-visible {
+			outline: 2px solid currentColor;
+			outline-offset: 2px;
+		}
+
+		.MuiAccordionSummary-content {
+			align-items: center;
+			gap: 0.65rem;
+			margin: 0.55rem 0 !important;
+		}
+	}
+
+	&__category {
+		margin: 0;
+		font-size: 0.875rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		line-height: 1.3;
+	}
+
+	&__count {
+		font-size: 0.7rem;
+		font-weight: 600;
+		min-width: 1.35rem;
+		height: 1.35rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 999px;
+		border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+		opacity: 0.75;
+	}
+
+	&__details {
+		padding: 0 0.25rem 0.45rem !important;
+	}
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+	}
+
+	&__row {
+		display: grid;
+		grid-template-columns: minmax(0, 1.25fr) minmax(10rem, 0.95fr);
+		gap: 0.75rem 1rem;
+		align-items: center;
+		padding: 0.65rem 0.45rem;
+		border-radius: 8px;
+
+		&:hover {
+			background: color-mix(in srgb, currentColor 4%, transparent);
+		}
+
+		@media (max-width: 560px) {
+			grid-template-columns: 1fr;
+			gap: 0.45rem;
+			padding: 0.75rem 0.45rem;
+		}
+	}
+
+	&__meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		min-width: 0;
+	}
+
+	&__label {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		line-height: 1.25;
+	}
+
+	&__desc {
+		font-size: 0.75rem;
+		line-height: 1.4;
+		opacity: 0.72;
+	}
+
+	&__control {
+		min-width: 0;
+
+		.MuiFormControl-root {
+			margin: 0;
+		}
+
+		/* Row already shows the action name — keep select label for a11y only. */
+		.MuiInputLabel-root,
+		.MuiFormLabel-root {
+			position: absolute !important;
+			width: 1px !important;
+			height: 1px !important;
+			padding: 0 !important;
+			margin: -1px !important;
+			overflow: hidden !important;
+			clip: rect(0, 0, 0, 0) !important;
+			white-space: nowrap !important;
+			border: 0 !important;
+		}
+
+		.MuiOutlinedInput-notchedOutline legend {
+			width: 0 !important;
+			max-width: 0 !important;
+			padding: 0 !important;
+			span {
+				display: none !important;
+			}
+		}
+
+		.MuiSelect-select {
+			font-size: 0.875rem;
+			font-weight: 500;
+		}
+	}
+
+	&__controlCluster {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		align-items: stretch;
+	}
+
+	&__hint {
+		font-size: 0.7rem;
+		opacity: 0.75;
+		line-height: 1.3;
+	}
+
+	&__reset {
+		align-self: flex-end;
+		border: none;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-size: 0.7rem;
+		text-decoration: underline;
+		cursor: pointer;
+		opacity: 0.72;
+		padding: 0;
+
+		&:hover {
+			opacity: 1;
+		}
+	}
+
+	&__actions {
+		margin-top: 0.25rem;
+	}
+
+	&__confirm {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		padding: 0.75rem 0.85rem;
+		border-radius: 8px;
+		border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+
+		p {
+			margin: 0;
+			font-size: 0.875rem;
+		}
+	}
+
+	&__confirmActions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+}

--- a/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.tsx
+++ b/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.tsx
@@ -1,0 +1,430 @@
+import React, { useId, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SelectChangeEvent } from '@mui/material/Select';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Headline } from '../../../components/headline/Headline';
+import { Text } from '../../../components/text/Text';
+import { OrisoSelect } from '../../../components/form/OrisoSelect';
+import { Button, BUTTON_TYPES } from '../../../components/button/Button';
+import {
+	NotificationsContext,
+	NOTIFICATION_TYPE_SUCCESS
+} from '../../../globalState/provider/NotificationsProvider';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import {
+	getSettingsShortcutRows,
+	SETTINGS_CATEGORY_ORDER
+} from '../constants/registry';
+import { ACTION_BINDING_OPTIONS } from '../constants/sendOptions';
+import { formatShortcut } from '../utils/format';
+import { bindingsEqual } from '../utils/binding';
+import {
+	getAvailableNewlineOptions,
+	resolveNewlineBinding
+} from '../utils/deriveNewline';
+import { resolveEffectiveBinding } from '../utils/resolveAction';
+import {
+	DEFAULT_EXPANDED_CATEGORY,
+	toggleExclusiveAccordion,
+	type ShortcutCategoryId
+} from '../utils/accordion';
+import {
+	bindingToOptionValue,
+	optionValueToBinding
+} from '../storage/preferenceStore';
+import type {
+	Platform,
+	ShortcutActionId,
+	ShortcutBinding,
+	ShortcutDefinition
+} from '../types';
+import '../../../components/profile/profile.styles';
+import './KeyboardShortcutsSettings.styles.scss';
+
+const useShortcutLabels = () => {
+	const { t } = useTranslation();
+	return useMemo(
+		() => ({
+			ctrl: t('shortcuts.keys.ctrl', { defaultValue: 'Ctrl' }),
+			cmd: t('shortcuts.keys.cmd', { defaultValue: 'Cmd' }),
+			alt: t('shortcuts.keys.alt', { defaultValue: 'Alt' }),
+			option: t('shortcuts.keys.option', { defaultValue: 'Option' }),
+			shift: t('shortcuts.keys.shift', { defaultValue: 'Shift' }),
+			enter: t('shortcuts.keys.enter', { defaultValue: 'Enter' }),
+			escape: t('shortcuts.keys.escape', { defaultValue: 'Esc' }),
+			arrowUp: t('shortcuts.keys.arrowUp', { defaultValue: '↑' })
+		}),
+		[t]
+	);
+};
+
+const toSelectOptions = (
+	bindings: ShortcutBinding[],
+	platform: Platform,
+	labels: ReturnType<typeof useShortcutLabels>,
+	extra?: { value: string; label: string }[]
+) => [
+	...bindings.map((binding) => ({
+		value: bindingToOptionValue(binding),
+		label: formatShortcut(binding, platform, { symbolic: true, labels })
+	})),
+	...(extra ?? [])
+];
+
+/** Map any stored binding onto a canonical option value so MUI never shows raw ids. */
+const resolveSelectValue = (
+	binding: ShortcutBinding | null,
+	options: ShortcutBinding[],
+	platform: Platform,
+	canDisable: boolean
+): string => {
+	if (binding === null) {
+		return canDisable ? 'disabled' : bindingToOptionValue(options[0]);
+	}
+	const matched = options.find((option) =>
+		bindingsEqual(option, binding, platform)
+	);
+	if (matched) {
+		return bindingToOptionValue(matched);
+	}
+	return bindingToOptionValue(options[0] ?? binding);
+};
+
+export const KeyboardShortcutsSettings = () => {
+	const { t: translate } = useTranslation();
+	const labels = useShortcutLabels();
+	const {
+		platform,
+		preferences,
+		setBinding,
+		restoreDefaults,
+		isNewlineLocked,
+		getWarningsForBinding
+	} = useKeyboardShortcuts();
+	const notifications = React.useContext(NotificationsContext);
+	const [errorKey, setErrorKey] = useState<string | null>(null);
+	const [warningKey, setWarningKey] = useState<string | null>(null);
+	const [confirmRestore, setConfirmRestore] = useState(false);
+	const [expanded, setExpanded] = useState<ShortcutCategoryId | null>(
+		DEFAULT_EXPANDED_CATEGORY
+	);
+	const errorId = useId();
+	const warningId = useId();
+	const liveId = useId();
+
+	const sendBinding =
+		resolveEffectiveBinding(preferences, 'chat.sendMessage', platform) ??
+		ACTION_BINDING_OPTIONS['chat.sendMessage'][0];
+	const newlineBinding = resolveNewlineBinding(
+		sendBinding,
+		preferences.bindings['chat.insertNewLine'],
+		platform
+	);
+
+	const newlineOptions = useMemo(
+		() => getAvailableNewlineOptions(sendBinding, platform),
+		[sendBinding, platform]
+	);
+
+	const rowsByCategory = useMemo(() => {
+		const rows = getSettingsShortcutRows();
+		return SETTINGS_CATEGORY_ORDER.map((category) => ({
+			category,
+			rows: rows.filter((row) => row.category === category)
+		})).filter((group) => group.rows.length > 0);
+	}, []);
+
+	const applyBinding = (
+		actionId: ShortcutActionId,
+		binding: ShortcutBinding | null
+	) => {
+		const result = setBinding(actionId, binding);
+		if (result.ok === false) {
+			setErrorKey(
+				result.conflicts[0]?.messageTranslationKey ??
+					'shortcuts.conflicts.duplicate'
+			);
+			setWarningKey(null);
+			return;
+		}
+		setErrorKey(null);
+		const warnings =
+			result.warnings ?? getWarningsForBinding(actionId, binding);
+		setWarningKey(warnings[0]?.messageTranslationKey ?? null);
+	};
+
+	const handleSelect =
+		(actionId: ShortcutActionId, options: ShortcutBinding[]) =>
+		(event: SelectChangeEvent<string>) => {
+			if (event.target.value === 'disabled') {
+				applyBinding(actionId, null);
+				return;
+			}
+			const next = optionValueToBinding(event.target.value, options);
+			if (!next) {
+				return;
+			}
+			applyBinding(actionId, next);
+		};
+
+	const handleResetAction = (actionId: ShortcutActionId) => {
+		const def = rowsByCategory
+			.flatMap((g) => g.rows)
+			.find((r) => r.id === actionId);
+		if (!def) {
+			return;
+		}
+		applyBinding(actionId, def.defaultBinding);
+	};
+
+	const handleRestoreConfirm = () => {
+		restoreDefaults();
+		setConfirmRestore(false);
+		setErrorKey(null);
+		setWarningKey(null);
+		notifications?.addNotification({
+			notificationType: NOTIFICATION_TYPE_SUCCESS,
+			title: translate('shortcuts.restoreDefaults'),
+			text: translate('shortcuts.restoreDefaultsSuccess')
+		});
+	};
+
+	const renderControl = (def: ShortcutDefinition) => {
+		const options =
+			def.id === 'chat.insertNewLine'
+				? newlineOptions
+				: (ACTION_BINDING_OPTIONS[def.id] ?? def.supportedBindings);
+
+		const current =
+			def.id === 'chat.insertNewLine'
+				? newlineBinding
+				: resolveEffectiveBinding(preferences, def.id, platform);
+
+		const selectValue = resolveSelectValue(
+			current ?? null,
+			options,
+			platform,
+			def.canDisable
+		);
+
+		const extra = def.canDisable
+			? [
+					{
+						value: 'disabled',
+						label: translate('shortcuts.disableShortcut')
+					}
+				]
+			: undefined;
+
+		const selectOptions = toSelectOptions(options, platform, labels, extra);
+		const labelByValue = new Map(
+			selectOptions.map((option) => [option.value, option.label])
+		);
+
+		return (
+			<div className="keyboardShortcutsSettings__controlCluster">
+				<OrisoSelect
+					id={`shortcut-${def.id.replace(/\./g, '-')}`}
+					label={translate(def.labelTranslationKey)}
+					options={selectOptions}
+					value={selectValue}
+					onChange={handleSelect(def.id, options)}
+					size="small"
+					fullWidth
+					disabled={
+						def.id === 'chat.insertNewLine' && isNewlineLocked
+					}
+					renderValue={(value) =>
+						labelByValue.get(String(value)) ??
+						formatShortcut(current, platform, {
+							symbolic: true,
+							labels
+						})
+					}
+				/>
+				{def.id === 'chat.insertNewLine' && isNewlineLocked && (
+					<span className="keyboardShortcutsSettings__hint">
+						{translate('shortcuts.lockedNewline')}
+					</span>
+				)}
+				{def.canDisable && (
+					<button
+						type="button"
+						className="keyboardShortcutsSettings__reset"
+						onClick={() => handleResetAction(def.id)}
+					>
+						{translate('shortcuts.resetAction')}
+					</button>
+				)}
+			</div>
+		);
+	};
+
+	return (
+		<div className="keyboardShortcutsSettings">
+			<div className="profile__content__title">
+				<div className="profile__content__header">
+					<Headline
+						text={translate('shortcuts.title')}
+						semanticLevel="5"
+					/>
+				</div>
+				<Text
+					text={translate('shortcuts.description')}
+					type="standard"
+					className="tertiary"
+				/>
+			</div>
+
+			<div
+				id={liveId}
+				className="keyboardShortcutsSettings__live"
+				aria-live="polite"
+			>
+				{errorKey && (
+					<p
+						id={errorId}
+						className="keyboardShortcutsSettings__error"
+						role="alert"
+					>
+						{translate(errorKey)}
+					</p>
+				)}
+				{!errorKey && warningKey && (
+					<p
+						id={warningId}
+						className="keyboardShortcutsSettings__warning"
+					>
+						{translate(warningKey)}
+					</p>
+				)}
+			</div>
+
+			<div className="keyboardShortcutsSettings__panel">
+				{rowsByCategory.map(({ category, rows }) => {
+					const isExpanded = expanded === category;
+					const panelId = `shortcuts-panel-${category}`;
+					const headerId = `shortcuts-header-${category}`;
+					return (
+						<Accordion
+							key={category}
+							className="keyboardShortcutsSettings__accordion"
+							expanded={isExpanded}
+							onChange={() =>
+								setExpanded((current) =>
+									toggleExclusiveAccordion(
+										current,
+										category as ShortcutCategoryId
+									)
+								)
+							}
+							disableGutters
+							elevation={0}
+							TransitionProps={{ unmountOnExit: true }}
+						>
+							<AccordionSummary
+								id={headerId}
+								aria-controls={panelId}
+								expandIcon={<ExpandMoreIcon />}
+								className="keyboardShortcutsSettings__summary"
+							>
+								<span className="keyboardShortcutsSettings__category">
+									{translate(
+										`shortcuts.categories.${category}`
+									)}
+								</span>
+								<span
+									className="keyboardShortcutsSettings__count"
+									aria-hidden
+								>
+									{rows.length}
+								</span>
+							</AccordionSummary>
+							<AccordionDetails
+								id={panelId}
+								className="keyboardShortcutsSettings__details"
+								role="region"
+								aria-labelledby={headerId}
+							>
+								{isExpanded && (
+									<ul className="keyboardShortcutsSettings__list">
+										{rows.map((def) => (
+											<li
+												key={def.id}
+												className="keyboardShortcutsSettings__row"
+											>
+												<div className="keyboardShortcutsSettings__meta">
+													<span className="keyboardShortcutsSettings__label">
+														{translate(
+															def.labelTranslationKey
+														)}
+													</span>
+													<span className="keyboardShortcutsSettings__desc">
+														{translate(
+															def.descriptionTranslationKey
+														)}
+													</span>
+												</div>
+												<div className="keyboardShortcutsSettings__control">
+													{renderControl(def)}
+												</div>
+											</li>
+										))}
+									</ul>
+								)}
+							</AccordionDetails>
+						</Accordion>
+					);
+				})}
+			</div>
+
+			<div className="keyboardShortcutsSettings__actions">
+				{!confirmRestore ? (
+					<Button
+						item={{
+							label: translate('shortcuts.restoreDefaults'),
+							type: BUTTON_TYPES.SECONDARY,
+							id: 'restore-shortcut-defaults'
+						}}
+						buttonHandle={() => setConfirmRestore(true)}
+					/>
+				) : (
+					<div
+						className="keyboardShortcutsSettings__confirm"
+						role="group"
+						aria-label={translate(
+							'shortcuts.restoreDefaultsConfirm'
+						)}
+					>
+						<p>{translate('shortcuts.restoreDefaultsConfirm')}</p>
+						<div className="keyboardShortcutsSettings__confirmActions">
+							<Button
+								item={{
+									label: translate(
+										'shortcuts.restoreDefaultsConfirmYes'
+									),
+									type: BUTTON_TYPES.PRIMARY,
+									id: 'confirm-restore-shortcut-defaults'
+								}}
+								buttonHandle={handleRestoreConfirm}
+							/>
+							<Button
+								item={{
+									label: translate(
+										'shortcuts.restoreDefaultsConfirmNo'
+									),
+									type: BUTTON_TYPES.SECONDARY,
+									id: 'cancel-restore-shortcut-defaults'
+								}}
+								buttonHandle={() => setConfirmRestore(false)}
+							/>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.styles.scss
+++ b/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.styles.scss
@@ -1,0 +1,93 @@
+.shortcutHelpDialog {
+	border: none;
+	padding: 0;
+	background: transparent;
+	max-width: min(28rem, calc(100vw - 2rem));
+	width: 100%;
+	max-height: min(85vh, calc(100% - 2rem));
+	margin: auto;
+	overflow: hidden;
+
+	&::backdrop {
+		background: rgba(0, 0, 0, 0.4);
+	}
+
+	&__panel {
+		background: var(--skin-color-primary-contrast, #fff);
+		color: inherit;
+		border-radius: 8px;
+		padding: 1.25rem 1.5rem;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+		display: flex;
+		flex-direction: column;
+		max-height: min(85vh, calc(100vh - 2rem));
+		overflow: hidden;
+		box-sizing: border-box;
+	}
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+		flex-shrink: 0;
+
+		h2 {
+			margin: 0;
+			font-size: 1.125rem;
+		}
+	}
+
+	&__close {
+		border: none;
+		background: transparent;
+		font-size: 1.5rem;
+		line-height: 1;
+		cursor: pointer;
+		padding: 0.25rem;
+	}
+
+	&__body {
+		overflow: auto;
+		flex: 1 1 auto;
+		min-height: 0;
+		padding-right: 0.15rem;
+	}
+
+	&__group {
+		margin-bottom: 1rem;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+
+		h3 {
+			margin: 0 0 0.5rem;
+			font-size: 0.9375rem;
+		}
+	}
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			gap: 1rem;
+			padding: 0.35rem 0;
+		}
+
+		kbd {
+			font-family: inherit;
+			font-size: 0.8125rem;
+			padding: 0.15rem 0.4rem;
+			border: 1px solid currentColor;
+			border-radius: 4px;
+			white-space: nowrap;
+		}
+	}
+}

--- a/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.styles.scss
+++ b/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.styles.scss
@@ -13,7 +13,7 @@
 	}
 
 	&__panel {
-		background: var(--skin-color-primary-contrast, #fff);
+		background: var(--m3-surface, #fff);
 		color: inherit;
 		border-radius: 8px;
 		padding: 1.25rem 1.5rem;

--- a/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.tsx
+++ b/src/features/keyboard-shortcuts/components/ShortcutHelpDialog.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useId, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import { getImplementedShortcuts } from '../constants/registry';
+import { formatShortcut } from '../utils/format';
+import { resolveEffectiveBinding } from '../utils/resolveAction';
+import type { ShortcutCategory } from '../types';
+import './ShortcutHelpDialog.styles.scss';
+
+const CATEGORY_ORDER: ShortcutCategory[] = [
+	'messaging',
+	'attachments',
+	'emoji',
+	'application'
+];
+
+export const ShortcutHelpDialog = () => {
+	const { t: translate } = useTranslation();
+	const { isHelpOpen, closeHelp, preferences, platform } =
+		useKeyboardShortcuts();
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const previousFocus = useRef<HTMLElement | null>(null);
+	const titleId = useId();
+	const keyLabels = {
+		ctrl: translate('shortcuts.keys.ctrl'),
+		cmd: translate('shortcuts.keys.cmd'),
+		alt: translate('shortcuts.keys.alt'),
+		option: translate('shortcuts.keys.option'),
+		shift: translate('shortcuts.keys.shift'),
+		enter: translate('shortcuts.keys.enter'),
+		escape: translate('shortcuts.keys.escape'),
+		arrowUp: translate('shortcuts.keys.arrowUp')
+	};
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+		if (!dialog) {
+			return;
+		}
+		if (isHelpOpen) {
+			previousFocus.current = document.activeElement as HTMLElement;
+			if (!dialog.open) {
+				dialog.showModal();
+			}
+		} else if (dialog.open) {
+			dialog.close();
+			previousFocus.current?.focus?.();
+		}
+	}, [isHelpOpen]);
+
+	const grouped = CATEGORY_ORDER.map((category) => ({
+		category,
+		items: getImplementedShortcuts().filter((d) => d.category === category)
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<dialog
+			ref={dialogRef}
+			className="shortcutHelpDialog"
+			aria-labelledby={titleId}
+			aria-modal="true"
+			onClose={closeHelp}
+			onCancel={(event) => {
+				event.preventDefault();
+				closeHelp();
+			}}
+		>
+			{isHelpOpen && (
+				<div className="shortcutHelpDialog__panel">
+					<header className="shortcutHelpDialog__header">
+						<h2 id={titleId}>
+							{translate('shortcuts.help.title')}
+						</h2>
+						<button
+							type="button"
+							className="shortcutHelpDialog__close"
+							onClick={closeHelp}
+							aria-label={translate('shortcuts.help.close')}
+						>
+							×
+						</button>
+					</header>
+					<div className="shortcutHelpDialog__body">
+						{grouped.map(({ category, items }) => (
+							<section
+								key={category}
+								className="shortcutHelpDialog__group"
+								aria-labelledby={`shortcut-cat-${category}`}
+							>
+								<h3 id={`shortcut-cat-${category}`}>
+									{translate(
+										`shortcuts.categories.${category}`
+									)}
+								</h3>
+								<ul className="shortcutHelpDialog__list">
+									{items.map((def) => {
+										const binding = resolveEffectiveBinding(
+											preferences,
+											def.id,
+											platform
+										);
+										if (!binding) {
+											return null;
+										}
+										const label = formatShortcut(
+											binding,
+											platform,
+											{ labels: keyLabels }
+										);
+										return (
+											<li key={def.id}>
+												<span>
+													{translate(
+														def.labelTranslationKey
+													)}
+												</span>
+												<kbd aria-label={label}>
+													{label}
+												</kbd>
+											</li>
+										);
+									})}
+								</ul>
+							</section>
+						))}
+					</div>
+				</div>
+			)}
+		</dialog>
+	);
+};

--- a/src/features/keyboard-shortcuts/constants/registry.ts
+++ b/src/features/keyboard-shortcuts/constants/registry.ts
@@ -1,0 +1,185 @@
+import type { Platform, ShortcutBinding, ShortcutDefinition } from '../types';
+import { bindingsEqual } from '../utils/binding';
+import {
+	CANCEL_BINDING_ESCAPE,
+	CANCEL_BINDING_OPTIONS,
+	EDIT_LAST_BINDING_ARROW_UP,
+	EDIT_LAST_BINDING_OPTIONS,
+	EMOJI_BINDING_OPTIONS,
+	EMOJI_BINDING_PRIMARY_E,
+	HELP_BINDING_F1,
+	HELP_BINDING_PRIMARY_SLASH,
+	HELP_BINDING_QUESTION,
+	NEWLINE_BINDING_ALT_ENTER,
+	NEWLINE_BINDING_ENTER,
+	NEWLINE_BINDING_PRIMARY_ENTER,
+	NEWLINE_BINDING_SHIFT_ENTER,
+	PALETTE_BINDING_OPTIONS,
+	PALETTE_BINDING_PRIMARY_K,
+	SEND_BINDING_ALT_ENTER,
+	SEND_BINDING_ENTER,
+	SEND_BINDING_PRIMARY_ENTER,
+	SEND_BINDING_SHIFT_ENTER,
+	UPLOAD_BINDING_OPTIONS,
+	UPLOAD_BINDING_PRIMARY_SHIFT_U
+} from './sendOptions';
+
+export const SHORTCUT_REGISTRY: ShortcutDefinition[] = [
+	{
+		id: 'chat.sendMessage',
+		category: 'messaging',
+		defaultBinding: SEND_BINDING_ALT_ENTER,
+		supportedBindings: [
+			SEND_BINDING_ALT_ENTER,
+			SEND_BINDING_PRIMARY_ENTER,
+			SEND_BINDING_ENTER,
+			SEND_BINDING_SHIFT_ENTER
+		],
+		activeInTextInput: true,
+		canDisable: false,
+		preventDefault: true,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.sendMessage.label',
+		descriptionTranslationKey: 'shortcuts.actions.sendMessage.description',
+		implemented: true
+	},
+	{
+		id: 'chat.insertNewLine',
+		category: 'messaging',
+		defaultBinding: NEWLINE_BINDING_ENTER,
+		supportedBindings: [
+			NEWLINE_BINDING_ENTER,
+			NEWLINE_BINDING_SHIFT_ENTER,
+			NEWLINE_BINDING_PRIMARY_ENTER,
+			NEWLINE_BINDING_ALT_ENTER
+		],
+		activeInTextInput: true,
+		canDisable: false,
+		preventDefault: false,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.insertNewLine.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.insertNewLine.description',
+		implemented: true
+	},
+	{
+		id: 'chat.editLastMessage',
+		category: 'messaging',
+		defaultBinding: EDIT_LAST_BINDING_ARROW_UP,
+		supportedBindings: EDIT_LAST_BINDING_OPTIONS,
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.editLastMessage.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.editLastMessage.description',
+		implemented: true
+	},
+	{
+		id: 'chat.cancelReplyOrEdit',
+		category: 'messaging',
+		defaultBinding: CANCEL_BINDING_ESCAPE,
+		supportedBindings: CANCEL_BINDING_OPTIONS,
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.cancelReplyOrEdit.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.cancelReplyOrEdit.description',
+		implemented: true
+	},
+	{
+		id: 'chat.uploadFile',
+		category: 'attachments',
+		defaultBinding: UPLOAD_BINDING_PRIMARY_SHIFT_U,
+		supportedBindings: UPLOAD_BINDING_OPTIONS,
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.uploadFile.label',
+		descriptionTranslationKey: 'shortcuts.actions.uploadFile.description',
+		implemented: true
+	},
+	{
+		id: 'chat.openEmojiPicker',
+		category: 'emoji',
+		defaultBinding: EMOJI_BINDING_PRIMARY_E,
+		supportedBindings: EMOJI_BINDING_OPTIONS,
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'composer',
+		labelTranslationKey: 'shortcuts.actions.openEmojiPicker.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.openEmojiPicker.description',
+		implemented: true
+	},
+	{
+		id: 'app.showShortcutHelp',
+		category: 'application',
+		defaultBinding: HELP_BINDING_PRIMARY_SLASH,
+		supportedBindings: [
+			HELP_BINDING_PRIMARY_SLASH,
+			HELP_BINDING_QUESTION,
+			HELP_BINDING_F1
+		],
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'global',
+		labelTranslationKey: 'shortcuts.actions.showShortcutHelp.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.showShortcutHelp.description',
+		implemented: true
+	},
+	{
+		id: 'app.openCommandPalette',
+		category: 'application',
+		defaultBinding: PALETTE_BINDING_PRIMARY_K,
+		supportedBindings: PALETTE_BINDING_OPTIONS,
+		activeInTextInput: true,
+		canDisable: true,
+		preventDefault: true,
+		scope: 'global',
+		labelTranslationKey: 'shortcuts.actions.openCommandPalette.label',
+		descriptionTranslationKey:
+			'shortcuts.actions.openCommandPalette.description',
+		implemented: true
+	}
+];
+
+/** Category display order in Settings. */
+export const SETTINGS_CATEGORY_ORDER = [
+	'messaging',
+	'attachments',
+	'emoji',
+	'application'
+] as const;
+
+export const getShortcutDefinition = (
+	id: ShortcutDefinition['id']
+): ShortcutDefinition | undefined =>
+	SHORTCUT_REGISTRY.find((entry) => entry.id === id);
+
+export const getImplementedShortcuts = (): ShortcutDefinition[] =>
+	SHORTCUT_REGISTRY.filter((entry) => entry.implemented);
+
+/** All registry rows for Settings. */
+export const getSettingsShortcutRows = (): ShortcutDefinition[] =>
+	SHORTCUT_REGISTRY.filter((entry) => entry.implemented);
+
+export const isSupportedBinding = (
+	definition: ShortcutDefinition,
+	binding: ShortcutBinding | null,
+	platform: Platform
+): boolean => {
+	if (binding === null) {
+		return definition.canDisable;
+	}
+	return definition.supportedBindings.some((supported) =>
+		bindingsEqual(supported, binding, platform)
+	);
+};

--- a/src/features/keyboard-shortcuts/constants/reserved.ts
+++ b/src/features/keyboard-shortcuts/constants/reserved.ts
@@ -1,0 +1,90 @@
+import type { Platform, ShortcutBinding } from '../types';
+import { bindingIdentity, normalizeBinding } from '../utils/binding';
+
+/**
+ * Hard-blocked browser / OS shortcuts (never assignable).
+ * Represented with primaryModifier where Ctrl/Cmd is interchangeable.
+ * L/N/U/F/K are intentionally allowed as options with warnings (see RISKY).
+ */
+export const RESERVED_BINDINGS: ShortcutBinding[] = [
+	{ key: 'W', primaryModifier: true },
+	{ key: 'T', primaryModifier: true },
+	{ key: 'R', primaryModifier: true },
+	{ key: 'Tab', ctrl: true },
+	{ key: 'Tab', ctrl: true, shift: true },
+	{ key: 'F4', alt: true },
+	{ key: 'Q', meta: true }
+];
+
+/**
+ * Risky browser shortcuts — allowed when listed in an action’s supportedBindings,
+ * but Settings should surface a warning.
+ */
+export const RISKY_BROWSER_BINDINGS: ShortcutBinding[] = [
+	{ key: 'F', primaryModifier: true },
+	{ key: 'K', primaryModifier: true },
+	{ key: 'P', primaryModifier: true },
+	{ key: 'S', primaryModifier: true },
+	{ key: 'L', primaryModifier: true },
+	{ key: 'N', primaryModifier: true },
+	{ key: 'U', primaryModifier: true }
+];
+
+export const isReservedBinding = (
+	binding: ShortcutBinding,
+	platform: Platform
+): boolean => {
+	const id = bindingIdentity(binding, platform);
+	if (!id) {
+		return false;
+	}
+	return RESERVED_BINDINGS.some(
+		(reserved) => bindingIdentity(reserved, platform) === id
+	);
+};
+
+export const isRiskyBrowserBinding = (
+	binding: ShortcutBinding,
+	platform: Platform
+): boolean => {
+	const id = bindingIdentity(binding, platform);
+	if (!id) {
+		return false;
+	}
+	return RISKY_BROWSER_BINDINGS.some(
+		(risky) => bindingIdentity(risky, platform) === id
+	);
+};
+
+/** Plain letter/symbol with no modifiers — unsafe while typing in inputs. */
+export const isUnsafePlainKeyBinding = (binding: ShortcutBinding): boolean => {
+	const n = normalizeBinding(binding, 'linux');
+	const hasModifier = !!(n.ctrl || n.meta || n.alt);
+	if (hasModifier) {
+		return false;
+	}
+	// Shift+Enter is a known newline combo, not a plain typing key.
+	if (n.shift && n.key === 'Enter') {
+		return false;
+	}
+	if (n.key === 'Enter' || n.key === 'Escape' || n.key === 'Tab') {
+		return false;
+	}
+	// ArrowUp used for edit-last is intentional when composer empty (runtime guard).
+	if (n.key === 'ArrowUp' || n.key === 'F1' || n.key === 'F2') {
+		return false;
+	}
+	// Single printable / navigation keys without modifiers
+	if (
+		n.key.length === 1 ||
+		n.key.startsWith('Arrow') ||
+		n.key === 'Backspace' ||
+		n.key === 'Delete'
+	) {
+		return !n.shift; // bare key
+	}
+	if (['/', ':', '?'].includes(n.key)) {
+		return true;
+	}
+	return false;
+};

--- a/src/features/keyboard-shortcuts/constants/sendOptions.ts
+++ b/src/features/keyboard-shortcuts/constants/sendOptions.ts
@@ -1,0 +1,137 @@
+import type { ShortcutActionId, ShortcutBinding } from '../types';
+
+/** Approved send bindings for Settings select (structured, not display strings). */
+export const SEND_BINDING_PRIMARY_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	primaryModifier: true
+};
+
+export const SEND_BINDING_ENTER: ShortcutBinding = {
+	key: 'Enter'
+};
+
+export const SEND_BINDING_SHIFT_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	shift: true
+};
+
+export const SEND_BINDING_ALT_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	alt: true
+};
+
+export const SEND_BINDING_OPTIONS: ShortcutBinding[] = [
+	SEND_BINDING_ALT_ENTER,
+	SEND_BINDING_PRIMARY_ENTER,
+	SEND_BINDING_ENTER,
+	SEND_BINDING_SHIFT_ENTER
+];
+
+export const NEWLINE_BINDING_ENTER: ShortcutBinding = {
+	key: 'Enter'
+};
+
+export const NEWLINE_BINDING_SHIFT_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	shift: true
+};
+
+export const NEWLINE_BINDING_PRIMARY_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	primaryModifier: true
+};
+
+export const NEWLINE_BINDING_ALT_ENTER: ShortcutBinding = {
+	key: 'Enter',
+	alt: true
+};
+
+/** User-selectable newline options when not forced by Enter-to-send. */
+export const NEWLINE_BINDING_OPTIONS: ShortcutBinding[] = [
+	NEWLINE_BINDING_ENTER,
+	NEWLINE_BINDING_SHIFT_ENTER,
+	NEWLINE_BINDING_PRIMARY_ENTER,
+	NEWLINE_BINDING_ALT_ENTER
+];
+
+export const HELP_BINDING_PRIMARY_SLASH: ShortcutBinding = {
+	key: '/',
+	primaryModifier: true
+};
+
+export const HELP_BINDING_QUESTION: ShortcutBinding = {
+	key: '?'
+};
+
+export const HELP_BINDING_F1: ShortcutBinding = {
+	key: 'F1'
+};
+
+export const HELP_BINDING_OPTIONS: ShortcutBinding[] = [
+	HELP_BINDING_PRIMARY_SLASH,
+	HELP_BINDING_QUESTION,
+	HELP_BINDING_F1
+];
+
+export const EDIT_LAST_BINDING_ARROW_UP: ShortcutBinding = { key: 'ArrowUp' };
+export const EDIT_LAST_BINDING_F2: ShortcutBinding = { key: 'F2' };
+export const EDIT_LAST_BINDING_OPTIONS: ShortcutBinding[] = [
+	EDIT_LAST_BINDING_ARROW_UP,
+	EDIT_LAST_BINDING_F2
+];
+
+export const CANCEL_BINDING_ESCAPE: ShortcutBinding = { key: 'Escape' };
+export const CANCEL_BINDING_OPTIONS: ShortcutBinding[] = [
+	CANCEL_BINDING_ESCAPE
+];
+
+export const UPLOAD_BINDING_PRIMARY_SHIFT_U: ShortcutBinding = {
+	key: 'U',
+	primaryModifier: true,
+	shift: true
+};
+export const UPLOAD_BINDING_PRIMARY_U: ShortcutBinding = {
+	key: 'U',
+	primaryModifier: true
+};
+export const UPLOAD_BINDING_OPTIONS: ShortcutBinding[] = [
+	UPLOAD_BINDING_PRIMARY_SHIFT_U,
+	UPLOAD_BINDING_PRIMARY_U
+];
+
+export const EMOJI_BINDING_PRIMARY_E: ShortcutBinding = {
+	key: 'E',
+	primaryModifier: true
+};
+export const EMOJI_BINDING_OPTIONS: ShortcutBinding[] = [
+	EMOJI_BINDING_PRIMARY_E
+];
+
+export const PALETTE_BINDING_PRIMARY_K: ShortcutBinding = {
+	key: 'K',
+	primaryModifier: true
+};
+export const PALETTE_BINDING_PRIMARY_SHIFT_P: ShortcutBinding = {
+	key: 'P',
+	primaryModifier: true,
+	shift: true
+};
+export const PALETTE_BINDING_OPTIONS: ShortcutBinding[] = [
+	PALETTE_BINDING_PRIMARY_K,
+	PALETTE_BINDING_PRIMARY_SHIFT_P
+];
+
+/** Approved selectable options per action (Settings dropdowns). */
+export const ACTION_BINDING_OPTIONS: Record<
+	ShortcutActionId,
+	ShortcutBinding[]
+> = {
+	'chat.sendMessage': SEND_BINDING_OPTIONS,
+	'chat.insertNewLine': NEWLINE_BINDING_OPTIONS,
+	'chat.editLastMessage': EDIT_LAST_BINDING_OPTIONS,
+	'chat.cancelReplyOrEdit': CANCEL_BINDING_OPTIONS,
+	'chat.uploadFile': UPLOAD_BINDING_OPTIONS,
+	'chat.openEmojiPicker': EMOJI_BINDING_OPTIONS,
+	'app.showShortcutHelp': HELP_BINDING_OPTIONS,
+	'app.openCommandPalette': PALETTE_BINDING_OPTIONS
+};

--- a/src/features/keyboard-shortcuts/context/KeyboardShortcutsProvider.tsx
+++ b/src/features/keyboard-shortcuts/context/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,292 @@
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+	type PropsWithChildren
+} from 'react';
+import { UserDataContext } from '../../../globalState/context/UserDataContext';
+import type {
+	KeyboardShortcutPreferencesV1,
+	Platform,
+	ShortcutActionId,
+	ShortcutBinding,
+	ShortcutConflict
+} from '../types';
+import {
+	deriveNewlineBinding,
+	isNewlineLockedToSend,
+	resolveNewlineBinding
+} from '../utils/deriveNewline';
+import { getPlatform } from '../utils/platform';
+import {
+	getBindingWarnings,
+	hasBlockingConflicts,
+	validateShortcutPreferences
+} from '../utils/conflicts';
+import {
+	clearShortcutPreferences,
+	createDefaultPreferences,
+	loadShortcutPreferences,
+	saveShortcutPreferences
+} from '../storage/preferenceStore';
+
+export type PersistResult =
+	| { ok: true; warnings?: ShortcutConflict[] }
+	| { ok: false; conflicts: ShortcutConflict[] };
+
+export type KeyboardShortcutsContextValue = {
+	platform: Platform;
+	preferences: KeyboardShortcutPreferencesV1;
+	isHelpOpen: boolean;
+	openHelp: () => void;
+	closeHelp: () => void;
+	toggleHelp: () => void;
+	isPaletteOpen: boolean;
+	openPalette: () => void;
+	closePalette: () => void;
+	togglePalette: () => void;
+	setBinding: (
+		actionId: ShortcutActionId,
+		binding: ShortcutBinding | null
+	) => PersistResult;
+	setSendBinding: (binding: ShortcutBinding) => PersistResult;
+	setHelpBinding: (binding: ShortcutBinding | null) => PersistResult;
+	restoreDefaults: () => void;
+	getBinding: (
+		actionId: keyof KeyboardShortcutPreferencesV1['bindings']
+	) => ShortcutBinding | null | undefined;
+	isNewlineLocked: boolean;
+	getWarningsForBinding: (
+		actionId: ShortcutActionId,
+		binding: ShortcutBinding | null
+	) => ShortcutConflict[];
+};
+
+const KeyboardShortcutsContext =
+	createContext<KeyboardShortcutsContextValue | null>(null);
+
+export const KeyboardShortcutsProvider = ({
+	children,
+	platformOverride
+}: PropsWithChildren<{ platformOverride?: Platform }>) => {
+	const userDataContext = useContext(UserDataContext);
+	const userId = userDataContext?.userData?.userId ?? null;
+	const platform = platformOverride ?? getPlatform();
+
+	const [preferences, setPreferences] =
+		useState<KeyboardShortcutPreferencesV1>(() =>
+			loadShortcutPreferences(userId)
+		);
+	const [isHelpOpen, setIsHelpOpen] = useState(false);
+	const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+
+	useEffect(() => {
+		setPreferences(loadShortcutPreferences(userId));
+	}, [userId]);
+
+	const persist = useCallback(
+		(next: KeyboardShortcutPreferencesV1): PersistResult => {
+			const send = next.bindings['chat.sendMessage'] ?? null;
+			const withNewline: KeyboardShortcutPreferencesV1 = {
+				version: 1,
+				bindings: {
+					...next.bindings,
+					'chat.insertNewLine': resolveNewlineBinding(
+						send,
+						next.bindings['chat.insertNewLine'],
+						platform
+					)
+				}
+			};
+			const conflicts = validateShortcutPreferences(
+				withNewline,
+				platform
+			);
+			if (hasBlockingConflicts(conflicts)) {
+				return { ok: false, conflicts };
+			}
+			saveShortcutPreferences(withNewline, userId);
+			setPreferences(withNewline);
+			return { ok: true };
+		},
+		[platform, userId]
+	);
+
+	const setBinding = useCallback(
+		(actionId: ShortcutActionId, binding: ShortcutBinding | null) => {
+			const nextBindings = {
+				...preferences.bindings,
+				[actionId]: binding
+			};
+			if (actionId === 'chat.sendMessage') {
+				nextBindings['chat.insertNewLine'] = deriveNewlineBinding(
+					binding,
+					platform
+				);
+			}
+			const result = persist({ version: 1, bindings: nextBindings });
+			if (result.ok) {
+				const warnings = getBindingWarnings(
+					actionId,
+					binding,
+					platform
+				);
+				return warnings.length
+					? { ok: true as const, warnings }
+					: { ok: true as const };
+			}
+			return result;
+		},
+		[persist, preferences.bindings, platform]
+	);
+
+	const setSendBinding = useCallback(
+		(binding: ShortcutBinding) => setBinding('chat.sendMessage', binding),
+		[setBinding]
+	);
+
+	const setHelpBinding = useCallback(
+		(binding: ShortcutBinding | null) =>
+			setBinding('app.showShortcutHelp', binding),
+		[setBinding]
+	);
+
+	const restoreDefaults = useCallback(() => {
+		clearShortcutPreferences(userId);
+		const defaults = createDefaultPreferences();
+		saveShortcutPreferences(defaults, userId);
+		setPreferences(defaults);
+	}, [userId]);
+
+	const getBinding = useCallback(
+		(actionId: keyof KeyboardShortcutPreferencesV1['bindings']) => {
+			if (actionId === 'chat.insertNewLine') {
+				return resolveNewlineBinding(
+					preferences.bindings['chat.sendMessage'] ?? null,
+					preferences.bindings['chat.insertNewLine'],
+					platform
+				);
+			}
+			return preferences.bindings[actionId];
+		},
+		[preferences.bindings, platform]
+	);
+
+	const getWarningsForBinding = useCallback(
+		(actionId: ShortcutActionId, binding: ShortcutBinding | null) =>
+			getBindingWarnings(actionId, binding, platform),
+		[platform]
+	);
+
+	const isNewlineLocked = isNewlineLockedToSend(
+		preferences.bindings['chat.sendMessage'] ?? null,
+		platform
+	);
+
+	const openHelp = useCallback(() => {
+		setIsPaletteOpen(false);
+		setIsHelpOpen(true);
+	}, []);
+	const closeHelp = useCallback(() => setIsHelpOpen(false), []);
+	const toggleHelp = useCallback(() => {
+		setIsHelpOpen((open) => {
+			if (open) {
+				return false;
+			}
+			setIsPaletteOpen(false);
+			return true;
+		});
+	}, []);
+	const openPalette = useCallback(() => {
+		setIsHelpOpen(false);
+		setIsPaletteOpen(true);
+	}, []);
+	const closePalette = useCallback(() => setIsPaletteOpen(false), []);
+	const togglePalette = useCallback(() => {
+		setIsPaletteOpen((open) => {
+			if (open) {
+				return false;
+			}
+			setIsHelpOpen(false);
+			return true;
+		});
+	}, []);
+
+	const value = useMemo<KeyboardShortcutsContextValue>(
+		() => ({
+			platform,
+			preferences,
+			isHelpOpen,
+			openHelp,
+			closeHelp,
+			toggleHelp,
+			isPaletteOpen,
+			openPalette,
+			closePalette,
+			togglePalette,
+			setBinding,
+			setSendBinding,
+			setHelpBinding,
+			restoreDefaults,
+			getBinding,
+			isNewlineLocked,
+			getWarningsForBinding
+		}),
+		[
+			platform,
+			preferences,
+			isHelpOpen,
+			openHelp,
+			closeHelp,
+			toggleHelp,
+			isPaletteOpen,
+			openPalette,
+			closePalette,
+			togglePalette,
+			setBinding,
+			setSendBinding,
+			setHelpBinding,
+			restoreDefaults,
+			getBinding,
+			isNewlineLocked,
+			getWarningsForBinding
+		]
+	);
+
+	return (
+		<KeyboardShortcutsContext.Provider value={value}>
+			{children}
+		</KeyboardShortcutsContext.Provider>
+	);
+};
+
+export const useKeyboardShortcuts = (): KeyboardShortcutsContextValue => {
+	const ctx = useContext(KeyboardShortcutsContext);
+	if (!ctx) {
+		const platform = getPlatform();
+		const preferences = createDefaultPreferences();
+		return {
+			platform,
+			preferences,
+			isHelpOpen: false,
+			openHelp: () => undefined,
+			closeHelp: () => undefined,
+			toggleHelp: () => undefined,
+			isPaletteOpen: false,
+			openPalette: () => undefined,
+			closePalette: () => undefined,
+			togglePalette: () => undefined,
+			setBinding: () => ({ ok: true }),
+			setSendBinding: () => ({ ok: true }),
+			setHelpBinding: () => ({ ok: true }),
+			restoreDefaults: () => undefined,
+			getBinding: (actionId) => preferences.bindings[actionId],
+			isNewlineLocked: false,
+			getWarningsForBinding: () => []
+		};
+	}
+	return ctx;
+};

--- a/src/features/keyboard-shortcuts/hooks/useChatComposerShortcuts.ts
+++ b/src/features/keyboard-shortcuts/hooks/useChatComposerShortcuts.ts
@@ -1,0 +1,129 @@
+import { useCallback } from 'react';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import {
+	resolveComposerShortcutAction,
+	type ResolveComposerOptions
+} from '../utils/resolveComposerShortcut';
+import { resolveMatchedAction } from '../utils/resolveAction';
+import type { MatchableKeyboardEvent } from '../utils/match';
+import type { ShortcutActionId } from '../types';
+
+export type ComposerActionHandlers = {
+	onSend: () => void;
+	onEditLast?: () => boolean;
+	onCancel?: () => boolean;
+	onUpload?: () => boolean;
+	onOpenEmoji?: () => boolean;
+};
+
+export type UseChatComposerShortcutsArgs = ResolveComposerOptions &
+	ComposerActionHandlers & {
+		/** When true, composer is empty (required for edit-last). */
+		isComposerEmpty?: boolean;
+	};
+
+/**
+ * Shared composer shortcut handler. Wire into TipTap editorProps.handleKeyDown.
+ * Returns true when the event was handled (caller should preventDefault).
+ */
+export const useChatComposerShortcuts = ({
+	onSend,
+	onEditLast,
+	onCancel,
+	onUpload,
+	onOpenEmoji,
+	disabled,
+	isSending,
+	hasOpenSuggestions,
+	isComposerEmpty
+}: UseChatComposerShortcutsArgs) => {
+	const { preferences, platform } = useKeyboardShortcuts();
+
+	const handleComposerKeyDown = useCallback(
+		(event: MatchableKeyboardEvent): boolean => {
+			const sendOrNewline = resolveComposerShortcutAction(
+				event,
+				preferences,
+				platform,
+				{ disabled, isSending, hasOpenSuggestions }
+			);
+			if (sendOrNewline === 'send') {
+				event.preventDefault?.();
+				onSend();
+				return true;
+			}
+			if (sendOrNewline === 'newline') {
+				return false;
+			}
+
+			const action = resolveMatchedAction(event, preferences, platform, {
+				scopes: ['composer'],
+				disabled,
+				isSending,
+				hasOpenSuggestions,
+				inTextInput: true,
+				exclude: ['chat.sendMessage', 'chat.insertNewLine']
+			});
+
+			if (!action) {
+				return false;
+			}
+
+			const handled = dispatchComposerAction(action, {
+				onEditLast,
+				onCancel,
+				onUpload,
+				onOpenEmoji,
+				isComposerEmpty,
+				hasOpenSuggestions
+			});
+			if (handled) {
+				event.preventDefault?.();
+			}
+			return handled;
+		},
+		[
+			preferences,
+			platform,
+			disabled,
+			isSending,
+			hasOpenSuggestions,
+			isComposerEmpty,
+			onSend,
+			onEditLast,
+			onCancel,
+			onUpload,
+			onOpenEmoji
+		]
+	);
+
+	return { handleComposerKeyDown, preferences, platform };
+};
+
+export const dispatchComposerAction = (
+	action: ShortcutActionId,
+	opts: {
+		onEditLast?: () => boolean;
+		onCancel?: () => boolean;
+		onUpload?: () => boolean;
+		onOpenEmoji?: () => boolean;
+		isComposerEmpty?: boolean;
+		hasOpenSuggestions?: boolean;
+	}
+): boolean => {
+	switch (action) {
+		case 'chat.cancelReplyOrEdit':
+			return opts.onCancel?.() ?? false;
+		case 'chat.editLastMessage':
+			if (opts.hasOpenSuggestions || opts.isComposerEmpty === false) {
+				return false;
+			}
+			return opts.onEditLast?.() ?? false;
+		case 'chat.uploadFile':
+			return opts.onUpload?.() ?? false;
+		case 'chat.openEmojiPicker':
+			return opts.onOpenEmoji?.() ?? false;
+		default:
+			return false;
+	}
+};

--- a/src/features/keyboard-shortcuts/hooks/useGlobalShortcuts.ts
+++ b/src/features/keyboard-shortcuts/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import {
+	hasOpenModalDialog,
+	resolveMatchedAction
+} from '../utils/resolveAction';
+import { isImeComposing } from '../utils/match';
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+	if (!(target instanceof HTMLElement)) {
+		return false;
+	}
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+		return true;
+	}
+	return target.isContentEditable;
+};
+
+/**
+ * Global shortcuts: help and command palette (toggle open/close).
+ */
+export const useGlobalShortcuts = (enabled = true) => {
+	const {
+		preferences,
+		platform,
+		toggleHelp,
+		togglePalette,
+		isHelpOpen,
+		isPaletteOpen
+	} = useKeyboardShortcuts();
+	const toggleHelpRef = useRef(toggleHelp);
+	const togglePaletteRef = useRef(togglePalette);
+	toggleHelpRef.current = toggleHelp;
+	togglePaletteRef.current = togglePalette;
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.defaultPrevented || isImeComposing(event)) {
+				return;
+			}
+
+			const action = resolveMatchedAction(event, preferences, platform, {
+				scopes: ['global'],
+				inTextInput: isEditableTarget(event.target)
+			});
+
+			// Always allow help / palette shortcuts to toggle even while open.
+			if (action === 'app.showShortcutHelp') {
+				event.preventDefault();
+				toggleHelpRef.current();
+				return;
+			}
+			if (action === 'app.openCommandPalette') {
+				event.preventDefault();
+				togglePaletteRef.current();
+				return;
+			}
+
+			if (isHelpOpen || isPaletteOpen || hasOpenModalDialog()) {
+				return;
+			}
+		};
+		// Capture phase so we beat browser defaults (Cmd+K, etc.).
+		window.addEventListener('keydown', onKeyDown, true);
+		return () => window.removeEventListener('keydown', onKeyDown, true);
+	}, [enabled, preferences, platform, isHelpOpen, isPaletteOpen]);
+};

--- a/src/features/keyboard-shortcuts/hooks/useShortcutHelpHotkey.ts
+++ b/src/features/keyboard-shortcuts/hooks/useShortcutHelpHotkey.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { useKeyboardShortcuts } from '../context/KeyboardShortcutsProvider';
+import { resolveEffectiveBinding } from '../utils/resolveComposerShortcut';
+import { isImeComposing, matchesShortcut } from '../utils/match';
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+	if (!(target instanceof HTMLElement)) {
+		return false;
+	}
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+		return true;
+	}
+	return target.isContentEditable;
+};
+
+/**
+ * Global listener for app.showShortcutHelp (toggle).
+ * Plain keys like `?` do not fire while typing in inputs.
+ */
+export const useShortcutHelpHotkey = (enabled = true) => {
+	const { preferences, platform, toggleHelp, isHelpOpen } =
+		useKeyboardShortcuts();
+	const toggleHelpRef = useRef(toggleHelp);
+	toggleHelpRef.current = toggleHelp;
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.defaultPrevented || isImeComposing(event)) {
+				return;
+			}
+			const binding = resolveEffectiveBinding(
+				preferences,
+				'app.showShortcutHelp',
+				platform
+			);
+			if (!binding || !matchesShortcut(event, binding, platform)) {
+				return;
+			}
+			const hasModifier = !!(
+				binding.primaryModifier ||
+				binding.ctrl ||
+				binding.meta ||
+				binding.alt
+			);
+			if (
+				!hasModifier &&
+				binding.key !== 'F1' &&
+				isEditableTarget(event.target)
+			) {
+				return;
+			}
+			// Allow toggle while our own help is open; block other modals.
+			if (!isHelpOpen) {
+				const dialog = document.querySelector(
+					'[role="dialog"][aria-modal="true"]'
+				);
+				if (dialog) {
+					return;
+				}
+			}
+			event.preventDefault();
+			toggleHelpRef.current();
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [enabled, preferences, platform, isHelpOpen]);
+};

--- a/src/features/keyboard-shortcuts/index.ts
+++ b/src/features/keyboard-shortcuts/index.ts
@@ -1,0 +1,48 @@
+export type {
+	Platform,
+	ShortcutActionId,
+	ShortcutBinding,
+	ShortcutDefinition,
+	KeyboardShortcutPreferencesV1,
+	ShortcutConflict,
+	ComposerShortcutAction
+} from './types';
+
+export {
+	SHORTCUT_REGISTRY,
+	getImplementedShortcuts
+} from './constants/registry';
+export {
+	SEND_BINDING_OPTIONS,
+	SEND_BINDING_PRIMARY_ENTER,
+	SEND_BINDING_ENTER,
+	SEND_BINDING_ALT_ENTER
+} from './constants/sendOptions';
+
+export { getPlatform, getPrimaryModifier } from './utils/platform';
+export { normalizeBinding, bindingsEqual } from './utils/binding';
+export { matchesShortcut } from './utils/match';
+export { formatShortcut } from './utils/format';
+export { deriveNewlineBinding } from './utils/deriveNewline';
+export { validateShortcutPreferences } from './utils/conflicts';
+export { resolveComposerShortcutAction } from './utils/resolveComposerShortcut';
+
+export {
+	KEYBOARD_SHORTCUTS_STORAGE_KEY,
+	loadShortcutPreferences,
+	saveShortcutPreferences,
+	createDefaultPreferences
+} from './storage/preferenceStore';
+
+export {
+	KeyboardShortcutsProvider,
+	useKeyboardShortcuts
+} from './context/KeyboardShortcutsProvider';
+export { useChatComposerShortcuts } from './hooks/useChatComposerShortcuts';
+export { useGlobalShortcuts } from './hooks/useGlobalShortcuts';
+export { useShortcutHelpHotkey } from './hooks/useShortcutHelpHotkey';
+// UI components: import from their files to avoid pulling i18n into composer tests
+export { KeyboardShortcutsSettings } from './components/KeyboardShortcutsSettings';
+export { ShortcutHelpDialog } from './components/ShortcutHelpDialog';
+export { CommandPaletteDialog } from './components/CommandPaletteDialog';
+export { KeyboardShortcutsAppShell } from './components/KeyboardShortcutsAppShell';

--- a/src/features/keyboard-shortcuts/storage/preferenceStore.test.ts
+++ b/src/features/keyboard-shortcuts/storage/preferenceStore.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	KEYBOARD_SHORTCUTS_STORAGE_KEY,
+	clearShortcutPreferences,
+	createDefaultPreferences,
+	loadShortcutPreferences,
+	saveShortcutPreferences
+} from './preferenceStore';
+import {
+	SEND_BINDING_ALT_ENTER,
+	SEND_BINDING_ENTER
+} from '../constants/sendOptions';
+
+const store: Record<string, string> = {};
+
+const localStorageMock = {
+	getItem: (key: string) => (key in store ? store[key] : null),
+	setItem: (key: string, value: string) => {
+		store[key] = String(value);
+	},
+	removeItem: (key: string) => {
+		delete store[key];
+	},
+	clear: () => {
+		Object.keys(store).forEach((k) => delete store[k]);
+	}
+};
+
+describe('preferenceStore', () => {
+	beforeEach(() => {
+		Object.keys(store).forEach((k) => delete store[k]);
+		Object.defineProperty(window, 'localStorage', {
+			value: localStorageMock,
+			configurable: true
+		});
+	});
+
+	afterEach(() => {
+		localStorageMock.clear();
+	});
+
+	it('returns defaults when empty', () => {
+		const prefs = loadShortcutPreferences('user-a');
+		expect(prefs.version).toBe(1);
+		expect(prefs.bindings['chat.sendMessage']).toEqual(
+			SEND_BINDING_ALT_ENTER
+		);
+	});
+
+	it('saves and reloads preferences per user', () => {
+		saveShortcutPreferences(
+			{
+				version: 1,
+				bindings: { 'chat.sendMessage': SEND_BINDING_ENTER }
+			},
+			'user-a'
+		);
+		expect(
+			loadShortcutPreferences('user-a').bindings['chat.sendMessage']
+		).toEqual(SEND_BINDING_ENTER);
+		expect(
+			loadShortcutPreferences('user-b').bindings['chat.sendMessage']
+		).toEqual(SEND_BINDING_ALT_ENTER);
+	});
+
+	it('falls back on malformed JSON', () => {
+		localStorageMock.setItem(KEYBOARD_SHORTCUTS_STORAGE_KEY, '{not-json');
+		expect(loadShortcutPreferences('user-a').version).toBe(1);
+	});
+
+	it('ignores unknown schema version', () => {
+		localStorageMock.setItem(
+			KEYBOARD_SHORTCUTS_STORAGE_KEY,
+			JSON.stringify({ version: 99, byUser: { 'user-a': {} } })
+		);
+		expect(
+			loadShortcutPreferences('user-a').bindings['chat.sendMessage']
+		).toEqual(SEND_BINDING_ALT_ENTER);
+	});
+
+	it('ignores unsupported action ids and malformed bindings', () => {
+		localStorageMock.setItem(
+			KEYBOARD_SHORTCUTS_STORAGE_KEY,
+			JSON.stringify({
+				version: 1,
+				byUser: {
+					'user-a': {
+						'chat.sendMessage': { key: 123 },
+						'not.a.real.action': {
+							key: 'K',
+							primaryModifier: true
+						}
+					}
+				}
+			})
+		);
+		const prefs = loadShortcutPreferences('user-a');
+		expect(prefs.bindings['chat.sendMessage']).toEqual(
+			SEND_BINDING_ALT_ENTER
+		);
+		expect(
+			(prefs.bindings as Record<string, unknown>)['not.a.real.action']
+		).toBeUndefined();
+	});
+
+	it('restore defaults via clear + createDefault', () => {
+		saveShortcutPreferences(
+			{
+				version: 1,
+				bindings: { 'chat.sendMessage': SEND_BINDING_ENTER }
+			},
+			'user-a'
+		);
+		clearShortcutPreferences('user-a');
+		expect(loadShortcutPreferences('user-a')).toEqual(
+			createDefaultPreferences()
+		);
+	});
+});

--- a/src/features/keyboard-shortcuts/storage/preferenceStore.ts
+++ b/src/features/keyboard-shortcuts/storage/preferenceStore.ts
@@ -1,0 +1,248 @@
+import type {
+	KeyboardShortcutPreferencesV1,
+	ShortcutActionId,
+	ShortcutBinding
+} from '../types';
+import {
+	getImplementedShortcuts,
+	isSupportedBinding
+} from '../constants/registry';
+import {
+	ACTION_BINDING_OPTIONS,
+	SEND_BINDING_OPTIONS
+} from '../constants/sendOptions';
+import { parseBinding } from '../utils/binding';
+import {
+	deriveNewlineBinding,
+	resolveNewlineBinding
+} from '../utils/deriveNewline';
+import { getPlatform } from '../utils/platform';
+
+export const KEYBOARD_SHORTCUTS_STORAGE_KEY = 'oriso.keyboardShortcuts.v1';
+
+type StoredBlobV1 = {
+	version: 1;
+	/** Per-user preference maps; `__anonymous__` when signed out. */
+	byUser: Record<string, KeyboardShortcutPreferencesV1['bindings']>;
+};
+
+const ANONYMOUS_USER = '__anonymous__';
+
+const safeGetStorage = (): Storage | null => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+};
+
+export const createDefaultPreferences = (): KeyboardShortcutPreferencesV1 => {
+	const bindings: KeyboardShortcutPreferencesV1['bindings'] = {};
+	for (const def of getImplementedShortcuts()) {
+		if (def.id === 'chat.insertNewLine') {
+			continue;
+		}
+		bindings[def.id] = def.defaultBinding
+			? { ...def.defaultBinding }
+			: null;
+	}
+	const platform = getPlatform();
+	const send = bindings['chat.sendMessage'] ?? null;
+	bindings['chat.insertNewLine'] = deriveNewlineBinding(send, platform);
+	return { version: 1, bindings };
+};
+
+const emptyBlob = (): StoredBlobV1 => ({
+	version: 1,
+	byUser: {}
+});
+
+const parseBlob = (raw: string | null): StoredBlobV1 => {
+	if (!raw) {
+		return emptyBlob();
+	}
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (
+			!parsed ||
+			typeof parsed !== 'object' ||
+			(parsed as StoredBlobV1).version !== 1
+		) {
+			return emptyBlob();
+		}
+		const byUser = (parsed as StoredBlobV1).byUser;
+		if (!byUser || typeof byUser !== 'object' || Array.isArray(byUser)) {
+			return emptyBlob();
+		}
+		const safeByUser: StoredBlobV1['byUser'] = {};
+		for (const [key, value] of Object.entries(byUser)) {
+			if (
+				key === '__proto__' ||
+				key === 'constructor' ||
+				key === 'prototype'
+			) {
+				continue;
+			}
+			safeByUser[key] =
+				value as KeyboardShortcutPreferencesV1['bindings'];
+		}
+		return { version: 1, byUser: safeByUser };
+	} catch {
+		return emptyBlob();
+	}
+};
+
+const sanitizeBindings = (
+	input: unknown
+): KeyboardShortcutPreferencesV1['bindings'] => {
+	const result: KeyboardShortcutPreferencesV1['bindings'] = {};
+	if (!input || typeof input !== 'object' || Array.isArray(input)) {
+		return result;
+	}
+	const implemented = getImplementedShortcuts();
+	const implementedIds = new Set(implemented.map((d) => d.id));
+	const platform = getPlatform();
+
+	for (const [key, value] of Object.entries(
+		input as Record<string, unknown>
+	)) {
+		if (!implementedIds.has(key as ShortcutActionId)) {
+			continue;
+		}
+		const actionId = key as ShortcutActionId;
+		if (value === null) {
+			result[actionId] = null;
+			continue;
+		}
+		const binding = parseBinding(value);
+		if (!binding) {
+			continue;
+		}
+		const def = implemented.find((d) => d.id === actionId);
+		if (!def) {
+			continue;
+		}
+		if (
+			actionId === 'chat.insertNewLine' ||
+			isSupportedBinding(def, binding, platform)
+		) {
+			result[actionId] = binding;
+		}
+	}
+	return result;
+};
+
+const userKey = (userId?: string | null): string =>
+	userId && String(userId).trim() ? String(userId) : ANONYMOUS_USER;
+
+export const loadShortcutPreferences = (
+	userId?: string | null
+): KeyboardShortcutPreferencesV1 => {
+	const defaults = createDefaultPreferences();
+	const storage = safeGetStorage();
+	if (!storage) {
+		return defaults;
+	}
+	const blob = parseBlob(storage.getItem(KEYBOARD_SHORTCUTS_STORAGE_KEY));
+	const stored = sanitizeBindings(blob.byUser[userKey(userId)]);
+	const merged: KeyboardShortcutPreferencesV1 = {
+		version: 1,
+		bindings: { ...defaults.bindings, ...stored }
+	};
+	const platform = getPlatform();
+	const send =
+		merged.bindings['chat.sendMessage'] ??
+		defaults.bindings['chat.sendMessage'] ??
+		null;
+	merged.bindings['chat.insertNewLine'] = resolveNewlineBinding(
+		send,
+		merged.bindings['chat.insertNewLine'],
+		platform
+	);
+	return merged;
+};
+
+export const saveShortcutPreferences = (
+	preferences: KeyboardShortcutPreferencesV1,
+	userId?: string | null
+): void => {
+	const storage = safeGetStorage();
+	if (!storage) {
+		return;
+	}
+	const blob = parseBlob(storage.getItem(KEYBOARD_SHORTCUTS_STORAGE_KEY));
+	const platform = getPlatform();
+	const send = preferences.bindings['chat.sendMessage'] ?? null;
+	const toStore: KeyboardShortcutPreferencesV1['bindings'] = {
+		...preferences.bindings,
+		'chat.insertNewLine': resolveNewlineBinding(
+			send,
+			preferences.bindings['chat.insertNewLine'],
+			platform
+		)
+	};
+	blob.byUser[userKey(userId)] = sanitizeBindings(toStore);
+	try {
+		storage.setItem(KEYBOARD_SHORTCUTS_STORAGE_KEY, JSON.stringify(blob));
+	} catch {
+		// Quota / private mode — ignore
+	}
+};
+
+export const clearShortcutPreferences = (userId?: string | null): void => {
+	const storage = safeGetStorage();
+	if (!storage) {
+		return;
+	}
+	const blob = parseBlob(storage.getItem(KEYBOARD_SHORTCUTS_STORAGE_KEY));
+	delete blob.byUser[userKey(userId)];
+	try {
+		storage.setItem(KEYBOARD_SHORTCUTS_STORAGE_KEY, JSON.stringify(blob));
+	} catch {
+		// ignore
+	}
+};
+
+export const bindingToOptionValue = (binding: ShortcutBinding): string => {
+	const parts = [
+		binding.key,
+		binding.primaryModifier ? 'primary' : '',
+		binding.ctrl ? 'ctrl' : '',
+		binding.meta ? 'meta' : '',
+		binding.shift ? 'shift' : '',
+		binding.alt ? 'alt' : ''
+	];
+	return parts.filter(Boolean).join('|');
+};
+
+export const optionValueToSendBinding = (
+	value: string
+): ShortcutBinding | null => optionValueToBinding(value, SEND_BINDING_OPTIONS);
+
+export const optionValueToBinding = (
+	value: string,
+	options: ShortcutBinding[]
+): ShortcutBinding | null => {
+	for (const option of options) {
+		if (bindingToOptionValue(option) === value) {
+			return { ...option };
+		}
+	}
+	return null;
+};
+
+export const ALL_SELECTABLE_BINDINGS: ShortcutBinding[] = Array.from(
+	new Map(
+		Object.values(ACTION_BINDING_OPTIONS)
+			.flat()
+			.map((binding) => [JSON.stringify(binding), binding] as const)
+	).values()
+);
+
+export const optionValueToAnyKnownBinding = (
+	value: string
+): ShortcutBinding | null =>
+	optionValueToBinding(value, ALL_SELECTABLE_BINDINGS);

--- a/src/features/keyboard-shortcuts/types.ts
+++ b/src/features/keyboard-shortcuts/types.ts
@@ -1,0 +1,68 @@
+export type Platform = 'mac' | 'windows' | 'linux' | 'unknown';
+
+export type ShortcutCategory =
+	| 'messaging'
+	| 'attachments'
+	| 'emoji'
+	| 'application';
+
+export type ShortcutScope = 'composer' | 'chat' | 'global';
+
+/**
+ * Canonical action identifiers. Only actions with existing app behavior
+ * are registered as `implemented` in the registry for Settings UI.
+ */
+export type ShortcutActionId =
+	| 'chat.sendMessage'
+	| 'chat.insertNewLine'
+	| 'chat.uploadFile'
+	| 'chat.editLastMessage'
+	| 'chat.cancelReplyOrEdit'
+	| 'chat.openEmojiPicker'
+	| 'app.showShortcutHelp'
+	| 'app.openCommandPalette';
+
+export interface ShortcutBinding {
+	key: string;
+	primaryModifier?: boolean;
+	ctrl?: boolean;
+	meta?: boolean;
+	shift?: boolean;
+	alt?: boolean;
+}
+
+export interface ShortcutDefinition {
+	id: ShortcutActionId;
+	category: ShortcutCategory;
+	defaultBinding: ShortcutBinding | null;
+	supportedBindings: ShortcutBinding[];
+	activeInTextInput: boolean;
+	canDisable: boolean;
+	preventDefault: boolean;
+	scope: ShortcutScope;
+	labelTranslationKey: string;
+	descriptionTranslationKey: string;
+	/** When false, omitted from Settings and help (types only / future). */
+	implemented: boolean;
+}
+
+export interface KeyboardShortcutPreferencesV1 {
+	version: 1;
+	bindings: Partial<Record<ShortcutActionId, ShortcutBinding | null>>;
+}
+
+export type ShortcutConflictType =
+	| 'duplicate'
+	| 'reserved'
+	| 'send-newline'
+	| 'unsafe-plain-key'
+	| 'unsupported';
+
+export interface ShortcutConflict {
+	actionId: ShortcutActionId;
+	conflictingActionId?: ShortcutActionId;
+	type: ShortcutConflictType;
+	messageTranslationKey: string;
+}
+
+export type ComposerShortcutAction = 'send' | 'newline';

--- a/src/features/keyboard-shortcuts/utils/accordion.ts
+++ b/src/features/keyboard-shortcuts/utils/accordion.ts
@@ -1,0 +1,22 @@
+/** Exclusive accordion helpers for Settings categories. */
+
+export type ShortcutCategoryId =
+	| 'messaging'
+	| 'attachments'
+	| 'emoji'
+	| 'application';
+
+export const DEFAULT_EXPANDED_CATEGORY: ShortcutCategoryId = 'messaging';
+
+/**
+ * Toggle exclusive accordion: opening one closes others; clicking open one collapses to null.
+ */
+export const toggleExclusiveAccordion = (
+	current: ShortcutCategoryId | null,
+	clicked: ShortcutCategoryId
+): ShortcutCategoryId | null => (current === clicked ? null : clicked);
+
+export const isCategoryExpanded = (
+	expanded: ShortcutCategoryId | null,
+	category: ShortcutCategoryId
+): boolean => expanded === category;

--- a/src/features/keyboard-shortcuts/utils/binding.ts
+++ b/src/features/keyboard-shortcuts/utils/binding.ts
@@ -1,0 +1,119 @@
+import type { Platform, ShortcutBinding } from '../types';
+import { getPrimaryModifier } from './platform';
+
+const normalizeKeyName = (key: string): string => {
+	if (!key) {
+		return '';
+	}
+	if (key === ' ') {
+		return 'Space';
+	}
+	if (key.length === 1) {
+		return key.toUpperCase();
+	}
+	// Enter, Escape, ArrowUp, etc.
+	return key.length === 1 ? key.toUpperCase() : key;
+};
+
+export const normalizeBindingKey = (key: string): string =>
+	normalizeKeyName(key);
+
+/**
+ * Expand primaryModifier into concrete ctrl/meta for the given platform.
+ * Does not mutate the original binding.
+ */
+export const normalizeBinding = (
+	binding: ShortcutBinding,
+	platform: Platform
+): ShortcutBinding => {
+	const key = normalizeBindingKey(binding.key);
+	const result: ShortcutBinding = {
+		key,
+		shift: !!binding.shift,
+		alt: !!binding.alt,
+		ctrl: !!binding.ctrl,
+		meta: !!binding.meta
+	};
+
+	if (binding.primaryModifier) {
+		const primary = getPrimaryModifier(platform);
+		if (primary === 'meta') {
+			result.meta = true;
+		} else {
+			result.ctrl = true;
+		}
+	}
+
+	return result;
+};
+
+/** Stable identity for conflict detection (platform-normalized). */
+export const bindingIdentity = (
+	binding: ShortcutBinding | null | undefined,
+	platform: Platform
+): string | null => {
+	if (!binding || !binding.key) {
+		return null;
+	}
+	const n = normalizeBinding(binding, platform);
+	return [
+		n.key,
+		n.ctrl ? 'c' : '',
+		n.meta ? 'm' : '',
+		n.shift ? 's' : '',
+		n.alt ? 'a' : ''
+	].join('+');
+};
+
+export const bindingsEqual = (
+	a: ShortcutBinding | null | undefined,
+	b: ShortcutBinding | null | undefined,
+	platform: Platform
+): boolean => {
+	const ia = bindingIdentity(a, platform);
+	const ib = bindingIdentity(b, platform);
+	if (ia === null || ib === null) {
+		return false;
+	}
+	return ia === ib;
+};
+
+export const isMalformedBinding = (value: unknown): boolean => {
+	if (!value || typeof value !== 'object') {
+		return true;
+	}
+	const b = value as Record<string, unknown>;
+	if (typeof b.key !== 'string' || !b.key.trim()) {
+		return true;
+	}
+	for (const flag of [
+		'primaryModifier',
+		'ctrl',
+		'meta',
+		'shift',
+		'alt'
+	] as const) {
+		if (flag in b && typeof b[flag] !== 'boolean') {
+			return true;
+		}
+	}
+	return false;
+};
+
+export const parseBinding = (value: unknown): ShortcutBinding | null => {
+	if (value === null) {
+		return null;
+	}
+	if (isMalformedBinding(value)) {
+		return null;
+	}
+	const b = value as ShortcutBinding;
+	return {
+		key: normalizeBindingKey(b.key),
+		...(b.primaryModifier ? { primaryModifier: true } : {}),
+		...(b.ctrl ? { ctrl: true } : {}),
+		...(b.meta ? { meta: true } : {}),
+		...(b.shift ? { shift: true } : {}),
+		...(b.alt ? { alt: true } : {})
+	};
+};

--- a/src/features/keyboard-shortcuts/utils/conflicts.ts
+++ b/src/features/keyboard-shortcuts/utils/conflicts.ts
@@ -1,0 +1,207 @@
+import type {
+	KeyboardShortcutPreferencesV1,
+	Platform,
+	ShortcutActionId,
+	ShortcutBinding,
+	ShortcutConflict
+} from '../types';
+import {
+	getImplementedShortcuts,
+	getShortcutDefinition
+} from '../constants/registry';
+import {
+	isReservedBinding,
+	isRiskyBrowserBinding,
+	isUnsafePlainKeyBinding
+} from '../constants/reserved';
+import { bindingIdentity, bindingsEqual } from './binding';
+import { resolveNewlineBinding } from './deriveNewline';
+
+const scopesOverlap = (
+	a: 'composer' | 'chat' | 'global',
+	b: 'composer' | 'chat' | 'global'
+): boolean => {
+	if (a === b) {
+		return true;
+	}
+	// Global overlaps everything; chat overlaps composer
+	if (a === 'global' || b === 'global') {
+		return true;
+	}
+	if (
+		(a === 'chat' && b === 'composer') ||
+		(a === 'composer' && b === 'chat')
+	) {
+		return true;
+	}
+	return false;
+};
+
+export const validateShortcutPreferences = (
+	preferences: KeyboardShortcutPreferencesV1,
+	platform: Platform
+): ShortcutConflict[] => {
+	const conflicts: ShortcutConflict[] = [];
+	const implemented = getImplementedShortcuts();
+
+	const effective = new Map<ShortcutActionId, ShortcutBinding | null>();
+
+	for (const def of implemented) {
+		const stored = preferences.bindings[def.id];
+		if (stored === undefined) {
+			effective.set(def.id, def.defaultBinding);
+		} else if (stored === null) {
+			if (!def.canDisable) {
+				conflicts.push({
+					actionId: def.id,
+					type: 'unsupported',
+					messageTranslationKey: 'shortcuts.conflicts.cannotDisable'
+				});
+				effective.set(def.id, def.defaultBinding);
+			} else {
+				effective.set(def.id, null);
+			}
+		} else {
+			const supported = def.supportedBindings.some((b) =>
+				bindingsEqual(b, stored, platform)
+			);
+			if (!supported) {
+				conflicts.push({
+					actionId: def.id,
+					type: 'unsupported',
+					messageTranslationKey: 'shortcuts.conflicts.unsupported'
+				});
+				effective.set(def.id, def.defaultBinding);
+			} else {
+				effective.set(def.id, stored);
+			}
+		}
+	}
+
+	// Resolve newline (locked when Enter-to-send; else allow stored)
+	const send = effective.get('chat.sendMessage') ?? null;
+	const storedNewline = preferences.bindings['chat.insertNewLine'];
+	effective.set(
+		'chat.insertNewLine',
+		resolveNewlineBinding(send, storedNewline, platform)
+	);
+
+	for (const [actionId, binding] of effective) {
+		if (!binding) {
+			continue;
+		}
+		if (isReservedBinding(binding, platform)) {
+			conflicts.push({
+				actionId,
+				type: 'reserved',
+				messageTranslationKey: 'shortcuts.conflicts.reserved'
+			});
+		}
+		// Risky browser shortcuts only block when not an intentional allowlisted option
+		const def = getShortcutDefinition(actionId);
+		const intentionallyAllowed =
+			!!def &&
+			def.supportedBindings.some((b) =>
+				bindingsEqual(b, binding, platform)
+			);
+		if (isRiskyBrowserBinding(binding, platform) && !intentionallyAllowed) {
+			conflicts.push({
+				actionId,
+				type: 'reserved',
+				messageTranslationKey: 'shortcuts.conflicts.browserConflict'
+			});
+		}
+		if (
+			def &&
+			def.activeInTextInput &&
+			isUnsafePlainKeyBinding(binding) &&
+			!intentionallyAllowed
+		) {
+			conflicts.push({
+				actionId,
+				type: 'unsafe-plain-key',
+				messageTranslationKey: 'shortcuts.conflicts.unsafePlainKey'
+			});
+		}
+	}
+
+	const sendBinding = effective.get('chat.sendMessage');
+	const newlineBinding = effective.get('chat.insertNewLine');
+	if (
+		sendBinding &&
+		newlineBinding &&
+		bindingsEqual(sendBinding, newlineBinding, platform)
+	) {
+		conflicts.push({
+			actionId: 'chat.sendMessage',
+			conflictingActionId: 'chat.insertNewLine',
+			type: 'send-newline',
+			messageTranslationKey: 'shortcuts.conflicts.sendNewline'
+		});
+	}
+
+	const seen = new Map<string, ShortcutActionId>();
+	for (const [actionId, binding] of effective) {
+		if (!binding) {
+			continue;
+		}
+		const def = getShortcutDefinition(actionId);
+		if (!def) {
+			continue;
+		}
+		const id = bindingIdentity(binding, platform);
+		if (!id) {
+			continue;
+		}
+		const previous = seen.get(id);
+		if (previous) {
+			const prevDef = getShortcutDefinition(previous);
+			if (prevDef && scopesOverlap(prevDef.scope, def.scope)) {
+				conflicts.push({
+					actionId,
+					conflictingActionId: previous,
+					type: 'duplicate',
+					messageTranslationKey: 'shortcuts.conflicts.duplicate'
+				});
+			}
+		} else {
+			seen.set(id, actionId);
+		}
+	}
+
+	return conflicts;
+};
+
+export const hasBlockingConflicts = (conflicts: ShortcutConflict[]): boolean =>
+	conflicts.length > 0;
+
+/**
+ * Non-blocking warnings for intentionally-allowed risky browser shortcuts.
+ * Callers should surface these in Settings (aria-live) without rejecting the binding.
+ */
+export const getBindingWarnings = (
+	actionId: ShortcutActionId,
+	binding: ShortcutBinding | null,
+	platform: Platform
+): ShortcutConflict[] => {
+	if (!binding) {
+		return [];
+	}
+	if (!isRiskyBrowserBinding(binding, platform)) {
+		return [];
+	}
+	const def = getShortcutDefinition(actionId);
+	const intentionallyAllowed =
+		!!def &&
+		def.supportedBindings.some((b) => bindingsEqual(b, binding, platform));
+	if (!intentionallyAllowed) {
+		return [];
+	}
+	return [
+		{
+			actionId,
+			type: 'reserved',
+			messageTranslationKey: 'shortcuts.conflicts.browserConflict'
+		}
+	];
+};

--- a/src/features/keyboard-shortcuts/utils/deriveNewline.ts
+++ b/src/features/keyboard-shortcuts/utils/deriveNewline.ts
@@ -1,0 +1,79 @@
+import type { Platform, ShortcutBinding } from '../types';
+import {
+	NEWLINE_BINDING_ENTER,
+	NEWLINE_BINDING_OPTIONS,
+	NEWLINE_BINDING_SHIFT_ENTER,
+	SEND_BINDING_ENTER,
+	SEND_BINDING_SHIFT_ENTER
+} from '../constants/sendOptions';
+import { bindingsEqual } from './binding';
+
+/**
+ * Default newline from send binding:
+ * - Enter sends → Shift+Enter newline
+ * - Shift+Enter sends → Enter newline
+ * - otherwise → Enter newline
+ */
+export const deriveNewlineBinding = (
+	sendBinding: ShortcutBinding | null | undefined,
+	platform: Platform
+): ShortcutBinding => {
+	if (
+		sendBinding &&
+		bindingsEqual(sendBinding, SEND_BINDING_ENTER, platform)
+	) {
+		return { ...NEWLINE_BINDING_SHIFT_ENTER };
+	}
+	if (
+		sendBinding &&
+		bindingsEqual(sendBinding, SEND_BINDING_SHIFT_ENTER, platform)
+	) {
+		return { ...NEWLINE_BINDING_ENTER };
+	}
+	return { ...NEWLINE_BINDING_ENTER };
+};
+
+/** True when newline must follow send (Enter-to-send locks Shift+Enter). */
+export const isNewlineLockedToSend = (
+	sendBinding: ShortcutBinding | null | undefined,
+	platform: Platform
+): boolean =>
+	!!(sendBinding && bindingsEqual(sendBinding, SEND_BINDING_ENTER, platform));
+
+/**
+ * Resolve effective newline: locked derivation, else stored if valid, else derived.
+ */
+export const resolveNewlineBinding = (
+	sendBinding: ShortcutBinding | null | undefined,
+	storedNewline: ShortcutBinding | null | undefined,
+	platform: Platform
+): ShortcutBinding => {
+	const derived = deriveNewlineBinding(sendBinding, platform);
+	if (isNewlineLockedToSend(sendBinding, platform)) {
+		return derived;
+	}
+	if (
+		storedNewline &&
+		NEWLINE_BINDING_OPTIONS.some((option) =>
+			bindingsEqual(option, storedNewline, platform)
+		) &&
+		!(sendBinding && bindingsEqual(storedNewline, sendBinding, platform))
+	) {
+		return { ...storedNewline };
+	}
+	return derived;
+};
+
+/** Newline options that do not conflict with the current send binding. */
+export const getAvailableNewlineOptions = (
+	sendBinding: ShortcutBinding | null | undefined,
+	platform: Platform
+): ShortcutBinding[] => {
+	if (isNewlineLockedToSend(sendBinding, platform)) {
+		return [NEWLINE_BINDING_SHIFT_ENTER];
+	}
+	return NEWLINE_BINDING_OPTIONS.filter(
+		(option) =>
+			!(sendBinding && bindingsEqual(option, sendBinding, platform))
+	);
+};

--- a/src/features/keyboard-shortcuts/utils/format.ts
+++ b/src/features/keyboard-shortcuts/utils/format.ts
@@ -1,0 +1,74 @@
+import type { Platform, ShortcutBinding } from '../types';
+import { normalizeBinding } from './binding';
+
+export type FormatShortcutOptions = {
+	/** Prefer ⌘ over Cmd for macOS (default true for compact UI). */
+	symbolic?: boolean;
+	/** Optional localized modifier / key labels from i18n. */
+	labels?: Partial<{
+		ctrl: string;
+		cmd: string;
+		alt: string;
+		option: string;
+		shift: string;
+		enter: string;
+		escape: string;
+		arrowUp: string;
+	}>;
+};
+
+/**
+ * Build a display label from a structured binding. Never store this string
+ * as the canonical preference value.
+ */
+export const formatShortcut = (
+	binding: ShortcutBinding | null | undefined,
+	platform: Platform,
+	options: FormatShortcutOptions = {}
+): string => {
+	if (!binding || !binding.key) {
+		return '';
+	}
+
+	const symbolic = options.symbolic !== false;
+	const labels = options.labels ?? {};
+	const n = normalizeBinding(binding, platform);
+	const parts: string[] = [];
+
+	if (n.ctrl) {
+		parts.push(labels.ctrl ?? 'Ctrl');
+	}
+	if (n.meta) {
+		parts.push(
+			symbolic && platform === 'mac' ? '⌘' : (labels.cmd ?? 'Cmd')
+		);
+	}
+	if (n.alt) {
+		parts.push(
+			platform === 'mac'
+				? (labels.option ?? 'Option')
+				: (labels.alt ?? 'Alt')
+		);
+	}
+	if (n.shift) {
+		parts.push(symbolic ? '⇧' : (labels.shift ?? 'Shift'));
+	}
+
+	const keyLabel =
+		n.key === 'Enter'
+			? (labels.enter ?? 'Enter')
+			: n.key === 'ArrowUp'
+				? (labels.arrowUp ?? '↑')
+				: n.key === 'Escape'
+					? (labels.escape ?? 'Esc')
+					: n.key === '/'
+						? '/'
+						: n.key === '?'
+							? '?'
+							: n.key.length === 1
+								? n.key.toUpperCase()
+								: n.key;
+
+	parts.push(keyLabel);
+	return parts.join('+');
+};

--- a/src/features/keyboard-shortcuts/utils/keyboardShortcuts.test.ts
+++ b/src/features/keyboard-shortcuts/utils/keyboardShortcuts.test.ts
@@ -1,0 +1,415 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { getPlatform, getPrimaryModifier } from './platform';
+import { normalizeBinding } from './binding';
+import { matchesShortcut, type MatchableKeyboardEvent } from './match';
+import { formatShortcut } from './format';
+import { deriveNewlineBinding } from './deriveNewline';
+import { resolveComposerShortcutAction } from './resolveComposerShortcut';
+import { resolveMatchedAction } from './resolveAction';
+import { validateShortcutPreferences } from './conflicts';
+import { isCategoryExpanded, toggleExclusiveAccordion } from './accordion';
+import { dispatchComposerAction } from '../hooks/useChatComposerShortcuts';
+import {
+	SEND_BINDING_ALT_ENTER,
+	SEND_BINDING_ENTER,
+	SEND_BINDING_PRIMARY_ENTER
+} from '../constants/sendOptions';
+import type { KeyboardShortcutPreferencesV1, Platform } from '../types';
+
+const evt = (
+	partial: Partial<MatchableKeyboardEvent> & { key: string }
+): MatchableKeyboardEvent => ({
+	ctrlKey: false,
+	metaKey: false,
+	shiftKey: false,
+	altKey: false,
+	isComposing: false,
+	defaultPrevented: false,
+	...partial
+});
+
+describe('platform', () => {
+	it('detects macOS', () => {
+		expect(getPlatform('Mozilla/5.0 (Macintosh)', 'MacIntel')).toBe('mac');
+		expect(getPrimaryModifier('mac')).toBe('meta');
+	});
+
+	it('detects Windows and Linux', () => {
+		expect(getPlatform('Windows NT 10.0', 'Win32')).toBe('windows');
+		expect(getPlatform('X11; Linux x86_64', 'Linux x86_64')).toBe('linux');
+		expect(getPrimaryModifier('windows')).toBe('ctrl');
+		expect(getPrimaryModifier('linux')).toBe('ctrl');
+	});
+});
+
+describe('normalizeBinding / formatShortcut', () => {
+	it('expands primary modifier per platform', () => {
+		expect(normalizeBinding(SEND_BINDING_PRIMARY_ENTER, 'mac').meta).toBe(
+			true
+		);
+		expect(
+			normalizeBinding(SEND_BINDING_PRIMARY_ENTER, 'windows').ctrl
+		).toBe(true);
+	});
+
+	it('formats Cmd on mac and Ctrl on Windows', () => {
+		expect(formatShortcut(SEND_BINDING_PRIMARY_ENTER, 'mac')).toContain(
+			'⌘'
+		);
+		expect(formatShortcut(SEND_BINDING_PRIMARY_ENTER, 'windows')).toBe(
+			'Ctrl+Enter'
+		);
+	});
+});
+
+describe('matchesShortcut', () => {
+	const cases: Array<{
+		name: string;
+		platform: Platform;
+		binding: typeof SEND_BINDING_PRIMARY_ENTER;
+		event: MatchableKeyboardEvent;
+		expected: boolean;
+	}> = [
+		{
+			name: 'Windows Ctrl+Enter',
+			platform: 'windows',
+			binding: SEND_BINDING_PRIMARY_ENTER,
+			event: evt({ key: 'Enter', ctrlKey: true }),
+			expected: true
+		},
+		{
+			name: 'Linux Ctrl+Enter',
+			platform: 'linux',
+			binding: SEND_BINDING_PRIMARY_ENTER,
+			event: evt({ key: 'Enter', ctrlKey: true }),
+			expected: true
+		},
+		{
+			name: 'macOS Cmd+Enter',
+			platform: 'mac',
+			binding: SEND_BINDING_PRIMARY_ENTER,
+			event: evt({ key: 'Enter', metaKey: true }),
+			expected: true
+		},
+		{
+			name: 'plain Enter',
+			platform: 'windows',
+			binding: SEND_BINDING_ENTER,
+			event: evt({ key: 'Enter' }),
+			expected: true
+		},
+		{
+			name: 'Shift+Enter for shift binding',
+			platform: 'windows',
+			binding: { key: 'Enter', shift: true },
+			event: evt({ key: 'Enter', shiftKey: true }),
+			expected: true
+		},
+		{
+			name: 'Alt+Enter',
+			platform: 'windows',
+			binding: SEND_BINDING_ALT_ENTER,
+			event: evt({ key: 'Enter', altKey: true }),
+			expected: true
+		},
+		{
+			name: 'wrong key',
+			platform: 'windows',
+			binding: SEND_BINDING_ENTER,
+			event: evt({ key: 'a' }),
+			expected: false
+		},
+		{
+			name: 'extra modifier',
+			platform: 'windows',
+			binding: SEND_BINDING_ENTER,
+			event: evt({ key: 'Enter', ctrlKey: true }),
+			expected: false
+		},
+		{
+			name: 'missing modifier',
+			platform: 'mac',
+			binding: SEND_BINDING_PRIMARY_ENTER,
+			event: evt({ key: 'Enter' }),
+			expected: false
+		},
+		{
+			name: 'isComposing blocks',
+			platform: 'windows',
+			binding: SEND_BINDING_ENTER,
+			event: evt({ key: 'Enter', isComposing: true }),
+			expected: false
+		},
+		{
+			name: 'defaultPrevented blocks',
+			platform: 'windows',
+			binding: SEND_BINDING_ENTER,
+			event: evt({ key: 'Enter', defaultPrevented: true }),
+			expected: false
+		},
+		{
+			name: 'case normalization for letter keys',
+			platform: 'windows',
+			binding: { key: 'a', primaryModifier: true },
+			event: evt({ key: 'A', ctrlKey: true }),
+			expected: true
+		}
+	];
+
+	it.each(cases)('$name', ({ platform, binding, event, expected }) => {
+		expect(matchesShortcut(event, binding, platform)).toBe(expected);
+	});
+
+	it('treats null binding as non-match (disabled)', () => {
+		expect(matchesShortcut(evt({ key: 'Enter' }), null, 'windows')).toBe(
+			false
+		);
+	});
+});
+
+describe('deriveNewlineBinding', () => {
+	it('uses Shift+Enter when Enter sends', () => {
+		expect(deriveNewlineBinding(SEND_BINDING_ENTER, 'mac')).toEqual({
+			key: 'Enter',
+			shift: true
+		});
+	});
+
+	it('uses Enter when primary, alt, or shift sends', () => {
+		expect(deriveNewlineBinding(SEND_BINDING_PRIMARY_ENTER, 'mac')).toEqual(
+			{
+				key: 'Enter'
+			}
+		);
+		expect(deriveNewlineBinding(SEND_BINDING_ALT_ENTER, 'windows')).toEqual(
+			{
+				key: 'Enter'
+			}
+		);
+		expect(
+			deriveNewlineBinding({ key: 'Enter', shift: true }, 'linux')
+		).toEqual({ key: 'Enter' });
+	});
+});
+
+describe('resolveComposerShortcutAction', () => {
+	const prefs = (
+		send: typeof SEND_BINDING_PRIMARY_ENTER
+	): KeyboardShortcutPreferencesV1 => ({
+		version: 1,
+		bindings: {
+			'chat.sendMessage': send,
+			'chat.insertNewLine': deriveNewlineBinding(send, 'windows')
+		}
+	});
+
+	it('primary mode: Enter newline, Ctrl+Enter send on Windows', () => {
+		const p = prefs(SEND_BINDING_PRIMARY_ENTER);
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'windows')
+		).toBe('newline');
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', ctrlKey: true }),
+				p,
+				'windows'
+			)
+		).toBe('send');
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', metaKey: true }),
+				p,
+				'mac'
+			)
+		).toBe('send');
+	});
+
+	it('enter-to-send mode', () => {
+		const p = prefs(SEND_BINDING_ENTER);
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'mac')
+		).toBe('send');
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', shiftKey: true }),
+				p,
+				'mac'
+			)
+		).toBe('newline');
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', ctrlKey: true }),
+				p,
+				'windows'
+			)
+		).toBeNull();
+	});
+
+	it('alt-enter mode', () => {
+		const p = prefs(SEND_BINDING_ALT_ENTER);
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', altKey: true }),
+				p,
+				'linux'
+			)
+		).toBe('send');
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'linux')
+		).toBe('newline');
+	});
+
+	it('ignores disabled, sending, suggestions, IME', () => {
+		const p = prefs(SEND_BINDING_ENTER);
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'mac', {
+				disabled: true
+			})
+		).toBeNull();
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'mac', {
+				isSending: true
+			})
+		).toBeNull();
+		expect(
+			resolveComposerShortcutAction(evt({ key: 'Enter' }), p, 'mac', {
+				hasOpenSuggestions: true
+			})
+		).toBeNull();
+		expect(
+			resolveComposerShortcutAction(
+				evt({ key: 'Enter', isComposing: true }),
+				p,
+				'mac'
+			)
+		).toBeNull();
+	});
+});
+
+describe('validateShortcutPreferences', () => {
+	it('flags send/newline conflict when forced equal', () => {
+		const conflicts = validateShortcutPreferences(
+			{
+				version: 1,
+				bindings: {
+					'chat.sendMessage': SEND_BINDING_ENTER,
+					'chat.insertNewLine': SEND_BINDING_ENTER
+				}
+			},
+			'windows'
+		);
+		// derive forces Shift+Enter so defaults should not conflict
+		expect(conflicts.some((c) => c.type === 'send-newline')).toBe(false);
+	});
+
+	it('flags reserved shortcuts', () => {
+		const conflicts = validateShortcutPreferences(
+			{
+				version: 1,
+				bindings: {
+					'chat.sendMessage': { key: 'W', primaryModifier: true }
+				}
+			},
+			'mac'
+		);
+		expect(
+			conflicts.some(
+				(c) => c.type === 'reserved' || c.type === 'unsupported'
+			)
+		).toBe(true);
+	});
+
+	it('allows default preferences including Alt+Enter send', () => {
+		const conflicts = validateShortcutPreferences(
+			{
+				version: 1,
+				bindings: {
+					'chat.sendMessage': SEND_BINDING_ALT_ENTER,
+					'app.showShortcutHelp': {
+						key: '/',
+						primaryModifier: true
+					}
+				}
+			},
+			'mac'
+		);
+		expect(conflicts.filter((c) => c.type === 'send-newline')).toHaveLength(
+			0
+		);
+		expect(conflicts.filter((c) => c.type === 'reserved')).toHaveLength(0);
+	});
+});
+
+describe('accordion helpers', () => {
+	it('toggles exclusive accordion', () => {
+		expect(toggleExclusiveAccordion('messaging', 'attachments')).toBe(
+			'attachments'
+		);
+		expect(toggleExclusiveAccordion('messaging', 'messaging')).toBeNull();
+		expect(isCategoryExpanded('messaging', 'messaging')).toBe(true);
+		expect(isCategoryExpanded(null, 'messaging')).toBe(false);
+	});
+});
+
+describe('resolveMatchedAction', () => {
+	it('matches palette bindings by scope', () => {
+		const preferences: KeyboardShortcutPreferencesV1 = {
+			version: 1,
+			bindings: {
+				'app.openCommandPalette': { key: 'K', primaryModifier: true }
+			}
+		};
+		expect(
+			resolveMatchedAction(
+				evt({ key: 'k', ctrlKey: true }),
+				preferences,
+				'windows',
+				{ scopes: ['global'], inTextInput: false }
+			)
+		).toBe('app.openCommandPalette');
+	});
+
+	it('matches edit-last ArrowUp in composer scope', () => {
+		const preferences: KeyboardShortcutPreferencesV1 = {
+			version: 1,
+			bindings: {
+				'chat.editLastMessage': { key: 'ArrowUp' }
+			}
+		};
+		expect(
+			resolveMatchedAction(evt({ key: 'ArrowUp' }), preferences, 'mac', {
+				scopes: ['composer'],
+				inTextInput: true
+			})
+		).toBe('chat.editLastMessage');
+	});
+});
+
+describe('dispatchComposerAction', () => {
+	it('guards edit-last when composer is not empty', () => {
+		expect(
+			dispatchComposerAction('chat.editLastMessage', {
+				isComposerEmpty: false,
+				onEditLast: () => true
+			})
+		).toBe(false);
+		expect(
+			dispatchComposerAction('chat.editLastMessage', {
+				isComposerEmpty: true,
+				onEditLast: () => true
+			})
+		).toBe(true);
+	});
+
+	it('handles cancel reply/edit', () => {
+		expect(
+			dispatchComposerAction('chat.cancelReplyOrEdit', {
+				onCancel: () => true
+			})
+		).toBe(true);
+		expect(dispatchComposerAction('chat.cancelReplyOrEdit', {})).toBe(
+			false
+		);
+	});
+});

--- a/src/features/keyboard-shortcuts/utils/match.ts
+++ b/src/features/keyboard-shortcuts/utils/match.ts
@@ -1,0 +1,84 @@
+import type { Platform, ShortcutBinding } from '../types';
+import { normalizeBinding, normalizeBindingKey } from './binding';
+import { isPrimaryModifierPressed } from './platform';
+
+export type MatchableKeyboardEvent = Pick<
+	KeyboardEvent,
+	| 'key'
+	| 'ctrlKey'
+	| 'metaKey'
+	| 'shiftKey'
+	| 'altKey'
+	| 'isComposing'
+	| 'defaultPrevented'
+> & {
+	keyCode?: number;
+	target?: EventTarget | null;
+	preventDefault?: () => void;
+};
+
+export const isImeComposing = (event: MatchableKeyboardEvent): boolean =>
+	!!event.isComposing || event.keyCode === 229;
+
+/**
+ * Exact modifier match against a structured binding (platform-aware).
+ */
+export const matchesShortcut = (
+	event: MatchableKeyboardEvent,
+	binding: ShortcutBinding | null | undefined,
+	platform: Platform
+): boolean => {
+	if (!binding || !binding.key) {
+		return false;
+	}
+	if (event.defaultPrevented) {
+		return false;
+	}
+	if (isImeComposing(event)) {
+		return false;
+	}
+
+	const expected = normalizeBinding(binding, platform);
+	const eventKey = normalizeBindingKey(event.key);
+	if (eventKey !== expected.key) {
+		return false;
+	}
+
+	const wantCtrl = !!expected.ctrl;
+	const wantMeta = !!expected.meta;
+	const wantShift = !!expected.shift;
+	const wantAlt = !!expected.alt;
+
+	// `?` is typed with Shift on most layouts — accept either shift state.
+	const ignoreShift = expected.key === '?' || expected.key === 'F1';
+
+	// When binding uses primaryModifier, require the platform primary only
+	// and reject the opposite modifier (avoids Ctrl+Cmd+Enter duplicates).
+	if (binding.primaryModifier) {
+		if (!isPrimaryModifierPressed(event, platform)) {
+			return false;
+		}
+		if (platform === 'mac' && event.ctrlKey) {
+			return false;
+		}
+		if (platform !== 'mac' && event.metaKey) {
+			return false;
+		}
+	} else {
+		if (event.ctrlKey !== wantCtrl) {
+			return false;
+		}
+		if (event.metaKey !== wantMeta) {
+			return false;
+		}
+	}
+
+	if (!ignoreShift && event.shiftKey !== wantShift) {
+		return false;
+	}
+	if (event.altKey !== wantAlt) {
+		return false;
+	}
+
+	return true;
+};

--- a/src/features/keyboard-shortcuts/utils/platform.ts
+++ b/src/features/keyboard-shortcuts/utils/platform.ts
@@ -1,0 +1,46 @@
+import type { Platform } from '../types';
+
+/**
+ * Detect runtime platform. Safe for SSR / tests — pass an injected navigator.
+ */
+export const getPlatform = (
+	userAgent?: string,
+	platformHint?: string
+): Platform => {
+	const ua =
+		userAgent ??
+		(typeof navigator !== 'undefined' ? navigator.userAgent : '');
+	const plat =
+		platformHint ??
+		(typeof navigator !== 'undefined'
+			? (
+					navigator as Navigator & {
+						userAgentData?: { platform?: string };
+					}
+				).userAgentData?.platform || navigator.platform
+			: '');
+
+	const haystack = `${ua} ${plat}`.toLowerCase();
+	if (/mac|iphone|ipad|ipod/.test(haystack)) {
+		return 'mac';
+	}
+	if (/win/.test(haystack)) {
+		return 'windows';
+	}
+	if (/linux|android|cros/.test(haystack)) {
+		return 'linux';
+	}
+	return 'unknown';
+};
+
+/** Primary modifier: Cmd (meta) on macOS, Ctrl elsewhere. */
+export const getPrimaryModifier = (platform: Platform): 'meta' | 'ctrl' =>
+	platform === 'mac' ? 'meta' : 'ctrl';
+
+export const isPrimaryModifierPressed = (
+	event: Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>,
+	platform: Platform
+): boolean => {
+	const primary = getPrimaryModifier(platform);
+	return primary === 'meta' ? event.metaKey : event.ctrlKey;
+};

--- a/src/features/keyboard-shortcuts/utils/resolveAction.ts
+++ b/src/features/keyboard-shortcuts/utils/resolveAction.ts
@@ -1,0 +1,162 @@
+import type {
+	KeyboardShortcutPreferencesV1,
+	Platform,
+	ShortcutActionId,
+	ShortcutBinding,
+	ShortcutScope
+} from '../types';
+import {
+	getImplementedShortcuts,
+	getShortcutDefinition
+} from '../constants/registry';
+import { resolveNewlineBinding } from './deriveNewline';
+import {
+	isImeComposing,
+	matchesShortcut,
+	type MatchableKeyboardEvent
+} from './match';
+
+export const resolveEffectiveBinding = (
+	preferences: KeyboardShortcutPreferencesV1,
+	actionId: ShortcutActionId,
+	platform: Platform
+): ShortcutBinding | null => {
+	const def = getShortcutDefinition(actionId);
+	if (!def) {
+		return null;
+	}
+	if (actionId === 'chat.insertNewLine') {
+		const send =
+			preferences.bindings['chat.sendMessage'] ??
+			getShortcutDefinition('chat.sendMessage')?.defaultBinding ??
+			null;
+		return resolveNewlineBinding(
+			send,
+			preferences.bindings['chat.insertNewLine'],
+			platform
+		);
+	}
+	const stored = preferences.bindings[actionId];
+	if (stored === undefined) {
+		return def.defaultBinding;
+	}
+	return stored;
+};
+
+export type ResolveActionOptions = {
+	/** Limit matching to these scopes (default: all implemented). */
+	scopes?: ShortcutScope[];
+	/** Skip when IME composing / modal / suggestions. */
+	disabled?: boolean;
+	isSending?: boolean;
+	hasOpenSuggestions?: boolean;
+	/** Skip actions that should not fire inside text inputs. */
+	inTextInput?: boolean;
+	/** Action ids to skip (e.g. send handled elsewhere). */
+	exclude?: ShortcutActionId[];
+};
+
+const isEditableTarget = (target: EventTarget | null | undefined): boolean => {
+	if (!(target instanceof HTMLElement)) {
+		return false;
+	}
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+		return true;
+	}
+	return target.isContentEditable;
+};
+
+export const hasOpenModalDialog = (): boolean => {
+	if (typeof document === 'undefined') {
+		return false;
+	}
+	// Prefer native <dialog open>. Also match explicit aria-modal dialogs that
+	// are not display:none / aria-hidden (avoids blocking on dormant overlays).
+	if (document.querySelector('dialog[open]')) {
+		return true;
+	}
+	const candidates = document.querySelectorAll(
+		'[role="dialog"][aria-modal="true"]'
+	);
+	for (const el of Array.from(candidates)) {
+		if (!(el instanceof HTMLElement)) {
+			continue;
+		}
+		if (el.getAttribute('aria-hidden') === 'true') {
+			continue;
+		}
+		const style = window.getComputedStyle(el);
+		if (style.display === 'none' || style.visibility === 'hidden') {
+			continue;
+		}
+		return true;
+	}
+	return false;
+};
+
+/**
+ * Match a keyboard event against preference bindings for the given scopes.
+ * Returns the first matching action id (registry order within scopes).
+ */
+export const resolveMatchedAction = (
+	event: MatchableKeyboardEvent,
+	preferences: KeyboardShortcutPreferencesV1,
+	platform: Platform,
+	options: ResolveActionOptions = {}
+): ShortcutActionId | null => {
+	if (event.defaultPrevented || isImeComposing(event)) {
+		return null;
+	}
+	if (options.disabled || options.isSending) {
+		return null;
+	}
+	if (options.hasOpenSuggestions) {
+		return null;
+	}
+
+	const scopes = options.scopes;
+	const exclude = new Set(options.exclude ?? []);
+	const inTextInput = options.inTextInput ?? isEditableTarget(event.target);
+
+	for (const def of getImplementedShortcuts()) {
+		if (exclude.has(def.id)) {
+			continue;
+		}
+		if (scopes && !scopes.includes(def.scope)) {
+			continue;
+		}
+		if (inTextInput && !def.activeInTextInput) {
+			// Still allow global help with modifiers / F1
+			const binding = resolveEffectiveBinding(
+				preferences,
+				def.id,
+				platform
+			);
+			const hasModifier =
+				!!binding &&
+				!!(
+					binding.primaryModifier ||
+					binding.ctrl ||
+					binding.meta ||
+					binding.alt ||
+					binding.shift
+				);
+			if (
+				def.scope !== 'global' ||
+				(!hasModifier && binding?.key !== 'F1')
+			) {
+				continue;
+			}
+		}
+
+		const binding = resolveEffectiveBinding(preferences, def.id, platform);
+		if (!binding) {
+			continue;
+		}
+		if (matchesShortcut(event, binding, platform)) {
+			return def.id;
+		}
+	}
+	return null;
+};

--- a/src/features/keyboard-shortcuts/utils/resolveComposerShortcut.ts
+++ b/src/features/keyboard-shortcuts/utils/resolveComposerShortcut.ts
@@ -1,0 +1,81 @@
+import type {
+	ComposerShortcutAction,
+	KeyboardShortcutPreferencesV1,
+	Platform
+} from '../types';
+import { resolveEffectiveBinding } from './resolveAction';
+import {
+	isImeComposing,
+	matchesShortcut,
+	type MatchableKeyboardEvent
+} from './match';
+
+export { resolveEffectiveBinding } from './resolveAction';
+
+export type ResolveComposerOptions = {
+	disabled?: boolean;
+	isSending?: boolean;
+	/** Mention / emoji / autocomplete owns Enter */
+	hasOpenSuggestions?: boolean;
+};
+
+/**
+ * Resolve composer keyboard intent from preferences.
+ * Does not call preventDefault — caller does when action is handled.
+ */
+export const resolveComposerShortcutAction = (
+	event: MatchableKeyboardEvent,
+	preferences: KeyboardShortcutPreferencesV1,
+	platform: Platform,
+	options: ResolveComposerOptions = {}
+): ComposerShortcutAction | null => {
+	if (event.defaultPrevented) {
+		return null;
+	}
+	if (isImeComposing(event)) {
+		return null;
+	}
+	if (options.disabled || options.isSending) {
+		return null;
+	}
+	if (options.hasOpenSuggestions) {
+		return null;
+	}
+
+	const sendBinding = resolveEffectiveBinding(
+		preferences,
+		'chat.sendMessage',
+		platform
+	);
+	const newlineBinding = resolveEffectiveBinding(
+		preferences,
+		'chat.insertNewLine',
+		platform
+	);
+
+	if (sendBinding && matchesShortcut(event, sendBinding, platform)) {
+		return 'send';
+	}
+
+	// When Enter sends, Shift+Enter is newline even if TipTap would also
+	// insert a hard break — we report newline so callers can skip send.
+	if (newlineBinding && matchesShortcut(event, newlineBinding, platform)) {
+		return 'newline';
+	}
+
+	// In primary/alt send modes, bare Shift+Enter should still be newline
+	// (TipTap default) even though derived newline is plain Enter.
+	if (
+		sendBinding &&
+		!matchesShortcut(event, sendBinding, platform) &&
+		event.key === 'Enter' &&
+		event.shiftKey &&
+		!event.altKey &&
+		!event.ctrlKey &&
+		!event.metaKey
+	) {
+		return 'newline';
+	}
+
+	return null;
+};

--- a/src/globalState/state.tsx
+++ b/src/globalState/state.tsx
@@ -12,6 +12,10 @@ import {
 	AgencySpecificProvider,
 	TopicsProvider
 } from '.';
+import { KeyboardShortcutsProvider } from '../features/keyboard-shortcuts';
+import { useGlobalShortcuts } from '../features/keyboard-shortcuts/hooks/useGlobalShortcuts';
+import { ShortcutHelpDialog } from '../features/keyboard-shortcuts/components/ShortcutHelpDialog';
+import { CommandPaletteDialog } from '../features/keyboard-shortcuts/components/CommandPaletteDialog';
 
 function ProviderComposer({ contexts, children }) {
 	return contexts.reduceRight(
@@ -22,6 +26,32 @@ function ProviderComposer({ contexts, children }) {
 		children
 	);
 }
+
+const KeyboardShortcutsShell = ({
+	children
+}: {
+	children?: React.ReactNode;
+}) => {
+	useGlobalShortcuts(true);
+	return (
+		<>
+			{children}
+			<ShortcutHelpDialog />
+			<CommandPaletteDialog />
+		</>
+	);
+};
+
+/** Must sit after UserDataProvider so preferences can isolate by userId. */
+const KeyboardShortcutsRoot = ({
+	children
+}: {
+	children?: React.ReactNode;
+}) => (
+	<KeyboardShortcutsProvider>
+		<KeyboardShortcutsShell>{children}</KeyboardShortcutsShell>
+	</KeyboardShortcutsProvider>
+);
 
 function ContextProvider({ children }) {
 	return (
@@ -37,7 +67,8 @@ function ContextProvider({ children }) {
 				<WebsocketConnectionDeactivatedProvider />,
 				<SessionsDataProvider />,
 				<ServerSettingsProvider />,
-				<ModalProvider />
+				<ModalProvider />,
+				<KeyboardShortcutsRoot />
 			]}
 		>
 			{children}

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -356,14 +356,6 @@
 				"long": "Februar",
 				"short": "Feb"
 			},
-			"10": {
-				"long": "November",
-				"short": "Nov"
-			},
-			"11": {
-				"long": "Dezember",
-				"short": "Dez"
-			},
 			"2": {
 				"long": "März",
 				"short": "Mär"
@@ -395,6 +387,14 @@
 			"9": {
 				"long": "Oktober",
 				"short": "Okt"
+			},
+			"10": {
+				"long": "November",
+				"short": "Nov"
+			},
+			"11": {
+				"long": "Dezember",
+				"short": "Dez"
 			}
 		}
 	},
@@ -905,9 +905,6 @@
 				"headline": "Video-Call",
 				"intro": "Damit Sie an Video-Calls teilnehmen können, müssen Sie sich über einen der unterstützten Browser anmelden. Die Chat-Beratung funktioniert weiterhin mit Firefox.",
 				"steps": {
-					"1.1": "Folgen Sie dem Link zu ",
-					"1.2": " oder ",
-					"1.3": " (nur für macOS und iOS verfügbar)",
 					"2": "Laden Sie einen der unterstützten Browser herunter.",
 					"3": "Installieren Sie diesen auf Ihrem PC/Laptop/Tablet/Smartphone.",
 					"4": {
@@ -916,6 +913,9 @@
 					},
 					"5": "Melden Sie sich bei der Online-Beratung an.",
 					"6": "Bitten Sie Ihre_n Berater_in Sie nochmals anzurufen.",
+					"1.1": "Folgen Sie dem Link zu ",
+					"1.2": " oder ",
+					"1.3": " (nur für macOS und iOS verfügbar)",
 					"headline": {
 						"1": "Schritt-für-Schritt-Anleitung",
 						"2": "Sie haben bereits Google Chrome, Microsoft Edge oder Safari?"
@@ -930,9 +930,6 @@
 				"headline": "Video-Call",
 				"intro": "Um einen Video-Call durchführen zu können, müssen Sie sich über einen der unterstützten Browser anmelden. Die Chat-Beratung funktioniert weiterhin mit Firefox.",
 				"steps": {
-					"1.1": "Folgen Sie dem Link zu ",
-					"1.2": " oder ",
-					"1.3": " (nur für macOS und iOS verfügbar)",
 					"2": "Laden Sie einen der unterstützten Browser herunter. Dafür brauchen Sie möglicherweise die Unterstützung Ihrer EDV.",
 					"3": "Installieren Sie diesen auf Ihrem PC/Laptop/Tablet/Smartphone.",
 					"4": {
@@ -941,6 +938,9 @@
 					},
 					"5": "Melden Sie sich bei der Online-Beratung an.",
 					"6": "Starten Sie den Video-Call.",
+					"1.1": "Folgen Sie dem Link zu ",
+					"1.2": " oder ",
+					"1.3": " (nur für macOS und iOS verfügbar)",
 					"headline": {
 						"1": "Schritt-für-Schritt-Anleitung",
 						"2": "Sie haben bereits Google Chrome, Microsoft Edge oder Safari?"
@@ -1823,7 +1823,7 @@
 			},
 			"inquiryAccepted": {
 				"title": "Anfrage angenommen",
-				"description": "Ihre Anfrage wurde von einer Beratungsfachkraft angenommen."
+				"description": "Ihre Anfrage wurde von einer Beraterin oder einem Berater angenommen."
 			},
 			"conversationFinished": {
 				"title": "Chat beendet",
@@ -1875,10 +1875,6 @@
 				"title": "Neue Chat-Nachricht",
 				"description": "Einer der Ihnen zugewiesenen Ratsuchenden hat Ihnen geantwortet"
 			},
-			"inquiryAccepted": {
-				"title": "Anfrage angenommen",
-				"description": "Ihre Anfrage wurde von einer Beraterin oder einem Berater angenommen."
-			},
 			"feed": {
 				"title": "System-Benachrichtigungen",
 				"description": "Hier sehen Sie alle System-Benachrichtigungen.",
@@ -1911,7 +1907,8 @@
 					"changePassword": "Passwort ändern",
 					"title": "Sicherheit"
 				},
-				"title": "Einstellungen"
+				"title": "Einstellungen",
+				"keyboardShortcuts": "Tastaturkürzel"
 			}
 		},
 		"spokenLanguages": {
@@ -2191,13 +2188,6 @@
 			"options": {
 				"0": "außerhalb Deutschlands",
 				"1": "Baden-Württemberg",
-				"10": "Nordrhein-Westfalen",
-				"11": "Rheinland-Pfalz",
-				"12": "Saarland",
-				"13": "Sachsen",
-				"14": "Sachsen-Anhalt",
-				"15": "Schleswig-Holstein",
-				"16": "Thüringen",
 				"2": "Bayern",
 				"3": "Berlin",
 				"4": "Brandenburg",
@@ -2205,7 +2195,14 @@
 				"6": "Hamburg",
 				"7": "Hessen",
 				"8": "Mecklenburg-Vorpommern",
-				"9": "Niedersachsen"
+				"9": "Niedersachsen",
+				"10": "Nordrhein-Westfalen",
+				"11": "Rheinland-Pfalz",
+				"12": "Saarland",
+				"13": "Sachsen",
+				"14": "Sachsen-Anhalt",
+				"15": "Schleswig-Holstein",
+				"16": "Thüringen"
 			}
 		},
 		"submitButton": {
@@ -2483,7 +2480,7 @@
 					"receiveGift": "Kleines Geschenk erhalten"
 				},
 				"serenity": {
-					"instruction": "Das Geschenk ist ein kleines Mantra, das vielen Menschen durch schwierige Zeiten geholfen hat. Es heißt das Gelassenheitsgebet: \u201CGott, gib mir die Gelassenheit, Dinge hinzunehmen, die ich nicht ändern kann, den Mut, Dinge zu ändern, die ich ändern kann, und die Weisheit, das eine vom anderen zu unterscheiden.\u201D"
+					"instruction": "Das Geschenk ist ein kleines Mantra, das vielen Menschen durch schwierige Zeiten geholfen hat. Es heißt das Gelassenheitsgebet: “Gott, gib mir die Gelassenheit, Dinge hinzunehmen, die ich nicht ändern kann, den Mut, Dinge zu ändern, die ich ändern kann, und die Weisheit, das eine vom anderen zu unterscheiden.”"
 				}
 			},
 			"presets": {
@@ -3104,16 +3101,20 @@
 			"age": {
 				"0": "unter 12",
 				"1": "12",
+				"2": "13",
+				"3": "14",
+				"4": "15",
+				"5": "16",
+				"6": "17",
+				"7": "18",
+				"8": "19",
+				"9": "20",
 				"10": "21",
 				"11": "22",
 				"12": "23",
 				"13": "24",
 				"14": "25",
 				"15": "über 25",
-				"2": "13",
-				"3": "14",
-				"4": "15",
-				"5": "16",
 				"50": "20",
 				"51": "21",
 				"52": "22",
@@ -3121,10 +3122,6 @@
 				"54": "24",
 				"55": "25",
 				"56": "26",
-				"6": "17",
-				"7": "18",
-				"8": "19",
-				"9": "20",
 				"selectLabel": "Alter auswählen*"
 			},
 			"gender": {
@@ -3142,13 +3139,6 @@
 			"state": {
 				"0": "außerhalb Deutschlands",
 				"1": "Baden-Württemberg",
-				"10": "Nordrhein-Westfalen",
-				"11": "Rheinland-Pfalz",
-				"12": "Saarland",
-				"13": "Sachsen",
-				"14": "Sachsen-Anhalt",
-				"15": "Schleswig-Holstein",
-				"16": "Thüringen",
 				"2": "Bayern",
 				"3": "Berlin",
 				"4": "Brandenburg",
@@ -3157,6 +3147,13 @@
 				"7": "Hessen",
 				"8": "Mecklenburg-Vorpommern",
 				"9": "Niedersachsen",
+				"10": "Nordrhein-Westfalen",
+				"11": "Rheinland-Pfalz",
+				"12": "Saarland",
+				"13": "Sachsen",
+				"14": "Sachsen-Anhalt",
+				"15": "Schleswig-Holstein",
+				"16": "Thüringen",
 				"selectLabel": "Bundesland auswählen*"
 			}
 		}
@@ -3499,6 +3496,111 @@
 			"remove": {
 				"confirm": "Möchten Sie diesen Supervisor wirklich entfernen?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Tastaturkürzel",
+		"description": "Tastenkürzel für den Chat anpassen. Änderungen gelten sofort und werden auf diesem Gerät gespeichert.",
+		"automaticallyConfigured": "automatisch konfiguriert",
+		"disableShortcut": "Deaktiviert",
+		"restoreDefaults": "Standard wiederherstellen",
+		"restoreDefaultsSuccess": "Standard-Tastaturkürzel wiederhergestellt.",
+		"primaryModifier": "Primärer Modifizierer",
+		"help": {
+			"title": "Tastaturkürzel",
+			"close": "Schließen"
+		},
+		"palette": {
+			"title": "Befehlspalette",
+			"close": "Schließen",
+			"searchPlaceholder": "Befehle suchen…",
+			"allShortcuts": "Alle Tastaturkürzel"
+		},
+		"editingBanner": "Nachricht bearbeiten",
+		"editingCancel": "Abbrechen",
+		"categories": {
+			"messaging": "Nachrichten",
+			"navigation": "Navigation",
+			"attachments": "Anhänge",
+			"emoji": "Emoji und Reaktionen",
+			"application": "Anwendung"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Nachricht senden",
+				"description": "Sendet die aktuelle Chat-Nachricht."
+			},
+			"insertNewLine": {
+				"label": "Neue Zeile einfügen",
+				"description": "Fügt eine neue Zeile im Eingabefeld ein. Wird vom Sende-Kürzel abgeleitet."
+			},
+			"showShortcutHelp": {
+				"label": "Tastaturkürzel anzeigen",
+				"description": "Öffnet die Hilfe zu Tastaturkürzeln."
+			},
+			"focusInput": {
+				"label": "Eingabefeld fokussieren",
+				"description": "Setzt den Fokus auf das Nachrichteneingabefeld."
+			},
+			"uploadFile": {
+				"label": "Datei hochladen",
+				"description": "Öffnet die Dateiauswahl für Anhänge."
+			},
+			"searchMessages": {
+				"label": "Nachrichten suchen",
+				"description": "Durchsucht Nachrichten in der aktuellen Unterhaltung."
+			},
+			"editLastMessage": {
+				"label": "Letzte Nachricht bearbeiten",
+				"description": "Bearbeitet Ihre zuletzt gesendete Nachricht."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Antwort oder Bearbeitung abbrechen",
+				"description": "Bricht die aktuelle Antwort oder Bearbeitung ab."
+			},
+			"openEmojiPicker": {
+				"label": "Emoji-Auswahl öffnen",
+				"description": "Öffnet die Emoji-Auswahl."
+			},
+			"startNewConversation": {
+				"label": "Neue Unterhaltung starten",
+				"description": "Startet eine neue Unterhaltung."
+			},
+			"openCommandPalette": {
+				"label": "Befehlspalette öffnen",
+				"description": "Öffnet die Befehlspalette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "Dieses Tastaturkürzel ist bereits vergeben.",
+			"reserved": "Dieses Tastaturkürzel ist vom Browser reserviert.",
+			"browserConflict": "Dieses Tastaturkürzel steht im Konflikt mit gängigen Browser-Kürzeln.",
+			"sendNewline": "Nachricht senden und Neue Zeile dürfen nicht dasselbe Kürzel verwenden.",
+			"unsupported": "Diese Kürzel-Option wird nicht unterstützt.",
+			"cannotDisable": "Dieses Tastaturkürzel kann nicht deaktiviert werden.",
+			"unsafePlainKey": "Diese Taste kann während der Eingabe nicht als Kürzel verwendet werden."
+		},
+		"hints": {
+			"enterSends": "Enter sendet die Nachricht",
+			"shiftEnterNewline": "Umschalt+Enter fügt eine neue Zeile ein",
+			"enterNewline": "Enter fügt eine neue Zeile ein",
+			"ctrlEnterSends": "Strg+Enter sendet die Nachricht",
+			"cmdEnterSends": "Cmd+Enter sendet die Nachricht"
+		},
+		"lockedNewline": "Auf Umschalt+Enter festgelegt, solange Enter die Nachricht sendet.",
+		"resetAction": "Zurücksetzen",
+		"restoreDefaultsConfirm": "Alle Tastenkürzel auf die Standardwerte zurücksetzen?",
+		"restoreDefaultsConfirmYes": "Zurücksetzen",
+		"restoreDefaultsConfirmNo": "Abbrechen",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Umschalt",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Strg",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -618,6 +618,11 @@
 			"successOverlay": {
 				"headline": "Du hast Deine E-Mail-Adresse erfolgreich gelöscht."
 			}
+		},
+		"routes": {
+			"settings": {
+				"keyboardShortcuts": "Tastaturkürzel"
+			}
 		}
 	},
 	"qrCode": {
@@ -885,7 +890,7 @@
 					"receiveGift": "Kleines Geschenk erhalten"
 				},
 				"serenity": {
-					"instruction": "Das Geschenk ist ein kleines Mantra, das vielen Menschen durch schwierige Zeiten geholfen hat. Es heißt das Gelassenheitsgebet: \u201CGott, gib mir die Gelassenheit, Dinge hinzunehmen, die ich nicht ändern kann, den Mut, Dinge zu ändern, die ich ändern kann, und die Weisheit, das eine vom anderen zu unterscheiden.\u201D"
+					"instruction": "Das Geschenk ist ein kleines Mantra, das vielen Menschen durch schwierige Zeiten geholfen hat. Es heißt das Gelassenheitsgebet: “Gott, gib mir die Gelassenheit, Dinge hinzunehmen, die ich nicht ändern kann, den Mut, Dinge zu ändern, die ich ändern kann, und die Weisheit, das eine vom anderen zu unterscheiden.”"
 				}
 			},
 			"presets": {
@@ -1467,5 +1472,110 @@
 		"liveChatToggleActive": "Live-Chat verfügbar",
 		"liveChatToggleInactive": "Live-Chat nicht verfügbar",
 		"myProfile": "Mein Profil"
+	},
+	"shortcuts": {
+		"title": "Tastaturkürzel",
+		"description": "Tastenkürzel für den Chat anpassen. Änderungen gelten sofort und werden auf diesem Gerät gespeichert.",
+		"automaticallyConfigured": "automatisch konfiguriert",
+		"disableShortcut": "Deaktiviert",
+		"restoreDefaults": "Standard wiederherstellen",
+		"restoreDefaultsSuccess": "Standard-Tastaturkürzel wiederhergestellt.",
+		"primaryModifier": "Primärer Modifizierer",
+		"help": {
+			"title": "Tastaturkürzel",
+			"close": "Schließen"
+		},
+		"palette": {
+			"title": "Befehlspalette",
+			"close": "Schließen",
+			"searchPlaceholder": "Befehle suchen…",
+			"allShortcuts": "Alle Tastaturkürzel"
+		},
+		"editingBanner": "Nachricht bearbeiten",
+		"editingCancel": "Abbrechen",
+		"categories": {
+			"messaging": "Nachrichten",
+			"navigation": "Navigation",
+			"attachments": "Anhänge",
+			"emoji": "Emoji und Reaktionen",
+			"application": "Anwendung"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Nachricht senden",
+				"description": "Sendet die aktuelle Chat-Nachricht."
+			},
+			"insertNewLine": {
+				"label": "Neue Zeile einfügen",
+				"description": "Fügt eine neue Zeile im Eingabefeld ein. Wird vom Sende-Kürzel abgeleitet."
+			},
+			"showShortcutHelp": {
+				"label": "Tastaturkürzel anzeigen",
+				"description": "Öffnet die Hilfe zu Tastaturkürzeln."
+			},
+			"focusInput": {
+				"label": "Eingabefeld fokussieren",
+				"description": "Setzt den Fokus auf das Nachrichteneingabefeld."
+			},
+			"uploadFile": {
+				"label": "Datei hochladen",
+				"description": "Öffnet die Dateiauswahl für Anhänge."
+			},
+			"searchMessages": {
+				"label": "Nachrichten suchen",
+				"description": "Durchsucht Nachrichten in der aktuellen Unterhaltung."
+			},
+			"editLastMessage": {
+				"label": "Letzte Nachricht bearbeiten",
+				"description": "Bearbeitet Ihre zuletzt gesendete Nachricht."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Antwort oder Bearbeitung abbrechen",
+				"description": "Bricht die aktuelle Antwort oder Bearbeitung ab."
+			},
+			"openEmojiPicker": {
+				"label": "Emoji-Auswahl öffnen",
+				"description": "Öffnet die Emoji-Auswahl."
+			},
+			"startNewConversation": {
+				"label": "Neue Unterhaltung starten",
+				"description": "Startet eine neue Unterhaltung."
+			},
+			"openCommandPalette": {
+				"label": "Befehlspalette öffnen",
+				"description": "Öffnet die Befehlspalette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "Dieses Tastaturkürzel ist bereits vergeben.",
+			"reserved": "Dieses Tastaturkürzel ist vom Browser reserviert.",
+			"browserConflict": "Dieses Tastaturkürzel steht im Konflikt mit gängigen Browser-Kürzeln.",
+			"sendNewline": "Nachricht senden und Neue Zeile dürfen nicht dasselbe Kürzel verwenden.",
+			"unsupported": "Diese Kürzel-Option wird nicht unterstützt.",
+			"cannotDisable": "Dieses Tastaturkürzel kann nicht deaktiviert werden.",
+			"unsafePlainKey": "Diese Taste kann während der Eingabe nicht als Kürzel verwendet werden."
+		},
+		"hints": {
+			"enterSends": "Enter sendet die Nachricht",
+			"shiftEnterNewline": "Umschalt+Enter fügt eine neue Zeile ein",
+			"enterNewline": "Enter fügt eine neue Zeile ein",
+			"ctrlEnterSends": "Strg+Enter sendet die Nachricht",
+			"cmdEnterSends": "Cmd+Enter sendet die Nachricht"
+		},
+		"lockedNewline": "Auf Umschalt+Enter festgelegt, solange Enter die Nachricht sendet.",
+		"resetAction": "Zurücksetzen",
+		"restoreDefaultsConfirm": "Alle Tastenkürzel auf die Standardwerte zurücksetzen?",
+		"restoreDefaultsConfirmYes": "Zurücksetzen",
+		"restoreDefaultsConfirmNo": "Abbrechen",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Umschalt",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Strg",
+			"cmd": "Cmd"
+		}
 	}
 }

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1869,7 +1869,8 @@
 					"changePassword": "Change password",
 					"title": "Security"
 				},
-				"title": "Settings"
+				"title": "Settings",
+				"keyboardShortcuts": "Keyboard Shortcuts"
 			}
 		},
 		"spokenLanguages": {
@@ -2419,7 +2420,7 @@
 					"receiveGift": "Receive little gift"
 				},
 				"serenity": {
-					"instruction": "The gift is a little mantra that's helped tons of people get through tough times. It's called the serenity prayer: \u201CGod, grant me the serenity to accept the things I cannot change, the courage to change the things I can, and the wisdom to know the difference.\u201D"
+					"instruction": "The gift is a little mantra that's helped tons of people get through tough times. It's called the serenity prayer: “God, grant me the serenity to accept the things I cannot change, the courage to change the things I can, and the wisdom to know the difference.”"
 				}
 			},
 			"presets": {
@@ -3397,6 +3398,111 @@
 			"remove": {
 				"confirm": "Are you sure you want to remove this supervisor?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Keyboard Shortcuts",
+		"description": "Customize chat shortcuts. Changes apply immediately and are saved on this device.",
+		"automaticallyConfigured": "automatically configured",
+		"disableShortcut": "Disabled",
+		"restoreDefaults": "Restore Defaults",
+		"restoreDefaultsSuccess": "Default shortcuts restored.",
+		"primaryModifier": "Primary modifier",
+		"help": {
+			"title": "Keyboard shortcuts",
+			"close": "Close"
+		},
+		"palette": {
+			"title": "Command Palette",
+			"close": "Close",
+			"searchPlaceholder": "Search commands…",
+			"allShortcuts": "All shortcuts"
+		},
+		"editingBanner": "Editing message",
+		"editingCancel": "Cancel",
+		"categories": {
+			"messaging": "Messaging",
+			"navigation": "Navigation",
+			"attachments": "Attachments",
+			"emoji": "Emoji and Reactions",
+			"application": "Application"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Send Message",
+				"description": "Send the current chat message."
+			},
+			"insertNewLine": {
+				"label": "Insert New Line",
+				"description": "Insert a new line in the message composer. Derived from the send shortcut."
+			},
+			"showShortcutHelp": {
+				"label": "Show Keyboard Shortcuts",
+				"description": "Open the keyboard shortcuts help dialog."
+			},
+			"focusInput": {
+				"label": "Focus Message Input",
+				"description": "Move focus to the message composer."
+			},
+			"uploadFile": {
+				"label": "Upload File",
+				"description": "Open the file attachment picker."
+			},
+			"searchMessages": {
+				"label": "Search Messages",
+				"description": "Search messages in the current conversation."
+			},
+			"editLastMessage": {
+				"label": "Edit Last Message",
+				"description": "Edit your last sent message."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Cancel Reply or Edit",
+				"description": "Cancel the current reply or edit."
+			},
+			"openEmojiPicker": {
+				"label": "Open Emoji Picker",
+				"description": "Open the emoji picker."
+			},
+			"startNewConversation": {
+				"label": "Start New Conversation",
+				"description": "Start a new conversation."
+			},
+			"openCommandPalette": {
+				"label": "Open Command Palette",
+				"description": "Open the command palette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "This shortcut is already assigned.",
+			"reserved": "This shortcut is reserved by the browser.",
+			"browserConflict": "This shortcut conflicts with common browser shortcuts.",
+			"sendNewline": "Send Message and Insert New Line cannot use the same shortcut.",
+			"unsupported": "This shortcut option is not supported.",
+			"cannotDisable": "This shortcut cannot be disabled.",
+			"unsafePlainKey": "This key cannot be used as a shortcut while typing."
+		},
+		"hints": {
+			"enterSends": "Enter sends the message",
+			"shiftEnterNewline": "Shift+Enter inserts a new line",
+			"enterNewline": "Enter inserts a new line",
+			"ctrlEnterSends": "Ctrl+Enter sends the message",
+			"cmdEnterSends": "Cmd+Enter sends the message"
+		},
+		"lockedNewline": "Locked to Shift+Enter while Enter sends the message.",
+		"resetAction": "Reset",
+		"restoreDefaultsConfirm": "Restore all shortcuts to their defaults?",
+		"restoreDefaultsConfirmYes": "Restore",
+		"restoreDefaultsConfirmNo": "Cancel",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Shift",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Ctrl",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/resources/i18n/fr/common.json
+++ b/src/resources/i18n/fr/common.json
@@ -1631,7 +1631,8 @@
 					"changePassword": "Modifier le mot de passe",
 					"title": "Sécurité"
 				},
-				"title": "Réglages"
+				"title": "Réglages",
+				"keyboardShortcuts": "Raccourcis clavier"
 			}
 		},
 		"spokenLanguages": {
@@ -2946,6 +2947,111 @@
 			"remove": {
 				"confirm": "Êtes-vous sûr de vouloir supprimer ce superviseur ?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Raccourcis clavier",
+		"description": "Personnalisez les raccourcis du chat. Les modifications s’appliquent immédiatement et sont enregistrées sur cet appareil.",
+		"automaticallyConfigured": "configuré automatiquement",
+		"disableShortcut": "Désactivé",
+		"restoreDefaults": "Restaurer les valeurs par défaut",
+		"restoreDefaultsSuccess": "Raccourcis par défaut restaurés.",
+		"primaryModifier": "Primary modifier",
+		"help": {
+			"title": "Raccourcis clavier",
+			"close": "Fermer"
+		},
+		"palette": {
+			"title": "Palette de commandes",
+			"close": "Fermer",
+			"searchPlaceholder": "Rechercher des commandes…",
+			"allShortcuts": "Tous les raccourcis"
+		},
+		"editingBanner": "Modification du message",
+		"editingCancel": "Annuler",
+		"categories": {
+			"messaging": "Messagerie",
+			"navigation": "Navigation",
+			"attachments": "Pièces jointes",
+			"emoji": "Emojis et réactions",
+			"application": "Application"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Envoyer le message",
+				"description": "Envoie le message de chat actuel."
+			},
+			"insertNewLine": {
+				"label": "Insérer une nouvelle ligne",
+				"description": "Insère une nouvelle ligne. Dérivé du raccourci d’envoi."
+			},
+			"showShortcutHelp": {
+				"label": "Afficher les raccourcis clavier",
+				"description": "Ouvre l’aide des raccourcis clavier."
+			},
+			"focusInput": {
+				"label": "Focus Message Input",
+				"description": "Move focus to the message composer."
+			},
+			"uploadFile": {
+				"label": "Upload File",
+				"description": "Open the file attachment picker."
+			},
+			"searchMessages": {
+				"label": "Search Messages",
+				"description": "Search messages in the current conversation."
+			},
+			"editLastMessage": {
+				"label": "Edit Last Message",
+				"description": "Edit your last sent message."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Cancel Reply or Edit",
+				"description": "Cancel the current reply or edit."
+			},
+			"openEmojiPicker": {
+				"label": "Open Emoji Picker",
+				"description": "Open the emoji picker."
+			},
+			"startNewConversation": {
+				"label": "Start New Conversation",
+				"description": "Start a new conversation."
+			},
+			"openCommandPalette": {
+				"label": "Open Command Palette",
+				"description": "Open the command palette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "Ce raccourci est déjà attribué.",
+			"reserved": "Ce raccourci est réservé par le navigateur.",
+			"browserConflict": "Ce raccourci entre en conflit avec des raccourcis courants du navigateur.",
+			"sendNewline": "Envoyer et Nouvelle ligne ne peuvent pas utiliser le même raccourci.",
+			"unsupported": "Cette option de raccourci n’est pas prise en charge.",
+			"cannotDisable": "Ce raccourci ne peut pas être désactivé.",
+			"unsafePlainKey": "Cette touche ne peut pas être utilisée comme raccourci pendant la saisie."
+		},
+		"hints": {
+			"enterSends": "Enter sends the message",
+			"shiftEnterNewline": "Shift+Enter inserts a new line",
+			"enterNewline": "Enter inserts a new line",
+			"ctrlEnterSends": "Ctrl+Enter sends the message",
+			"cmdEnterSends": "Cmd+Enter sends the message"
+		},
+		"lockedNewline": "Verrouillé sur Maj+Entrée tant qu’Entrée envoie le message.",
+		"resetAction": "Réinitialiser",
+		"restoreDefaultsConfirm": "Restaurer tous les raccourcis par défaut ?",
+		"restoreDefaultsConfirmYes": "Restaurer",
+		"restoreDefaultsConfirmNo": "Annuler",
+		"keys": {
+			"enter": "Entrée",
+			"escape": "Échap",
+			"arrowUp": "↑",
+			"shift": "Maj",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Ctrl",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/resources/i18n/ru/common.json
+++ b/src/resources/i18n/ru/common.json
@@ -1631,7 +1631,8 @@
 					"changePassword": "Изменить пароль",
 					"title": "Безопасность"
 				},
-				"title": "Настройки"
+				"title": "Настройки",
+				"keyboardShortcuts": "Горячие клавиши"
 			}
 		},
 		"spokenLanguages": {
@@ -2946,6 +2947,111 @@
 			"remove": {
 				"confirm": "Вы уверены, что хотите удалить этого супервизора?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Горячие клавиши",
+		"description": "Настройте сочетания клавиш для чата. Изменения применяются сразу и сохраняются на этом устройстве.",
+		"automaticallyConfigured": "настроено автоматически",
+		"disableShortcut": "Отключено",
+		"restoreDefaults": "Восстановить значения по умолчанию",
+		"restoreDefaultsSuccess": "Стандартные горячие клавиши восстановлены.",
+		"primaryModifier": "Primary modifier",
+		"help": {
+			"title": "Горячие клавиши",
+			"close": "Закрыть"
+		},
+		"palette": {
+			"title": "Палитра команд",
+			"close": "Закрыть",
+			"searchPlaceholder": "Поиск команд…",
+			"allShortcuts": "Все горячие клавиши"
+		},
+		"editingBanner": "Редактирование сообщения",
+		"editingCancel": "Отмена",
+		"categories": {
+			"messaging": "Сообщения",
+			"navigation": "Навигация",
+			"attachments": "Вложения",
+			"emoji": "Эмодзи и реакции",
+			"application": "Приложение"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Отправить сообщение",
+				"description": "Отправляет текущее сообщение чата."
+			},
+			"insertNewLine": {
+				"label": "Вставить новую строку",
+				"description": "Вставляет новую строку. Определяется сочетанием для отправки."
+			},
+			"showShortcutHelp": {
+				"label": "Показать горячие клавиши",
+				"description": "Открывает справку по горячим клавишам."
+			},
+			"focusInput": {
+				"label": "Focus Message Input",
+				"description": "Move focus to the message composer."
+			},
+			"uploadFile": {
+				"label": "Upload File",
+				"description": "Open the file attachment picker."
+			},
+			"searchMessages": {
+				"label": "Search Messages",
+				"description": "Search messages in the current conversation."
+			},
+			"editLastMessage": {
+				"label": "Edit Last Message",
+				"description": "Edit your last sent message."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Cancel Reply or Edit",
+				"description": "Cancel the current reply or edit."
+			},
+			"openEmojiPicker": {
+				"label": "Open Emoji Picker",
+				"description": "Open the emoji picker."
+			},
+			"startNewConversation": {
+				"label": "Start New Conversation",
+				"description": "Start a new conversation."
+			},
+			"openCommandPalette": {
+				"label": "Open Command Palette",
+				"description": "Open the command palette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "Это сочетание уже назначено.",
+			"reserved": "Это сочетание зарезервировано браузером.",
+			"browserConflict": "Это сочетание конфликтует с типичными сочетаниями браузера.",
+			"sendNewline": "Отправка и новая строка не могут использовать одно сочетание.",
+			"unsupported": "Этот вариант сочетания не поддерживается.",
+			"cannotDisable": "Это сочетание нельзя отключить.",
+			"unsafePlainKey": "Эту клавишу нельзя использовать как сочетание во время ввода."
+		},
+		"hints": {
+			"enterSends": "Enter sends the message",
+			"shiftEnterNewline": "Shift+Enter inserts a new line",
+			"enterNewline": "Enter inserts a new line",
+			"ctrlEnterSends": "Ctrl+Enter sends the message",
+			"cmdEnterSends": "Cmd+Enter sends the message"
+		},
+		"lockedNewline": "Зафиксировано как Shift+Enter, пока Enter отправляет сообщение.",
+		"resetAction": "Сбросить",
+		"restoreDefaultsConfirm": "Восстановить все сочетания клавиш по умолчанию?",
+		"restoreDefaultsConfirmYes": "Восстановить",
+		"restoreDefaultsConfirmNo": "Отмена",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Shift",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Ctrl",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/resources/i18n/ti/common.json
+++ b/src/resources/i18n/ti/common.json
@@ -1631,7 +1631,8 @@
 					"changePassword": "ፓስዎርድ ምቕያር",
 					"title": "ድሕንነት"
 				},
-				"title": "ቅጥዕታት"
+				"title": "ቅጥዕታት",
+				"keyboardShortcuts": "Keyboard Shortcuts"
 			}
 		},
 		"spokenLanguages": {
@@ -2946,6 +2947,111 @@
 			"remove": {
 				"confirm": "እዚ ሱፐርቫይዘር ንምእልፍል እርግጠኛ ዲኻ?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Keyboard Shortcuts",
+		"description": "Customize chat shortcuts. Changes apply immediately and are saved on this device.",
+		"automaticallyConfigured": "automatically configured",
+		"disableShortcut": "Disabled",
+		"restoreDefaults": "Restore Defaults",
+		"restoreDefaultsSuccess": "Default shortcuts restored.",
+		"primaryModifier": "Primary modifier",
+		"help": {
+			"title": "Keyboard shortcuts",
+			"close": "Close"
+		},
+		"palette": {
+			"title": "Command Palette",
+			"close": "Close",
+			"searchPlaceholder": "Search commands…",
+			"allShortcuts": "All shortcuts"
+		},
+		"editingBanner": "Editing message",
+		"editingCancel": "Cancel",
+		"categories": {
+			"messaging": "Messaging",
+			"navigation": "Navigation",
+			"attachments": "Attachments",
+			"emoji": "Emoji and Reactions",
+			"application": "Application"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Send Message",
+				"description": "Send the current chat message."
+			},
+			"insertNewLine": {
+				"label": "Insert New Line",
+				"description": "Insert a new line in the message composer. Derived from the send shortcut."
+			},
+			"showShortcutHelp": {
+				"label": "Show Keyboard Shortcuts",
+				"description": "Open the keyboard shortcuts help dialog."
+			},
+			"focusInput": {
+				"label": "Focus Message Input",
+				"description": "Move focus to the message composer."
+			},
+			"uploadFile": {
+				"label": "Upload File",
+				"description": "Open the file attachment picker."
+			},
+			"searchMessages": {
+				"label": "Search Messages",
+				"description": "Search messages in the current conversation."
+			},
+			"editLastMessage": {
+				"label": "Edit Last Message",
+				"description": "Edit your last sent message."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Cancel Reply or Edit",
+				"description": "Cancel the current reply or edit."
+			},
+			"openEmojiPicker": {
+				"label": "Open Emoji Picker",
+				"description": "Open the emoji picker."
+			},
+			"startNewConversation": {
+				"label": "Start New Conversation",
+				"description": "Start a new conversation."
+			},
+			"openCommandPalette": {
+				"label": "Open Command Palette",
+				"description": "Open the command palette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "This shortcut is already assigned.",
+			"reserved": "This shortcut is reserved by the browser.",
+			"browserConflict": "This shortcut conflicts with common browser shortcuts.",
+			"sendNewline": "Send Message and Insert New Line cannot use the same shortcut.",
+			"unsupported": "This shortcut option is not supported.",
+			"cannotDisable": "This shortcut cannot be disabled.",
+			"unsafePlainKey": "This key cannot be used as a shortcut while typing."
+		},
+		"hints": {
+			"enterSends": "Enter sends the message",
+			"shiftEnterNewline": "Shift+Enter inserts a new line",
+			"enterNewline": "Enter inserts a new line",
+			"ctrlEnterSends": "Ctrl+Enter sends the message",
+			"cmdEnterSends": "Cmd+Enter sends the message"
+		},
+		"lockedNewline": "Locked to Shift+Enter while Enter sends the message.",
+		"resetAction": "Reset",
+		"restoreDefaultsConfirm": "Restore all shortcuts to their defaults?",
+		"restoreDefaultsConfirmYes": "Restore",
+		"restoreDefaultsConfirmNo": "Cancel",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Shift",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Ctrl",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/resources/i18n/tr/common.json
+++ b/src/resources/i18n/tr/common.json
@@ -1631,7 +1631,8 @@
 					"changePassword": "Şifre değiştirme",
 					"title": "Güvenlik"
 				},
-				"title": "Ayarlar"
+				"title": "Ayarlar",
+				"keyboardShortcuts": "Klavye Kısayolları"
 			}
 		},
 		"spokenLanguages": {
@@ -2976,6 +2977,111 @@
 			"remove": {
 				"confirm": "Bu süpervizörü kaldırmak istediğinizden emin misiniz?"
 			}
+		}
+	},
+	"shortcuts": {
+		"title": "Klavye Kısayolları",
+		"description": "Sohbet kısayollarını özelleştirin. Değişiklikler hemen uygulanır ve bu cihazda kaydedilir.",
+		"automaticallyConfigured": "otomatik yapılandırıldı",
+		"disableShortcut": "Devre dışı",
+		"restoreDefaults": "Varsayılanları Geri Yükle",
+		"restoreDefaultsSuccess": "Varsayılan kısayollar geri yüklendi.",
+		"primaryModifier": "Primary modifier",
+		"help": {
+			"title": "Klavye kısayolları",
+			"close": "Kapat"
+		},
+		"palette": {
+			"title": "Komut Paleti",
+			"close": "Kapat",
+			"searchPlaceholder": "Komut ara…",
+			"allShortcuts": "Tüm kısayollar"
+		},
+		"editingBanner": "Mesaj düzenleniyor",
+		"editingCancel": "İptal",
+		"categories": {
+			"messaging": "Mesajlaşma",
+			"navigation": "Gezinme",
+			"attachments": "Ekler",
+			"emoji": "Emoji ve Tepkiler",
+			"application": "Uygulama"
+		},
+		"actions": {
+			"sendMessage": {
+				"label": "Mesaj Gönder",
+				"description": "Geçerli sohbet mesajını gönderir."
+			},
+			"insertNewLine": {
+				"label": "Yeni Satır Ekle",
+				"description": "Yeni satır ekler. Gönderme kısayolundan türetilir."
+			},
+			"showShortcutHelp": {
+				"label": "Klavye Kısayollarını Göster",
+				"description": "Klavye kısayolları yardımını açar."
+			},
+			"focusInput": {
+				"label": "Focus Message Input",
+				"description": "Move focus to the message composer."
+			},
+			"uploadFile": {
+				"label": "Upload File",
+				"description": "Open the file attachment picker."
+			},
+			"searchMessages": {
+				"label": "Search Messages",
+				"description": "Search messages in the current conversation."
+			},
+			"editLastMessage": {
+				"label": "Edit Last Message",
+				"description": "Edit your last sent message."
+			},
+			"cancelReplyOrEdit": {
+				"label": "Cancel Reply or Edit",
+				"description": "Cancel the current reply or edit."
+			},
+			"openEmojiPicker": {
+				"label": "Open Emoji Picker",
+				"description": "Open the emoji picker."
+			},
+			"startNewConversation": {
+				"label": "Start New Conversation",
+				"description": "Start a new conversation."
+			},
+			"openCommandPalette": {
+				"label": "Open Command Palette",
+				"description": "Open the command palette."
+			}
+		},
+		"conflicts": {
+			"duplicate": "Bu kısayol zaten atanmış.",
+			"reserved": "Bu kısayol tarayıcı tarafından ayrılmıştır.",
+			"browserConflict": "Bu kısayol yaygın tarayıcı kısayollarıyla çakışır.",
+			"sendNewline": "Mesaj Gönder ve Yeni Satır aynı kısayolu kullanamaz.",
+			"unsupported": "Bu kısayol seçeneği desteklenmiyor.",
+			"cannotDisable": "Bu kısayol devre dışı bırakılamaz.",
+			"unsafePlainKey": "Bu tuş yazarken kısayol olarak kullanılamaz."
+		},
+		"hints": {
+			"enterSends": "Enter sends the message",
+			"shiftEnterNewline": "Shift+Enter inserts a new line",
+			"enterNewline": "Enter inserts a new line",
+			"ctrlEnterSends": "Ctrl+Enter sends the message",
+			"cmdEnterSends": "Cmd+Enter sends the message"
+		},
+		"lockedNewline": "Enter mesaj gönderirken Shift+Enter olarak kilitlenir.",
+		"resetAction": "Sıfırla",
+		"restoreDefaultsConfirm": "Tüm kısayollar varsayılana döndürülsün mü?",
+		"restoreDefaultsConfirmYes": "Geri yükle",
+		"restoreDefaultsConfirmNo": "İptal",
+		"keys": {
+			"enter": "Enter",
+			"escape": "Esc",
+			"arrowUp": "↑",
+			"shift": "Shift",
+			"alt": "Alt",
+			"option": "Option",
+			"ctrl": "Ctrl",
+			"cmd": "Cmd"
 		}
 	}
 }

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -227,6 +227,22 @@ export class MatrixClientService {
 		}
 	}
 
+	public async editMessage(
+		roomId: string,
+		eventId: string,
+		message: string
+	): Promise<any> {
+		await this.ensureFreshToken();
+		if (!this.client) throw new Error('Matrix client not initialized');
+		const content = {
+			'msgtype': 'm.text',
+			'body': `* ${message}`,
+			'm.new_content': { msgtype: 'm.text', body: message },
+			'm.relates_to': { rel_type: 'm.replace', event_id: eventId }
+		};
+		return this.client.sendMessage(roomId, content as any);
+	}
+
 	public async sendFileMessage(
 		roomId: string,
 		file: File,


### PR DESCRIPTION
## Summary
Closes [#23](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/23): ships a full, configurable keyboard-shortcut system with accordion Settings, Alt/Option+Enter send default, help dialog, command palette, and end-to-end runtime wiring.

Video:
https://cap.dreambau.com/s/6rdypxywmn664rx


## What changed
- Central registry + hooks as single source of truth (`src/features/keyboard-shortcuts/`)
- Settings: exclusive MUI accordions (Messaging open by default), per-action selects, restore-defaults confirm, browser-conflict warnings
- Persistence: `oriso.keyboardShortcuts.v1` per user; platform-aware labels (⌘ / Ctrl / Option / Alt)
- Composer shortcuts: send, newline, edit last (↑), cancel (Esc), upload, emoji
- Global: shortcut help (`⌘+/`) and command palette (`⌘+K`) — both toggle open/close
- Edit-last: load last own message into composer + editing banner; send via Matrix `m.replace` (`editMessage`)
- Help + palette UIs are viewport-safe (scroll inside panel)

## Follow-up fixes (after initial wiring)
- Edit-last empty check fixed for TipTap HTML (`<p></p>`); transport tokens (`[[align:]]` / `[[hl:]]`) decoded for clean edit UI
- Capture-phase handlers so app shortcuts beat the browser where needed
- Navigation shortcuts (focus / in-chat search / new conversation) removed after UX review
- Emoji: `⌘+E` toggles; picker stays open for multi-select; toolbar toggle no longer fights outside-click

## Test plan
- [ ] `npx vitest run src/features/keyboard-shortcuts`
- [ ] `npx vitest run src/components/messageSubmitInterface/transportMarkupToComposerHtml.test.ts`
- [ ] `npm run lint:scripts`
- [ ] Settings → Keyboard shortcuts: no Coming soon; accordion exclusive; restore defaults persists