### PR TITLE
OBS-P3: report client errors to SigNoz via new endpoint

### DIFF
--- a/src/api/apiPostError.test.ts
+++ b/src/api/apiPostError.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	apiPostError,
+	ERROR_LEVEL_ERROR,
+	ERROR_LEVEL_FATAL,
+	ERROR_LEVEL_WARN
+} from './apiPostError';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		error: 'https://users.oriso-dev.site/service/error-reports'
+	}
+}));
+
+describe('apiPostError', () => {
+	it('posts a frontend error report to the UserService error-reports endpoint', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 202 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const error = {
+			name: 'TypeError',
+			message: 'Cannot read properties of undefined',
+			stack: 'TypeError: ...\n  at Component.render',
+			level: ERROR_LEVEL_FATAL,
+			url: 'https://app.oriso-dev.site/chat',
+			headers: { 'User-Agent': 'test-agent' }
+		} as Parameters<typeof apiPostError>[0];
+
+		await expect(apiPostError(error, undefined, 'corr-1')).resolves.toEqual(
+			{}
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://users.oriso-dev.site/service/error-reports',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					source: 'frontend',
+					message: 'Cannot read properties of undefined',
+					stack: 'TypeError: ...\n  at Component.render',
+					url: 'https://app.oriso-dev.site/chat',
+					userAgent: 'test-agent',
+					correlationId: 'corr-1',
+					severity: 'error'
+				})
+			}
+		);
+	});
+
+	it('maps a WARN-level error to severity warn', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response(null, { status: 202 }))
+		);
+
+		const error = {
+			name: 'Warning',
+			message: 'a recoverable hiccup',
+			level: ERROR_LEVEL_WARN,
+			url: 'https://app.oriso-dev.site/'
+		} as Parameters<typeof apiPostError>[0];
+
+		const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+
+		await apiPostError(error);
+
+		const [, options] = fetchMock.mock.calls[0];
+		expect(JSON.parse(options.body).severity).toBe('warn');
+	});
+
+	it('never rejects when the network call fails', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockRejectedValue(new Error('network down'))
+		);
+
+		const error = {
+			name: 'Error',
+			message: 'boom',
+			level: ERROR_LEVEL_ERROR,
+			url: 'https://app.oriso-dev.site/'
+		} as Parameters<typeof apiPostError>[0];
+
+		await expect(apiPostError(error)).resolves.toEqual({});
+	});
+
+	it('falls back to a placeholder message when the error has none', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response(null, { status: 202 }))
+		);
+		const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+
+		await apiPostError({} as Parameters<typeof apiPostError>[0]);
+
+		const [, options] = fetchMock.mock.calls[0];
+		const body = JSON.parse(options.body);
+		expect(body.message).toBe('Unknown frontend error');
+		expect(body.source).toBe('frontend');
+	});
+});

--- a/src/api/apiPostError.ts
+++ b/src/api/apiPostError.ts
@@ -1,4 +1,5 @@
 import { ErrorInfo } from 'react';
+import { endpoints } from '../resources/scripts/endpoints';
 
 export interface ErrorResponse {}
 
@@ -28,21 +29,66 @@ export type TError = Error & {
 };
 
 export type ErrorRequestBody = {
-	request: {
-		correlationId: string;
-		timestamp: string;
-	};
-	serviceName: string;
-	error: TError;
-	info?: ErrorInfo;
+	source: 'frontend';
+	message: string;
+	stack?: string;
+	url: string;
+	userAgent?: string;
+	correlationId?: string;
+	severity: 'error' | 'warn';
 };
 
