### PR TITLE
feat: add UTD (decryption-failure) telemetry tracker (OBS-P9)

### DIFF
--- a/src/initApp.tsx
+++ b/src/initApp.tsx
@@ -19,6 +19,7 @@ import { Privacy } from './components/legalInformationLinks/Privacy';
 import { Imprint } from './components/legalInformationLinks/Imprint';
 import { initMeterProvider } from './utils/observability/meterProvider';
 import { initWebVitals } from './utils/observability/webVitals';
+import { initUtdTracking } from './utils/observability/utdTracker';
 
 // OBS-P8 (ORISO-Helm#62): browser-side Real User Monitoring. Register the
 // MeterProvider before anything else gets a chance to call
@@ -28,6 +29,9 @@ import { initWebVitals } from './utils/observability/webVitals';
 // load. Both are best-effort: see the try/catch in each module.
 initMeterProvider();
 initWebVitals();
+// OBS-P9 (ORISO-Helm#62, ORISO-Frontend#440): Unable-To-Decrypt (UTD)
+// failure tracking for encrypted counselling conversations.
+initUtdTracking();
 
 const ThemeDemo = lazy(() =>
 	import('./components/themeDemo/ThemeDemo').then((m) => ({

--- a/src/utils/observability/utdTracker.test.ts
+++ b/src/utils/observability/utdTracker.test.ts
@@ -1,0 +1,498 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DecryptionFailureCode } from 'matrix-js-sdk/lib/crypto-api';
+
+// vi.mock factories are hoisted above imports, so referenced variables must
+// be prefixed with "mock" (Vitest's hoisting convention) -- see
+// https://vitest.dev/api/vi.html#vi-mock
+const mockAdd = vi.fn();
+const mockCreateCounter = vi.fn(() => ({ add: mockAdd }));
+const mockGetMeter = vi.fn(() => ({ createCounter: mockCreateCounter }));
+
+vi.mock('@opentelemetry/api', () => ({
+	metrics: { getMeter: mockGetMeter }
+}));
+
+const CLIENT_POLL_INTERVAL_MS = 2000;
+const GRACE_PERIOD_MS = 5 * 60 * 1000;
+
+type Listener = (...args: any[]) => void;
+
+/**
+ * Minimal Matrix client double: just enough EventEmitter surface for a
+ * global 'Room.timeline' listener (no per-room filtering -- the tracker
+ * must observe every room).
+ */
+const createFakeMatrixClient = () => {
+	const listeners = new Map<string, Set<Listener>>();
+	return {
+		on: (event: string, listener: Listener) => {
+			if (!listeners.has(event)) {
+				listeners.set(event, new Set());
+			}
+			listeners.get(event)!.add(listener);
+		},
+		off: (event: string, listener: Listener) => {
+			listeners.get(event)?.delete(listener);
+		},
+		emit: (event: string, ...args: any[]) => {
+			listeners.get(event)?.forEach((listener) => listener(...args));
+		},
+		listenerCount: (event: string) => listeners.get(event)?.size || 0
+	};
+};
+
+/**
+ * Minimal MatrixEvent double for an `m.room.encrypted` event: enough surface
+ * to drive `Event.decrypted` (success/failure) transitions the way
+ * matrix-js-sdk does -- `getType()` stays `m.room.encrypted` on failure and
+ * only changes on success.
+ */
+const createFakeEncryptedEvent = (id: string) => {
+	const decryptionListeners = new Set<Listener>();
+	let type = 'm.room.encrypted';
+	let failing = false;
+	let failureReason: DecryptionFailureCode | null = null;
+
+	return {
+		getId: () => id,
+		getType: () => type,
+		isDecryptionFailure: () => failing,
+		get decryptionFailureReason() {
+			return failureReason;
+		},
+		on: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted') decryptionListeners.add(listener);
+		},
+		off: (name: string, listener: Listener) => {
+			if (name === 'Event.decrypted')
+				decryptionListeners.delete(listener);
+		},
+		listenerCount: () => decryptionListeners.size,
+		simulateFailure: (reason: DecryptionFailureCode | null) => {
+			type = 'm.room.encrypted';
+			failing = true;
+			failureReason = reason;
+			decryptionListeners.forEach((listener) => listener());
+		},
+		simulateSuccess: () => {
+			type = 'm.room.message';
+			failing = false;
+			decryptionListeners.forEach((listener) => listener());
+		}
+	};
+};
+
+/** Advances past one client-poll tick so a just-registered client gets picked up. */
+const flushClientPoll = () => {
+	vi.advanceTimersByTime(CLIENT_POLL_INTERVAL_MS);
+};
+
+/**
+ * `vi.resetModules()` gives `./utdTracker` a fresh module instance per test
+ * (so its `initialized` singleton flag and internal tracking Maps reset
+ * too) -- but that means anything it imports internally (in particular
+ * `matrixClientRegistry`, a stateful singleton) must be re-imported
+ * *dynamically* from the same fresh registry, not statically at the top of
+ * this file, or the test would be setting the client ref on a different
+ * module instance than the one `utdTracker` reads from.
+ */
+const loadModules = async () => {
+	const { initUtdTracking } = await import('./utdTracker');
+	const { setMatrixClientServiceRef } = await import(
+		'../../services/matrixClientRegistry'
+	);
+	return { initUtdTracking, setMatrixClientServiceRef };
+};
+
+describe('initUtdTracking', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('gets a meter named exactly "utd-tracker"', async () => {
+		const { initUtdTracking } = await loadModules();
+
+		initUtdTracking();
+
+		expect(mockGetMeter).toHaveBeenCalledWith('utd-tracker');
+	});
+
+	it('creates a counter named exactly "decryption_failure"', async () => {
+		const { initUtdTracking } = await loadModules();
+
+		initUtdTracking();
+
+		expect(mockCreateCounter).toHaveBeenCalledWith('decryption_failure');
+	});
+
+	it('only wires the meter/counter once even if called repeatedly', async () => {
+		const { initUtdTracking } = await loadModules();
+
+		initUtdTracking();
+		initUtdTracking();
+		initUtdTracking();
+
+		expect(mockGetMeter).toHaveBeenCalledTimes(1);
+		expect(mockCreateCounter).toHaveBeenCalledTimes(1);
+	});
+
+	it('never throws when the meter is unavailable', async () => {
+		mockGetMeter.mockImplementationOnce(() => {
+			throw new Error('boom');
+		});
+		const { initUtdTracking } = await loadModules();
+
+		expect(() => initUtdTracking()).not.toThrow();
+	});
+
+	describe('grace-period classification', () => {
+		it('does not count a decryption failure that resolves before the grace period elapses', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+
+			event.simulateFailure(
+				DecryptionFailureCode.OLM_UNKNOWN_MESSAGE_INDEX
+			);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS - 1000);
+			event.simulateSuccess();
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).not.toHaveBeenCalledWith(
+				1,
+				expect.objectContaining({ outcome: 'permanent' })
+			);
+		});
+
+		it('optionally counts a resolved-before-timeout failure as transient_resolved with the original cause', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+
+			event.simulateFailure(
+				DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			);
+			event.simulateSuccess();
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'transient_resolved',
+				cause: DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			});
+		});
+
+		it('counts a decryption failure still unresolved after five minutes as permanent, with the right cause/category', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_SENDER_DEVICE);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: DecryptionFailureCode.UNKNOWN_SENDER_DEVICE,
+				category: 'bug'
+			});
+		});
+
+		it('does not increment a second time if the event resolves after already timing out', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_ERROR);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+			expect(mockAdd).toHaveBeenCalledTimes(1);
+
+			// The permanent-timeout path detaches the listener, so a later
+			// success (if the SDK ever fired one) shouldn't be observed --
+			// but even if it were, this must not add a second time.
+			event.simulateSuccess();
+			expect(mockAdd).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not restart the grace timer on a repeated failure fire for the same event', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_ERROR);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS - 1000);
+			// A second failure fire for the same still-pending event must not
+			// push the deadline out further.
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_ERROR);
+			vi.advanceTimersByTime(1000);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: DecryptionFailureCode.UNKNOWN_ERROR,
+				category: 'bug'
+			});
+		});
+
+		it('ignores non-encrypted timeline events', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const plainEvent = {
+				getId: () => '$plain1',
+				getType: () => 'm.room.message',
+				isDecryptionFailure: () => false,
+				decryptionFailureReason: null,
+				on: vi.fn(),
+				off: vi.fn()
+			};
+			client.emit('Room.timeline', plainEvent);
+
+			expect(plainEvent.on).not.toHaveBeenCalled();
+			expect(mockAdd).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('category classification', () => {
+		const withheldCodes = [
+			DecryptionFailureCode.MEGOLM_KEY_WITHHELD,
+			DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE
+		];
+		const bugCodes = Object.values(DecryptionFailureCode).filter(
+			(code) => !withheldCodes.includes(code as DecryptionFailureCode)
+		);
+
+		it.each(withheldCodes)(
+			'classifies %s as category "withheld"',
+			async (code) => {
+				const { initUtdTracking, setMatrixClientServiceRef } =
+					await loadModules();
+				initUtdTracking();
+
+				const client = createFakeMatrixClient();
+				setMatrixClientServiceRef({ getClient: () => client } as any);
+				flushClientPoll();
+
+				const event = createFakeEncryptedEvent(`$${code}`);
+				client.emit('Room.timeline', event);
+				event.simulateFailure(code);
+				vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+				expect(mockAdd).toHaveBeenCalledWith(1, {
+					outcome: 'permanent',
+					cause: code,
+					category: 'withheld'
+				});
+			}
+		);
+
+		it.each(bugCodes)('classifies %s as category "bug"', async (code) => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent(`$${code}`);
+			client.emit('Room.timeline', event);
+			event.simulateFailure(code as DecryptionFailureCode);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: code,
+				category: 'bug'
+			});
+		});
+
+		it('classifies UNKNOWN_ERROR specifically as "bug"', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$unknown-error');
+			client.emit('Room.timeline', event);
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_ERROR);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: DecryptionFailureCode.UNKNOWN_ERROR,
+				category: 'bug'
+			});
+		});
+
+		it('falls back to UNKNOWN_ERROR (category "bug") when decryptionFailureReason is null', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt-null-reason');
+			client.emit('Room.timeline', event);
+			// isDecryptionFailure() true but decryptionFailureReason left null.
+			event.simulateFailure(null);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: DecryptionFailureCode.UNKNOWN_ERROR,
+				category: 'bug'
+			});
+		});
+	});
+
+	describe('no PII / identifying attributes', () => {
+		it('attaches exactly {outcome, cause, category} for a permanent failure -- no event id, room id, sender, or user id', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+			event.simulateFailure(
+				DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP
+			);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			const [, attributes] = mockAdd.mock.calls[0];
+			expect(Object.keys(attributes).sort()).toEqual(
+				['category', 'cause', 'outcome'].sort()
+			);
+		});
+
+		it('attaches exactly {outcome, cause} for a transient_resolved failure -- no event id, room id, sender, or user id', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+			event.simulateFailure(
+				DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			);
+			event.simulateSuccess();
+
+			const [, attributes] = mockAdd.mock.calls[0];
+			expect(Object.keys(attributes).sort()).toEqual(
+				['cause', 'outcome'].sort()
+			);
+		});
+	});
+
+	describe('resilience', () => {
+		it('never throws when the counter add fails', async () => {
+			mockAdd.mockImplementationOnce(() => {
+				throw new Error('export failed');
+			});
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+			event.simulateFailure(DecryptionFailureCode.UNKNOWN_ERROR);
+
+			expect(() => vi.advanceTimersByTime(GRACE_PERIOD_MS)).not.toThrow();
+		});
+
+		it('detaches from the old client and attaches to the new one when the Matrix client instance changes', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const clientA = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => clientA } as any);
+			flushClientPoll();
+			expect(clientA.listenerCount('Room.timeline')).toBe(1);
+
+			const clientB = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => clientB } as any);
+			flushClientPoll();
+
+			expect(clientA.listenerCount('Room.timeline')).toBe(0);
+			expect(clientB.listenerCount('Room.timeline')).toBe(1);
+		});
+
+		it('does not double-track the same event id across repeated Room.timeline fires', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$evt1');
+			client.emit('Room.timeline', event);
+			client.emit('Room.timeline', event);
+			client.emit('Room.timeline', event);
+
+			expect(event.listenerCount()).toBe(1);
+		});
+	});
+});

