### PR TITLE
ci: publish storybook release image

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -11,6 +11,7 @@ env:
   REGISTRY: ghcr.io
   ORG: openresilienceinitiative
   IMAGE_NAME: oriso-frontend
+  STORYBOOK_IMAGE_NAME: oriso-storybook
 
 permissions:
   contents: write
@@ -53,6 +54,7 @@ jobs:
 
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "IMAGE=${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}" >> "$GITHUB_ENV"
+          echo "STORYBOOK_IMAGE=${REGISTRY}/${ORG}/${STORYBOOK_IMAGE_NAME}:${VERSION}" >> "$GITHUB_ENV"
 
       - name: Run frontend validation and build
         uses: ./.github/actions/node-build
@@ -83,6 +85,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Publish versioned Storybook Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.storybook
+          push: true
+          tags: ${{ env.STORYBOOK_IMAGE }}
+          labels: |
+            org.opencontainers.image.title=${{ env.STORYBOOK_IMAGE_NAME }}
+            org.opencontainers.image.version=${{ env.VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Create and push release tag
         shell: bash
         run: |
@@ -102,8 +118,9 @@ jobs:
           body: |
             ## Release Artifact
 
-            Docker image:
+            Docker images:
             `${{ env.IMAGE }}`
+            `${{ env.STORYBOOK_IMAGE }}`
 
             Source commit:
             `${{ github.sha }}`
@@ -118,6 +135,7 @@ jobs:
             echo ""
             echo "- Git tag: \`v${VERSION}\`"
             echo "- Image: \`${IMAGE}\`"
+            echo "- Storybook image: \`${STORYBOOK_IMAGE}\`"
             echo "- Source branch: \`${GITHUB_REF_NAME}\`"
             echo "- GitHub Release: \`Frontend v${VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the existing Storybook GHCR package to the release branch workflow.\n\nThe workflow still runs only from release/frontend-* branches and now publishes both fixed version images:\n- ghcr.io/openresilienceinitiative/oriso-frontend:<version>\n- ghcr.io/openresilienceinitiative/oriso-storybook:<version>\n\nIt keeps the existing package names used by the dev/main workflows.