### PR TITLE
Fix anonymous live-chat room refresh before first send

### DIFF
--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -22,6 +22,12 @@ vi.mock('../api/apiPostMessageEventNotification', () => ({
 		apiPostMessageEventNotification(input)
 }));
 
+const apiGetSessionRoomBySessionId = vi.fn();
+vi.mock('../api/apiGetSessionRooms', () => ({
+	apiGetSessionRoomBySessionId: (sessionId: number) =>
+		apiGetSessionRoomBySessionId(sessionId)
+}));
+
 const ROOM_ID = '!room:matrix.oriso.org';
 const OTHER_ROOM_ID = '!other:matrix.oriso.org';
 
@@ -410,6 +416,54 @@ describe('chatTransportService sendTextMessage (Matrix-only transport)', () => {
 				matrixClientServiceOverride: override
 			})
 		).rejects.toThrow('Matrix client not initialized');
+	});
+
+	it('refreshes a stale pre-accept session to resolve its Matrix room before sending', async () => {
+		apiGetSessionRoomBySessionId.mockResolvedValueOnce({
+			sessions: [{ session: { id: 42, matrixRoomId: ROOM_ID } }]
+		});
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$evt:matrix.oriso.org' })
+		);
+		const override = {
+			getClient: () => createFakeMatrixClient(),
+			sendMessage
+		} as any;
+
+		await chatTransportService.sendTextMessage({
+			roomIdOrSessionId: 42,
+			message: 'hello after accept',
+			sendMailNotification: false,
+			isEncrypted: false,
+			sessionId: 42,
+			matrixRoomId: undefined,
+			matrixClientServiceOverride: override
+		});
+
+		expect(apiGetSessionRoomBySessionId).toHaveBeenCalledWith(42);
+		expect(sendMessage).toHaveBeenCalledWith(
+			ROOM_ID,
+			'hello after accept'
+		);
+	});
+
+	it('rejects when refreshing a stale session still returns no Matrix room', async () => {
+		apiGetSessionRoomBySessionId.mockResolvedValueOnce({ sessions: [] });
+
+		await expect(
+			chatTransportService.sendTextMessage({
+				roomIdOrSessionId: 42,
+				message: 'hello',
+				sendMailNotification: false,
+				isEncrypted: false,
+				sessionId: 42,
+				matrixRoomId: undefined,
+				matrixClientServiceOverride: {
+					getClient: () => createFakeMatrixClient(),
+					sendMessage: vi.fn()
+				} as any
+			})
+		).rejects.toThrow('Cannot send message: session has no Matrix room');
 	});
 
 	it('sends via the Matrix client with the room id and message when a room id is present', async () => {

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -3,7 +3,11 @@ import {
 	apiPostMessageEventNotification,
 	MessageEventNotificationInput
 } from '../api/apiPostMessageEventNotification';
-import { isMatrixRoom } from '../utils/matrixRoomUtils';
+import { apiGetSessionRoomBySessionId } from '../api/apiGetSessionRooms';
+import {
+	isMatrixRoom,
+	resolveSessionRoomRouteId
+} from '../utils/matrixRoomUtils';
 import { getMatrixClientService } from './matrixClientRegistry';
 import type {
 	MatrixClientService,
@@ -89,15 +93,24 @@ class ChatTransportService {
 	public async sendTextMessage({
 		message,
 		matrixRoomId,
+		sessionId,
 		threadRootId,
 		supervisorMessage,
 		senderDisplayName,
 		matrixClientServiceOverride
 	}: SendTextMessageOptions): Promise<any> {
+		let resolvedMatrixRoomId = matrixRoomId;
+		if (!resolvedMatrixRoomId && sessionId) {
+			const { sessions } = await apiGetSessionRoomBySessionId(sessionId);
+			resolvedMatrixRoomId = resolveSessionRoomRouteId(
+				sessions?.[0]?.session
+			);
+		}
+
 		// Matrix is the only chat transport. Sessions without a Matrix room
 		// (stale pre-migration data) fail gracefully instead of falling back
 		// to the removed Rocket.Chat REST path.
-		if (!matrixRoomId) {
+		if (!resolvedMatrixRoomId) {
 			return Promise.reject(
 				new Error('Cannot send message: session has no Matrix room')
 			);
@@ -110,7 +123,7 @@ class ChatTransportService {
 		}
 
 		const response = await matrixClientService.sendMessage(
-			matrixRoomId,
+			resolvedMatrixRoomId,
 			message
 		);
 
@@ -118,7 +131,7 @@ class ChatTransportService {
 		// (messagePreview / threadParentPreview) across the Matrix privacy
 		// boundary. Only non-content metadata is sent.
 		apiPostMessageEventNotification({
-			roomId: matrixRoomId,
+			roomId: resolvedMatrixRoomId,
 			matrixRoom: true,
 			threadRootId: threadRootId || null,
 			supervisorMessage: !!supervisorMessage,

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -7,6 +7,9 @@ const mockedMatrixClient = vi.hoisted(() => ({
 	initRustCrypto: vi.fn(),
 	on: vi.fn(),
 	removeAllListeners: vi.fn(),
+	getRoom: vi.fn(),
+	joinRoom: vi.fn(),
+	sendMessage: vi.fn(),
 	startClient: vi.fn(),
 	stopClient: vi.fn()
 }));
@@ -186,6 +189,69 @@ describe('MatrixClientService', () => {
 			msgtype: 'm.text',
 			body: 'Hello Matrix'
 		});
+	});
+
+	it('joins a newly accepted room that is not yet present in the running client', async () => {
+		const callOrder: string[] = [];
+		const joinRoom = vi.fn(async () => {
+			callOrder.push('join');
+			return { roomId: '!room:example.org' };
+		});
+		const sendMessage = vi.fn(async () => {
+			callOrder.push('send');
+			return { event_id: '$event' };
+		});
+		const service = new MatrixClientService();
+		setClient(service, {
+			getRoom: () => null,
+			joinRoom,
+			sendMessage
+		});
+
+		await service.sendMessage('!room:example.org', 'Hello after accept');
+
+		expect(joinRoom).toHaveBeenCalledWith('!room:example.org');
+		expect(sendMessage).toHaveBeenCalled();
+		expect(callOrder).toEqual(['join', 'send']);
+	});
+
+	it('refreshes an expired token during join and retries join before sending', async () => {
+		const expiredError = {
+			errcode: 'M_UNKNOWN',
+			httpStatus: 401,
+			message: 'Access token has expired'
+		};
+		const firstJoin = vi.fn(() => Promise.reject(expiredError));
+		const service = new MatrixClientService();
+		setClient(service, {
+			getRoom: () => null,
+			joinRoom: firstJoin,
+			sendMessage: vi.fn(),
+			stopClient: vi.fn(),
+			removeAllListeners: vi.fn()
+		});
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'replacement-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		mockedMatrixClient.getRoom.mockReturnValue(null);
+		mockedMatrixClient.joinRoom.mockResolvedValue({
+			roomId: '!room:example.org'
+		});
+		mockedMatrixClient.sendMessage.mockResolvedValue({ event_id: '$event' });
+
+		await expect(
+			service.sendMessage('!room:example.org', 'Hello after refresh')
+		).resolves.toEqual({ event_id: '$event' });
+
+		expect(firstJoin).toHaveBeenCalledOnce();
+		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
+		expect(mockedMatrixClient.joinRoom).toHaveBeenCalledWith(
+			'!room:example.org'
+		);
+		expect(mockedMatrixClient.sendMessage).toHaveBeenCalledOnce();
 	});
 
 	it('sends typing state in migration rooms without native Matrix encryption state', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -202,28 +202,30 @@ export class MatrixClientService {
 	public async sendMessage(roomId: string, message: string): Promise<any> {
 		await this.ensureFreshToken();
 
-		if (!this.client) {
-			throw new Error('Matrix client not initialized');
-		}
-
 		const content = {
 			msgtype: 'm.text',
 			body: message
 		} as any;
+		const sendToRoom = async () => {
+			const client = this.client;
+			if (!client) {
+				throw new Error('Matrix client not initialized');
+			}
+			if (!client.getRoom(roomId)) {
+				await client.joinRoom(roomId);
+			}
+			return client.sendMessage(roomId, content);
+		};
 
 		try {
-			return await this.client.sendMessage(roomId, content);
+			return await sendToRoom();
 		} catch (error) {
 			if (!isMatrixExpiredTokenError(error)) {
 				throw error;
 			}
 
 			await this.refreshMatrixToken();
-			if (!this.client) {
-				throw new Error('Matrix client not initialized');
-			}
-
-			return this.client.sendMessage(roomId, content);
+			return sendToRoom();
 		}
 	}
 


### PR DESCRIPTION
## Summary

- refresh a stale anonymous live-chat session to resolve the Matrix room created during consultant acceptance
- join/synchronize a newly accepted room when the running Matrix client does not know it yet
- include room join and delivery in the same expired-token retry operation

## Verification

- TDD red: stale sessions rejected before resolving their room; unknown SDK rooms sent without joining
- Green: `chatTransportService.test.ts` and `matrixClientService.test.ts` — 33 tests passed
- `npm run lint:scripts` passed (ESLint + TypeScript)
- local CodeRabbit major finding addressed; final rerun was rate-limited for 21 minutes
- diagnostic PreDev proof: the existing flow sends 200/200 after reload, confirming stale room hydration as the remaining cause

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Text messages now send successfully for older sessions by resolving the correct Matrix room automatically.
  - Messages are no longer attempted when a session has no available Matrix room.
  - The app now joins newly accepted rooms before sending queued messages.
  - Expired access tokens are refreshed automatically, allowing message delivery to continue without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->