--- a/src/utils/observability/utdTracker.ts
+++ b/src/utils/observability/utdTracker.ts
@@ -1,0 +1,253 @@
+import { metrics, type Counter, type Attributes } from '@opentelemetry/api';
+import {
+	MatrixEventEvent,
+	type MatrixClient,
+	type MatrixEvent
+} from 'matrix-js-sdk';
+import { DecryptionFailureCode } from 'matrix-js-sdk/lib/crypto-api';
+import { getMatrixClientService } from '../../services/matrixClientRegistry';
+
+/**
+ * "Unable To Decrypt" (UTD) failure tracking (OBS-P9, ORISO-Helm#62,
+ * ORISO-Frontend#440). Exports one OpenTelemetry counter -- how often
+ * encrypted counselling messages permanently fail to decrypt -- to our
+ * self-hosted SigNoz collector via the MeterProvider set up in
+ * `meterProvider.ts`.
+ *
+ * The meter name ('utd-tracker') and the counter name ('decryption_failure')
+ * are a dashboard contract: a follow-up SigNoz dashboard queries these names
+ * by string, so a typo here breaks that silently.
+ *
+ * Deliberately NOT included, ever: room id, event id, sender, user id, or
+ * anything else that could identify a specific conversation or person. This
+ * is dev/ops tooling only, never per-user/per-conversation tracking
+ * (ADR-011) -- doubly so here since this observes encrypted counselling
+ * conversations specifically. `cause`/`outcome`/`category` describe the
+ * health of the crypto pipeline without revealing who talked to whom.
+ *
+ * Grace period: matrix-js-sdk does not distinguish a transient failure (the
+ * decryption key arrives a little late and the SDK self-heals) from a
+ * permanent one -- that's left to the consumer. This mirrors the 5-minute
+ * grace-period pattern `chatTransportService.onMatrixTimeline` already uses
+ * for its own (unrelated) UI-refresh purpose, so both classify "how long is
+ * too long" the same way. That existing mechanism is scoped to whichever
+ * single room a component currently has open, though, so it can't be reused
+ * as-is for telemetry that must span every room -- this module runs its own,
+ * separate grace-period tracker, keyed by event id, wired directly onto the
+ * Matrix client's `Room.timeline` event (which already fires for all rooms).
+ *
+ * Best-effort, must never throw -- same try/catch discipline as the rest of
+ * this observability code.
+ */
+
+const METER_NAME = 'utd-tracker';
+const COUNTER_NAME = 'decryption_failure';
+const GRACE_PERIOD_MS = 5 * 60 * 1000;
+
+// How often to check whether a Matrix client has become available (login)
+// or been swapped out (token refresh creates a new client instance, logout
+// clears it). initUtdTracking() runs once, very early at app startup --
+// long before login -- so there is no login/logout/refresh hook to attach
+// to directly without reaching into matrixClientService.ts; polling is the
+// simplest way to stay a self-contained, additive module.
+const CLIENT_POLL_INTERVAL_MS = 2000;
+
+const WITHHELD_CODES: ReadonlySet<DecryptionFailureCode> = new Set([
+	DecryptionFailureCode.MEGOLM_KEY_WITHHELD,
+	DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE
+]);
+
+// MSC4153-adjacent: a withheld key is an intentional, expected outcome (the
+// sender chose not to share it, e.g. to an unverified device), not a bug.
+// Every other code indicates the crypto pipeline itself misbehaved.
+const categoryFor = (cause: DecryptionFailureCode): 'withheld' | 'bug' =>
+	WITHHELD_CODES.has(cause) ? 'withheld' : 'bug';
+
+type PendingFailure = {
+	cause: DecryptionFailureCode;
+	timeout: ReturnType<typeof setTimeout>;
+};
+
+type TrackedListener = {
+	event: MatrixEvent;
+	onDecrypted: () => void;
+};
+
+/**
+ * Attaches the per-client 'Room.timeline' + per-event 'Event.decrypted'
+ * tracking. Returns a detach function that undoes everything (listeners and
+ * in-flight timers) so it can be safely re-run against a new client
+ * instance (e.g. after a token refresh recreates the underlying
+ * MatrixClient).
+ */
+const attachToClient = (
+	client: MatrixClient,
+	counter: Counter
+): (() => void) => {
+	const pendingFailures = new Map<string, PendingFailure>();
+	const trackedListeners = new Map<string, TrackedListener>();
+
+	const safeAdd = (attributes: Attributes): void => {
+		try {
+			counter.add(1, attributes);
+		} catch {
+			// telemetry must never throw
+		}
+	};
+
+	const detach = (eventId: string): void => {
+		const tracked = trackedListeners.get(eventId);
+		if (!tracked) {
+			return;
+		}
+		try {
+			(tracked.event as any).off(
+				MatrixEventEvent.Decrypted,
+				tracked.onDecrypted
+			);
+		} catch {
+			// telemetry must never throw
+		}
+		trackedListeners.delete(eventId);
+	};
+
+	const clearPending = (eventId: string): void => {
+		const pending = pendingFailures.get(eventId);
+		if (!pending) {
+			return;
+		}
+		clearTimeout(pending.timeout);
+		pendingFailures.delete(eventId);
+	};
+
+	// Re-evaluates one event's current decryption state, either right after
+	// attaching (covers the race where decryption already concluded before
+	// we got a listener on) or from the 'Event.decrypted' callback (the
+	// normal path).
+	const evaluate = (eventId: string, event: MatrixEvent): void => {
+		if (event.getType() !== 'm.room.encrypted') {
+			// Decrypted successfully (the event's type was promoted away
+			// from the encrypted envelope type).
+			const pending = pendingFailures.get(eventId);
+			if (pending) {
+				clearPending(eventId);
+				safeAdd({
+					outcome: 'transient_resolved',
+					cause: pending.cause
+				});
+			}
+			detach(eventId);
+			return;
+		}
+
+		if (event.isDecryptionFailure()) {
+			if (pendingFailures.has(eventId)) {
+				// Already tracking this failure; a repeat 'Event.decrypted'
+				// fire with another failure doesn't restart the clock.
+				return;
+			}
+			const cause =
+				event.decryptionFailureReason ??
+				DecryptionFailureCode.UNKNOWN_ERROR;
+			const timeout = setTimeout(() => {
+				pendingFailures.delete(eventId);
+				detach(eventId);
+				safeAdd({
+					outcome: 'permanent',
+					cause,
+					category: categoryFor(cause)
+				});
+			}, GRACE_PERIOD_MS);
+			pendingFailures.set(eventId, { cause, timeout });
+			return;
+		}
+
+		// Still the encrypted envelope type but not (yet) a failure: no
+		// decryption attempt has concluded yet. Keep waiting.
+	};
+
+	const handleTimeline = (event: MatrixEvent | undefined): void => {
+		try {
+			if (!event || event.getType() !== 'm.room.encrypted') {
+				return;
+			}
+			const eventId = event.getId?.();
+			if (!eventId || trackedListeners.has(eventId)) {
+				return;
+			}
+
+			const onDecrypted = (): void => evaluate(eventId, event);
+			trackedListeners.set(eventId, { event, onDecrypted });
+			(event as any).on(MatrixEventEvent.Decrypted, onDecrypted);
+
+			// Cover the race where the event already finished decrypting
+			// (success or failure) before this listener was attached.
+			evaluate(eventId, event);
+		} catch {
+			// telemetry must never throw
+		}
+	};
+
+	(client as any).on('Room.timeline', handleTimeline);
+
+	return () => {
+		try {
+			(client as any).off('Room.timeline', handleTimeline);
+		} catch {
+			// telemetry must never throw
+		}
+		Array.from(trackedListeners.keys()).forEach(detach);
+		Array.from(pendingFailures.keys()).forEach(clearPending);
+	};
+};
+
+let initialized = false;
+
+/**
+ * Wires the UTD (Unable To Decrypt) tracker to an OpenTelemetry counter.
+ * Only needs to run once per page load -- call this once at app startup,
+ * alongside `initMeterProvider`/`initWebVitals`, not per component.
+ *
+ * The Matrix client doesn't exist yet at app startup (it's created on
+ * login, and re-created on token refresh), so this polls for it becoming
+ * available/changing rather than requiring a direct hook into
+ * matrixClientService.ts.
+ */
+export const initUtdTracking = (): void => {
+	if (initialized) {
+		return;
+	}
+	initialized = true;
+
+	try {
+		const meter = metrics.getMeter(METER_NAME);
+		const counter = meter.createCounter(COUNTER_NAME);
+
+		let attachedClient: MatrixClient | null = null;
+		let detachFromClient: (() => void) | null = null;
+
+		const checkForClient = (): void => {
+			try {
+				const client = getMatrixClientService()?.getClient?.() ?? null;
+
+				if (client === attachedClient) {
+					return;
+				}
+
+				detachFromClient?.();
+				attachedClient = client;
+				detachFromClient = client
+					? attachToClient(client, counter)
+					: null;
+			} catch {
+				// telemetry must never throw
+			}
+		};
+
+		checkForClient();
+		setInterval(checkForClient, CLIENT_POLL_INTERVAL_MS);
+	} catch (e) {
+		// Swallow wiring failures -- this is telemetry, not a critical
+		// path, and must never surface as a new error or block app startup.
+	}
+};


