### PR TITLE
feat(timeline): real-time feed refresh on live event

### DIFF
--- a/src/globalState/provider/NotificationsProvider.test.tsx
+++ b/src/globalState/provider/NotificationsProvider.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationsProvider } from './NotificationsProvider';
+import { messageEventEmitter } from '../../services/messageEventEmitter';
+
+const apiGetEventNotifications = vi.fn();
+
+vi.mock('../../api/apiEventNotifications', () => ({
+	apiGetEventNotifications: (...args: unknown[]) =>
+		apiGetEventNotifications(...args),
+	apiMarkEventNotificationRead: vi.fn(),
+	apiMarkAllEventNotificationsRead: vi.fn(),
+	apiClearEventNotifications: vi.fn()
+}));
+
+vi.mock('../../components/sessionCookie/accessSessionCookie', () => ({
+	getValueFromCookie: () => 'fake-token'
+}));
+
+describe('NotificationsProvider real-time refresh (#473)', () => {
+	beforeEach(() => {
+		apiGetEventNotifications.mockReset();
+		apiGetEventNotifications.mockResolvedValue({
+			items: [],
+			unreadCount: 0
+		});
+	});
+
+	// The provider subscribes to a singleton emitter — unmount it between cases so
+	// stale listeners don't fire on the next test's emit.
+	afterEach(() => cleanup());
+
+	it('refetches the feed when a live directMessage event fires, without waiting for the 15s poll', async () => {
+		render(
+			<NotificationsProvider>
+				<div />
+			</NotificationsProvider>
+		);
+
+		// Initial mount fetch — let it settle, then isolate the live-event refetch.
+		await waitFor(() =>
+			expect(apiGetEventNotifications).toHaveBeenCalled()
+		);
+		apiGetEventNotifications.mockClear();
+
+		// The backend fires a `directMessage` live event to the recipient whenever a
+		// notification is persisted; the websocket handler re-emits it on messageEventEmitter.
+		messageEventEmitter.emit({});
+
+		await waitFor(() =>
+			expect(apiGetEventNotifications).toHaveBeenCalledTimes(1)
+		);
+	});
+
+	it('collapses a burst of live events into a single debounced refetch', async () => {
+		render(
+			<NotificationsProvider>
+				<div />
+			</NotificationsProvider>
+		);
+		await waitFor(() =>
+			expect(apiGetEventNotifications).toHaveBeenCalled()
+		);
+		apiGetEventNotifications.mockClear();
+
+		messageEventEmitter.emit({});
+		messageEventEmitter.emit({});
+		messageEventEmitter.emit({});
+
+		await waitFor(() =>
+			expect(apiGetEventNotifications).toHaveBeenCalledTimes(1)
+		);
+		// Give any un-debounced extra calls a chance to (wrongly) fire.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(apiGetEventNotifications).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/globalState/provider/NotificationsProvider.tsx
+++ b/src/globalState/provider/NotificationsProvider.tsx
@@ -21,6 +21,7 @@ import {
 import { getValueFromCookie } from '../../components/sessionCookie/accessSessionCookie';
 import { EventActionParams } from '../../components/notificationsCenter/eventDescriptors';
 import { parseEventActionParams } from '../../components/notificationsCenter/notificationActionTarget';
+import { messageEventEmitter } from '../../services/messageEventEmitter';
 
 export const NOTIFICATION_DEFAULT_TIMEOUT = 3000;
 
@@ -178,6 +179,26 @@ export function NotificationsProvider(props) {
 		refreshNotificationFeedSafe();
 		const interval = window.setInterval(refreshNotificationFeedSafe, 15000);
 		return () => window.clearInterval(interval);
+	}, [refreshNotificationFeedSafe]);
+
+	// Real-time backbone: the backend fires a `directMessage` live event to the
+	// recipient whenever a notification is persisted (ORISO-UserService
+	// EventNotificationService), and WebsocketHandler re-emits it on
+	// messageEventEmitter. Refresh the feed on that signal instead of waiting for
+	// the 15s fallback poll above. Debounced so a burst of events (e.g. one live
+	// message fanning out to several notifications) collapses into a single
+	// refetch.
+	useEffect(() => {
+		let debounceTimer: number | undefined;
+		const onLiveEvent = () => {
+			window.clearTimeout(debounceTimer);
+			debounceTimer = window.setTimeout(refreshNotificationFeedSafe, 400);
+		};
+		messageEventEmitter.on(onLiveEvent);
+		return () => {
+			messageEventEmitter.off(onLiveEvent);
+			window.clearTimeout(debounceTimer);
+		};
 	}, [refreshNotificationFeedSafe]);
 
 	const hasNotification = useCallback(


### PR DESCRIPTION
## Why
The Activity Timeline feed only refreshed on a 15s client poll, so even notifications that already have backend writers surfaced up to 15s late — reading as "notifications don't work". This is the frontend half of making the feed real-time.

## What
`NotificationsProvider` subscribes to `messageEventEmitter` and refetches the event-notifications feed when a `directMessage` live event arrives — the signal the backend now fires to a recipient whenever a notification is persisted (see ORISO-UserService PR #443). Debounced (400ms) so a burst of events collapses into a single refetch. The 15s poll is untouched and remains a slow fallback.

## Tests (TDD)
`NotificationsProvider.test.tsx` (new): a live event triggers exactly one feed refetch (not waiting for the poll); a burst of three events collapses into one debounced refetch.

## Backend counterpart
ORISO-UserService PR #443 (live-event push on persist).

Closes #473 (frontend half). Refs #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)