### PR TITLE
rescue: reduce production Matrix console logging (dev → pre-dev)

### DIFF
--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -15,3 +15,7 @@ TipTap empty docs are markup like `<p></p>`. Using `!composerText.trim()` for �
 ## 2026-07-12 — Browser shortcut conflicts need capture phase
 
 App handlers for Cmd/Ctrl+F, Cmd/Ctrl+Shift+N, Cmd/Ctrl+K must listen in the capture phase and `preventDefault()` before the browser’s default Find / New Window / etc. Bubble-phase listeners are too late. Also set `activeInTextInput: true` when the action must work with the composer focused.
+
+## 2026-07-08 — matrix-js-sdk production logging
+
+`matrix-js-sdk` defaults child loggers to `DEBUG`, so `FetchHttpApi` sync lines appear even when app `console.log` calls are removed. Call `logger.setLevel('error')` at startup and patch `getChild` so child namespaces inherit the same level; pass `logger` into every `createClient` call.

--- a/src/components/agencyRadioSelect/AgencyRadioSelect.tsx
+++ b/src/components/agencyRadioSelect/AgencyRadioSelect.tsx
@@ -29,10 +29,7 @@ export const AgencyRadioSelect = ({
 	const agencyIdAsString = agency.id.toString();
 
 	return (
-		<div 
-			className="agencyRadioSelect__wrapper"
-			onClick={() => console.log('🟣 Wrapper clicked!', agency.id)}
-		>
+		<div className="agencyRadioSelect__wrapper">
 			{prefix && (
 				<Headline semanticLevel="4" styleLevel="5" text={prefix} />
 			)}
@@ -40,11 +37,10 @@ export const AgencyRadioSelect = ({
 				className={clsx('agencyRadioSelect__radioContainer', {
 					'agencyRadioSelect__radioContainer--withHeadline': !!prefix
 				})}
-				onClick={() => console.log('🟡 RadioContainer clicked!', agency.id)}
 			>
 				<RadioButton
 					name="agencySelection"
-				handleRadioButton={(e) => onChange && onChange(agency)}
+					handleRadioButton={(e) => onChange && onChange(agency)}
 					onKeyDown={(e: KeyboardEvent) => onKeyDown && onKeyDown(e)}
 					type="smaller"
 					value={agencyIdAsString}

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -16,7 +16,7 @@ import { MessageDisplayName } from './MessageDisplayName';
 import { formatToHHMM } from '../../utils/dateHelpers';
 import { markdownToDraft } from 'markdown-draft-js';
 import { stateToHTML } from 'draft-js-export-html';
-import { convertFromRaw, ContentState } from 'draft-js';
+import { convertFromRaw } from 'draft-js';
 import {
 	markdownToDraftDefaultOptions,
 	normalizeHighlightColor,
@@ -861,27 +861,32 @@ export const MessageItemComponent = ({
 			return;
 		}
 
-		const rawMessageObject = markdownToDraft(
-			preparedMessage,
-			markdownToDraftDefaultOptions
-		);
-		const contentStateMessage: ContentState =
-			convertFromRaw(rawMessageObject);
+		try {
+			const rawMessageObject = markdownToDraft(
+				preparedMessage,
+				markdownToDraftDefaultOptions
+			);
+			const contentStateMessage = convertFromRaw(rawMessageObject);
 
-		setRenderedMessage(
-			contentStateMessage.hasText()
-				? sanitizeHtml(
-						renderHighlightTokens(
-							renderImageMarkers(
-								urlifyLinksInText(
-									stateToHTML(contentStateMessage)
+			setRenderedMessage(
+				contentStateMessage.hasText()
+					? sanitizeHtml(
+							renderHighlightTokens(
+								renderImageMarkers(
+									urlifyLinksInText(
+										stateToHTML(contentStateMessage)
+									)
 								)
-							)
-						),
-						sanitizeHtmlDefaultOptions
-					)
-				: ''
-		);
+							),
+							sanitizeHtmlDefaultOptions
+						)
+					: ''
+			);
+		} catch {
+			setRenderedMessage(
+				sanitizeHtml(preparedMessage, sanitizeHtmlDefaultOptions)
+			);
+		}
 		// parsedMessage is memoized on decryptedMessage, so this stays
 		// equivalent to depending on decryptedMessage alone.
 	}, [decryptedMessage, parsedMessage.cleanedMessage]);

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -882,7 +882,13 @@ export const MessageItemComponent = ({
 						)
 					: ''
 			);
-		} catch {
+		} catch (error) {
+			// Markdown parsing failed; fall back to the sanitized raw message.
+			// eslint-disable-next-line no-console
+			console.debug(
+				'Message markdown render failed, using raw text',
+				error
+			);
 			setRenderedMessage(
 				sanitizeHtml(preparedMessage, sanitizeHtmlDefaultOptions)
 			);

--- a/src/components/messageSubmitInterface/richtextHelpers.ts
+++ b/src/components/messageSubmitInterface/richtextHelpers.ts
@@ -105,8 +105,7 @@ export const markdownToDraftDefaultOptions = {
 	remarkablePreset: 'commonmark',
 	remarkableOptions: {
 		html: true,
-		breaks: true,
-		linkify: true
+		breaks: true
 	}
 };
 

--- a/src/components/sessionAssign/RequestSessionAssign.tsx
+++ b/src/components/sessionAssign/RequestSessionAssign.tsx
@@ -174,7 +174,7 @@ export const RequestSessionAssign = (props: { value?: string }) => {
 					.catch((error) => {
 						if (error === FETCH_ERRORS.CONFLICT) {
 							return null;
-						} else console.log(error);
+						}
 					});
 				break;
 			case OVERLAY_FUNCTIONS.REASSIGN:

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -9,6 +9,7 @@ import {
 import { fetchData } from '../../api/fetchData';
 import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { createClient } from 'matrix-js-sdk';
+import { getMatrixClientLogger } from '../../utils/matrixLogging';
 
 vi.mock('../../resources/scripts/endpoints', () => ({
 	endpoints: {
@@ -213,7 +214,8 @@ describe('getMatrixAccessToken', () => {
 			accessToken: 'matrix-token',
 			userId: '@consultant:matrix.example.test',
 			deviceId: 'ORISO_WEB_TEST_DEVICE',
-			fallbackICEServerAllowed: true
+			fallbackICEServerAllowed: true,
+			logger: getMatrixClientLogger()
 		});
 		expect(client).toEqual({
 			config: {
@@ -221,7 +223,8 @@ describe('getMatrixAccessToken', () => {
 				accessToken: 'matrix-token',
 				userId: '@consultant:matrix.example.test',
 				deviceId: 'ORISO_WEB_TEST_DEVICE',
-				fallbackICEServerAllowed: true
+				fallbackICEServerAllowed: true,
+				logger: getMatrixClientLogger()
 			}
 		});
 	});

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -2,6 +2,7 @@ import { createClient, MatrixClient } from 'matrix-js-sdk';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { fetchData, FETCH_ERRORS, FETCH_METHODS } from '../../api/fetchData';
+import { getMatrixClientLogger } from '../../utils/matrixLogging';
 
 export interface MatrixLoginData {
 	accessToken: string;
@@ -178,6 +179,7 @@ export const createMatrixClient = (
 		accessToken: loginData.accessToken,
 		userId: loginData.userId,
 		deviceId: loginData.deviceId,
-		fallbackICEServerAllowed: true
+		fallbackICEServerAllowed: true,
+		logger: getMatrixClientLogger()
 	});
 };

--- a/src/configureMatrixLogging.ts
+++ b/src/configureMatrixLogging.ts
@@ -1,0 +1,3 @@
+import { configureMatrixLogging } from './utils/matrixLogging';
+
+configureMatrixLogging();

--- a/src/initApp.tsx
+++ b/src/initApp.tsx
@@ -1,3 +1,4 @@
+import './configureMatrixLogging';
 import './polyfill';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -8,6 +8,10 @@ import 'element-scroll-polyfill';
 import elementClosest from 'element-closest';
 import * as ReactDOM from 'react-dom';
 
+(
+	globalThis as typeof globalThis & { TONE_SILENCE_LOGGING?: boolean }
+).TONE_SILENCE_LOGGING = true;
+
 elementClosest(window);
 
 // Polyfill for findDOMNode (removed in React 19) for intro.js-react compatibility

--- a/src/resources/scripts/endpoints.test.ts
+++ b/src/resources/scripts/endpoints.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const loadEndpoints = async (env: Record<string, string | undefined> = {}) => {
+const loadEndpoints = async (
+	env: Record<string, string | undefined> = {},
+	nodeEnv: 'development' | 'production' = 'production'
+) => {
 	vi.resetModules();
-	vi.stubEnv('NODE_ENV', 'production');
+	vi.stubEnv('NODE_ENV', nodeEnv);
 	vi.stubEnv('REACT_APP_KEYCLOAK_REALM', 'online-beratung');
 	vi.stubEnv('REACT_APP_API_URL', 'https://api.oriso.org');
 
@@ -59,6 +62,22 @@ describe('endpoints service origins', () => {
 		);
 		expect(endpoints.keycloakAccessToken).toBe(
 			'https://api.oriso.org/auth/realms/online-beratung/protocol/openid-connect/token'
+		);
+	});
+
+	it('uses relative service paths in development to avoid CORS', async () => {
+		const { endpoints } = await loadEndpoints(
+			{
+				REACT_APP_API_URL: 'https://api.oriso-dev.site',
+				REACT_APP_USER_SERVICE_ORIGIN: 'https://api.oriso-dev.site'
+			},
+			'development'
+		);
+
+		expect(endpoints.userData).toBe('/service/users/data');
+		expect(endpoints.serviceSettings).toBe('/service/settings');
+		expect(endpoints.keycloakAccessToken).toBe(
+			'/auth/realms/online-beratung/protocol/openid-connect/token'
 		);
 	});
 });

--- a/src/resources/scripts/runtimeConfig.ts
+++ b/src/resources/scripts/runtimeConfig.ts
@@ -150,8 +150,34 @@ export const getMatrixHomeserverUrl = (): string =>
 export const getRuntimeApiBaseUrl = (): string =>
 	ensureHttps(pickValue('REACT_APP_API_URL', 'VITE_API_URL'));
 
+const isLocalServiceOrigin = (value?: string | null): boolean =>
+	/^(https?:\/\/)?(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(
+		String(value || '').trim()
+	);
+
+/**
+ * In local dev, remote service origins must stay same-origin so webpack-dev-server
+ * can proxy /service and /auth to REACT_APP_DEV_REMOTE_API_URL. Absolute remote
+ * URLs bypass the proxy and trigger browser CORS failures.
+ */
+const resolveServiceOriginForEnvironment = (origin: string): string => {
+	if (!origin) {
+		return '';
+	}
+
+	const nodeEnv =
+		typeof process !== 'undefined' ? process.env.NODE_ENV : undefined;
+	if (nodeEnv === 'development' && !isLocalServiceOrigin(origin)) {
+		return '';
+	}
+
+	return origin;
+};
+
 const getServiceOrigin = (key: string, fallbackOrigin: string): string =>
-	stripTrailingSlashes(ensureHttps(pickValue(key) || fallbackOrigin));
+	resolveServiceOriginForEnvironment(
+		stripTrailingSlashes(ensureHttps(pickValue(key) || fallbackOrigin))
+	);
 
 export const getUserServiceOrigin = (
 	fallbackOrigin = getRuntimeApiBaseUrl()

--- a/src/services/matrixRegistrationService.ts
+++ b/src/services/matrixRegistrationService.ts
@@ -1,5 +1,6 @@
 import { createClient } from 'matrix-js-sdk';
 import { getMatrixHomeserverUrl } from '../resources/scripts/runtimeConfig';
+import { getMatrixClientLogger } from '../utils/matrixLogging';
 
 export interface MatrixRegistrationData {
 	username: string;
@@ -31,7 +32,8 @@ export const registerMatrixUser = async (
 
 		// Create Matrix client
 		const client = createClient({
-			baseUrl: homeserverUrl
+			baseUrl: homeserverUrl,
+			logger: getMatrixClientLogger()
 		});
 
 		// Register user with proper type casting
@@ -99,7 +101,8 @@ export const loginMatrixUser = async (
 
 		// Create Matrix client
 		const client = createClient({
-			baseUrl: homeserverUrl
+			baseUrl: homeserverUrl,
+			logger: getMatrixClientLogger()
 		});
 
 		// Login user

--- a/src/utils/matrixLogging.test.ts
+++ b/src/utils/matrixLogging.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { childSetLevel, rootSetLevel, originalGetChild, mockLogger } =
+	vi.hoisted(() => {
+		const childSetLevel = vi.fn();
+		const rootSetLevel = vi.fn();
+		const originalGetChild = vi.fn(() => ({
+			setLevel: childSetLevel
+		}));
+
+		const mockLogger = {
+			setLevel: rootSetLevel,
+			getChild: originalGetChild
+		};
+
+		return { childSetLevel, rootSetLevel, originalGetChild, mockLogger };
+	});
+
+vi.mock('matrix-js-sdk/lib/logger', () => ({
+	logger: mockLogger
+}));
+
+// eslint-disable-next-line import/first -- must load after vi.mock
+import {
+	configureMatrixLogging,
+	getMatrixClientLogger,
+	resetMatrixLoggingForTests
+} from './matrixLogging';
+
+describe('matrixLogging', () => {
+	beforeEach(() => {
+		resetMatrixLoggingForTests();
+		rootSetLevel.mockClear();
+		childSetLevel.mockClear();
+		originalGetChild.mockClear();
+		mockLogger.getChild = originalGetChild;
+	});
+
+	it('does not change log level when verbose logging is enabled', () => {
+		configureMatrixLogging('true');
+
+		expect(rootSetLevel).not.toHaveBeenCalled();
+	});
+
+	it('sets error log level by default', () => {
+		configureMatrixLogging();
+
+		expect(rootSetLevel).toHaveBeenCalledWith('error');
+	});
+
+	it('sets error log level when verbose logging is disabled', () => {
+		configureMatrixLogging('false');
+
+		expect(rootSetLevel).toHaveBeenCalledWith('error');
+	});
+
+	it('keeps child loggers at error level in production', () => {
+		configureMatrixLogging();
+
+		const child = getMatrixClientLogger().getChild('sync');
+
+		expect(originalGetChild).toHaveBeenCalledWith('sync');
+		expect(childSetLevel).toHaveBeenCalledWith('error');
+		expect(child).toBeDefined();
+	});
+
+	it('runs configuration only once', () => {
+		configureMatrixLogging();
+		configureMatrixLogging();
+
+		expect(rootSetLevel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/matrixLogging.ts
+++ b/src/utils/matrixLogging.ts
@@ -1,0 +1,68 @@
+import type { Logger } from 'matrix-js-sdk/lib/logger';
+import { logger } from 'matrix-js-sdk/lib/logger';
+
+type MatrixLogger = typeof logger;
+
+type LogLevelDesc = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+type LevelSettableLogger = Logger & {
+	setLevel(level: LogLevelDesc, persist?: boolean): void;
+};
+
+const isLevelSettable = (target: Logger): target is LevelSettableLogger =>
+	typeof (target as LevelSettableLogger).setLevel === 'function';
+
+const setLoggerLevel = (target: Logger, level: LogLevelDesc): void => {
+	if (isLevelSettable(target)) {
+		target.setLevel(level);
+	}
+};
+
+const PRODUCTION_LOG_LEVEL: LogLevelDesc = 'error';
+
+let configured = false;
+
+const isMatrixVerboseLoggingEnabled = (
+	verboseLogging: string | undefined = process.env
+		.REACT_APP_MATRIX_VERBOSE_LOGGING
+): boolean => verboseLogging === 'true';
+
+const applyProductionLogLevel = (rootLogger: MatrixLogger): void => {
+	setLoggerLevel(rootLogger, PRODUCTION_LOG_LEVEL);
+
+	const originalGetChild = rootLogger.getChild?.bind(rootLogger);
+	if (!originalGetChild) {
+		return;
+	}
+
+	rootLogger.getChild = (namespace: string) => {
+		const child = originalGetChild(namespace);
+		setLoggerLevel(child, PRODUCTION_LOG_LEVEL);
+		return child;
+	};
+};
+
+/**
+ * Suppresses verbose matrix-js-sdk logging (e.g. FetchHttpApi sync traffic).
+ * Set REACT_APP_MATRIX_VERBOSE_LOGGING=true to keep SDK debug output.
+ * Safe to call multiple times; runs once.
+ */
+export const configureMatrixLogging = (
+	verboseLogging: string | undefined = process.env
+		.REACT_APP_MATRIX_VERBOSE_LOGGING
+): void => {
+	if (configured || isMatrixVerboseLoggingEnabled(verboseLogging)) {
+		return;
+	}
+
+	configured = true;
+	applyProductionLogLevel(logger);
+};
+
+/** Logger instance passed to Matrix client construction. */
+export const getMatrixClientLogger = (): MatrixLogger => logger;
+
+/** @internal test helper */
+export const resetMatrixLoggingForTests = (): void => {
+	configured = false;
+};


### PR DESCRIPTION
## rescue

Moves a feature that had landed **directly on `dev`** over to **`pre-dev`**, where it was still missing (per the team policy that features go through `pre-dev`).

### What this is
The Matrix production-logging fix (originally PR #397, commit `5b539e1` by Nikunj Rohit): `matrix-js-sdk` child loggers default to `DEBUG`, so `FetchHttpApi` sync lines flood the production console even after app `console.log` calls are removed. This sets the SDK logger to `error` at startup and makes child namespaces inherit that level.

### Assessment (dev vs. pre-dev)
Comparing `dev` and `pre-dev`, only **one** real feature was unique to `dev` — this one (`src/utils/matrixLogging.ts` did not exist on `pre-dev`). The other two `dev`-only commits were merge commits, and `pre-dev` is otherwise ahead of `dev` (18 commits). This PR is that single rescued feature.

### ⚠️ Bundled scope (heads-up per review)
The rescued commit `5b539e1` (PR #397) is **one commit that bundles several changes** beyond logging. Kept intact here to preserve a faithful rescue rather than re-splitting a colleague's merged commit. What's inside:
- **Matrix logging** (the headline change): `matrixLogging.ts`, `configureMatrixLogging.ts`, `getMatrixAccessToken.ts`, `matrixRegistrationService.ts`, `initApp.tsx`, `polyfill.ts`.
- **Service-origin / dev CORS** (`runtimeConfig.ts` → `resolveServiceOriginForEnvironment`): forces non-local service origins to relative `''` in `NODE_ENV=development`. Dev-only; prod unaffected. (See reply thread — this matches `getApiBaseUrl.ts`'s existing behavior.)
- **Message-render fallback** (`MessageItemComponent.tsx`): `try/catch` around markdown render; now logs at `debug` before falling back to sanitized raw text.
- **`linkify` removal** (`richtextHelpers.ts`): bare-URL linkification is still handled downstream by `urlifyLinksInText` (see reply thread).

### Changes
- `src/utils/matrixLogging.ts` (+ test), `src/configureMatrixLogging.ts`, `src/resources/scripts/runtimeConfig.ts`, `src/polyfill.ts`, `src/initApp.tsx`
- `src/components/message/MessageItemComponent.tsx`, `src/components/sessionCookie/getMatrixAccessToken.ts` (+ test), `src/services/matrixRegistrationService.ts`, and related
- 15 files. Original author preserved via cherry-pick; one follow-up commit adds the debug log in the fallback catch (review feedback).

### How it was rescued
Cherry-picked `5b539e1` onto `pre-dev`. Only trivial conflicts in `.gitignore` (kept the `*.pem` superset) and `.learnings/LEARNINGS.md` (union — kept both sets of notes); all source files auto-merged.

### Testing
`vitest run` on the affected tests — **17 passed** (`matrixLogging.test.ts`, `endpoints.test.ts`, `getMatrixAccessToken.test.ts`).

> Note: the logging code is unchanged from the already-reviewed & merged PR #397, re-homed onto `pre-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)