### PR TITLE
rescue: add-to-calendar ICS helper (→ pre-dev)

### DIFF
--- a/src/components/downloadICSFile/downloadICSFile.tsx
+++ b/src/components/downloadICSFile/downloadICSFile.tsx
@@ -1,62 +1,34 @@
 import * as React from 'react';
 import { Text } from '../text/Text';
 import { ReactComponent as CalendarICSIcon } from '../../resources/img/icons/calendar-ics.svg';
-import { addMissingZero } from '../../utils/dateHelpers';
 import './downloadICSFile.styles';
 import { useTranslation } from 'react-i18next';
+import { buildAppointmentIcs } from '../../utils/appointmentIcs';
+import { downloadICSFile } from '../../utils/downloadICSFile';
 
 export interface AppointmentInfoICS {
-	date: string;
-	duration: string;
+	/** Start as ISO-8601 string, epoch millis or Date. */
+	start: string | number | Date;
+	/** End of the appointment; alternative to `durationMinutes`. */
+	end?: string | number | Date;
+	/** Length in minutes; alternative to `end`. */
+	durationMinutes?: number;
 	title: string;
+	description?: string;
+	location?: string;
+	/** Stable id (e.g. the booking uid) so re-exports update the same event. */
+	uid?: string;
 }
 
-const downloadICSFile = (filename: string, icsMSG: string) => {
-	const link = document.createElement('a');
-	link.download = `${filename}.ics`;
-	link.href = `data:text/calendar;",${escape(icsMSG)}`;
-	document.body.appendChild(link);
-	link.click();
-	document.body.removeChild(link);
-};
-
 const handleICSAppointment = (appointmentInfo: AppointmentInfoICS) => {
-	const date = appointmentInfo.date.split(' ')[1];
-	const [day, month, year] = date.split('.');
-	const [startHour, , endHour] = appointmentInfo.duration.split(' ');
-	const timeStart = new Date('01/01/2007 ' + startHour);
-	const timeEnd = new Date('01/01/2007 ' + endHour);
-	const duration = appointmentInfo.duration.split('-').length
-		? appointmentInfo.duration
-		: (Math.abs(timeEnd.getTime() - timeStart.getTime()) / (1000 * 60)) %
-			60;
-
-	const icsMSG =
-		'BEGIN:VCALENDAR\n' +
-		'VERSION:2.0\n' +
-		'CALSCALE:GREGORIAN\n' +
-		'PRODID:adamgibbons/ics\n' +
-		'METHOD:PUBLISH\n' +
-		'X-PUBLISHED-TTL:PT1H\n' +
-		'BEGIN:VEVENT\n' +
-		'SUMMARY:' +
-		appointmentInfo.title +
-		'\n' +
-		'DTSTART:' +
-		'20' +
-		addMissingZero(parseInt(year)) +
-		addMissingZero(parseInt(month)) +
-		day +
-		'T' +
-		startHour.replace(':', '') +
-		'00\n' +
-		'DURATION:PT' +
-		duration +
-		'M\n' +
-		'END:VEVENT\n' +
-		'END:VCALENDAR\n';
-
-	downloadICSFile(appointmentInfo.title, icsMSG);
+	try {
+		const ics = buildAppointmentIcs(appointmentInfo);
+		downloadICSFile(appointmentInfo.title || 'appointment', ics);
+	} catch (error) {
+		// Never let a malformed appointment crash the surrounding message/list.
+		// eslint-disable-next-line no-console
+		console.error('Could not create calendar file', error);
+	}
 };
 
 export const DownloadICSFile = (params: AppointmentInfoICS) => {
@@ -64,7 +36,7 @@ export const DownloadICSFile = (params: AppointmentInfoICS) => {
 	return (
 		<div
 			className="downloadICSFile--flex"
-			onClick={handleICSAppointment.bind(this, params)}
+			onClick={() => handleICSAppointment(params)}
 		>
 			<CalendarICSIcon className="downloadICSFile__icon" />
 			<Text

--- a/src/components/message/Appointment.tsx
+++ b/src/components/message/Appointment.tsx
@@ -155,9 +155,11 @@ export const Appointment = (param: {
 				)}
 				{showAddToCalendarComponent && (
 					<DownloadICSFile
-						date={appointmentDate}
-						duration={appointmentHours}
+						start={parsedData.date}
+						durationMinutes={duration}
 						title={parsedData.title}
+						description={parsedData.note}
+						location={parsedData.location}
 					/>
 				)}
 			</div>

--- a/src/containers/bookings/components/Event/event.tsx
+++ b/src/containers/bookings/components/Event/event.tsx
@@ -82,11 +82,13 @@ export const Event: React.FC<EventProps> = ({ event, bookingStatus }) => {
 	};
 
 	const handleRescheduleAppointment = (event: BookingEventUiInterface) => {
-		navigate('/booking/reschedule', { state: {
+		navigate('/booking/reschedule', {
+			state: {
 				rescheduleLink: event.rescheduleLink,
 				bookingId: event.id,
 				askerId: event.askerId
-			} });
+			}
+		});
 	};
 
 	const handleVideoLink = (videoAppointmentId: string) => {
@@ -132,9 +134,11 @@ export const Event: React.FC<EventProps> = ({ event, bookingStatus }) => {
 					{activeBookings && (
 						<div className="bookingEvents__ics--mobile bookingEvents--flex bookingEvents--pointer">
 							<DownloadICSFile
-								date={event.date}
-								duration={event.duration}
+								start={event.startTime}
+								end={event.endTime}
 								title={event.title}
+								description={event.description}
+								uid={event.uid}
 							/>
 						</div>
 					)}
@@ -189,9 +193,11 @@ export const Event: React.FC<EventProps> = ({ event, bookingStatus }) => {
 				{activeBookings && (
 					<div className="bookingEvents__ics bookingEvents--flex bookingEvents--pointer">
 						<DownloadICSFile
-							date={event.date}
-							duration={event.duration}
+							start={event.startTime}
+							end={event.endTime}
 							title={event.title}
+							description={event.description}
+							uid={event.uid}
 						/>
 					</div>
 				)}

--- a/src/globalState/interfaces/BookingsInterface.ts
+++ b/src/globalState/interfaces/BookingsInterface.ts
@@ -27,6 +27,9 @@ export interface BookingEventUiInterface {
 	uid: string;
 	date: string;
 	duration: string;
+	/** Raw ISO-8601 start/end kept for calendar export (`.ics`). */
+	startTime: string;
+	endTime: string;
 	location:
 		| 'CHAT'
 		| 'PHONE_CALL'

--- a/src/utils/appointmentIcs.test.ts
+++ b/src/utils/appointmentIcs.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { buildAppointmentIcs } from './appointmentIcs';
+
+// A fixed reference instant so DTSTART/DTEND/DTSTAMP are deterministic
+// regardless of the machine timezone the tests run in.
+const START_ISO = '2026-07-12T09:30:00Z';
+const STAMP = new Date('2026-07-01T00:00:00Z');
+
+const baseInput = {
+	start: START_ISO,
+	durationMinutes: 60,
+	title: 'Beratungstermin',
+	uid: 'evt-1@oriso',
+	dtstamp: STAMP
+};
+
+// Per RFC 5545 lines are separated by CRLF.
+const lines = (ics: string) => ics.split('\r\n');
+
+describe('buildAppointmentIcs', () => {
+	describe('envelope', () => {
+		it('starts with BEGIN:VCALENDAR and ends with END:VCALENDAR', () => {
+			const ics = buildAppointmentIcs(baseInput);
+			const l = lines(ics).filter(Boolean);
+			expect(l[0]).toBe('BEGIN:VCALENDAR');
+			expect(l[l.length - 1]).toBe('END:VCALENDAR');
+		});
+
+		it('declares iCalendar VERSION 2.0', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain('VERSION:2.0');
+		});
+
+		it('contains exactly one VEVENT block', () => {
+			const ics = buildAppointmentIcs(baseInput);
+			expect(ics.match(/BEGIN:VEVENT/g)).toHaveLength(1);
+			expect(ics.match(/END:VEVENT/g)).toHaveLength(1);
+		});
+
+		it('uses CRLF line endings', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain('\r\n');
+		});
+
+		it('carries a PRODID line', () => {
+			expect(buildAppointmentIcs(baseInput)).toMatch(/\r\nPRODID:.+/);
+		});
+
+		it('honours a custom PRODID', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				prodId: '-//Acme//Cal//EN'
+			});
+			expect(ics).toContain('PRODID:-//Acme//Cal//EN');
+		});
+	});
+
+	describe('timestamps', () => {
+		it('formats DTSTART as UTC basic format with trailing Z', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain(
+				'DTSTART:20260712T093000Z'
+			);
+		});
+
+		it('derives DTEND from durationMinutes', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain(
+				'DTEND:20260712T103000Z'
+			);
+		});
+
+		it('uses an explicit end over durationMinutes when both given', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				end: '2026-07-12T11:00:00Z'
+			});
+			expect(ics).toContain('DTEND:20260712T110000Z');
+		});
+
+		it('formats DTSTAMP from the injected stamp', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain(
+				'DTSTAMP:20260701T000000Z'
+			);
+		});
+
+		it('accepts a Date instance for start', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				start: new Date(START_ISO)
+			});
+			expect(ics).toContain('DTSTART:20260712T093000Z');
+		});
+
+		it('accepts an epoch-millis number for start', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				start: new Date(START_ISO).getTime()
+			});
+			expect(ics).toContain('DTSTART:20260712T093000Z');
+		});
+	});
+
+	describe('content fields', () => {
+		it('renders the title as SUMMARY', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain(
+				'SUMMARY:Beratungstermin'
+			);
+		});
+
+		it('omits DESCRIPTION when no description is given', () => {
+			expect(buildAppointmentIcs(baseInput)).not.toContain(
+				'DESCRIPTION:'
+			);
+		});
+
+		it('renders DESCRIPTION when provided', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				description: 'Bitte puenktlich sein'
+			});
+			expect(ics).toContain('DESCRIPTION:Bitte puenktlich sein');
+		});
+
+		it('omits LOCATION when no location is given', () => {
+			expect(buildAppointmentIcs(baseInput)).not.toContain('LOCATION:');
+		});
+
+		it('renders LOCATION when provided', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				location: 'Videocall'
+			});
+			expect(ics).toContain('LOCATION:Videocall');
+		});
+	});
+
+	describe('uid', () => {
+		it('uses the provided uid', () => {
+			expect(buildAppointmentIcs(baseInput)).toContain('UID:evt-1@oriso');
+		});
+
+		it('generates a uid when none is provided', () => {
+			const { uid, ...rest } = baseInput;
+			const ics = buildAppointmentIcs(rest);
+			const uidLine = lines(ics).find((l) => l.startsWith('UID:'));
+			expect(uidLine).toBeTruthy();
+			expect(uidLine).toContain('@');
+		});
+
+		it('generates a stable uid for identical input', () => {
+			const { uid, ...rest } = baseInput;
+			expect(buildAppointmentIcs(rest)).toBe(buildAppointmentIcs(rest));
+		});
+	});
+
+	describe('text escaping (RFC 5545 3.3.11)', () => {
+		it('escapes comma, semicolon and backslash', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				title: 'A, B; C \\ D'
+			});
+			expect(ics).toContain('SUMMARY:A\\, B\\; C \\\\ D');
+		});
+
+		it('escapes newlines as \\n', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				description: 'line1\nline2'
+			});
+			expect(ics).toContain('DESCRIPTION:line1\\nline2');
+		});
+
+		it('does not escape colons in text', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				title: 'Termin: heute'
+			});
+			expect(ics).toContain('SUMMARY:Termin: heute');
+		});
+	});
+
+	describe('line folding', () => {
+		it('folds content lines longer than 75 octets', () => {
+			const ics = buildAppointmentIcs({
+				...baseInput,
+				description: 'x'.repeat(200)
+			});
+			for (const line of lines(ics)) {
+				// folded continuation lines start with a single space
+				expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(75);
+			}
+			// a continuation line must exist
+			expect(ics).toMatch(/\r\n /);
+		});
+	});
+
+	describe('validation', () => {
+		it('throws on an unparseable start', () => {
+			expect(() =>
+				buildAppointmentIcs({ ...baseInput, start: 'not-a-date' })
+			).toThrow();
+		});
+
+		it('throws when neither end nor durationMinutes is given', () => {
+			const { durationMinutes, ...rest } = baseInput;
+			expect(() => buildAppointmentIcs(rest)).toThrow();
+		});
+
+		it('throws when end is not after start', () => {
+			expect(() =>
+				buildAppointmentIcs({
+					...baseInput,
+					durationMinutes: undefined,
+					end: START_ISO
+				})
+			).toThrow();
+		});
+
+		it('throws on a non-positive durationMinutes', () => {
+			expect(() =>
+				buildAppointmentIcs({ ...baseInput, durationMinutes: 0 })
+			).toThrow();
+		});
+
+		it('throws on a missing title', () => {
+			expect(() =>
+				buildAppointmentIcs({ ...baseInput, title: '' })
+			).toThrow();
+		});
+	});
+});

