### PR TITLE
feat: wire up messages-sent tile and dynamic year labels on consultant statistics

### DIFF
--- a/src/api/apiGetConsultantStatistics.ts
+++ b/src/api/apiGetConsultantStatistics.ts
@@ -6,6 +6,7 @@ export interface ConsultantStatisticsDTO {
 	endDate: string;
 	numberOfAssignedSessions: number;
 	numberOfActiveSessions: number;
+	numberOfSentMessages: number;
 }
 
 export interface ApiGetConsultantStatisticsInterface {

--- a/src/components/profile/ConsultantStatistics.test.tsx
+++ b/src/components/profile/ConsultantStatistics.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConsultantStatistics } from './ConsultantStatistics';
+
+const apiGetConsultantStatisticsMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key
+	})
+}));
+
+vi.mock('../../api', () => ({
+	apiGetConsultantStatistics: (...args: unknown[]) =>
+		apiGetConsultantStatisticsMock(...args)
+}));
+
+// Icon imports are SVGR (`ReactComponent as X from '*.svg'`), which this
+// project's vitest setup does not transform - no existing test renders an
+// icon component directly, so this gap was latent until now. Mocking the
+// icon modules (rather than adding a project-wide SVGR transform) keeps the
+// fix scoped to this test file.
+vi.mock('../../resources/img/icons/persons.svg', () => ({
+	ReactComponent: () => <svg data-testid="icon-persons" />
+}));
+vi.mock('../../resources/img/icons/speech-bubble.svg', () => ({
+	ReactComponent: () => <svg data-testid="icon-speech-bubble" />
+}));
+vi.mock('../../resources/img/icons/speech-bubble-plus.svg', () => ({
+	ReactComponent: () => <svg data-testid="icon-speech-bubble-plus" />
+}));
+vi.mock('../../resources/img/icons/download.svg', () => ({
+	ReactComponent: () => <svg data-testid="icon-download" />
+}));
+
+describe('ConsultantStatistics', () => {
+	it('renders the messages-sent tile from the API response', async () => {
+		apiGetConsultantStatisticsMock.mockResolvedValue({
+			startDate: '2026-07-01',
+			endDate: '2026-07-31',
+			numberOfAssignedSessions: 7,
+			numberOfActiveSessions: 3,
+			numberOfSentMessages: 12
+		});
+
+		render(<ConsultantStatistics />);
+
+		await waitFor(() => {
+			expect(screen.getByText('12')).toBeDefined();
+		});
+		expect(
+			screen.getByText(
+				'profile.statistics.csvHeader.numberOfSentMessages'
+			)
+		).toBeDefined();
+		expect(screen.getByTestId('icon-speech-bubble-plus')).toBeDefined();
+		// Assigned/active tiles still render alongside the new one.
+		expect(screen.getByText('7')).toBeDefined();
+		expect(screen.getByText('3')).toBeDefined();
+	});
+
+	it('defaults the messages-sent tile to 0 before the first response arrives', () => {
+		apiGetConsultantStatisticsMock.mockReturnValue(new Promise(() => {}));
+
+		render(<ConsultantStatistics />);
+
+		expect(screen.getAllByText('0')).toHaveLength(3);
+	});
+});

--- a/src/components/profile/ConsultantStatistics.tsx
+++ b/src/components/profile/ConsultantStatistics.tsx
@@ -10,6 +10,7 @@ import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
 import { ReactComponent as PersonsIcon } from '../../resources/img/icons/persons.svg';
 import { ReactComponent as SpeechBubbleIcon } from '../../resources/img/icons/speech-bubble.svg';
+import { ReactComponent as SpeechBubblePlusIcon } from '../../resources/img/icons/speech-bubble-plus.svg';
 import { ReactComponent as DownloadIcon } from '../../resources/img/icons/download.svg';
 import { CSVLink } from 'react-csv';
 import { formatToDDMMYYYY } from '../../utils/dateHelpers';
