### PR TITLE
test: repair StageLayout and notification-settings unit tests on pre-dev

### DIFF
--- a/src/test/jsdomPolyfills.ts
+++ b/src/test/jsdomPolyfills.ts
@@ -50,3 +50,58 @@ if (typeof Element !== 'undefined') {
 		Element.prototype.scrollIntoView = () => {};
 	}
 }
+
+/**
+ * Node >= 22 ships its own `localStorage`/`sessionStorage` globals (behind
+ * `--localstorage-file`; enabled by default in recent versions). Without that
+ * flag the global is a getter that returns `undefined`. Vitest's jsdom
+ * environment only copies window keys onto `globalThis` when they are absent
+ * there or on its known-keys allowlist — and the Web Storage globals are on
+ * neither (vitest 3.2.x), so Node's undefined-returning getter shadows
+ * jsdom's working implementation. Any test (or module under test) touching
+ * bare `localStorage` then crashes with
+ * "Cannot read properties of undefined (reading 'getItem')".
+ *
+ * Bridge the gap with an in-memory Storage — same semantics jsdom would have
+ * provided. Guarded so it is a no-op under the node environment and on
+ * runtimes where the environment already supplies a real Storage.
+ */
+class MemoryStorage {
+	private store = new Map<string, string>();
+	get length(): number {
+		return this.store.size;
+	}
+	clear(): void {
+		this.store.clear();
+	}
+	getItem(key: string): string | null {
+		return this.store.get(String(key)) ?? null;
+	}
+	key(index: number): string | null {
+		return [...this.store.keys()][index] ?? null;
+	}
+	removeItem(key: string): void {
+		this.store.delete(String(key));
+	}
+	setItem(key: string, value: string): void {
+		this.store.set(String(key), String(value));
+	}
+}
+
+if (typeof document !== 'undefined') {
+	for (const key of ['localStorage', 'sessionStorage'] as const) {
+		let storageMissing = false;
+		try {
+			storageMissing = globalThis[key] === undefined;
+		} catch {
+			storageMissing = true;
+		}
+		if (storageMissing) {
+			Object.defineProperty(globalThis, key, {
+				value: new MemoryStorage(),
+				configurable: true,
+				writable: true
+			});
+		}
+	}
+}


### PR DESCRIPTION
Fixes #459.
Part of #456.

## Root cause (one cause, all 6 failures)

On Node >= 22 the runtime ships its own `localStorage`/`sessionStorage` globals — getters that return `undefined` unless `--localstorage-file` is passed (hence the `ExperimentalWarning: localStorage is not available` lines in every test run). Vitest 3.2.x's jsdom environment (`populateGlobal`) only copies a window key onto `globalThis` when the key is *absent* there or on Vitest's known-keys allowlist. The Web Storage keys are on neither, so Node's undefined-returning getter shadows jsdom's working `localStorage`, and any bare `localStorage` access in a jsdom test resolves to `undefined`.

Per failure:

| Failure | Symptom | Why |
| --- | --- | --- |
| `StageLayout.test.tsx` (whole-file collect error) | `TypeError: Cannot read properties of undefined (reading 'getItem')` at `DevToolbar.tsx:200` | `StageLayout` → `globalState` → `i18n.ts` → `DevToolbar.tsx` reads `localStorage.getItem(...)` at module load; the global is Node's `undefined` |
| 6 store tests in `notificationSettings.test.ts` (hydrate / seed legacy / updateSettings / device silence / cross-device sync / no-client mirror) | `TypeError: Cannot read properties of undefined (reading 'clear')` at `beforeEach` → `localStorage.clear()` | Same shadowing; the shared `beforeEach` dies before any assertion runs |

Neither the product code nor the tests regressed — `git log` shows no relevant changes to either file since the WP-06 Slice 6a commit (5c9b179); the failures are a Node-version/toolchain interaction. Other jsdom tests (e.g. `preferenceStore.test.ts`) kept passing only because they mock `localStorage` themselves.

## Fix

Extend the existing jsdom setup file (`src/test/jsdomPolyfills.ts`, already wired via `setupFiles` for exactly this class of "jsdom environment gap" problem) with a guarded in-memory Web Storage bridge: if a DOM is present and `globalThis.localStorage`/`sessionStorage` resolve to `undefined`, install an in-memory `Storage` implementation (same semantics jsdom would have provided). It is a no-op under the node test environment and on runtimes where the environment already supplies a real Storage. The property stays configurable/writable, so tests that install their own mocks (e.g. `preferenceStore.test.ts`) are unaffected.

No assertions were changed, no tests skipped or deleted.

## Verification

- `npm run test:unit`: **Test Files 118 passed (118), Tests 735 passed (735)** (was: 2 files / 6 tests failing on pristine `origin/pre-dev` @ 82adf88)
- `eslint src/test/jsdomPolyfills.ts --max-warnings=0` and `tsc`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
