### PR TITLE
ci: trigger frontend release from release branches

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,19 +1,11 @@
 name: Frontend Release Image
 
-run-name: Publish frontend release image v${{ inputs.version }}
+run-name: Publish frontend release image from ${{ github.ref_name }}
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Release version without the v prefix, for example 2.0.1
-        required: true
-        type: string
-      create_tag:
-        description: Create and push Git tag from this release branch
-        required: true
-        default: true
-        type: boolean
+  push:
+    branches:
+      - "release/frontend-*"
 
 env:
   REGISTRY: ghcr.io
@@ -27,6 +19,7 @@ permissions:
 jobs:
   release:
     name: validate, build, tag and publish release image
+    if: ${{ github.event.deleted == false }}
     runs-on: ubuntu-latest
 
     steps:
@@ -35,22 +28,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate release input
+      - name: Extract and validate release version
         shell: bash
         run: |
           set -euo pipefail
 
-          VERSION="${{ inputs.version }}"
-          EXPECTED_BRANCH="release/frontend-${VERSION}"
+          BRANCH="${GITHUB_REF_NAME}"
+          VERSION="${BRANCH#release/frontend-}"
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version must use MAJOR.MINOR.PATCH format, for example 2.0.1"
+          if [[ "$BRANCH" == "$VERSION" ]]; then
+            echo "Invalid release branch. Expected release/frontend-X.Y.Z"
             exit 1
           fi
 
-          if [[ "${GITHUB_REF_NAME}" != "$EXPECTED_BRANCH" ]]; then
-            echo "This workflow must run from ${EXPECTED_BRANCH}"
-            echo "Current ref is ${GITHUB_REF_NAME}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must use MAJOR.MINOR.PATCH format, for example 2.0.1"
             exit 1
           fi
 
@@ -59,23 +51,13 @@ jobs:
             exit 1
           fi
 
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "IMAGE=${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}" >> "$GITHUB_ENV"
+
       - name: Run frontend validation and build
         uses: ./.github/actions/node-build
         with:
           node_version: '18'
-
-      - name: Create and push release tag
-        if: ${{ inputs.create_tag }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ inputs.version }}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release frontend v${VERSION}"
-          git push origin "v${VERSION}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -93,13 +75,40 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}
+          tags: ${{ env.IMAGE }}
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Create and push release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release frontend v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: Frontend v${{ env.VERSION }}
+          generate_release_notes: true
+          body: |
+            ## Release Artifact
+
+            Docker image:
+            `${{ env.IMAGE }}`
+
+            Source commit:
+            `${{ github.sha }}`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release summary
         shell: bash
@@ -107,7 +116,8 @@ jobs:
           {
             echo "### Frontend release image"
             echo ""
-            echo "- Git tag: \`v${{ inputs.version }}\`"
-            echo "- Image: \`${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}\`"
+            echo "- Git tag: \`v${VERSION}\`"
+            echo "- Image: \`${IMAGE}\`"
             echo "- Source branch: \`${GITHUB_REF_NAME}\`"
+            echo "- GitHub Release: \`Frontend v${VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Updates the frontend release workflow to run automatically only for release/frontend-* branch pushes. The workflow extracts the version from the branch name, validates/builds the frontend, publishes the versioned Docker image, creates the v-prefixed Git tag, and creates a GitHub Release with generated notes.