@@ -85,8 +86,16 @@ export const ConsultantStatistics = () => {
 				'profile.statistics.csvHeader.numberOfSessionsWhereConsultantWasActive'
 			),
 			key: 'numberOfActiveSessions'
+		},
+		{
+			label: translate(
+				'profile.statistics.csvHeader.numberOfSentMessages'
+			),
+			key: 'numberOfSentMessages'
 		}
 	];
+
+	const currentYear = dayjs().get('year');
 
 	const statisticsPeriodOptions: {
 		value: statisticOptions;
@@ -102,11 +111,19 @@ export const ConsultantStatistics = () => {
 		},
 		{
 			value: statisticsPeriodOptionCurrentYear,
-			label: translate('profile.statistics.period.currentYear')
+			// Caritas parity: the year picker shows the concrete year, not
+			// just "current"/"past" - appending it needs no new translation
+			// keys across all 6 languages, unlike a "Jahres {{year}}" key
+			// would (grammar differs per language, e.g. genitive in German).
+			label: `${translate(
+				'profile.statistics.period.currentYear'
+			)} (${currentYear})`
 		},
 		{
 			value: statisticsPeriodOptionLastYear,
-			label: translate('profile.statistics.period.lastYear')
+			label: `${translate(
+				'profile.statistics.period.lastYear'
+			)} (${currentYear - 1})`
 		}
 	];
 
@@ -143,7 +160,8 @@ export const ConsultantStatistics = () => {
 					{
 						numberOfAssignedSessions:
 							response.numberOfAssignedSessions,
-						numberOfActiveSessions: response.numberOfActiveSessions
+						numberOfActiveSessions: response.numberOfActiveSessions,
+						numberOfSentMessages: response.numberOfSentMessages
 					}
 				];
 
@@ -213,7 +231,7 @@ export const ConsultantStatistics = () => {
 							type="standard"
 						/>
 					</div>
-					<div className="statistics__visualization pl--4">
+					<div className="statistics__visualization pl--4 pr--4 br--1">
 						<span>
 							<SpeechBubbleIcon
 								aria-hidden="true"
@@ -227,6 +245,23 @@ export const ConsultantStatistics = () => {
 						<Text
 							text={translate(
 								'profile.statistics.csvHeader.numberOfSessionsWhereConsultantWasActive'
+							)}
+							type="standard"
+						/>
+					</div>
+					<div className="statistics__visualization pl--4">
+						<span>
+							<SpeechBubblePlusIcon
+								aria-hidden="true"
+								focusable="false"
+							/>
+							<p>
+								{selectedStatistics?.numberOfSentMessages || 0}
+							</p>
+						</span>
+						<Text
+							text={translate(
+								'profile.statistics.csvHeader.numberOfSentMessages'
 							)}
 							type="standard"
 						/>


### PR DESCRIPTION
## Why

Björn (stakeholder) asked for Caritas parity on the consultant \"Meine Statistik\" self-view: a messages-written tile and a year picker showing the concrete year. The messages tile was previously stripped out (ORISO-Frontend#418) because the backend had no data source; ORISO-UserService#391 now adds it back (pseudonymized server-side, see that PR).

## What

- `apiGetConsultantStatistics.ts`: `numberOfSentMessages` added to the DTO
- `ConsultantStatistics.tsx`: third stat tile wired to the existing (previously orphaned) `numberOfSentMessages` i18n key present in all 6 languages already - no new translation strings needed; included in the CSV export
- Year-period dropdown options now show the concrete year, e.g. \"current year (2026)\", via string interpolation rather than a new i18n key (avoids per-language grammar risk, e.g. German genitive \"des Jahres 2026\")

## Verification

- `npx vitest run src/components/profile/ConsultantStatistics.test.tsx` - 2/2 green (new test file - component had none before)
- `npx tsc --noEmit` - clean
- `npx eslint` on changed files - clean

Depends on ORISO-UserService#391 for the `numberOfSentMessages` field to actually return data (fails soft to 0 until then, same pattern as the rest of this tab).