### PR TITLE
feat(crypto): MSC4153 invisible crypto behind release toggle (#438)

### DIFF
--- a/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
@@ -72,4 +72,11 @@ interface ReleaseToggles {
 	enableNewNotifications?: boolean;
 	featureVideoGroupChatsEnabled?: boolean;
 	enableMagicLinksLogin?: boolean;
+	/**
+	 * #438 MSC4153 "invisible crypto": when on, Megolm keys are shared only with
+	 * cross-signed devices (`OnlySignedDevicesIsolationMode`) — unverified
+	 * devices receive no keys and see undecryptable noise. Hard-depends on the
+	 * key-backup/recovery onboarding (#437) so legitimate users can verify.
+	 */
+	enableInvisibleCrypto?: boolean;
 }

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -7,6 +7,8 @@ import {
 } from '../components/sessionCookie/getMatrixAccessToken';
 import { matrixCallService } from './matrixCallService';
 import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
+import { applyDeviceIsolationMode } from './matrixDeviceIsolation';
+import { appConfig } from '../utils/appConfig';
 import { matrixLiveEventBridge } from './matrixLiveEventBridge';
 import { encryptMatrixAttachment } from '../utils/matrixEncryptedAttachment';
 import { buildMatrixRoomEncryptionInitialState } from '../utils/matrixRoomEncryption';
@@ -121,6 +123,14 @@ export class MatrixClientService {
 			this.stopCurrentClient();
 			throw error;
 		}
+
+		// #438 MSC4153 invisible crypto: once the rust crypto stack is up, share
+		// Megolm keys only with cross-signed devices when the toggle is on.
+		// Best-effort — never breaks client startup.
+		applyDeviceIsolationMode(
+			client,
+			appConfig?.releaseToggles?.enableInvisibleCrypto === true
+		);
 
 		(client as any).on(
 			'sync',

--- a/src/services/matrixDeviceIsolation.test.ts
+++ b/src/services/matrixDeviceIsolation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DeviceIsolationModeKind } from 'matrix-js-sdk/lib/crypto-api';
+import { applyDeviceIsolationMode } from './matrixDeviceIsolation';
+
+/**
+ * #438 MSC4153 invisible crypto — device isolation mode helper. The SDK
+ * (Apache-2.0) implements the isolation itself; we only choose the mode
+ * behind the release toggle.
+ */
+
+const buildClient = (crypto: unknown) => ({ getCrypto: () => crypto }) as any;
+
+describe('applyDeviceIsolationMode (#438)', () => {
+	it('sets OnlySignedDevicesIsolationMode when invisible crypto is enabled', () => {
+		const setDeviceIsolationMode = vi.fn();
+		const applied = applyDeviceIsolationMode(
+			buildClient({ setDeviceIsolationMode }),
+			true
+		);
+
+		expect(applied).toBe(true);
+		expect(setDeviceIsolationMode).toHaveBeenCalledTimes(1);
+		expect(setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.OnlySignedDevicesIsolationMode
+		);
+	});
+
+	it('sets AllDevicesIsolationMode (non-erroring) when disabled', () => {
+		const setDeviceIsolationMode = vi.fn();
+		const applied = applyDeviceIsolationMode(
+			buildClient({ setDeviceIsolationMode }),
+			false
+		);
+
+		expect(applied).toBe(true);
+		expect(setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+	});
+
+	it('is a no-op that returns false when the client has no crypto', () => {
+		expect(applyDeviceIsolationMode(buildClient(null), true)).toBe(false);
+	});
+
+	it('is a no-op when the client exposes no getCrypto method', () => {
+		expect(applyDeviceIsolationMode({} as any, true)).toBe(false);
+	});
+
+	it('never throws if the SDK call fails (best-effort)', () => {
+		const setDeviceIsolationMode = vi.fn(() => {
+			throw new Error('rust boom');
+		});
+		expect(() =>
+			applyDeviceIsolationMode(
+				buildClient({ setDeviceIsolationMode }),
+				true
+			)
+		).not.toThrow();
+	});
+});

--- a/src/services/matrixDeviceIsolation.ts
+++ b/src/services/matrixDeviceIsolation.ts
@@ -1,0 +1,47 @@
+import type { MatrixClient } from 'matrix-js-sdk';
+import {
+	AllDevicesIsolationMode,
+	OnlySignedDevicesIsolationMode
+} from 'matrix-js-sdk/lib/crypto-api';
+
+/**
+ * #438 MSC4153 "invisible crypto". When enabled, the SDK shares Megolm keys
+ * only with cross-signed devices (`OnlySignedDevicesIsolationMode`): an
+ * unverified device (e.g. an attacker who logged in with a stolen password)
+ * receives no keys and sees only undecryptable noise — device hygiene enforced
+ * at the protocol level, no dismissable warning banners.
+ *
+ * When disabled we set the SDK default (`AllDevicesIsolationMode(false)` —
+ * share to all, don't hard-fail on unverified devices) explicitly, so toggling
+ * the flag off at runtime restores prior behaviour.
+ *
+ * The isolation itself is implemented by matrix-js-sdk (Apache-2.0); we only
+ * choose the mode behind the `enableInvisibleCrypto` release toggle. Hard
+ * depends on #437 key-backup/recovery so legitimate users can verify a new
+ * device instead of locking themselves out.
+ *
+ * Best-effort: must be called after `initRustCrypto`; a failure here must never
+ * break client startup.
+ *
+ * @returns true if a mode was applied, false if the client had no crypto.
+ */
+export const applyDeviceIsolationMode = (
+	client: MatrixClient,
+	invisibleCryptoEnabled: boolean
+): boolean => {
+	const crypto = client.getCrypto?.();
+	if (!crypto) {
+		return false;
+	}
+	try {
+		crypto.setDeviceIsolationMode(
+			invisibleCryptoEnabled
+				? new OnlySignedDevicesIsolationMode()
+				: new AllDevicesIsolationMode(false)
+		);
+		return true;
+	} catch {
+		// Only supported by the rust crypto stack; never break startup on it.
+		return false;
+	}
+};


### PR DESCRIPTION
## Why
MSC4153 "invisible crypto": Megolm keys are shared **only** with cross-signed devices. An unverified device — e.g. an attacker who logged in with a stolen password — receives no keys and sees only undecryptable noise. Device hygiene enforced at the protocol level, so there's nothing left to warn about (hence "invisible").

## What
- `applyDeviceIsolationMode(client, enabled)` (new `matrixDeviceIsolation.ts`): sets `OnlySignedDevicesIsolationMode` when on, else the SDK default `AllDevicesIsolationMode(false)` so toggling off restores prior behaviour.
- Called in `matrixClientService.initializeClient` right after `initRustCrypto`, gated by the new **`enableInvisibleCrypto`** release toggle (off by default).
- Best-effort: guarded for missing crypto and rust-only support — never breaks client startup.

The isolation itself is matrix-js-sdk (Apache-2.0); we only choose the mode.

## Tests (TDD)
`matrixDeviceIsolation.test.ts` (5): OnlySigned when enabled, AllDevices when disabled, no-op without crypto / without `getCrypto`, never throws on SDK failure. Existing `matrixClientService.test.ts` stays green (8).

## ⚠️ Rollout — do NOT flip the toggle yet
Hard dependency on **#437 key backup + recovery** (PR #481): with invisible crypto on, a device must be cross-signed (verified via existing device or recovery key) to read messages. Without the recovery onboarding, legitimate users lock themselves out. Staged rollout (consultants first), watched via the UTD tracker (#440).

Remaining #438 tasks (verification-on-login flow, onboarding copy, ops runbook, E2E "unverified device cannot decrypt", rollout metrics) stay open on the issue.

Refs #438. Depends on #481 (#437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)