### PR TITLE
fix(chat): fix chatroom header display for all chat type conditions

### DIFF
--- a/src/components/sessionHeader/GroupChatHeader/index.tsx
+++ b/src/components/sessionHeader/GroupChatHeader/index.tsx
@@ -11,6 +11,7 @@ import { useSearchParam } from '../../../hooks/useSearchParams';
 import { SESSION_LIST_TAB } from '../../session/sessionHelpers';
 import { mobileListView } from '../../app/navigationHandler';
 import { BackIcon, GroupChatInfoIcon } from '../../../resources/img/icons';
+import { ReactComponent as PeopleIcon } from '../../../resources/img/icons/persons-two.svg';
 import { useTranslation } from 'react-i18next';
 import { decodeUsername } from '../../../utils/encryptionHelpers';
 import { BUTTON_TYPES, Button, ButtonItem } from '../../button/Button';
@@ -317,7 +318,10 @@ export const GroupChatHeader = ({
 			!userId.includes('@system') && !userId.includes('@caritas.local')
 		);
 	});
-	const stackedMembers = visibleMembers.slice(0, 3);
+	// Figma #430: up to 4 members render every avatar; beyond that we collapse
+	// the stack into a single "+N people" count badge instead of avatars.
+	const showMemberCountBadge = visibleMembers.length > 4;
+	const stackedMembers = showMemberCountBadge ? [] : visibleMembers;
 
 	return (
 		<div className="sessionInfo">
@@ -336,6 +340,14 @@ export const GroupChatHeader = ({
 								type="internal"
 								showAddIcon={isActive && !isJoinGroupChatView}
 							/>
+							{showMemberCountBadge && (
+								<div className="sessionInfo__memberCount">
+									<span className="sessionInfo__memberCountNumber">
+										+{visibleMembers.length}
+									</span>
+									<PeopleIcon className="sessionInfo__memberCountIcon" />
+								</div>
+							)}
 							{stackedMembers.map((member, index) => {
 								const userId = member.userId || '';
 								const parsedUsername =

--- a/src/components/sessionHeader/SessionHeader.stories.tsx
+++ b/src/components/sessionHeader/SessionHeader.stories.tsx
@@ -1,0 +1,548 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, waitFor } from 'storybook/test';
+import {
+	ActiveSessionContext,
+	AUTHORITIES,
+	buildExtendedSession,
+	ConsultantListContext,
+	ConsultingTypesContext,
+	E2EEContext,
+	SessionsDataContext,
+	SessionTypeContext,
+	TopicsContext,
+	UserDataContext,
+	type ExtendedSessionInterface
+} from '../../globalState';
+import { ServerSettingsContext } from '../../globalState/provider/ServerSettingsProvider';
+import { MatrixClientContext } from '../../globalState/context/MatrixClientContext';
+import type {
+	ConsultingTypeInterface,
+	GroupChatItemInterface,
+	ListItemInterface,
+	SessionItemInterface,
+	TopicsDataInterface
+} from '../../globalState/interfaces';
+import {
+	REGISTRATION_TYPE_REGISTERED,
+	STATUS_ACTIVE,
+	STATUS_EMPTY,
+	STATUS_ENQUIRY
+} from '../../globalState/interfaces';
+import { SESSION_LIST_TYPES } from '../session/sessionHelpers';
+import { SessionHeaderComponent } from './SessionHeaderComponent';
+import { GroupChatHeader } from './GroupChatHeader';
+import './sessionHeader.styles.scss';
+
+const APP_ORISO_CHAT_HEADER_FIGMA_URL =
+	'https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=1131-44172&t=7scG0mpt60RDLUqB-4';
+
+/* ------------------------------------------------------------------ *
+ * Shared fixtures
+ * ------------------------------------------------------------------ */
+
+const storyTopic: TopicsDataInterface = {
+	id: 1,
+	name: 'Familienberatung',
+	slug: 'familienberatung',
+	description: 'Storybook fixture topic.',
+	internalIdentifier: 'familienberatung',
+	status: 'active',
+	createDate: '2026-03-01T00:00:00.000Z',
+	updateDate: '2026-03-01T00:00:00.000Z',
+	fallbackUrl: '',
+	titles: {
+		short: 'Familie',
+		long: 'Familienberatung',
+		registrationDropdown: 'Familienberatung',
+		welcome: 'Familienberatung'
+	}
+};
+
+const storyConsultingType: ConsultingTypeInterface = {
+	id: 1,
+	showAskerProfile: true,
+	titles: {
+		default: '1-1 Beratung',
+		short: '1-1',
+		long: '1-1 Beratung',
+		welcome: 'Willkommen',
+		registrationDropdown: '1-1 Beratung'
+	},
+	isVideoCallAllowed: true,
+	isSubsequentRegistrationAllowed: true,
+	urls: {
+		registrationPostcodeFallbackUrl: '',
+		requiredAidMissingRedirectUrl: ''
+	},
+	registration: {
+		autoSelectAgency: false,
+		autoSelectPostcode: false,
+		notes: {}
+	},
+	groupChat: {
+		isGroupChat: false,
+		groupChatRules: ['']
+	},
+	description: 'Storybook fixture for the chatroom header.',
+	slug: 'one-on-one',
+	languageFormal: true,
+	welcomeScreen: {
+		anonymous: {
+			title: 'Willkommen',
+			text: ''
+		}
+	}
+};
+
+// Consultant viewer. `userId` matches the session consultant id below so the
+// header does not treat the current user as a read-only supervisor (which would
+// otherwise suppress the interactive "+").
+const CONSULTANT_ID = 'consultant-storybook';
+const storyUserData = {
+	userId: CONSULTANT_ID,
+	userName: 'beraterin@example.invalid',
+	displayName: 'Beraterin ORISO',
+	grantedAuthorities: [AUTHORITIES.CONSULTANT_DEFAULT],
+	userRoles: ['CONSULTANT'],
+	twoFactorAuth: {
+		isEnabled: false,
+		isActive: false,
+		isShown: false,
+		isToBeActivated: false,
+		secret: '',
+		qrCode: ''
+	}
+} as any;
+
+/* ------------------------------------------------------------------ *
+ * Matrix client mock (GroupChatHeader reads members from the client)
+ * ------------------------------------------------------------------ */
+
+type MockMember = { userId: string; name: string };
+
+const makeMembers = (count: number): MockMember[] =>
+	Array.from({ length: count }, (_, index) => ({
+		userId: `@mitglied${index + 1}:matrix.storybook.test`,
+		name: `Mitglied ${index + 1}`
+	}));
+
+// Minimal stand-in for MatrixClientService exposing just enough of the
+// getClient()/getRoom()/getJoinedMembers() surface GroupChatHeader touches.
+const makeMatrixClientService = (members: MockMember[]) => {
+	const room = {
+		getJoinedMembers: () => members,
+		getMember: () => ({ powerLevel: 0 })
+	};
+	const client = {
+		getRoom: () => room,
+		getRooms: () => [room]
+	};
+	return {
+		getClient: () => client
+	} as any;
+};
+
+/* ------------------------------------------------------------------ *
+ * Session presets (one factory per Figma condition)
+ * ------------------------------------------------------------------ */
+
+const buildSingleSession = (
+	status: typeof STATUS_ACTIVE | typeof STATUS_EMPTY | typeof STATUS_ENQUIRY
+): ExtendedSessionInterface =>
+	buildExtendedSession(
+		{
+			user: {
+				username: 'ruhiges-yak-kim@example.invalid',
+				displayName: 'Ruhiges Yak Kim',
+				sessionData: {}
+			},
+			consultant: {
+				consultantId: CONSULTANT_ID,
+				id: CONSULTANT_ID,
+				username: 'beraterin@example.invalid',
+				displayName: 'Beraterin ORISO',
+				absent: false,
+				absenceMessage: ''
+			},
+			language: 'de',
+			session: {
+				id: 4401,
+				agencyId: 101,
+				askerRcId: 'asker-4401',
+				attachment: null,
+				consultingType: 1,
+				groupId: 'sb-single-room-4401',
+				matrixRoomId: 'sb-single-room-4401',
+				e2eLastMessage: null,
+				lastMessage: 'Anfrage gesendet',
+				messageDate: 1773822900,
+				createDate: '2026-03-18T06:15:00.000Z',
+				messagesRead: true,
+				postcode: 12345,
+				registrationType: REGISTRATION_TYPE_REGISTERED,
+				status,
+				videoCallMessageDTO: null,
+				topic: {
+					id: 1,
+					name: 'Familienberatung',
+					description: ''
+				}
+			} as unknown as SessionItemInterface
+		} as ListItemInterface,
+		''
+	);
+
+const buildGroupSession = (): ExtendedSessionInterface =>
+	buildExtendedSession(
+		{
+			consultant: {
+				consultantId: CONSULTANT_ID,
+				id: CONSULTANT_ID,
+				username: 'beraterin@example.invalid',
+				displayName: 'Beraterin ORISO',
+				absent: false,
+				absenceMessage: ''
+			},
+			language: 'de',
+			chat: {
+				active: true,
+				assignedAgencies: [],
+				attachment: null,
+				consultingType: 1,
+				duration: 60,
+				groupId: 'sb-group-room-9001',
+				matrixRoomId: 'sb-group-room-9001',
+				hintMessage: '',
+				id: 9001,
+				lastMessage: 'Willkommen im Team-Austausch.',
+				e2eLastMessage: null,
+				messageDate: 1773822900,
+				messagesRead: true,
+				moderators: [],
+				repetitive: false,
+				startDate: '2026-03-18',
+				startTime: '10:00',
+				subscribed: true,
+				topic: 'Team Austausch',
+				createdAt: '2026-03-18T06:15:00.000Z'
+			} as unknown as GroupChatItemInterface
+		} as ListItemInterface,
+		''
+	);
+
+// 1. Group, ≤4 members (design shows individual member avatars).
+export const mockGroupSessionSmall = () => ({
+	session: buildGroupSession(),
+	members: makeMembers(4)
+});
+
+// 2. Group, >4 members (design shows a "+N" overflow badge).
+export const mockGroupSessionLarge = () => ({
+	session: buildGroupSession(),
+	members: makeMembers(27)
+});
+
+// 3. Active 1-on-1 (nearby / vicinity, AGENCY_COUNSELLING) → house + add.
+export const mockActiveConversation = () => ({
+	session: buildSingleSession(STATUS_ACTIVE)
+});
+
+// 4. Waiting room (empty enquiry) — design pairs the clock glyph with an add button.
+export const mockWaitingRoomWithAdd = () => ({
+	session: buildSingleSession(STATUS_EMPTY)
+});
+
+// 5. Inquiry (non-empty enquiry) — design pairs the "C" glyph with an add button.
+export const mockInquiryWithAdd = () => ({
+	session: buildSingleSession(STATUS_ENQUIRY)
+});
+
+// 6. Waiting room, no add.
+export const mockWaitingRoom = () => ({
+	session: buildSingleSession(STATUS_EMPTY)
+});
+
+// 7. Inquiry, no add.
+export const mockInquiry = () => ({
+	session: buildSingleSession(STATUS_ENQUIRY)
+});
+
+/* ------------------------------------------------------------------ *
+ * Providers shared by every story
+ * ------------------------------------------------------------------ */
+
+const headerShell: React.CSSProperties = {
+	maxWidth: 720,
+	margin: '0 auto',
+	background: '#fff'
+};
+
+const StoryProviders = ({
+	session,
+	members = [],
+	children
+}: {
+	session: ExtendedSessionInterface;
+	members?: MockMember[];
+	children: React.ReactNode;
+}) => {
+	const matrixClientService = React.useMemo(
+		() => makeMatrixClientService(members),
+		[members]
+	);
+
+	return (
+		<div style={headerShell}>
+			<UserDataContext.Provider
+				value={{
+					userData: storyUserData,
+					setUserData: () => {},
+					reloadUserData: async () => storyUserData
+				}}
+			>
+				<SessionTypeContext.Provider
+					value={{
+						type: SESSION_LIST_TYPES.MY_SESSION,
+						path: '/sessions/consultant/sessionView'
+					}}
+				>
+					<ConsultingTypesContext.Provider
+						value={{
+							consultingTypes: [storyConsultingType],
+							setConsultingTypes: () => {}
+						}}
+					>
+						<TopicsContext.Provider
+							value={{
+								topics: [storyTopic],
+								refreshTopics: () => {}
+							}}
+						>
+							<SessionsDataContext.Provider
+								value={{
+									ready: true,
+									sessions: [],
+									dispatch: () => {}
+								}}
+							>
+								<E2EEContext.Provider
+									value={{
+										key: '',
+										reloadPrivateKey: () => {},
+										isE2eeEnabled: false,
+										e2EEReady: true
+									}}
+								>
+									<ConsultantListContext.Provider
+										value={{
+											consultantList: [],
+											setConsultantList: () => {}
+										}}
+									>
+										<ServerSettingsContext.Provider
+											value={{
+												settings: [],
+												settingsReady: true,
+												getSetting: () => null
+											}}
+										>
+											<MatrixClientContext.Provider
+												value={{
+													matrixClientService,
+													setMatrixClientService:
+														() => {}
+												}}
+											>
+												<ActiveSessionContext.Provider
+													value={{
+														activeSession: session,
+														reloadActiveSession:
+															() => {},
+														readActiveSession:
+															() => {}
+													}}
+												>
+													{children}
+												</ActiveSessionContext.Provider>
+											</MatrixClientContext.Provider>
+										</ServerSettingsContext.Provider>
+									</ConsultantListContext.Provider>
+								</E2EEContext.Provider>
+							</SessionsDataContext.Provider>
+						</TopicsContext.Provider>
+					</ConsultingTypesContext.Provider>
+				</SessionTypeContext.Provider>
+			</UserDataContext.Provider>
+		</div>
+	);
+};
+
+const noopRef = { current: false };
+
+const renderGroupHeader = (preset: {
+	session: ExtendedSessionInterface;
+	members?: MockMember[];
+}) => (
+	<StoryProviders session={preset.session} members={preset.members}>
+		<GroupChatHeader
+			hasUserInitiatedStopOrLeaveRequest={noopRef}
+			isJoinGroupChatView={false}
+			bannedUsers={[]}
+		/>
+	</StoryProviders>
+);
+
+const renderSessionHeader = (
+	preset: {
+		session: ExtendedSessionInterface;
+	},
+	showAddButton?: boolean
+) => (
+	<StoryProviders session={preset.session}>
+		<SessionHeaderComponent
+			bannedUsers={[]}
+			showAddButton={showAddButton}
+		/>
+	</StoryProviders>
+);
+
+// Asserts the "+" add pill is present and rendered to the LEFT of the type
+// glyph (Figma #430 layout order).
+const expectAddButtonLeftOfType = async (canvasElement: HTMLElement) => {
+	await waitFor(() => {
+		const add = canvasElement.querySelector(
+			'.chatroomMainInteractionIcon__add'
+		);
+		const type = canvasElement.querySelector(
+			'.chatroomMainInteractionIcon__type'
+		);
+		expect(add).toBeTruthy();
+		expect(type).toBeTruthy();
+		// eslint-disable-next-line no-bitwise
+		const addIsBeforeType =
+			add!.compareDocumentPosition(type!) &
+			Node.DOCUMENT_POSITION_FOLLOWING;
+		expect(addIsBeforeType).toBeTruthy();
+	});
+};
+
+/* ------------------------------------------------------------------ *
+ * Meta + stories
+ * ------------------------------------------------------------------ */
+
+const meta = {
+	title: 'Components/Session/SessionHeader',
+	tags: ['autodocs'],
+	// The `mock*` factories are exported presets, not stories — keep them out
+	// of the Storybook sidebar.
+	excludeStories: /^mock.*/,
+	parameters: {
+		layout: 'fullscreen',
+		router: {
+			initialPath: '/sessions/consultant/sessionView/session/4401'
+		},
+		design: {
+			type: 'figma',
+			url: APP_ORISO_CHAT_HEADER_FIGMA_URL
+		},
+		docs: {
+			description: {
+				component:
+					'Chatroom left header across the seven Figma conditions. Group stories render `GroupChatHeader`; the 1-on-1 stories render `SessionHeaderComponent`. TODO notes flag where the current implementation diverges from the Figma design.'
+			}
+		}
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Group chat with ≤4 members.
+ * Expected (Figma #430): every member avatar is shown (no cap), no overflow badge.
+ * TODO: keep verifying against Figma until Fix 1 (GroupChatHeader member logic)
+ * is merged — the ≤4 branch now renders all avatars instead of the old 3-cap.
+ */
+export const GroupChatSmall: Story = {
+	render: () => renderGroupHeader(mockGroupSessionSmall())
+};
+
+/**
+ * Group chat with >4 members (27 here).
+ * Expected (Figma #430): no avatars, a single "+N people" count badge instead.
+ */
+export const GroupChatLarge: Story = {
+	render: () => renderGroupHeader(mockGroupSessionLarge()),
+	play: async ({ canvasElement }) => {
+		await waitFor(() => {
+			const badge = canvasElement.querySelector(
+				'.sessionInfo__memberCount'
+			);
+			expect(badge).toBeTruthy();
+			expect(
+				canvasElement.querySelector('.sessionInfo__memberCountNumber')
+					?.textContent
+			).toContain('+27');
+			// No stacked member avatars when the badge is shown.
+			expect(
+				canvasElement.querySelectorAll('.sessionInfo__memberBubble')
+					.length
+			).toBe(0);
+		});
+	}
+};
+
+/**
+ * Active 1-on-1 conversation (nearby / vicinity, AGENCY_COUNSELLING).
+ * Expected (Figma): house icon + add button + single contact avatar. Matches.
+ */
+export const ActiveConversation: Story = {
+	render: () => renderSessionHeader(mockActiveConversation())
+};
+
+/**
+ * Waiting room (empty enquiry) with the add button.
+ * Expected (Figma #430): add button on the LEFT + clock glyph on the RIGHT.
+ * `showAddButton` opts this enquiry state into showing the "+".
+ */
+export const WaitingRoomWithAdd: Story = {
+	render: () => renderSessionHeader(mockWaitingRoomWithAdd(), true),
+	play: async ({ canvasElement }) => {
+		await expectAddButtonLeftOfType(canvasElement);
+		expect(
+			canvasElement.querySelector('.chatroomMainInteractionIcon--waiting')
+		).toBeTruthy();
+	}
+};
+
+/**
+ * Inquiry (non-empty enquiry) with the add button.
+ * Expected (Figma #430): add button on the LEFT + red "C" glyph on the RIGHT.
+ * `showAddButton` opts this enquiry state into showing the "+".
+ */
+export const InquiryWithAdd: Story = {
+	render: () => renderSessionHeader(mockInquiryWithAdd(), true),
+	play: async ({ canvasElement }) => {
+		await expectAddButtonLeftOfType(canvasElement);
+		expect(
+			canvasElement.querySelector('.chatroomMainInteractionIcon--inquiry')
+		).toBeTruthy();
+	}
+};
+
+/**
+ * Waiting room (empty enquiry), no add button.
+ * Expected (Figma): clock glyph, no add button. Matches.
+ */
+export const WaitingRoom: Story = {
+	render: () => renderSessionHeader(mockWaitingRoom())
+};
+
+/**
+ * Inquiry (non-empty enquiry), no add button.
+ * Expected (Figma): red "C" glyph, no add button. Matches.
+ */
+export const Inquiry: Story = {
+	render: () => renderSessionHeader(mockInquiry())
+};

--- a/src/components/sessionHeader/SessionHeaderComponent.tsx
+++ b/src/components/sessionHeader/SessionHeaderComponent.tsx
@@ -88,6 +88,12 @@ export interface SessionHeaderProps {
 	hasUserInitiatedStopOrLeaveRequest?: React.MutableRefObject<boolean>;
 	isJoinGroupChatView?: boolean;
 	bannedUsers: string[];
+	/**
+	 * Controls the header "+" add button. When omitted the button follows the
+	 * legacy behavior (shown only outside enquiry states). Provide an explicit
+	 * value to force the button on/off per state (Figma #430).
+	 */
+	showAddButton?: boolean;
 }
 
 export const SessionHeaderComponent = (props: SessionHeaderProps) => {
@@ -985,7 +991,10 @@ export const SessionHeaderComponent = (props: SessionHeaderProps) => {
 							<div className="sessionInfo__memberStack">
 								<ChatroomMainInteractionIcon
 									type={sessionHeaderConversationIconType}
-									showAddIcon={!activeSession.isEnquiry}
+									showAddIcon={
+										props.showAddButton ??
+										!activeSession.isEnquiry
+									}
 									addLabel={translate(
 										'sessionHeader.supervisor.modal.title',
 										'Supervisor hinzufügen'

--- a/src/components/sessionHeader/sessionHeader.styles.scss
+++ b/src/components/sessionHeader/sessionHeader.styles.scss
@@ -546,6 +546,37 @@ $iconSize: 24px;
 		flex: 0 0 auto;
 	}
 
+	// Figma #430: collapsed "+N people" badge shown for groups with >4 members.
+	&__memberCount {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		height: 32px;
+		padding: 0 12px;
+		margin-left: -10px;
+		border-radius: 20px;
+		background: #ffd1d1;
+		color: var(--m3-primary, $primary);
+		flex: 0 0 auto;
+	}
+
+	&__memberCountNumber {
+		font-size: 14px;
+		font-weight: 600;
+		line-height: 1;
+		white-space: nowrap;
+	}
+
+	&__memberCountIcon {
+		width: 18px;
+		height: 18px;
+		flex: 0 0 auto;
+
+		path {
+			fill: currentColor;
+		}
+	}
+
 	// Video call buttons spacing
 	&__videoCallButtons {
 		display: flex;


### PR DESCRIPTION

## What
Closes #430

Fixes chatroom left header to correctly display all 7 chat type 
conditions per Figma design.

### GroupChatHeader
- **≤4 members** — show all member avatars (previously capped at 3)
- **>4 members** — show "+N 👥" count badge, no avatars 
  (previously showed 3 avatars + text list only)

https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=7608-40761&t=7scG0mpt60RDLUqB-0
### SessionHeaderComponent 
- Added optional `showAddButton` prop to control add button visibility
- **Waiting room + add** — add button now shows on left, clock on right
- **Inquiry + add** — add button now shows on left, red "C" on right
- Existing states unchanged (active conversation, waiting no-add, 
  inquiry no-add)

### Storybook
- 7 stories covering all chatroom header conditions
- Play assertions for GroupChatLarge, WaitingRoomWithAdd, InquiryWithAdd

## Figma references
- ≤4 members: node 7608-40723
- >4 members: node 7608-40761
- Waiting room + add: node 7608-40828
- Inquiry + add: node 7608-41037

## Verification
Tested in app and Storybook:
- ✅ Group ≤4: all avatars visible
- ✅ Group >4: "+N 👥" badge, no avatars
- ✅ Waiting + add: add button left, clock right
- ✅ Inquiry + add: add button left, red "C" right
- ✅ Active conversation: unchanged
- ✅ Waiting no-add: unchanged
- ✅ Inquiry no-add: unchanged

## Notes
- No backend changes
- `showAddButton` prop is optional — defaults to existing behavior 
  when omitted, so no regressions on other usages