### PR TITLE
fix: stop pagehide from finishing anonymous enquiries and gate accept…

### DIFF
--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -65,7 +65,6 @@ import { apiPatchUserData } from '../../api/apiPatchUserData';
 import { apiGetUserData } from '../../api/apiGetUserData';
 import { apiGetAnonymousEnquiryDetails } from '../../api/apiGetAnonymousEnquiryDetails';
 import {
-	bindAnonymousChatUnloadCleanup,
 	ensureAnonymousChatPreLogoutCleanup,
 	registerAnonymousChatSessionForCleanup
 } from '../../utils/anonymousChatSessionCleanup';
@@ -1898,14 +1897,11 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 							? details.numAvailableConsultants
 							: null
 					);
-					/* Anything other than INITIAL/NEW means a consultant has
-					   started handling this enquiry — flip the action bar to
-					   the "Start chat now" prompt. */
-					if (
-						details?.status &&
-						details.status !== 'INITIAL' &&
-						details.status !== 'NEW'
-					) {
+					/* Only IN_PROGRESS means a consultant is handling this
+					   enquiry. DONE/IN_ARCHIVE must NOT flip the bar — a
+					   finished session would otherwise show "Start chat
+					   now" over a chat that can never connect. */
+					if (details?.status === 'IN_PROGRESS') {
 						setConsultantAccepted(true);
 						/* Accepting provisions the Matrix room server-side,
 						   but the session in memory was loaded before that
@@ -1939,8 +1935,15 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	]);
 
 	/**
-	 * When an anonymous asker leaves (logout, navigate away, tab close), finish the
-	 * session immediately so the waiting queue count drops for everyone else.
+	 * When an anonymous asker logs out, finish the session so the waiting
+	 * queue count drops for everyone else.
+	 *
+	 * Deliberately NOT bound to pagehide/unload: pagehide also fires on a
+	 * plain page refresh or navigation, and finishing there sets the session
+	 * to DONE and deactivates the anonymous Keycloak user — permanently
+	 * removing the enquiry from the consultant queue while the asker is
+	 * still waiting. Abandoned sessions are expired server-side by the
+	 * anonymous deactivate workflow instead.
 	 */
 	useEffect(() => {
 		ensureAnonymousChatPreLogoutCleanup();
@@ -1958,8 +1961,6 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 				: activeSession.item?.matrixRoomId,
 			userData?.userName
 		);
-
-		return bindAnonymousChatUnloadCleanup(activeSession.item.id);
 	}, [
 		isAnonymousAskerExperience,
 		activeSession.item?.id,

--- a/src/utils/anonymousChatSessionCleanup.ts
+++ b/src/utils/anonymousChatSessionCleanup.ts
@@ -1,11 +1,5 @@
 import { apiFinishAnonymousConversation } from '../api/apiFinishAnonymousConversation';
 import { FETCH_ERRORS } from '../api/fetchData';
-import { endpoints } from '../resources/scripts/endpoints';
-import {
-	getValueFromCookie,
-	setValueInCookie
-} from '../components/sessionCookie/accessSessionCookie';
-import { generateCsrfToken } from './generateCsrfToken';
 import { addEventListener, removeEventListener } from './eventHandler';
 import { EVENT_PRE_LOGOUT } from '../components/logout/logout';
 import {
@@ -43,32 +37,6 @@ export const registerAnonymousChatSessionForCleanup = (
 		return;
 	}
 	pendingSessionId = sessionId;
-};
-
-export const finishAnonymousChatSessionKeepalive = (
-	sessionId: number
-): void => {
-	const accessToken = getValueFromCookie('keycloak');
-	if (!accessToken) {
-		return;
-	}
-
-	const csrfToken = getValueFromCookie('CSRF-TOKEN') || generateCsrfToken();
-	if (!getValueFromCookie('CSRF-TOKEN')) {
-		setValueInCookie('CSRF-TOKEN', csrfToken);
-	}
-
-	void fetch(endpoints.finishAnonymousConversation(sessionId), {
-		method: 'PUT',
-		keepalive: true,
-		headers: {
-			'Content-Type': 'application/json',
-			'Authorization': `Bearer ${accessToken}`,
-			'X-CSRF-TOKEN': csrfToken
-		}
-	}).catch(() => {
-		/* best-effort on tab close */
-	});
 };
 
 export const finishPendingAnonymousChatSession = async (): Promise<void> => {
@@ -111,17 +79,14 @@ export const teardownAnonymousChatPreLogoutCleanup = (): void => {
 	preLogoutListenerRegistered = false;
 };
 
-export const bindAnonymousChatUnloadCleanup = (
-	sessionId: number | null | undefined
-): (() => void) => {
-	const onPageHide = () => {
-		if (sessionId != null) {
-			finishAnonymousChatSessionKeepalive(sessionId);
-		}
-	};
-
-	window.addEventListener('pagehide', onPageHide);
-	return () => window.removeEventListener('pagehide', onPageHide);
-};
+/*
+ * NOTE: there is intentionally no pagehide/unload hook here. pagehide fires
+ * on plain page refreshes and navigations too, and finishing the anonymous
+ * conversation there sets the session to DONE and deactivates the anonymous
+ * Keycloak user — silently destroying an enquiry that is still waiting in
+ * the consultant queue. Abandoned sessions are expired server-side by the
+ * anonymous deactivate workflow; the client finishes only on explicit
+ * logout (EVENT_PRE_LOGOUT above).
+ */
 
 export { STATUS_FINISHED, isOpenAnonymousSessionStatus };


### PR DESCRIPTION
… flip on IN_PROGRESS

The pagehide hook fired on plain page refreshes and navigations, sending PUT /conversations/anonymous/{id}/finish. That sets the session to DONE and deactivates the anonymous Keycloak user, permanently removing the enquiry from the consultant Live Chat queue (which only lists NEW sessions) while the asker is still waiting. Finishing now happens only on explicit logout; abandoned sessions are expired by the server-side anonymous deactivate workflow.

The waiting-queue poll also treated any non-NEW status as a consultant accept, so a finished session showed 'Start chat now' over a chat that could never connect. The flip now requires status IN_PROGRESS.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

