### PR TITLE
Fix/session list item

### DIFF
--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -1916,57 +1916,6 @@ export const MessageItemComponent = ({
 							) : null}
 						</div>
 					)}
-
-					{onOpenThread &&
-						renderMode === 'main' &&
-						!alias?.messageType && (
-							<button
-								type="button"
-								className={clsx(
-									'messageItem__threadButton',
-									isMyMessage &&
-										'messageItem__threadButton--right',
-									threadSummary?.replyCount
-										? 'messageItem__threadButton--hasReplies'
-										: ''
-								)}
-								onClick={(e) => {
-									e.preventDefault();
-									e.stopPropagation();
-									onOpenThread();
-								}}
-							>
-								<span className="messageItem__threadButtonMain">
-									{threadSummary?.replyCount
-										? translate(
-												'message.thread.replies',
-												'{{count}} replies',
-												{
-													count: threadSummary.replyCount
-												}
-											)
-										: translate(
-												'message.thread.reply',
-												'Reply'
-											)}
-								</span>
-								{threadSummary?.replyCount ? (
-									<span className="messageItem__threadButtonMeta">
-										{threadSummary.lastReplyText}
-									</span>
-								) : (
-									<span className="messageItem__threadButtonMeta">
-										&nbsp;
-									</span>
-								)}
-								<span className="messageItem__threadButtonHover">
-									{translate(
-										'message.thread.view',
-										'View thread'
-									)}
-								</span>
-							</button>
-						)}
 				</div>
 			</div>
 			{isActionMenuOpen && actionMenuPosition

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -214,7 +214,7 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 	}
 
 	&__sideColumn--left {
-		left: 4px;
+		left: 0px;
 		top: -18px;
 		z-index: 5;
 	}
@@ -222,7 +222,7 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 	&__sideColumn--right {
 		position: absolute;
 		right: -32px;
-		bottom: -18px;
+		bottom: -14px;
 		z-index: 5;
 	}
 