-// For the Matrix integration errors are no longer posted to logstash; this
-// stub keeps the call sites working and simply resolves.
+const WARN_LEVELS: ReadonlyArray<TError['level']> = [
+	ERROR_LEVEL_WARN,
+	ERROR_LEVEL_INFO,
+	ERROR_LEVEL_DEBUG,
+	ERROR_LEVEL_TRACE
+];
+
+const severityFor = (level?: TError['level']): 'error' | 'warn' =>
+	level && WARN_LEVELS.includes(level) ? 'warn' : 'error';
+
+const currentUrl = (fallback?: string): string =>
+	fallback || (typeof window !== 'undefined' && window.location?.href) || '';
+
+const currentUserAgent = (headers?: TErrorHeaders): string | undefined =>
+	headers?.['User-Agent'] ||
+	(typeof navigator !== 'undefined' ? navigator.userAgent : undefined);
+
+/**
+ * Best-effort, fire-and-forget client error report (OBS-P3, ORISO-Helm#62).
+ *
+ * Replaces the dead `/service/logstash` intake: errors are now sent to
+ * UserService's unauthenticated `/error-reports` endpoint, which logs them
+ * through its existing structured logger for SigNoz to pick up. This must
+ * never throw or reject -- a failure to *report* an error must not itself
+ * become a new error that blocks the UI or the caller's error-handling flow.
+ */
 export const apiPostError = async (
 	error: TError,
 	info?: ErrorInfo,
 	correlationId?: string
 ): Promise<ErrorResponse> => {
-	return Promise.resolve({});
+	try {
+		const body: ErrorRequestBody = {
+			source: 'frontend',
+			message: error?.message || error?.name || 'Unknown frontend error',
+			stack: error?.stack || info?.componentStack || undefined,
+			url: currentUrl(error?.url),
+			userAgent: currentUserAgent(error?.headers),
+			correlationId,
+			severity: severityFor(error?.level)
+		};
+
+		await fetch(endpoints.error, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body)
+		});
+	} catch (e) {
+		// Swallow network/reporting failures -- this is telemetry, not a
+		// critical path, and must never surface as a new error.
+	}
+
+	return {};
 };

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -80,7 +80,9 @@ export const endpoints = {
 	draftMessages: userServiceOrigin + '/service/messages/draft',
 	userDrafts: userServiceOrigin + '/service/users/drafts',
 	email: userServiceOrigin + '/service/users/email',
-	error: apiUrl + '/service/logstash',
+	// logstash intake was retired; client crash reports now go to UserService's
+	// OBS-P3 error-intake endpoint, which logs them into SigNoz (ORISO-Helm#62).
+	error: userServiceOrigin + '/service/error-reports',
 	groupChatBase: userServiceOrigin + '/service/users/chat/',
 	chatSeriesBase: userServiceOrigin + '/service/users/chat-series/',
 	keycloakAccessToken:


### PR DESCRIPTION
## Summary
- `apiPostError()` used to POST to `/service/logstash`. That endpoint has been dead for a while — the call site was already stubbed out to a no-op `Promise.resolve()` (see the comment it replaces). Repoints it at UserService's new OBS-P3 unauthenticated error-intake endpoint (`/service/error-reports`, via `userServiceOrigin`) so `ErrorBoundary`, `MessageSubmitErrorBoundary`, and the session-decryption-error reporter in `SessionItemComponent` actually reach SigNoz again.
- Kept fire-and-forget by design: the `fetch` call is wrapped in try/catch and `apiPostError` never rejects, so a reporting failure cannot itself surface as a new error and block the UI or interfere with callers that already depend on it resolving (`redirectToErrorPage`'s `.finally()`, the `Promise.all()` over decryption errors in `SessionItemComponent`).
- No call sites needed changes — they already build the same `TError` shape; only `apiPostError.ts` (transport) and `endpoints.ts` (target URL) changed.

## Test plan
- [x] New `src/api/apiPostError.test.ts`: posts the expected `{ source: 'frontend', message, stack, url, userAgent, correlationId, severity }` body, maps `WARN`-family levels to `severity: 'warn'`, never rejects when the network call fails, falls back to a placeholder message when the error has none.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` on changed files clean (`--max-warnings=0`).
- [x] Full `vitest run` suite green: 667 tests / 112 files.

Part of ORISO-Helm#62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)