--- a/src/utils/appointmentIcs.ts
+++ b/src/utils/appointmentIcs.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure helper that turns appointment data into a valid iCalendar (`.ics`)
+ * document (RFC 5545). It is intentionally free of DOM/framework imports so it
+ * can be unit tested in isolation — the browser download lives in
+ * `downloadICSFile`.
+ *
+ * The previous implementation parsed already-formatted, locale-dependent
+ * display strings and produced an invalid `VEVENT` (missing UID/DTSTAMP,
+ * broken DURATION, unescaped text). This helper takes raw timestamps instead.
+ */
+
+export interface AppointmentIcsInput {
+	/** Event start as a Date, ISO-8601 string or epoch milliseconds. */
+	start: Date | string | number;
+	/** Event end. Takes precedence over `durationMinutes` when both are set. */
+	end?: Date | string | number;
+	/** Alternative to `end`: length of the appointment in minutes. */
+	durationMinutes?: number;
+	/** Human-readable title, rendered as SUMMARY. */
+	title: string;
+	/** Optional longer note, rendered as DESCRIPTION. */
+	description?: string;
+	/** Optional location, rendered as LOCATION. */
+	location?: string;
+	/** Stable unique id. Generated deterministically when omitted. */
+	uid?: string;
+	/** Creation timestamp (DTSTAMP). Defaults to "now". */
+	dtstamp?: Date;
+	/** Product identifier line. */
+	prodId?: string;
+}
+
+const DEFAULT_PROD_ID = '-//ORISO//Appointment//EN';
+const MS_PER_MINUTE = 60 * 1000;
+const MAX_LINE_OCTETS = 75;
+
+const toDate = (value: Date | string | number, label: string): Date => {
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		throw new RangeError(`Invalid ${label}: ${String(value)}`);
+	}
+	return date;
+};
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+
+/** Format a Date as an iCalendar UTC date-time: `YYYYMMDDTHHMMSSZ`. */
+const formatUtc = (date: Date): string =>
+	`${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(
+		date.getUTCDate()
+	)}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(
+		date.getUTCSeconds()
+	)}Z`;
+
+/** Escape a TEXT value per RFC 5545 §3.3.11 (backslash first). */
+const escapeText = (value: string): string =>
+	value
+		.replace(/\\/g, '\\\\')
+		.replace(/;/g, '\\;')
+		.replace(/,/g, '\\,')
+		.replace(/\r\n|\r|\n/g, '\\n');
+
+/** Fold a single content line to <= 75 octets using CRLF + space (§3.1). */
+const foldLine = (line: string): string => {
+	const encoder = new TextEncoder();
+	let out = '';
+	let current = '';
+	let currentOctets = 0;
+	for (const char of line) {
+		const charOctets = encoder.encode(char).length;
+		// Continuation lines carry a leading space that counts toward the limit.
+		const limit = out === '' ? MAX_LINE_OCTETS : MAX_LINE_OCTETS - 1;
+		if (currentOctets + charOctets > limit) {
+			out += (out === '' ? '' : '\r\n ') + current;
+			current = char;
+			currentOctets = charOctets;
+		} else {
+			current += char;
+			currentOctets += charOctets;
+		}
+	}
+	out += (out === '' ? '' : '\r\n ') + current;
+	return out;
+};
+
+/** Deterministic, dependency-free uid so repeated exports stay stable. */
+const generateUid = (start: Date, title: string): string => {
+	let hash = 0;
+	for (let i = 0; i < title.length; i++) {
+		hash = (hash * 31 + title.charCodeAt(i)) | 0;
+	}
+	return `${start.getTime()}-${(hash >>> 0).toString(36)}@oriso.org`;
+};
+
+export const buildAppointmentIcs = (input: AppointmentIcsInput): string => {
+	const title = input.title?.trim();
+	if (!title) {
+		throw new Error('buildAppointmentIcs: title is required');
+	}
+
+	const start = toDate(input.start, 'start');
+
+	let end: Date;
+	if (input.end !== undefined && input.end !== null) {
+		end = toDate(input.end, 'end');
+	} else if (input.durationMinutes !== undefined) {
+		if (!(input.durationMinutes > 0)) {
+			throw new Error(
+				'buildAppointmentIcs: durationMinutes must be positive'
+			);
+		}
+		end = new Date(start.getTime() + input.durationMinutes * MS_PER_MINUTE);
+	} else {
+		throw new Error(
+			'buildAppointmentIcs: either end or durationMinutes is required'
+		);
+	}
+
+	if (end.getTime() <= start.getTime()) {
+		throw new Error('buildAppointmentIcs: end must be after start');
+	}
+
+	const dtstamp = input.dtstamp ?? new Date();
+	const uid = input.uid ?? generateUid(start, title);
+
+	const lines: string[] = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		`PRODID:${input.prodId ?? DEFAULT_PROD_ID}`,
+		'CALSCALE:GREGORIAN',
+		'METHOD:PUBLISH',
+		'BEGIN:VEVENT',
+		`UID:${uid}`,
+		`DTSTAMP:${formatUtc(dtstamp)}`,
+		`DTSTART:${formatUtc(start)}`,
+		`DTEND:${formatUtc(end)}`,
+		`SUMMARY:${escapeText(title)}`
+	];
+
+	if (input.description) {
+		lines.push(`DESCRIPTION:${escapeText(input.description)}`);
+	}
+	if (input.location) {
+		lines.push(`LOCATION:${escapeText(input.location)}`);
+	}
+
+	lines.push('END:VEVENT', 'END:VCALENDAR');
+
+	return lines.map(foldLine).join('\r\n') + '\r\n';
+};