@@ -399,10 +399,12 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 
 	&__visibilityChip--incoming {
 		margin-top: -2px;
+		translate: 0% 50%;
 	}
 
 	&__visibilityChip--outgoing {
 		margin-bottom: -2px;
+		translate: 0% -50%;
 	}
 
 	&__visibilityMenu {

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -239,6 +239,8 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		flex: 1;
 		padding-right: 0;
 		scrollbar-width: none; // Firefox: hide native scrollbar
+		margin-left: 25px;
+		margin-right: 25px;
 
 		@include breakpoint($fromLarge) {
 			margin-top: 0;
@@ -258,8 +260,6 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		&--hasToolbar {
 			padding-top: 0;
 			margin-top: 0;
-			margin-left: 25px;
-			margin-right: 25px;
 		}
 	}
 

--- a/src/components/sessionsListItem/SessionListItem.stories.tsx
+++ b/src/components/sessionsListItem/SessionListItem.stories.tsx
@@ -9,6 +9,8 @@ import { ReactComponent as HelpIcon } from '../../resources/img/icons/i.svg';
 import { ReactComponent as PlusIcon } from '../../resources/img/icons/plus.svg';
 import { ReactComponent as PackageIcon } from '../../resources/img/icons/documents.svg';
 import nearbyConversationIcon from '../../resources/img/icons/chatroom/nearby_conv_type_200.svg';
+import internalConversationIcon from '../../resources/img/icons/chatroom/internal_conversation_200.svg';
+import selfHelpIcon from '../../resources/img/icons/session-toolbar/supervision_chats.svg';
 import teamImage from '../../resources/img/illustrations/Team.svg';
 import {
 	ActiveSessionContext,
@@ -733,6 +735,208 @@ function RuntimeSessionListItem() {
 	);
 }
 
+/** Overlapping initials circles for group rows (Interna / Gesprächskreis). */
+function StackedAvatarsMock({ initials }: { initials: string[] }) {
+	const palette = ['#c8e6c9', '#bbdefb', '#e8b4f0'];
+	const visible = initials.slice(0, 2);
+	const overflow = initials.length - visible.length;
+
+	return (
+		<div className="sessionsListItem__stackedAvatars">
+			{visible.map((label, index) => (
+				<div key={index} className="sessionsListItem__avatarWrapper">
+					<div
+						style={{
+							width: 32,
+							height: 32,
+							borderRadius: '50%',
+							background: palette[index % palette.length],
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							fontWeight: 600,
+							fontSize: 12,
+							color: '#333'
+						}}
+					>
+						{label}
+					</div>
+				</div>
+			))}
+			{overflow > 0 ? (
+				<div className="sessionsListItem__avatarWrapper sessionsListItem__avatarWrapper--plus">
+					<div className="sessionsListItem__plusAvatar">
+						+{overflow}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * Internal counsellor group chat (Figma 98-20465).
+ * Stacked initials avatars + group name + sender-prefixed preview, the
+ * consulting-type tag "Interna", and the "Interna" chat-type icon on the right.
+ */
+function InternalCounsellorCardMock() {
+	return (
+		<div className="sessionsListItem sessionsListItem--groupChat">
+			<div className="sessionsListItem__content">
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__rowLeft">
+						<div className="sessionsListItem__topic">Interna</div>
+					</div>
+					<div className="sessionsListItem__rowRight">
+						<div className="sessionsListItem__date">now</div>
+						<button
+							type="button"
+							className="sessionsListItem__menuIcon"
+							aria-label="Chatraum Einstellungen"
+						>
+							<MenuVerticalIcon />
+						</button>
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<StackedAvatarsMock initials={['MK', 'AB', 'CD']} />
+					<div className="sessionsListItem__username">
+						Anfragenkoordinierung
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__subject">
+						Mario K: Das ist schon komisch mit di…
+					</div>
+					<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--internal">
+						<img
+							src={internalConversationIcon}
+							alt="Interna"
+							className="sessionsListItem__consultingTypeIcon--internalIcon"
+						/>
+						<span className="sessionsListItem__consultingTypeIcon--internalLabel">
+							Interna
+						</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Anonymous live chat (Figma 287-23471).
+ * Animal pseudonym as the display name, no postcode pill, and the "Live Chat"
+ * chat-type icon + label on the right.
+ */
+function LiveChatCardMock() {
+	return (
+		<div className="sessionsListItem sessionsListItem--anonymous">
+			<div className="sessionsListItem__content sessionsListItem__content--anonymous">
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__rowLeft">
+						<div className="sessionsListItem__topic">
+							Familienberatung
+						</div>
+						<div className="sessionsListItem__consultingType" />
+					</div>
+					<div className="sessionsListItem__rowRight">
+						<div className="sessionsListItem__date">now</div>
+						<button
+							type="button"
+							className="sessionsListItem__menuIcon"
+							aria-label="Chatraum Einstellungen"
+						>
+							<MenuVerticalIcon />
+						</button>
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<MockAvatar letter="Y" bg="#ffe0b2" />
+					<div className="sessionsListItem__username">
+						ruhiges Yak Kim
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__subject">
+						Das soll aber einzigartig
+					</div>
+					<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--liveChat">
+						<svg
+							width="22"
+							height="19"
+							viewBox="0 0 22 19"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+							aria-hidden="true"
+						>
+							<path
+								d="M0 18V6L8 0L14.95 5.19175C14.55 5.20842 14.1639 5.25008 13.7917 5.31675C13.4194 5.38342 13.0527 5.47783 12.6917 5.6L8 2.08325L1.66675 6.83325V16.3333H8.11675C8.25558 16.6444 8.41525 16.9361 8.59575 17.2083C8.77642 17.4806 8.97225 17.7445 9.18325 18H0ZM10.8333 17.5833C10.2056 16.9832 9.71533 16.2847 9.3625 15.4875C9.00967 14.6903 8.83325 13.8612 8.83325 13C8.83325 11.2278 9.44992 9.72925 10.6832 8.50425C11.9166 7.27925 13.4111 6.66675 15.1667 6.66675C16.9389 6.66675 18.4375 7.27925 19.6625 8.50425C20.8875 9.72925 21.5 11.2278 21.5 13C21.5 13.8612 21.3306 14.6876 20.9918 15.4792C20.6528 16.2709 20.1638 16.9639 19.525 17.5583L18.7 16.7332C19.2388 16.2499 19.6458 15.6861 19.9207 15.0418C20.1957 14.3973 20.3333 13.7167 20.3333 13C20.3333 11.5555 19.8333 10.3332 18.8333 9.33325C17.8333 8.33325 16.6111 7.83325 15.1667 7.83325C13.7389 7.83325 12.5208 8.33325 11.5125 9.33325C10.5042 10.3332 10 11.5555 10 13C10 13.7167 10.1431 14.3986 10.4292 15.0457C10.7153 15.6931 11.1249 16.2584 11.6582 16.7417L10.8333 17.5833ZM12.6083 15.7917C12.2083 15.4306 11.8958 15.0083 11.6708 14.525C11.4458 14.0417 11.3333 13.5333 11.3333 13C11.3333 11.9278 11.7083 11.0209 12.4583 10.2793C13.2083 9.53758 14.1111 9.16675 15.1667 9.16675C16.2389 9.16675 17.1458 9.53758 17.8875 10.2793C18.6292 11.0209 19 11.9278 19 13C19 13.5278 18.8958 14.0362 18.6875 14.525C18.4792 15.0138 18.1722 15.4388 17.7667 15.8L16.925 14.9832C17.2138 14.7277 17.4374 14.4277 17.5958 14.0832C17.7541 13.7389 17.8333 13.3778 17.8333 13C17.8333 12.2555 17.5749 11.6249 17.0583 11.1082C16.5416 10.5916 15.9111 10.3333 15.1667 10.3333C14.4334 10.3333 13.8056 10.5916 13.2833 11.1082C12.7611 11.6249 12.5 12.2555 12.5 13C12.5 13.3778 12.5833 13.7362 12.75 14.075C12.9167 14.4138 13.1389 14.7111 13.4167 14.9668L12.6083 15.7917ZM14.5833 19V13.9168C14.4332 13.8056 14.3124 13.6708 14.2208 13.5125C14.1291 13.3542 14.0833 13.1833 14.0833 13C14.0833 12.6945 14.1888 12.4376 14.4 12.2292C14.6112 12.0209 14.8667 11.9167 15.1667 11.9167C15.4722 11.9167 15.7292 12.0209 15.9375 12.2292C16.1458 12.4376 16.25 12.6945 16.25 13C16.25 13.1833 16.2097 13.3556 16.1292 13.5168C16.0486 13.6778 15.9222 13.8111 15.75 13.9168V19H14.5833Z"
+								fill="#4B515A"
+							/>
+						</svg>
+						<span className="sessionsListItem__consultingTypeIcon--liveChatLabel">
+							Live Chat
+						</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Guided self-help group / Gesprächskreis (Figma 115-28318).
+ * Stacked initials avatars + group name, the consulting-type tag
+ * "Gesprächskreis", and the "Gesprächskreis" chat-type icon on the right.
+ */
+function SelfHelpCardMock() {
+	return (
+		<div className="sessionsListItem sessionsListItem--groupChat">
+			<div className="sessionsListItem__content">
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__rowLeft">
+						<div className="sessionsListItem__topic">
+							Gesprächskreis
+						</div>
+					</div>
+					<div className="sessionsListItem__rowRight">
+						<div className="sessionsListItem__date">now</div>
+						<button
+							type="button"
+							className="sessionsListItem__menuIcon"
+							aria-label="Chatraum Einstellungen"
+						>
+							<MenuVerticalIcon />
+						</button>
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<StackedAvatarsMock initials={['MO', 'JS', 'GF', 'LK']} />
+					<div className="sessionsListItem__username">
+						Montagsrunde
+					</div>
+				</div>
+				<div className="sessionsListItem__row">
+					<div className="sessionsListItem__subject">
+						Das soll aber einzigartig
+					</div>
+					<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--selfHelp">
+						<img
+							src={selfHelpIcon}
+							alt="Gesprächskreis"
+							className="sessionsListItem__consultingTypeIcon--selfHelpIcon"
+						/>
+						<span className="sessionsListItem__consultingTypeIcon--selfHelpLabel">
+							Gesprächskreis
+						</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 const meta = {
 	title: 'Components/Session/List/SessionListItem',
 	tags: ['autodocs'],
@@ -820,4 +1024,52 @@ export const InteractiveMenuAndLongContent: Story = {
 		}
 	},
 	render: () => <InteractiveMenuPlayground />
+};
+
+/* ------------------------------------------------------------------ *
+ * Figma-node stories (self-contained visual mocks)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Internal counsellor chat (Figma 98-20465).
+ * Stacked avatars + group name + sender-prefixed preview, consulting-type tag
+ * "Interna", and no chat-type icon on the right.
+ */
+export const InternalCounsellorChat: Story = {
+	render: () => (
+		<div style={listShell}>
+			<InternalCounsellorCardMock />
+		</div>
+	)
+};
+
+// ZipTopicSelection (Nähe, Figma 98-20505) is intentionally NOT a separate
+// story: its layout (topic tag + postcode pill + "Nähe" chat-type icon) is
+// already covered by `ConsultantUnselected` (ConsultantCardMock). Adding it
+// again would just duplicate that story, so it is skipped per the refactor.
+
+/**
+ * Anonymous live chat (Figma 287-23471).
+ * Animal pseudonym as the display name, no postcode, "Live Chat" chat-type
+ * icon + label.
+ */
+export const LiveChat: Story = {
+	render: () => (
+		<div style={listShell}>
+			<LiveChatCardMock />
+		</div>
+	)
+};
+
+/**
+ * Guided self-help group / Gesprächskreis (Figma 115-28318).
+ * Stacked avatars + group name, consulting-type tag "Gesprächskreis", and no
+ * chat-type icon on the right (Kreis icon not yet implemented — see mock TODO).
+ */
+export const GuidedSelfHelpGroup: Story = {
+	render: () => (
+		<div style={listShell}>
+			<SelfHelpCardMock />
+		</div>
+	)
 };

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -28,6 +28,8 @@ import { ReactComponent as TextModalityIcon } from '../../resources/img/icons/ch
 import { ReactComponent as AudioModalityIcon } from '../../resources/img/icons/call.svg';
 import { ReactComponent as VideoModalityIcon } from '../../resources/img/icons/video-call.svg';
 import nearbyConversationIcon from '../../resources/img/icons/chatroom/nearby_conv_type_200.svg';
+import internalConversationIcon from '../../resources/img/icons/chatroom/internal_conversation_200.svg';
+import selfHelpIcon from '../../resources/img/icons/session-toolbar/supervision_chats.svg';
 import teamImage from '../../resources/img/illustrations/Team.svg';
 import {
 	SESSION_LIST_TAB,
@@ -742,6 +744,7 @@ export const SessionListItemComponent = ({
 		const defaultSubjectText = isMyChat()
 			? translate('groupChat.listItem.subjectEmpty.self')
 			: translate('groupChat.listItem.subjectEmpty.other');
+		const groupModality = getModality(activeSession);
 		return (
 			<div
 				onClick={handleOnClick}
@@ -832,13 +835,62 @@ export const SessionListItemComponent = ({
 								attachment={activeSession.item.attachment}
 							/>
 						)}
-						<div className="sessionsListItem__consultingTypeIcon">
-							<img
-								src={teamImage}
-								alt="Team Beratung"
-								className="sessionsListItem__consultingTypeIcon--team"
-							/>
-						</div>
+						{groupModality === Modality.INTERNAL_GROUP && (
+							<div
+								className={clsx(
+									'sessionsListItem__consultingTypeIcon',
+									'sessionsListItem__consultingTypeIcon--internal'
+								)}
+							>
+								<img
+									src={internalConversationIcon}
+									alt={translate(
+										'sessionList.item.sessionType.internal',
+										'Interna'
+									)}
+									className="sessionsListItem__consultingTypeIcon--internalIcon"
+								/>
+								<span className="sessionsListItem__consultingTypeIcon--internalLabel">
+									{translate(
+										'sessionList.item.sessionType.internal',
+										'Interna'
+									)}
+								</span>
+							</div>
+						)}
+						{groupModality === Modality.SELF_HELP && (
+							<div
+								className={clsx(
+									'sessionsListItem__consultingTypeIcon',
+									'sessionsListItem__consultingTypeIcon--selfHelp'
+								)}
+							>
+								<img
+									src={selfHelpIcon}
+									alt={translate(
+										'sessionList.item.sessionType.selfHelp',
+										'Gesprächskreis'
+									)}
+									className="sessionsListItem__consultingTypeIcon--selfHelpIcon"
+								/>
+								<span className="sessionsListItem__consultingTypeIcon--selfHelpLabel">
+									{translate(
+										'sessionList.item.sessionType.selfHelp',
+										'Gesprächskreis'
+									)}
+								</span>
+							</div>
+						)}
+						{groupModality !== Modality.INTERNAL_GROUP &&
+							groupModality !== Modality.SELF_HELP && (
+								<div className="sessionsListItem__consultingTypeIcon">
+									<img
+										src={teamImage}
+										alt="Team Beratung"
+										className="sessionsListItem__consultingTypeIcon--team"
+									/>
+								</div>
+							)}
 					</div>
 				</div>
 			</div>
@@ -865,6 +917,7 @@ export const SessionListItemComponent = ({
 	}
 
 	const postcodeLabel = getDisplayablePostcode(activeSession.item.postcode);
+	const modality = getModality(activeSession);
 	const isAnonymousChat = getModality(activeSession) === Modality.LIVE_CHAT;
 	const shouldShowPostcode =
 		!isAsker &&
@@ -1515,38 +1568,36 @@ export const SessionListItemComponent = ({
 								: caseHandoverListLabel}
 						</button>
 					) : (
-						(() => {
-							if (isAnonymousChat) {
-								return (
-									<div
-										className={clsx(
-											'sessionsListItem__consultingTypeIcon',
-											'sessionsListItem__consultingTypeIcon--liveChat'
-										)}
+						<>
+							{modality === Modality.LIVE_CHAT && (
+								<div
+									className={clsx(
+										'sessionsListItem__consultingTypeIcon',
+										'sessionsListItem__consultingTypeIcon--liveChat'
+									)}
+								>
+									<svg
+										width="22"
+										height="19"
+										viewBox="0 0 22 19"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+										aria-hidden="true"
 									>
-										<svg
-											width="22"
-											height="19"
-											viewBox="0 0 22 19"
-											fill="none"
-											xmlns="http://www.w3.org/2000/svg"
-											aria-hidden="true"
-										>
-											<path
-												d="M0 18V6L8 0L14.95 5.19175C14.55 5.20842 14.1639 5.25008 13.7917 5.31675C13.4194 5.38342 13.0527 5.47783 12.6917 5.6L8 2.08325L1.66675 6.83325V16.3333H8.11675C8.25558 16.6444 8.41525 16.9361 8.59575 17.2083C8.77642 17.4806 8.97225 17.7445 9.18325 18H0ZM10.8333 17.5833C10.2056 16.9832 9.71533 16.2847 9.3625 15.4875C9.00967 14.6903 8.83325 13.8612 8.83325 13C8.83325 11.2278 9.44992 9.72925 10.6832 8.50425C11.9166 7.27925 13.4111 6.66675 15.1667 6.66675C16.9389 6.66675 18.4375 7.27925 19.6625 8.50425C20.8875 9.72925 21.5 11.2278 21.5 13C21.5 13.8612 21.3306 14.6876 20.9918 15.4792C20.6528 16.2709 20.1638 16.9639 19.525 17.5583L18.7 16.7332C19.2388 16.2499 19.6458 15.6861 19.9207 15.0418C20.1957 14.3973 20.3333 13.7167 20.3333 13C20.3333 11.5555 19.8333 10.3332 18.8333 9.33325C17.8333 8.33325 16.6111 7.83325 15.1667 7.83325C13.7389 7.83325 12.5208 8.33325 11.5125 9.33325C10.5042 10.3332 10 11.5555 10 13C10 13.7167 10.1431 14.3986 10.4292 15.0457C10.7153 15.6931 11.1249 16.2584 11.6582 16.7417L10.8333 17.5833ZM12.6083 15.7917C12.2083 15.4306 11.8958 15.0083 11.6708 14.525C11.4458 14.0417 11.3333 13.5333 11.3333 13C11.3333 11.9278 11.7083 11.0209 12.4583 10.2793C13.2083 9.53758 14.1111 9.16675 15.1667 9.16675C16.2389 9.16675 17.1458 9.53758 17.8875 10.2793C18.6292 11.0209 19 11.9278 19 13C19 13.5278 18.8958 14.0362 18.6875 14.525C18.4792 15.0138 18.1722 15.4388 17.7667 15.8L16.925 14.9832C17.2138 14.7277 17.4374 14.4277 17.5958 14.0832C17.7541 13.7389 17.8333 13.3778 17.8333 13C17.8333 12.2555 17.5749 11.6249 17.0583 11.1082C16.5416 10.5916 15.9111 10.3333 15.1667 10.3333C14.4334 10.3333 13.8056 10.5916 13.2833 11.1082C12.7611 11.6249 12.5 12.2555 12.5 13C12.5 13.3778 12.5833 13.7362 12.75 14.075C12.9167 14.4138 13.1389 14.7111 13.4167 14.9668L12.6083 15.7917ZM14.5833 19V13.9168C14.4332 13.8056 14.3124 13.6708 14.2208 13.5125C14.1291 13.3542 14.0833 13.1833 14.0833 13C14.0833 12.6945 14.1888 12.4376 14.4 12.2292C14.6112 12.0209 14.8667 11.9167 15.1667 11.9167C15.4722 11.9167 15.7292 12.0209 15.9375 12.2292C16.1458 12.4376 16.25 12.6945 16.25 13C16.25 13.1833 16.2097 13.3556 16.1292 13.5168C16.0486 13.6778 15.9222 13.8111 15.75 13.9168V19H14.5833Z"
-												fill="#4B515A"
-											/>
-										</svg>
-										<span className="sessionsListItem__consultingTypeIcon--liveChatLabel">
-											{translate(
-												'sessionList.item.sessionType.liveChat',
-												'Live Chat'
-											)}
-										</span>
-									</div>
-								);
-							}
-							return (
+										<path
+											d="M0 18V6L8 0L14.95 5.19175C14.55 5.20842 14.1639 5.25008 13.7917 5.31675C13.4194 5.38342 13.0527 5.47783 12.6917 5.6L8 2.08325L1.66675 6.83325V16.3333H8.11675C8.25558 16.6444 8.41525 16.9361 8.59575 17.2083C8.77642 17.4806 8.97225 17.7445 9.18325 18H0ZM10.8333 17.5833C10.2056 16.9832 9.71533 16.2847 9.3625 15.4875C9.00967 14.6903 8.83325 13.8612 8.83325 13C8.83325 11.2278 9.44992 9.72925 10.6832 8.50425C11.9166 7.27925 13.4111 6.66675 15.1667 6.66675C16.9389 6.66675 18.4375 7.27925 19.6625 8.50425C20.8875 9.72925 21.5 11.2278 21.5 13C21.5 13.8612 21.3306 14.6876 20.9918 15.4792C20.6528 16.2709 20.1638 16.9639 19.525 17.5583L18.7 16.7332C19.2388 16.2499 19.6458 15.6861 19.9207 15.0418C20.1957 14.3973 20.3333 13.7167 20.3333 13C20.3333 11.5555 19.8333 10.3332 18.8333 9.33325C17.8333 8.33325 16.6111 7.83325 15.1667 7.83325C13.7389 7.83325 12.5208 8.33325 11.5125 9.33325C10.5042 10.3332 10 11.5555 10 13C10 13.7167 10.1431 14.3986 10.4292 15.0457C10.7153 15.6931 11.1249 16.2584 11.6582 16.7417L10.8333 17.5833ZM12.6083 15.7917C12.2083 15.4306 11.8958 15.0083 11.6708 14.525C11.4458 14.0417 11.3333 13.5333 11.3333 13C11.3333 11.9278 11.7083 11.0209 12.4583 10.2793C13.2083 9.53758 14.1111 9.16675 15.1667 9.16675C16.2389 9.16675 17.1458 9.53758 17.8875 10.2793C18.6292 11.0209 19 11.9278 19 13C19 13.5278 18.8958 14.0362 18.6875 14.525C18.4792 15.0138 18.1722 15.4388 17.7667 15.8L16.925 14.9832C17.2138 14.7277 17.4374 14.4277 17.5958 14.0832C17.7541 13.7389 17.8333 13.3778 17.8333 13C17.8333 12.2555 17.5749 11.6249 17.0583 11.1082C16.5416 10.5916 15.9111 10.3333 15.1667 10.3333C14.4334 10.3333 13.8056 10.5916 13.2833 11.1082C12.7611 11.6249 12.5 12.2555 12.5 13C12.5 13.3778 12.5833 13.7362 12.75 14.075C12.9167 14.4138 13.1389 14.7111 13.4167 14.9668L12.6083 15.7917ZM14.5833 19V13.9168C14.4332 13.8056 14.3124 13.6708 14.2208 13.5125C14.1291 13.3542 14.0833 13.1833 14.0833 13C14.0833 12.6945 14.1888 12.4376 14.4 12.2292C14.6112 12.0209 14.8667 11.9167 15.1667 11.9167C15.4722 11.9167 15.7292 12.0209 15.9375 12.2292C16.1458 12.4376 16.25 12.6945 16.25 13C16.25 13.1833 16.2097 13.3556 16.1292 13.5168C16.0486 13.6778 15.9222 13.8111 15.75 13.9168V19H14.5833Z"
+											fill="#4B515A"
+										/>
+									</svg>
+									<span className="sessionsListItem__consultingTypeIcon--liveChatLabel">
+										{translate(
+											'sessionList.item.sessionType.liveChat',
+											'Live Chat'
+										)}
+									</span>
+								</div>
+							)}
+							{modality === Modality.AGENCY_COUNSELLING && (
 								<div
 									className={clsx(
 										'sessionsListItem__consultingTypeIcon',
@@ -1568,8 +1619,54 @@ export const SessionListItemComponent = ({
 										)}
 									</span>
 								</div>
-							);
-						})()
+							)}
+							{modality === Modality.INTERNAL_GROUP && (
+								<div
+									className={clsx(
+										'sessionsListItem__consultingTypeIcon',
+										'sessionsListItem__consultingTypeIcon--internal'
+									)}
+								>
+									<img
+										src={internalConversationIcon}
+										alt={translate(
+											'sessionList.item.sessionType.internal',
+											'Interna'
+										)}
+										className="sessionsListItem__consultingTypeIcon--internalIcon"
+									/>
+									<span className="sessionsListItem__consultingTypeIcon--internalLabel">
+										{translate(
+											'sessionList.item.sessionType.internal',
+											'Interna'
+										)}
+									</span>
+								</div>
+							)}
+							{modality === Modality.SELF_HELP && (
+								<div
+									className={clsx(
+										'sessionsListItem__consultingTypeIcon',
+										'sessionsListItem__consultingTypeIcon--selfHelp'
+									)}
+								>
+									<img
+										src={selfHelpIcon}
+										alt={translate(
+											'sessionList.item.sessionType.selfHelp',
+											'Gesprächskreis'
+										)}
+										className="sessionsListItem__consultingTypeIcon--selfHelpIcon"
+									/>
+									<span className="sessionsListItem__consultingTypeIcon--selfHelpLabel">
+										{translate(
+											'sessionList.item.sessionType.selfHelp',
+											'Gesprächskreis'
+										)}
+									</span>
+								</div>
+							)}
+						</>
 					)}
 				</div>
 			</div>

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -122,6 +122,11 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		.sessionsListItem__consultingTypeIcon--nearbyLabel {
 			color: #da5248 !important;
 		}
+
+		.sessionsListItem__consultingTypeIcon--internalLabel,
+		.sessionsListItem__consultingTypeIcon--selfHelpLabel {
+			color: #da5248 !important;
+		}
 	}
 
 	// Read state: muted gray background for sessions the counselor has already read
@@ -873,6 +878,32 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		}
 
 		&--nearbyLabel {
+			font-family: $font-family-sans-serif;
+			font-size: 14px;
+			font-weight: 600;
+			color: var(--m3-secondary, #4b515a);
+			line-height: 20px;
+			letter-spacing: 0;
+		}
+
+		&--internal,
+		&--selfHelp {
+			margin-right: 0;
+			padding-right: 12px;
+			gap: 8px;
+			height: 38px;
+			white-space: nowrap;
+		}
+
+		&--internalIcon,
+		&--selfHelpIcon {
+			width: 24px !important;
+			height: 24px !important;
+			flex-shrink: 0;
+		}
+
+		&--internalLabel,
+		&--selfHelpLabel {
 			font-family: $font-family-sans-serif;
 			font-size: 14px;
 			font-weight: 600;


### PR DESCRIPTION
#### [Issue #446](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/446)

## Summary
- Render dedicated session-type icons + labels for **Internal group** ("Interna") and **Guided self-help group** ("Gesprächskreis") in session list items, in both the group-chat and standard list-item render paths.
- Refactor the session-type badge from an inline IIFE (`isAnonymousChat ? … : …`) into explicit, modality-based rendering covering `LIVE_CHAT`, `AGENCY_COUNSELLING`, `INTERNAL_GROUP`, and `SELF_HELP`.
- Fix session-list horizontal margins so the `25px` left/right margin always applies, not only when a toolbar is present.
- Minor message layout alignment tweaks (side-column offset, visibility-chip translate) to match Figma/production.
- Add Storybook stories covering the session-list item session types.

## Changes
**`SessionListItemComponent.tsx`**
- Import `internalConversationIcon` and `selfHelpIcon`.
- Compute `groupModality` / `modality` via `getModality(activeSession)`.
- Group-chat path: render Internal / Self-help icon+label when applicable, otherwise fall back to the team image.
- Standard path: replace the live-chat-vs-agency IIFE with explicit `modality === …` branches for Live Chat, Agency counselling, Internal group, and Self-help group.

**`sessionsListItem.styles.scss`**
- Add `--internal` / `--selfHelp` container, icon (24×24), and label styles.
- Apply the active-state label color to the new labels.

**`sessionsList.styles.scss`**
- Move `margin-left/right: 25px` from `&--hasToolbar` to the base list rule.

**`message.styles.scss`**
- Adjust `&__sideColumn--left` (`left: 0`), `&__sideColumn--right` (`bottom: -14px`), and add `translate` to incoming/outgoing visibility chips.

**Storybook**
- Add `SessionListItem.stories.tsx` with Internal counsellor chat, Live Chat, and Guided self-help group stories.

## Notes / to confirm
- This branch also removes the thread "Reply" button block in `MessageItemComponent.tsx` (~51 lines). Please confirm this is intended for this PR — it appears outside the session-list scope and may belong in a separate change.

## Test plan
- [ ] Consultant list shows correct icon + label for Live Chat, Agency, Internal, and Self-help sessions.
- [ ] Internal/self-help labels use the active color when the item is selected.
- [ ] List items are horizontally aligned (25px) with and without a toolbar.
- [ ] `npm run lint:style` / `npm run lint:scripts` pass.
- [ ] Storybook renders the new stories without errors.

<img width="772" height="705" alt="image" src="https://github.com/user-attachments/assets/b92ae9a6-98b0-439a-8d8c-08c2188cf4d3" />


#### Asker/User View Chat
<img width="1490" height="933" alt="image" src="https://github.com/user-attachments/assets/20c8f848-b6f6-46bf-91f2-24d151a4497b" />

#### Councellor View
<img width="1598" height="908" alt="image" src="https://github.com/user-attachments/assets/074daeeb-07ff-41a3-b2c1-95d6b3c11bb0" />


#### Internal Councellor Chat
<img width="1531" height="551" alt="image" src="https://github.com/user-attachments/assets/4d40c81c-e1c9-4011-a574-7e4dc567876a" />

#### Live Chat
<img width="1535" height="562" alt="image" src="https://github.com/user-attachments/assets/4e516654-e392-4b49-ac1a-aec0a72ff624" />


#### Guided Self Help Group
<img width="1530" height="558" alt="image" src="https://github.com/user-attachments/assets/9bf7dfb8-a4e4-4c46-84db-641a3a002886" />



