### PR TITLE
chore: add NOTICE (license & attribution baseline)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+ORISO Frontend
+Copyright 2025-2026 Open Resilience Initiative
+
+This repository is a modified version of Onlineberatung/onlineBeratung-frontend
+(original work Copyright virtualidentity AG and contributors /
+Caritas Deutschland, licensed under AGPL-3.0).
+
+This version has been modified by the Open Resilience Initiative,
+2025-2026. The git history is the record of modifications
+(AGPL-3.0 section 5(a)).


### PR DESCRIPTION
Part of the license & attribution baseline (Refs OpenResilienceInitiative/ORISO-Docs#59, parent epic OpenResilienceInitiative/ORISO-Docs#50).

Adds a **NOTICE** file asserting the correct copyright chain for this forked repository: upstream copyright preserved (AGPL-3.0), `Modifications Copyright 2025-2026 Open Resilience Initiative`, and the AGPL-3.0 §5(a) modified-version statement (git history as the modification record). The LICENSE file is unchanged.

No code changes; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
