### PR TITLE
fix: surface finished anonymous enquiries and failed live chat feed

### DIFF
--- a/src/api/apiGetConsultantSessionList.ts
+++ b/src/api/apiGetConsultantSessionList.ts
@@ -67,10 +67,16 @@ export const apiGetConsultantSessionList = async ({
 	const [registered, anonymous] = await Promise.all([
 		fetchListUrl(registeredUrl, signal),
 		// The anonymous queue is best-effort: a failure there must not hide the
-		// registered enquiries a consultant is responsible for.
-		fetchListUrl(anonymousUrl, signal).catch(
-			() => ({ sessions: [] }) as ListItemsResponseInterface
-		)
+		// registered enquiries a consultant is responsible for. It must be
+		// loud, though — a silent empty result is indistinguishable from
+		// "no live chat enquiries" and hides backend 500s from diagnosis.
+		fetchListUrl(anonymousUrl, signal).catch((error) => {
+			console.error(
+				'Anonymous enquiry feed failed — live chat enquiries may be missing from the list:',
+				error
+			);
+			return { sessions: [] } as ListItemsResponseInterface;
+		})
 	]);
 
 	return mergeEnquiryFeeds(registered, anonymous);

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -509,6 +509,13 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	);
 	const [consultantAccepted, setConsultantAccepted] = useState(false);
 	/**
+	 * The anonymous enquiry was finished server-side (asker logout, backend
+	 * expiry workflow, admin cleanup) while this tab was still on the
+	 * waiting screen. Waiting longer is pointless — no consultant can see
+	 * a finished enquiry — so the queue UI switches to a closed notice.
+	 */
+	const [enquiryClosed, setEnquiryClosed] = useState(false);
+	/**
 	 * Live count of consultants currently available for this anonymous
 	 * enquiry, fed by the `apiGetAnonymousEnquiryDetails` poll. `null` while
 	 * unknown. When this drops to 0 the "Live-Chat ist zurzeit leider
@@ -663,6 +670,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const liveChatClosedModalOpen =
 		isInAnonymousWaitingQueuePhase &&
 		!consultantAccepted &&
+		!enquiryClosed &&
 		numAvailableConsultants === 0 &&
 		!liveChatClosedDismissed;
 	const isJoinRoomAvailable = Boolean(activeSession.consultant?.id);
@@ -1877,7 +1885,11 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	 * enquiries queued ahead for the same consulting type.
 	 */
 	useEffect(() => {
-		if (!isInAnonymousWaitingQueuePhase || !activeSession.item?.id) {
+		if (
+			!isInAnonymousWaitingQueuePhase ||
+			!activeSession.item?.id ||
+			enquiryClosed
+		) {
 			return;
 		}
 
@@ -1889,6 +1901,18 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 			apiGetAnonymousEnquiryDetails(sessionId)
 				.then((details) => {
 					if (cancelled) return;
+					/* DONE/IN_ARCHIVE: the enquiry was finished server-side.
+					   Consultants can never see or accept it — stop polling
+					   and show the closed notice instead of queue position
+					   and availability, which would suggest it is still
+					   waiting. */
+					if (
+						details?.status === 'DONE' ||
+						details?.status === 'IN_ARCHIVE'
+					) {
+						setEnquiryClosed(true);
+						return;
+					}
 					if (typeof details?.peopleAhead === 'number') {
 						setQueuePeopleAhead(details.peopleAhead);
 					}
@@ -1931,7 +1955,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		isInAnonymousWaitingQueuePhase,
 		activeSession.item?.id,
 		activeSession.item?.matrixRoomId,
-		reloadActiveSession
+		reloadActiveSession,
+		enquiryClosed
 	]);
 
 	/**
@@ -4639,8 +4664,23 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 				</div>
 			)}
 
+			{shouldShowPseudonymGate && pseudonymConfirmed && enquiryClosed && (
+				<div className="session__pseudonymActionBarSlot">
+					<div
+						className="session__anonymousEnquiryClosedNote"
+						role="status"
+					>
+						{translate(
+							'anonymousChat.enquiryClosed',
+							'Dieser Live-Chat wurde beendet. Um einen neuen Chat zu starten, öffnen Sie bitte Ihren Einladungslink erneut.'
+						)}
+					</div>
+				</div>
+			)}
+
 			{shouldShowPseudonymGate &&
 				pseudonymConfirmed &&
+				!enquiryClosed &&
 				!consultantAccepted && (
 					<div className="session__pseudonymActionBarSlot">
 						<WaitingQueueActionBar
@@ -4652,6 +4692,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 
 			{shouldShowPseudonymGate &&
 				pseudonymConfirmed &&
+				!enquiryClosed &&
 				consultantAccepted && (
 					<div className="session__pseudonymActionBarSlot">
 						<ConsultantAcceptedActionBar

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -994,6 +994,15 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		border-top: 1px solid rgba(0, 0, 0, 0.06);
 	}
 
+	&__anonymousEnquiryClosedNote {
+		padding: 16px 24px;
+		text-align: center;
+		font-size: 15px;
+		line-height: 1.4;
+		color: #4c555f;
+		background-color: #f4f6f9;
+	}
+
 	&__content--consentGate {
 		display: flex;
 		align-items: center;

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -3455,7 +3455,8 @@
 			"consultantAccepted": "Sie werden jetzt von ihrer Berater_in im Chat erwartet.",
 			"startChatNow": "Jetzt Chat starten",
 			"dismissAcceptedBanner": "Hinweis ausblenden"
-		}
+		},
+		"enquiryClosed": "Dieser Live-Chat wurde beendet. Um einen neuen Chat zu starten, öffnen Sie bitte Ihren Einladungslink erneut."
 	},
 	"sessionHeader": {
 		"anonymous": {

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -1443,7 +1443,8 @@
 			"consultantAccepted": "Du wirst jetzt von deiner/deinem Berater_in im Chat erwartet.",
 			"startChatNow": "Jetzt Chat starten",
 			"dismissAcceptedBanner": "Hinweis ausblenden"
-		}
+		},
+		"enquiryClosed": "Dieser Live-Chat wurde beendet. Um einen neuen Chat zu starten, öffne bitte deinen Einladungslink erneut."
 	},
 	"sessionHeader": {
 		"anonymous": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -3357,7 +3357,8 @@
 			"consultantAccepted": "Your counselor is now expecting you in the chat.",
 			"startChatNow": "Start chat now",
 			"dismissAcceptedBanner": "Dismiss notice"
-		}
+		},
+		"enquiryClosed": "This live chat has ended. To start a new chat, please open your invite link again."
 	},
 	"sessionHeader": {
 		"anonymous": {


### PR DESCRIPTION
A finished (DONE/IN_ARCHIVE) anonymous enquiry can never appear in the consultant Live Chat queue, but the asker's waiting screen kept polling and showing queue position and the availability modal as if it were still waiting. The waiting-queue poll now detects the finished status, stops polling and shows a clear 'chat ended - open your invite link again' notice instead.

The consultant enquiry list swallowed anonymous-feed failures silently, making a backend error indistinguishable from an empty live chat queue. Failures are now logged while registered enquiries still load.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