--- a/src/utils/downloadICSFile.ts
+++ b/src/utils/downloadICSFile.ts
@@ -1,8 +1,25 @@
+/**
+ * Trigger a browser download of an already-built iCalendar document.
+ *
+ * Kept separate from `buildAppointmentIcs` so the ICS generation stays pure and
+ * unit-testable while this thin helper owns the DOM side effect.
+ */
 export const downloadICSFile = (filename: string, icsMSG: string) => {
+	// Sanitize the filename so slashes / illegal characters can't break the
+	// download (the title is user-facing text).
+	const safeName =
+		filename.replace(/[^\p{L}\p{N}\-_ ]+/gu, '_').trim() || 'appointment';
+
+	const blob = new Blob([icsMSG], { type: 'text/calendar;charset=utf-8' });
+	const url = URL.createObjectURL(blob);
+
 	const link = document.createElement('a');
-	link.download = `${filename}.ics`;
-	link.href = `data:text/calendar;",${escape(icsMSG)}`;
+	link.download = `${safeName}.ics`;
+	link.href = url;
 	document.body.appendChild(link);
 	link.click();
 	document.body.removeChild(link);
+
+	// Release the object URL on the next tick so the click has been handled.
+	setTimeout(() => URL.revokeObjectURL(url), 0);
 };

