### PR TITLE
fix: refresh anonymous live-chat stream after send

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -25,6 +25,7 @@ import {
 } from './inputField/composerResize';
 import { isAskerEnquirySubmission } from './messageEncryptionMode';
 import { resolveAsideTargetRoomId } from './asideRouting';
+import { reloadSessionAfterSendIfNeeded } from './sessionRefreshAfterSend';
 import { chatTransportService } from '../../services/chatTransportService';
 import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
 import { getModality, Modality } from '../session/getModality';
@@ -1136,6 +1137,13 @@ export const MessageSubmitInterfaceComponent = ({
 	);
 
 	const handleMessageSendSuccess = useCallback(() => {
+		reloadSessionAfterSendIfNeeded(
+			{
+				isMatrixSession: resolvedChatSession.isMatrixSession,
+				clientRoomId: resolvedChatSession.matrixRoomId
+			},
+			reloadActiveSession
+		);
 		onMessageSendSuccess?.();
 		setEditorState(EditorState.createEmpty());
 		setComposerText('');
@@ -1168,6 +1176,9 @@ export const MessageSubmitInterfaceComponent = ({
 		audienceOptions,
 		clearDraftMessage,
 		onMessageSendSuccess,
+		reloadActiveSession,
+		resolvedChatSession.isMatrixSession,
+		resolvedChatSession.matrixRoomId,
 		resizeTextarea
 	]);
 

--- a/src/components/messageSubmitInterface/sessionRefreshAfterSend.test.ts
+++ b/src/components/messageSubmitInterface/sessionRefreshAfterSend.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import {
+	reloadSessionAfterSendIfNeeded,
+	shouldReloadSessionAfterSend
+} from './sessionRefreshAfterSend';
+
+describe('shouldReloadSessionAfterSend', () => {
+	it('reloads a Matrix session whose room appeared after the page loaded', () => {
+		expect(
+			shouldReloadSessionAfterSend({
+				isMatrixSession: true,
+				clientRoomId: undefined
+			})
+		).toBe(true);
+	});
+
+	it.each([
+		{ isMatrixSession: true, clientRoomId: '!room:matrix.example' },
+		{ isMatrixSession: false, clientRoomId: undefined }
+	])('does not reload an already-current or non-Matrix session', (input) => {
+		expect(shouldReloadSessionAfterSend(input)).toBe(false);
+	});
+});
+
+describe('reloadSessionAfterSendIfNeeded', () => {
+	it('refreshes the active session after the first successful stale-room send', () => {
+		const reload = vi.fn();
+
+		reloadSessionAfterSendIfNeeded(
+			{ isMatrixSession: true, clientRoomId: undefined },
+			reload
+		);
+
+		expect(reload).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		{ isMatrixSession: true, clientRoomId: '!room:matrix.example' },
+		{ isMatrixSession: false, clientRoomId: undefined }
+	])('does not reload when no refresh is needed', (input) => {
+		const reload = vi.fn();
+
+		reloadSessionAfterSendIfNeeded(input, reload);
+
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it('allows the optional reload callback to be omitted', () => {
+		expect(() =>
+			reloadSessionAfterSendIfNeeded({
+				isMatrixSession: true,
+				clientRoomId: undefined
+			})
+		).not.toThrow();
+	});
+});

--- a/src/components/messageSubmitInterface/sessionRefreshAfterSend.ts
+++ b/src/components/messageSubmitInterface/sessionRefreshAfterSend.ts
@@ -1,0 +1,19 @@
+type SessionRefreshAfterSendInput = {
+	isMatrixSession: boolean;
+	clientRoomId?: string | null;
+};
+
+export const shouldReloadSessionAfterSend = ({
+	isMatrixSession,
+	clientRoomId
+}: SessionRefreshAfterSendInput): boolean =>
+	isMatrixSession && !clientRoomId;
+
+export const reloadSessionAfterSendIfNeeded = (
+	input: SessionRefreshAfterSendInput,
+	reload?: () => void
+): void => {
+	if (shouldReloadSessionAfterSend(input)) {
+		reload?.();
+	}
+};


### PR DESCRIPTION
## Summary

- refresh the active session after a successful Matrix send when the page loaded before the room existed
- let `SessionStream` bind its timeline and lifecycle listeners to the late-created anonymous live-chat room
- share the refresh path across text and attachment send success
- keep current Matrix and non-Matrix sessions free from unnecessary reloads

Closes #428

## Tests

- `npm run test:unit -- --run` — 111 files, 662 tests passed
- `npm run lint:scripts` — ESLint and TypeScript passed
- local CodeRabbit review: both findings addressed (no-op branch coverage and shared attachment success path); final rerun hit the temporary plan rate limit

## Release scope

Merge target: `pre-dev` only. Do not merge or push to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)