### PR TITLE
fix(chat): recover from M_UNKNOWN_TOKEN by refreshing the Matrix token

### DIFF
--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getMatrixAccessToken } from '../components/sessionCookie/getMatrixAccessToken';
 import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
-import { MatrixClientService } from './matrixClientService';
+import {
+	MatrixClientService,
+	isMatrixExpiredTokenError
+} from './matrixClientService';
 
 const mockedMatrixClient = vi.hoisted(() => ({
 	initRustCrypto: vi.fn(),
@@ -166,6 +169,47 @@ describe('MatrixClientService', () => {
 		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
 	});
 
+	it('refreshes the token when sync fails with M_UNKNOWN_TOKEN (invalidated access token)', async () => {
+		let syncListener:
+			| ((
+					state: string,
+					previous: string | null,
+					error?: unknown
+			  ) => void)
+			| undefined;
+		mockedMatrixClient.on.mockImplementation((_event, listener) => {
+			syncListener = listener;
+		});
+		const service = new MatrixClientService();
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'invalidated-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		vi.mocked(getMatrixAccessToken).mockClear();
+		vi.mocked(getMatrixAccessToken).mockRejectedValueOnce(
+			new Error('refresh failed')
+		);
+
+		// Exact shape delivered by matrix-js-sdk sync state ERROR when Synapse
+		// rejects an invalidated token: ISyncStateData wrapping a MatrixError.
+		syncListener?.('ERROR', null, {
+			error: {
+				errcode: 'M_UNKNOWN_TOKEN',
+				data: {
+					errcode: 'M_UNKNOWN_TOKEN',
+					error: 'Invalid access token passed.'
+				},
+				httpStatus: 401,
+				message: 'MatrixError: [401] Invalid access token passed.'
+			}
+		});
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
+	});
+
 	it('sends Matrix messages in migration rooms without native Matrix encryption state', async () => {
 		const sendMessage = vi.fn(() =>
 			Promise.resolve({ event_id: '$event' })
@@ -278,5 +322,47 @@ describe('MatrixClientService', () => {
 			true,
 			30000
 		);
+	});
+});
+
+describe('isMatrixExpiredTokenError', () => {
+	it('recognizes a Synapse M_UNKNOWN_TOKEN error (invalidated access token)', () => {
+		expect(
+			isMatrixExpiredTokenError({
+				errcode: 'M_UNKNOWN_TOKEN',
+				data: {
+					errcode: 'M_UNKNOWN_TOKEN',
+					error: 'Invalid access token passed.'
+				},
+				httpStatus: 401,
+				message: 'MatrixError: [401] Invalid access token passed.'
+			})
+		).toBe(true);
+	});
+
+	it('recognizes M_UNKNOWN_TOKEN inside the sync state ERROR wrapper', () => {
+		expect(
+			isMatrixExpiredTokenError({
+				error: {
+					errcode: 'M_UNKNOWN_TOKEN',
+					data: {
+						errcode: 'M_UNKNOWN_TOKEN',
+						error: 'Invalid access token passed.'
+					},
+					httpStatus: 401,
+					message: 'MatrixError: [401] Invalid access token passed.'
+				}
+			})
+		).toBe(true);
+	});
+
+	it('does not treat a 403 M_FORBIDDEN as an expired token', () => {
+		expect(
+			isMatrixExpiredTokenError({
+				errcode: 'M_FORBIDDEN',
+				httpStatus: 403,
+				message: 'MatrixError: [403] You are not invited to this room.'
+			})
+		).toBe(false);
 	});
 });

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -76,8 +76,13 @@ export const isMatrixExpiredTokenError = (error: unknown): boolean => {
 	const message = typeof rawMessage === 'string' ? rawMessage : '';
 	const httpStatus = matrixError?.httpStatus || matrixError?.statusCode;
 
+	// Synapse rejects an invalidated token (hard TTL hit, or a newer login
+	// re-used the same device_id) with M_UNKNOWN_TOKEN and "Invalid access
+	// token passed." — recoverable by re-fetching a token from the backend.
 	return (
 		message.includes('Access token has expired') ||
+		matrixError?.errcode === 'M_UNKNOWN_TOKEN' ||
+		matrixError?.data?.errcode === 'M_UNKNOWN_TOKEN' ||
 		(httpStatus === 401 &&
 			(message.toLowerCase().includes('expired') ||
 				matrixError?.errcode === 'M_UNKNOWN' ||


### PR DESCRIPTION
## Problem

During normal consultant-app use the Matrix access token can become invalid mid-session. Synapse then rejects `/sync`, `/keys/upload`, `/keys/query` and the filter endpoint with `M_UNKNOWN_TOKEN [401] Invalid access token passed.`. The matrix-js-sdk stops sync **permanently** on `M_UNKNOWN_TOKEN` (`shouldAbortSync`) and, with no `tokenRefreshFunction` configured, logs "Unable to refresh token - no refresh token or refresh function". The chat hard-ends ("Der Chat wurde beendet") instead of silently re-authenticating.

## Root cause

The recovery machinery already exists in `matrixClientService.ts` (proactive refresh timer, sync-ERROR hook, per-send retry) — but `isMatrixExpiredTokenError` only matched `errcode === 'M_UNKNOWN'` or messages containing "expired". Synapse's actual invalid-token error is `errcode: 'M_UNKNOWN_TOKEN'` with "Invalid access token passed.", so the detector returned `false` and no refresh was ever triggered.

This is not test-user-specific: UserService issues browser tokens with a hard 55-minute TTL (`MATRIX_BROWSER_TOKEN_TTL_MS`), and every token fetch re-logins with the same `device_id`, which invalidates the previous token for that device (second tab / re-bootstrap). Any session older than 55 minutes whose proactive refresh failed once hits this.

## Fix

Recognize `M_UNKNOWN_TOKEN` (top-level `errcode` and nested `data.errcode`, including the sync-state `{ error }` wrapper) as a refreshable token error. The existing sync-ERROR hook and send-retry paths then re-login via the UserService token endpoint and re-initialize the client.

## Tests (TDD)

- `isMatrixExpiredTokenError` recognizes the exact Synapse `M_UNKNOWN_TOKEN` error shape (top-level and sync-wrapper) — watched fail before the fix
- sync `ERROR` with `M_UNKNOWN_TOKEN` triggers a token refresh through the service — watched fail before the fix
- negative guard: `M_FORBIDDEN [403]` is still not treated as a token error

`vitest run src/services/matrixClientService.test.ts`: 12/12 green. Full unit suite: only pre-existing failures on `pre-dev` (`StageLayout.test.tsx`, `notificationSettings.test.ts` — identical on a pristine checkout, unrelated to this change).

## Out of scope (follow-ups)

- SDK-level `tokenRefreshFunction` / `Session.logged_out` handling as belt-and-braces
- `SessionStream` room listeners are not re-attached after a token-refresh client swap (live updates silently die after a successful refresh)
- Floating rich-text-editor dropdown survives the "chat ended" overlay transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