--- a/src/utils/transformBookingData.ts
+++ b/src/utils/transformBookingData.ts
@@ -32,6 +32,8 @@ export const transformBookingData = (bookings: BookingEventsInterface[]) => {
 		bookingEvents.push({
 			id: event.id,
 			date,
+			startTime: event.startTime,
+			endTime: event.endTime,
 			title: event.title,
 			duration,
 			location: event.location,


### PR DESCRIPTION
## rescue

Lands the "Add to calendar" rework on **`pre-dev`** (the work was previously started on a `main`-based branch; this is a clean, single-commit re-home onto `pre-dev`).

### Problem
The existing "Add to calendar" action produced **invalid iCalendar**: it parsed already-formatted, locale-dependent display strings (`"14:00 - 15:00"`), emitted a `VEVENT` with no `UID`/`DTSTAMP`, a broken `DURATION`, unescaped text, and a malformed `data:` URI built with the deprecated `escape()`.

### Changes
- **`src/utils/appointmentIcs.ts`** — new pure `buildAppointmentIcs()`: RFC 5545 output from raw timestamps (`Date`/ISO/epoch) — `UID`, `DTSTAMP`, UTC `DTSTART`/`DTEND`, text escaping (§3.3.11), 75-octet line folding. No DOM/framework imports → unit-testable.
- **`src/utils/downloadICSFile.ts`** — `Blob` download + `charset=utf-8` + filename sanitization (drops `escape()` and the malformed `data:` URI).
- **`DownloadICSFile`** — structured props, delegates to the helper; string parsing removed.
- **`transformBookingData` / `BookingEventUiInterface`** — carry raw `startTime`/`endTime` so the bookings entry point exports real timestamps instead of re-parsed display strings.

### Testing
- **29 unit tests** in `src/utils/appointmentIcs.test.ts` (pre-dev's vitest) — envelope, UTC timestamps, duration vs. explicit end, escaping, folding, uid generation, validation. **All green.**
- `tsc --noEmit` passes project-wide.

> Uses `pre-dev`'s existing vitest setup (`vitest.config.mts`, `*.test.ts` naming); no duplicate config or dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrURMWRMXa1oyRZcoTzgtg)_