### PR DESCRIPTION
## Summary

- Adds `initUtdTracking()` (`src/utils/observability/utdTracker.ts`), wired after `initMeterProvider()`/`initWebVitals()` in `initApp.tsx` -- the OTel-export half of the "Unable To Decrypt" (UTD) tracker for encrypted counselling conversations.
- Observes every room's `Event.decrypted` firings on `m.room.encrypted` timeline events via a client-level `Room.timeline` listener (polling for the Matrix client to become available/change, since the client doesn't exist yet at app startup and can be recreated on token refresh).
- A per-event 5-minute grace-period timer classifies each failure as `transient_resolved` (key arrived before the timer fired, optional/nice-to-have signal) or `permanent` (still failing after 5 minutes, the primary signal). `category` splits `permanent` failures into `withheld` (`MEGOLM_KEY_WITHHELD` / `MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE` -- MSC4153-adjacent, intentional/expected) vs `bug` (every other code).
- **No PII/identifying attributes ever**: only `{outcome, cause}` or `{outcome, cause, category}` are attached -- never room id, event id, sender, or user id. Same dev/ops-only telemetry principle as OBS-P3/OBS-P8 (ADR-011), doubly so here since this observes encrypted counselling conversations specifically.
- Meter name `'utd-tracker'`, counter name `'decryption_failure'` -- exact strings a follow-up SigNoz dashboard will query by name.

