### PR TITLE
feat(registration): free stepper navigation with lossless step values

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -53,6 +53,7 @@ import {
 	registrationMd3,
 	registrationMotion
 } from './registrationDesign/registrationDesign';
+import { clearAccountDataDraft } from './accountData/accountDataDraft';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
@@ -69,6 +70,8 @@ import PlaceRoundedIcon from '@mui/icons-material/PlaceRounded';
  * For Caritas there is no consultingType tenant relation and every tenant could have different consultingType depending on agency. So before agency is selected no idea which consultingType settings to load before agency is selected
  * @constructor
  */
+
+const registrationMaxStepSessionStorageKey = 'registrationMaxStepReached';
 
 export const Registration = () => {
 	const { t } = useTranslation(['common', 'consultingTypes', 'agencies']);
@@ -138,6 +141,62 @@ export const Registration = () => {
 		[availableSteps, step]
 	);
 
+	/* Highest step the user has reached so far (prototype parity): the stepper
+	   is clickable back AND forth up to this step, so users can freely move
+	   between steps without losing anything. Persisted per tab so a reload
+	   within the registration keeps the reached range. */
+	const [maxReachedStepName, setMaxReachedStepName] = useState<string | null>(
+		() => {
+			try {
+				return sessionStorage.getItem(
+					registrationMaxStepSessionStorageKey
+				);
+			} catch {
+				return null;
+			}
+		}
+	);
+
+	const persistMaxReachedStepName = useCallback((name: string | null) => {
+		setMaxReachedStepName(name);
+		try {
+			if (name) {
+				sessionStorage.setItem(
+					registrationMaxStepSessionStorageKey,
+					name
+				);
+			} else {
+				sessionStorage.removeItem(registrationMaxStepSessionStorageKey);
+			}
+		} catch {
+			/* non-fatal — navigation still works, just not across reloads */
+		}
+	}, []);
+
+	const maxReachedStepIndex = useMemo(() => {
+		const storedIndex = availableSteps.findIndex(
+			({ name }) => name === maxReachedStepName
+		);
+		return Math.max(storedIndex, currStepIndex);
+	}, [availableSteps, maxReachedStepName, currStepIndex]);
+
+	useEffect(() => {
+		if (currStepIndex < 0) {
+			return;
+		}
+		const storedIndex = availableSteps.findIndex(
+			({ name }) => name === maxReachedStepName
+		);
+		if (currStepIndex > storedIndex) {
+			persistMaxReachedStepName(availableSteps[currStepIndex].name);
+		}
+	}, [
+		availableSteps,
+		currStepIndex,
+		maxReachedStepName,
+		persistMaxReachedStepName
+	]);
+
 	// The step form renders only for a real step; bare /registration (no/unknown
 	// :step) redirects to the first step — dev's stabilized entry, no separate
 	// welcome screen.
@@ -192,17 +251,24 @@ export const Registration = () => {
 			? t('registration.topicInstruction', 'Wählen Sie ein Thema aus.')
 			: noneSelectedLabel;
 
-	const onNextClick = useCallback(() => {
+	/* Navigating between steps must never discard what was entered: merge the
+	   current step's data into the registration context instead of throwing it
+	   away (prototype parity — moving back and forth keeps every value). */
+	const commitStepData = useCallback(() => {
 		updateRegistrationData(stepData);
 		setStepData({});
+	}, [updateRegistrationData, stepData]);
+
+	const onNextClick = useCallback(() => {
+		commitStepData();
 		if (nextStepUrl) {
 			navigate(nextStepUrl);
 		}
-	}, [updateRegistrationData, stepData, navigate, nextStepUrl]);
+	}, [commitStepData, navigate, nextStepUrl]);
 
 	const onPrevClick = useCallback(() => {
-		setStepData({});
-	}, []);
+		commitStepData();
+	}, [commitStepData]);
 
 	const onClearSelection = useCallback(() => {
 		setStepData({});
@@ -277,12 +343,36 @@ export const Registration = () => {
 		selectedTopicLabel
 	]);
 
+	/* Forward navigation is additionally capped by data validity: once an
+	   earlier step's mandatory value was cleared (chip ✕), later steps stop
+	   being clickable until the flow is completed again. The missing step
+	   itself stays clickable so it can be fixed directly. */
+	const maxNavigableStepIndex = useMemo(() => {
+		const firstMissingIndex = availableSteps.findIndex(
+			({ mandatoryFields }, index) =>
+				index < maxReachedStepIndex &&
+				mandatoryFields?.some(
+					(field) => mergedRegistrationData?.[field] === undefined
+				)
+		);
+		return firstMissingIndex >= 0
+			? Math.min(maxReachedStepIndex, firstMissingIndex)
+			: maxReachedStepIndex;
+	}, [availableSteps, maxReachedStepIndex, mergedRegistrationData]);
+
+	/* Every step already reached is clickable — back AND forth (prototype
+	   parity). The missing-mandatory-fields effect below still bounces the
+	   user back if an earlier step was cleared in the meantime. */
 	const clickableStepperStepNames = useMemo(
 		() =>
 			availableSteps
-				.slice(0, Math.max(currStepIndex, 0))
+				.filter(
+					(_, index) =>
+						index <= maxNavigableStepIndex &&
+						index !== currStepIndex
+				)
 				.map(({ name }) => name),
-		[availableSteps, currStepIndex]
+		[availableSteps, maxNavigableStepIndex, currStepIndex]
 	);
 
 	const onStepperClick = useCallback(
@@ -291,14 +381,23 @@ export const Registration = () => {
 				({ name }) => name === targetStepName
 			);
 
-			if (targetStepIndex < 0 || targetStepIndex > currStepIndex) {
+			if (
+				targetStepIndex < 0 ||
+				targetStepIndex > maxNavigableStepIndex
+			) {
 				return;
 			}
 
-			setStepData({});
+			commitStepData();
 			navigate(makeStepUrl(targetStepName));
 		},
-		[availableSteps, currStepIndex, navigate, makeStepUrl]
+		[
+			availableSteps,
+			maxNavigableStepIndex,
+			commitStepData,
+			navigate,
+			makeStepUrl
+		]
 	);
 
 	useEffect(() => {
@@ -392,6 +491,10 @@ export const Registration = () => {
 			)
 				.then(() => {
 					sessionStorage.removeItem(registrationSessionStorageKey);
+					sessionStorage.removeItem(
+						registrationMaxStepSessionStorageKey
+					);
+					clearAccountDataDraft();
 					// Skip the manual "registration successful" overlay: flag the app
 					// to play the welcome loading animation and go straight into the
 					// chat room (autoLogin already ran inside apiPostRegistration).

--- a/src/components/registration/accountData/AccountData.tsx
+++ b/src/components/registration/accountData/AccountData.tsx
@@ -50,6 +50,7 @@ import {
 	type Pseudonym
 } from '../../../utils/pseudonymGenerator';
 import { PasswordRuleChips } from './PasswordRuleChips';
+import { getAccountDataDraft, setAccountDataDraft } from './accountDataDraft';
 import { allPasswordCriteriaPass } from './passwordRules';
 import { getUsernameFeedback } from './usernameFeedback';
 import genUserIcon from '../../../resources/img/registration-md3/icons/gen-user.svg';
@@ -131,17 +132,28 @@ export const AccountData: FC<{
 	const legalLinks = useContext(LegalLinksContext);
 	const { locale } = useContext(LocaleContext);
 	const { t } = useTranslation();
-	const [identity, setIdentity] = useState<Pseudonym>(() =>
-		generatePseudonym(locale)
+	/* Restore the in-memory draft (if any) so navigating away and back in the
+	   stepper keeps everything typed — identity, username, passwords and the
+	   privacy checkbox. The draft never touches session/localStorage. */
+	const [restoredDraft] = useState(() => getAccountDataDraft());
+	const [identity, setIdentity] = useState<Pseudonym>(
+		() => restoredDraft?.identity ?? generatePseudonym(locale)
 	);
-	const [password, setPassword] = useState<string>('');
-	const [repeatPassword, setRepeatPassword] = useState<string>('');
+	const [password, setPassword] = useState<string>(
+		restoredDraft?.password ?? ''
+	);
+	const [repeatPassword, setRepeatPassword] = useState<string>(
+		restoredDraft?.repeatPassword ?? ''
+	);
 	const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
-	const [dataProtectionChecked, setDataProtectionChecked] =
-		useState<boolean>(false);
+	const [dataProtectionChecked, setDataProtectionChecked] = useState<boolean>(
+		restoredDraft?.dataProtectionChecked ?? false
+	);
 	const [isRepeatPasswordVisible, setIsRepeatPasswordVisible] =
 		useState<boolean>(false);
-	const [username, setUsername] = useState<string>('');
+	const [username, setUsername] = useState<string>(
+		restoredDraft?.username ?? ''
+	);
 	const [isUsernameAvailable, setIsUsernameAvailable] =
 		useState<boolean>(true);
 	const [usernameWasBlurred, setUsernameWasBlurred] =
@@ -170,11 +182,26 @@ export const AccountData: FC<{
 	);
 
 	useEffect(() => {
-		applyGeneratedUsername(identity);
 		// Run once so first entry shows the same generated identity until the
-		// user intentionally changes it.
+		// user intentionally changes it. When a draft was restored the user's
+		// previous identity/username must NOT be overwritten by a fresh one —
+		// the debounced availability effect below re-checks it anyway.
+		if (!restoredDraft) {
+			applyGeneratedUsername(identity);
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
+
+	/* Keep the draft current on every change so stepper navigation is lossless. */
+	useEffect(() => {
+		setAccountDataDraft({
+			identity,
+			username,
+			password,
+			repeatPassword,
+			dataProtectionChecked
+		});
+	}, [identity, username, password, repeatPassword, dataProtectionChecked]);
 
 	const isUsernameLongEnough =
 		REGISTRATION_DATA_VALIDATION.username.validation(username);

--- a/src/components/registration/accountData/accountDataDraft.ts
+++ b/src/components/registration/accountData/accountDataDraft.ts
@@ -1,0 +1,27 @@
+import type { Pseudonym } from '../../../utils/anonName/engine';
+
+/**
+ * In-memory draft of the account step so nothing typed is lost when the user
+ * navigates back and forth in the registration stepper. The values (incl. the
+ * password) deliberately never touch session/localStorage — the draft only has
+ * to survive step navigation inside the running app.
+ */
+export interface AccountDataDraft {
+	identity: Pseudonym;
+	username: string;
+	password: string;
+	repeatPassword: string;
+	dataProtectionChecked: boolean;
+}
+
+let draft: AccountDataDraft | null = null;
+
+export const getAccountDataDraft = (): AccountDataDraft | null => draft;
+
+export const setAccountDataDraft = (next: AccountDataDraft): void => {
+	draft = next;
+};
+
+export const clearAccountDataDraft = (): void => {
+	draft = null;
+};

--- a/src/components/registration/zipcodeInput/ZipcodeInput.tsx
+++ b/src/components/registration/zipcodeInput/ZipcodeInput.tsx
@@ -29,11 +29,18 @@ export const ZipcodeInput: FC<{
 	useEffect(() => {
 		if (REGISTRATION_DATA_VALIDATION.zipcode.validation(value)) {
 			setDisabledNextButton(false);
-			onChange({
-				zipcode: value,
-				agencyId: undefined,
-				agency: undefined
-			});
+			/* Only invalidate a chosen agency when the zipcode actually
+			   changed — merely revisiting this step (free stepper navigation)
+			   must not erase the agency selection on commit. */
+			onChange(
+				value === registrationData.zipcode
+					? { zipcode: value }
+					: {
+							zipcode: value,
+							agencyId: undefined,
+							agency: undefined
+						}
+			);
 		} else {
 			setDisabledNextButton(true);
 			onChange({
@@ -42,7 +49,7 @@ export const ZipcodeInput: FC<{
 				agency: undefined
 			});
 		}
-	}, [setDisabledNextButton, onChange, value]);
+	}, [setDisabledNextButton, onChange, value, registrationData.zipcode]);
 
 	return (
 		<Box

--- a/src/globalState/provider/RegistrationProvider.tsx
+++ b/src/globalState/provider/RegistrationProvider.tsx
@@ -212,7 +212,10 @@ export function RegistrationProvider({ children }: PropsWithChildren<{}>) {
 	);
 
 	useEffect(() => {
-		const { topic, mainTopic, agency, ...sessionStorageData } =
+		// The password stays in memory only — with free stepper navigation the
+		// account step's values are committed on back-navigation too, and a
+		// plaintext password must never be written to sessionStorage.
+		const { topic, mainTopic, agency, password, ...sessionStorageData } =
 			registrationData || {};
 
 		setSessionStorageData({


### PR DESCRIPTION
## Why

The old registration click-prototype had one thing the rebuilt flow lost: you could move back and forth freely in the stepper without ever losing what you had entered. This PR ports exactly that behavior into the production flow.

## What

- **Forward-clickable stepper**: every step already reached is clickable — back AND forward (previously only strictly-backward). The highest reached step is persisted per tab (`registrationMaxStepReached` in sessionStorage), so a reload keeps the reached range.
- **Validity cap**: forward clicks are additionally capped by data validity. Removing a foundational value via the selection chip (topic/zipcode ✕) locks later steps until the flow is completed again; the missing step itself stays clickable so it can be fixed directly. No racy resets of the persisted marker — the cap is derived from the merged registration data.
- **Lossless navigation**: back/stepper navigation commits the current step's data into the registration context instead of discarding it.
- **Account step draft**: identity (pseudonym/avatar), username, both password fields and the privacy checkbox survive navigation via an in-memory draft (`accountDataDraft.ts`). The draft never touches session/localStorage and is cleared after successful registration. The username availability re-check runs automatically on return.
- **Security**: `RegistrationProvider` now strips the password from the sessionStorage persistence — with commit-on-back it would otherwise have been written there in plaintext.
- **ZipcodeInput**: only invalidates the chosen agency when the zipcode actually changed, so merely revisiting the step no longer erases the agency selection.

## Verification

Manually verified against the Pre-Dev backend (real topics/agencies for zipcode 12043):

- topic → zipcode → agency → account: stepper shows check marks, chips populate
- jump from account-data back to step 1 via stepper, then FORWARD directly to account-data: generated identity/avatar, username ("geeignet" re-checked), password and repeat-password all still present
- chip ✕ on the topic: navigates to topic-selection, all forward steps locked; after re-picking a topic, steps unlock exactly up to the first missing mandatory value (agency), account-data stays locked
- `sessionStorage.registrationData` never contains the password
- `tsc --noEmit`, ESLint, Prettier clean; 37 registration unit tests pass; production build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs OpenResilienceInitiative/ORISO-Frontend#254