### PR TITLE
Guard destroyed TipTap editor during anonymous Matrix transition

### DIFF
--- a/src/components/messageSubmitInterface/TipTapComposer.destroyedEditor.test.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.destroyedEditor.test.tsx
@@ -48,7 +48,7 @@ describe('TipTapComposer destroyed editor lifecycle', () => {
 		const ref = createRef<TipTapComposerRef>();
 		const onChange = vi.fn();
 
-		render(
+		const view = render(
 			<TipTapComposer
 				ref={ref}
 				value=""
@@ -69,5 +69,24 @@ describe('TipTapComposer destroyed editor lifecycle', () => {
 			mocks.options.onUpdate({ editor: mocks.editor })
 		).not.toThrow();
 		expect(onChange).not.toHaveBeenCalled();
+
+		view.rerender(
+			<TipTapComposer
+				ref={ref}
+				value=""
+				placeholder="test"
+				showToolbar={true}
+				readOnly={false}
+				onChange={onChange}
+				onSubmitShortcut={() => {}}
+			/>
+		);
+		expect(
+			view.container.querySelector('.tiptap-composer__loading')
+		).toBeTruthy();
+		expect(view.container.querySelector('.tiptap-composer')).toBeNull();
+		expect(
+			view.container.querySelector('.tiptap-composer__toolbar')
+		).toBeNull();
 	});
 });

--- a/src/components/messageSubmitInterface/TipTapComposer.destroyedEditor.test.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.destroyedEditor.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { createRef } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+	const commands = {
+		setTextAlign: vi.fn(),
+		setContent: vi.fn(),
+		clearContent: vi.fn(),
+		focus: vi.fn()
+	};
+	const editor: any = {
+		isDestroyed: false,
+		setEditable: vi.fn(),
+		getHTML: vi.fn(() => '')
+	};
+	Object.defineProperty(editor, 'commands', {
+		get() {
+			if (!editor.isDestroyed) {
+				return commands;
+			}
+			throw new TypeError(
+				"Cannot read properties of null (reading 'commands')"
+			);
+		}
+	});
+	return { editor, options: null as any };
+});
+
+vi.mock('@tiptap/react', () => ({
+	EditorContent: () => null,
+	useEditor: (options: any) => {
+		mocks.options = options;
+		return mocks.editor;
+	}
+}));
+
+// The component import must follow the hoisted module mock in this lifecycle test.
+// eslint-disable-next-line import/first
+import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
+
+afterEach(() => cleanup());
+
+describe('TipTapComposer destroyed editor lifecycle', () => {
+	it('ignores imperative clear after the editor was destroyed during a room transition', async () => {
+		const ref = createRef<TipTapComposerRef>();
+		const onChange = vi.fn();
+
+		render(
+			<TipTapComposer
+				ref={ref}
+				value=""
+				placeholder="test"
+				showToolbar={false}
+				readOnly={false}
+				onChange={onChange}
+				onSubmitShortcut={() => {}}
+			/>
+		);
+
+		await waitFor(() => expect(ref.current).toBeTruthy());
+		mocks.editor.isDestroyed = true;
+		expect(() => ref.current!.clear()).not.toThrow();
+		expect(() => ref.current!.isActionActive('bold')).not.toThrow();
+		expect(ref.current!.isActionActive('bold')).toBe(false);
+		expect(() =>
+			mocks.options.onUpdate({ editor: mocks.editor })
+		).not.toThrow();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/messageSubmitInterface/TipTapComposer.tsx
+++ b/src/components/messageSubmitInterface/TipTapComposer.tsx
@@ -66,6 +66,9 @@ interface TipTapComposerProps {
 const getEditorPlainTextLength = (editorLike: any): number =>
 	(editorLike?.state?.doc?.textContent || '').length;
 
+const isEditorReady = (editorLike: any): boolean =>
+	Boolean(editorLike && !editorLike.isDestroyed);
+
 const getSelectionTextLength = (
 	editorLike: any,
 	from: number,
@@ -91,7 +94,7 @@ const enforceEditorMaxLength = (
 	editorLike: any,
 	maxLength?: number
 ): boolean => {
-	if (!maxLength) {
+	if (!maxLength || !isEditorReady(editorLike)) {
 		return false;
 	}
 
@@ -258,7 +261,7 @@ export const TipTapComposer = forwardRef<
 				onFocusChange?.(false);
 			},
 			onUpdate: ({ editor: currentEditor }) => {
-				if (isSyncingFromValue) {
+				if (isSyncingFromValue || !isEditorReady(currentEditor)) {
 					return;
 				}
 				if (enforceEditorMaxLength(currentEditor, maxLength)) {
@@ -268,7 +271,7 @@ export const TipTapComposer = forwardRef<
 				onChange(currentEditor.getHTML());
 			},
 			onSelectionUpdate: ({ editor: currentEditor }) => {
-				if (!onSelectionSnippet) {
+				if (!onSelectionSnippet || !isEditorReady(currentEditor)) {
 					return;
 				}
 				const { from, to } = currentEditor.state.selection;
@@ -288,14 +291,14 @@ export const TipTapComposer = forwardRef<
 		});
 
 		useEffect(() => {
-			if (!editor) {
+			if (!isEditorReady(editor)) {
 				return;
 			}
 			editor.setEditable(!readOnly);
 		}, [editor, readOnly]);
 
 		useEffect(() => {
-			if (!editor) {
+			if (!isEditorReady(editor)) {
 				return;
 			}
 			const normalizedValue = (value || '')
@@ -331,28 +334,34 @@ export const TipTapComposer = forwardRef<
 
 		useImperativeHandle(ref, () => ({
 			clear: () => {
-				editor?.commands.clearContent();
+				if (isEditorReady(editor)) {
+					editor.commands.clearContent();
+				}
 			},
 			focus: () => {
-				editor?.commands.focus();
+				if (isEditorReady(editor)) {
+					editor.commands.focus();
+				}
 			},
 			setText: (nextValue: string) => {
-				editor?.commands.setContent(nextValue || '');
+				if (isEditorReady(editor)) {
+					editor.commands.setContent(nextValue || '');
+				}
 			},
 			getHTML: () => {
-				if (!editor) {
+				if (!isEditorReady(editor)) {
 					return '';
 				}
 				return editor.getHTML();
 			},
 			insertText: (nextValue: string) => {
-				if (!editor || !nextValue) {
+				if (!isEditorReady(editor) || !nextValue) {
 					return;
 				}
 				editor.chain().focus().insertContent(nextValue).run();
 			},
 			insertMentionTrigger: () => {
-				if (!editor) {
+				if (!isEditorReady(editor)) {
 					return;
 				}
 				// The mention suggestion only fires on '@' at a line start or
@@ -373,7 +382,7 @@ export const TipTapComposer = forwardRef<
 					.run();
 			},
 			insertSnippet: (payload: HighlightSnippetPayload) => {
-				if (!editor || !payload?.text) {
+				if (!isEditorReady(editor) || !payload?.text) {
 					return;
 				}
 				const anchorMeta = payload.anchorId
@@ -389,7 +398,7 @@ export const TipTapComposer = forwardRef<
 					.run();
 			},
 			runAction: (action: string) => {
-				if (!editor) {
+				if (!isEditorReady(editor)) {
 					return;
 				}
 
@@ -595,7 +604,7 @@ export const TipTapComposer = forwardRef<
 				}
 			},
 			isActionActive: (action: string) => {
-				if (!editor) {
+				if (!isEditorReady(editor)) {
 					return false;
 				}
 				const activeTextAlign = editor.isActive('heading')
@@ -655,7 +664,7 @@ export const TipTapComposer = forwardRef<
 			}
 		}));
 
-		if (!editor) {
+		if (!isEditorReady(editor)) {
 			return <div className="tiptap-composer__loading" />;
 		}
 


### PR DESCRIPTION
## Summary
- guard TipTap effects, render paths, and imperative helpers when the editor instance is already destroyed during a room transition
- render the existing loading state instead of accessing stale toolbar/editor APIs
- add a lifecycle regression test that initializes normally, destroys the mounted editor, and exercises imperative and update paths

## PreDev evidence
- anonymous invite redeem: 200
- queue accept: 200
- both participants reached the new Matrix room
- first send failed before this fix with `TypeError: Cannot read properties of null (reading commands)` and no Matrix request

## Validation
- TDD RED: destroyed-editor lifecycle reproduced the exact exception
- GREEN: 8/8 focused composer/send tests
- `npm run lint:scripts` (ESLint + TypeScript)
- `git diff --check`
- Full Vitest run printed all executed tests green but retained an open worker after five minutes; GitHub CI remains the full-suite gate.

Refs #424
Refs OpenResilienceInitiative/ORISO-UserService#413

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer stability when the text editor is still loading or has been destroyed.
  * Prevented editing actions, content updates, selection changes, and callbacks from causing errors in these states.
  * Ensured destroyed editors correctly report actions as inactive and display the loading state when appropriate.

* **Tests**
  * Added coverage for safe behavior after the editor is destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->