### PR TITLE
fix: reload anonymous session after consultant accept so live chat co…

### DIFF
--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -389,7 +389,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const { t: translate } = useTranslation();
 	const tenantData = useTenant();
 
-	const { activeSession } = useContext(ActiveSessionContext);
+	const { activeSession, reloadActiveSession } =
+		useContext(ActiveSessionContext);
 	const { userData, setUserData } = useContext(UserDataContext);
 	const { addEventNotification } = useContext(NotificationsContext);
 	const { type } = useContext(SessionTypeContext);
@@ -1883,6 +1884,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 
 		let cancelled = false;
 		const sessionId = activeSession.item.id;
+		const hasMatrixRoom = Boolean(activeSession.item?.matrixRoomId);
 
 		const refresh = () => {
 			apiGetAnonymousEnquiryDetails(sessionId)
@@ -1905,6 +1907,15 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 						details.status !== 'NEW'
 					) {
 						setConsultantAccepted(true);
+						/* Accepting provisions the Matrix room server-side,
+						   but the session in memory was loaded before that
+						   and still has no matrixRoomId — without it the
+						   chat never connects. Reload the session on every
+						   poll tick until the room id arrives (acceptance
+						   can race the room creation by a moment). */
+						if (!hasMatrixRoom) {
+							reloadActiveSession?.();
+						}
 					}
 				})
 				.catch(() => {
@@ -1920,7 +1931,12 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 			cancelled = true;
 			window.clearInterval(poll);
 		};
-	}, [isInAnonymousWaitingQueuePhase, activeSession.item?.id]);
+	}, [
+		isInAnonymousWaitingQueuePhase,
+		activeSession.item?.id,
+		activeSession.item?.matrixRoomId,
+		reloadActiveSession
+	]);
 
 	/**
 	 * When an anonymous asker leaves (logout, navigate away, tab close), finish the
@@ -2017,10 +2033,20 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	}, []);
 
 	const handleStartAcceptedChat = useCallback(() => {
+		/* Safety net: if the accepted session still lacks its Matrix room
+		   id (reload raced the room provisioning), fetch it again now so
+		   the unlocked composer can actually send. */
+		if (!activeSession.item?.matrixRoomId) {
+			reloadActiveSession?.();
+		}
 		void import('../messageSubmitInterface/messageSubmitInterfaceComponent')
 			.then(() => setWaitingGateDismissed(true))
 			.catch(() => setWaitingGateDismissed(true));
-	}, [setWaitingGateDismissed]);
+	}, [
+		activeSession.item?.matrixRoomId,
+		reloadActiveSession,
+		setWaitingGateDismissed
+	]);
 
 	useEffect(() => {
 		if (!shouldShowRobotMessages) {


### PR DESCRIPTION
…nnects

The Matrix room for an anonymous external-inbound enquiry is only provisioned when a consultant accepts, but the asker's client kept the session loaded at redeem time with a null matrixRoomId, so the chat never connected without a manual page reload.

Reload the active session from the waiting-queue poll once acceptance is detected (retrying until the room id arrives), and again from the 'Start chat now' action as a safety net.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