## Relation to #412 (`fix: refresh delayed Matrix decryption`)

\#412 is already merged into `pre-dev` (commit `20ad545`) and already implements a 5-minute grace-period pattern for `Event.decrypted` in `chatTransportService.onMatrixTimeline` -- but for a different purpose (UI refresh) and a different scope (only the single room a `SessionStream` component currently has open, via `onMatrixTimeline(matrixRoomId, listener)`).

Since this telemetry needs to span *every* room, not just whichever one is currently open in the UI, #412's per-room mechanism can't be reused as-is. This PR ships its own, separate, minimal grace-period tracker (same 5-minute window, for classification consistency) wired directly onto the Matrix client's `Room.timeline` event, which already fires for all rooms. `chatTransportService.ts` and `meterProvider.ts`/`webVitals.ts` are untouched -- this PR only adds two new files plus the two-line wiring (`initApp.tsx`).

## Metric schema (for the follow-up SigNoz dashboard)

- Meter: `utd-tracker`
- Counter: `decryption_failure`
- Attributes:
  - Permanent failure: `{ outcome: 'permanent', cause: <DecryptionFailureCode>, category: 'withheld' | 'bug' }`
  - Transient resolved (optional/nice-to-have): `{ outcome: 'transient_resolved', cause: <DecryptionFailureCode> }`

**Known limitation, tracked separately, not addressed here**: matrix-js-sdk's crypto engine is never actually initialized anywhere in this app today (#464), so `Event.decrypted` basically never fires for real yet -- this tracker will show near-zero live data until that separate issue is fixed. Built correctly anyway so it's live the moment crypto init lands.

Refs OpenResilienceInitiative/ORISO-Helm#62
Refs OpenResilienceInitiative/ORISO-Frontend#440

## Test plan

- [x] `npx eslint src/utils/observability/utdTracker.ts src/utils/observability/utdTracker.test.ts src/initApp.tsx --max-warnings=0`
- [x] `npx tsc` (full project typecheck)
- [x] `npm run test:unit` -- 121 files / 785 tests pass, including 29 new tests covering: grace-period resolve-before-timeout vs timeout-fires, all 12 `DecryptionFailureCode` values classified into `withheld`/`bug`, exact attribute-set assertions (no PII), meter/counter name exactness, dedupe of repeated `Room.timeline`/`Event.decrypted` fires, client-swap re-attach, and never-throw resilience -- using `vi.useFakeTimers()` to advance past the 5-minute window.
- [x] `CI=false npm run build` -- succeeds (only pre-existing, unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)