### PR TITLE
feat(sessions): Case Handover search organism (filter tabs, radio topics, confirm checkmark)

### DIFF
--- a/src/components/sessionsList/SessionSearchPanel.stories.tsx
+++ b/src/components/sessionsList/SessionSearchPanel.stories.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import {
+	SessionSearchPanel,
+	SessionSearchPanelLabels,
+	SessionSearchPersonOption,
+	SessionSearchTab,
+	SessionSearchTopicOption,
+	SessionSearchTypeOption
+} from './SessionSearchPanel';
+import {
+	CASE_HANDOVER_SEARCH_FIGMA_URL,
+	ORISO_M3_FIGMA_URL
+} from '../storybookDesignLinks';
+import './sessionsList.styles.scss';
+
+const shell: React.CSSProperties = {
+	backgroundColor: '#eae7e8',
+	padding: 16,
+	maxWidth: 420,
+	margin: '0 auto',
+	position: 'relative'
+};
+
+const labelsEn: SessionSearchPanelLabels = {
+	refineHint: 'Refine your search further using filters',
+	tabPeople: 'People',
+	tabType: 'By type',
+	tabCentre: 'Counseling center',
+	tabArchiveOnly: 'Archive only',
+	emptyPeople: 'No matching people found.',
+	emptyTypes: 'No chat types available.',
+	emptyTopics: 'No topics found for your counseling centers.'
+};
+
+const labelsDe: SessionSearchPanelLabels = {
+	refineHint: 'Verfeinere deine Suche durch Filter weiter',
+	tabPeople: 'Personen',
+	tabType: 'Nach Typ',
+	tabCentre: 'Beratungsstelle',
+	tabArchiveOnly: 'Nur Archiv',
+	emptyPeople: 'Keine passenden Personen gefunden.',
+	emptyTypes: 'Keine Chat-Typen verfügbar.',
+	emptyTopics: 'Keine Themen für deine Beratungsstellen gefunden.'
+};
+
+const people: SessionSearchPersonOption[] = [
+	{
+		id: 'ingrid-koschmider',
+		name: 'Ingrid Koschmider',
+		subtitle: 'Berater:in | Mainz 30232'
+	},
+	{
+		id: 'hans-p',
+		name: 'Hans P.',
+		subtitle: 'Berat. Person | Berlin 10117'
+	},
+	{
+		id: 'rango-durango',
+		name: 'Rango Durango',
+		subtitle: 'Berater:in | Mainz 30232'
+	}
+];
+
+const topics: SessionSearchTopicOption[] = [
+	{ id: 'schulden', label: 'Schulden', subtitle: 'Mainz 30232' },
+	{ id: 'suchtberatung', label: 'Suchtberatung', subtitle: 'Mainz 30232' }
+];
+
+const types: SessionSearchTypeOption[] = [
+	{ id: 'oneToOne', label: '1-1 Beratung' },
+	{ id: 'liveChat', label: 'Live Chat' },
+	{ id: 'nearby', label: 'Nähe' },
+	{ id: 'group', label: 'Kreis' }
+];
+
+type PlaygroundProps = {
+	labels?: SessionSearchPanelLabels;
+	initialTab?: SessionSearchTab;
+	initialSelectedPersonIds?: string[];
+	initialSelectedTopicId?: string | null;
+	initialArchiveOnly?: boolean;
+	people?: SessionSearchPersonOption[];
+	topics?: SessionSearchTopicOption[];
+	types?: SessionSearchTypeOption[];
+};
+
+function SessionSearchPanelPlayground({
+	labels = labelsDe,
+	initialTab = 'people',
+	initialSelectedPersonIds = [],
+	initialSelectedTopicId = null,
+	initialArchiveOnly = false,
+	people: peopleOptions = people,
+	topics: topicOptions = topics,
+	types: typeOptions = types
+}: PlaygroundProps) {
+	const [tab, setTab] = useState<SessionSearchTab>(initialTab);
+	const [selectedPersonIds, setSelectedPersonIds] = useState<string[]>(
+		initialSelectedPersonIds
+	);
+	const [selectedTopicId, setSelectedTopicId] = useState<string | null>(
+		initialSelectedTopicId
+	);
+	const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
+	const [archiveOnly, setArchiveOnly] = useState(initialArchiveOnly);
+
+	return (
+		<div style={shell} className="sessionsListToolbar">
+			<div style={{ position: 'relative', height: 1 }}>
+				<SessionSearchPanel
+					labels={labels}
+					activeTab={tab}
+					onTabChange={setTab}
+					archiveOnly={archiveOnly}
+					onArchiveOnlyChange={setArchiveOnly}
+					people={peopleOptions}
+					selectedPersonIds={selectedPersonIds}
+					onPersonToggle={(id) =>
+						setSelectedPersonIds((prev) =>
+							prev.includes(id)
+								? prev.filter((entry) => entry !== id)
+								: [...prev, id]
+						)
+					}
+					types={typeOptions}
+					selectedTypeId={selectedTypeId}
+					onTypeSelect={setSelectedTypeId}
+					topics={topicOptions}
+					selectedTopicId={selectedTopicId}
+					onTopicSelect={setSelectedTopicId}
+				/>
+			</div>
+		</div>
+	);
+}
+
+const meta: Meta = {
+	title: 'Organisms/CaseHandoverSearch/SessionSearchPanel',
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		design: [
+			{
+				type: 'figma',
+				name: 'CARX Case Handover — Search Bar Organisms',
+				url: CASE_HANDOVER_SEARCH_FIGMA_URL
+			},
+			{
+				type: 'figma',
+				name: 'Design System M3 ORISO',
+				url: ORISO_M3_FIGMA_URL
+			}
+		],
+		docs: {
+			description: {
+				component:
+					'Search refinement panel for the session-list search pill (Case Handover flow). Tabs: **People** (checkbox multi-select), **By type** (radio), **Counseling center** (topic radio — one topic only, per Section 00: a person must never combine two topics), plus the independent **Archive only** toggle tab. Confirm affordance (red checkmark / Enter) lives in the search pill (`SessionsListToolbar`).'
+			}
+		}
+	}
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PeopleTab: Story = {
+	render: () => (
+		<SessionSearchPanelPlayground
+			initialSelectedPersonIds={['ingrid-koschmider']}
+		/>
+	)
+};
+
+export const PeopleTabEnglish: Story = {
+	render: () => (
+		<SessionSearchPanelPlayground
+			labels={labelsEn}
+			initialSelectedPersonIds={['ingrid-koschmider']}
+		/>
+	)
+};
+
+export const CounselingCenterTab: Story = {
+	render: () => (
+		<SessionSearchPanelPlayground
+			initialTab="centre"
+			initialSelectedTopicId="schulden"
+		/>
+	)
+};
+
+export const ByTypeTab: Story = {
+	render: () => <SessionSearchPanelPlayground initialTab="type" />
+};
+
+export const ArchiveOnlyActive: Story = {
+	render: () => (
+		<SessionSearchPanelPlayground
+			initialArchiveOnly
+			initialSelectedPersonIds={['ingrid-koschmider']}
+		/>
+	)
+};
+
+export const EmptyResults: Story = {
+	render: () => (
+		<SessionSearchPanelPlayground people={[]} topics={[]} types={[]} />
+	)
+};
+
+/** Topic selection is exclusive: choosing a second topic deselects the first. */
+export const TopicRadioIsExclusive: Story = {
+	render: () => <SessionSearchPanelPlayground initialTab="centre" />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const schulden = await canvas.findByRole('radio', {
+			name: /Schulden/
+		});
+		const sucht = await canvas.findByRole('radio', {
+			name: /Suchtberatung/
+		});
+		await userEvent.click(schulden);
+		await expect(schulden).toHaveAttribute('aria-checked', 'true');
+		await userEvent.click(sucht);
+		await expect(sucht).toHaveAttribute('aria-checked', 'true');
+		await expect(schulden).toHaveAttribute('aria-checked', 'false');
+	}
+};
+
+/** People selection is additive (checkboxes). */
+export const PeopleMultiSelect: Story = {
+	render: () => <SessionSearchPanelPlayground />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const ingrid = await canvas.findByRole('checkbox', {
+			name: /Ingrid Koschmider/
+		});
+		const hans = await canvas.findByRole('checkbox', { name: /Hans P/ });
+		await userEvent.click(ingrid);
+		await userEvent.click(hans);
+		await expect(ingrid).toHaveAttribute('aria-checked', 'true');
+		await expect(hans).toHaveAttribute('aria-checked', 'true');
+	}
+};

--- a/src/components/sessionsList/SessionSearchPanel.tsx
+++ b/src/components/sessionsList/SessionSearchPanel.tsx
@@ -1,0 +1,330 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import './sessionsList.styles';
+
+/**
+ * Search refinement panel (organism) — the dropdown attached to the session
+ * list search pill. Figma: "CARX — Teamberatung Case Handover", Section 07
+ * "Search Bar | Organisms" (node 4121-12160) and Section 00 behaviour notes.
+ *
+ * Tabs: People (checkbox multi-select), By type (radio), Counselling centre
+ * (topic radio — a person must never have two topics selected at once, hence
+ * single-select), plus an independent "Archive only" toggle tab.
+ *
+ * Purely controlled; confirm semantics (checkmark / Enter) live with the
+ * caller because the confirm affordance sits in the search pill itself.
+ */
+
+export type SessionSearchTab = 'people' | 'type' | 'centre';
+
+export interface SessionSearchPersonOption {
+	id: string;
+	name: string;
+	/** e.g. "Berater:in | Mainz 30232" */
+	subtitle: string;
+}
+
+export interface SessionSearchTopicOption {
+	id: string;
+	/** Topic name, e.g. "Schulden" */
+	label: string;
+	/** Optional department/agency context, e.g. "Mainz 30232" */
+	subtitle?: string;
+}
+
+export interface SessionSearchTypeOption {
+	id: string;
+	label: string;
+}
+
+export interface SessionSearchPanelLabels {
+	refineHint: string;
+	tabPeople: string;
+	tabType: string;
+	tabCentre: string;
+	tabArchiveOnly: string;
+	emptyPeople: string;
+	emptyTypes: string;
+	emptyTopics: string;
+}
+
+interface SessionSearchPanelProps {
+	labels: SessionSearchPanelLabels;
+	activeTab: SessionSearchTab;
+	onTabChange: (tab: SessionSearchTab) => void;
+	archiveOnly: boolean;
+	onArchiveOnlyChange: (archiveOnly: boolean) => void;
+	people: SessionSearchPersonOption[];
+	selectedPersonIds: string[];
+	onPersonToggle: (id: string) => void;
+	types: SessionSearchTypeOption[];
+	selectedTypeId: string | null;
+	onTypeSelect: (id: string | null) => void;
+	topics: SessionSearchTopicOption[];
+	selectedTopicId: string | null;
+	onTopicSelect: (id: string | null) => void;
+}
+
+const iconFill = (active: boolean) =>
+	active
+		? 'var(--m3-primary, #a5000a)'
+		: 'var(--m3-on-surface-variant, #444748)';
+
+const IconPeopleTab = ({ active }: { active: boolean }) => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+		<path
+			d="M5.85 17.1C6.7 16.45 7.65 15.9375 8.7 15.5625C9.75 15.1875 10.85 15 12 15C13.15 15 14.25 15.1875 15.3 15.5625C16.35 15.9375 17.3 16.45 18.15 17.1C18.7333 16.4167 19.1875 15.6417 19.5125 14.775C19.8375 13.9083 20 12.9833 20 12C20 9.78333 19.2208 7.89583 17.6625 6.3375C16.1042 4.77917 14.2167 4 12 4C9.78333 4 7.89583 4.77917 6.3375 6.3375C4.77917 7.89583 4 9.78333 4 12C4 12.9833 4.1625 13.9083 4.4875 14.775C4.8125 15.6417 5.26667 16.4167 5.85 17.1ZM12 13C11.0167 13 10.1875 12.6625 9.5125 11.9875C8.8375 11.3125 8.5 10.4833 8.5 9.5C8.5 8.51667 8.8375 7.6875 9.5125 7.0125C10.1875 6.3375 11.0167 6 12 6C12.9833 6 13.8125 6.3375 14.4875 7.0125C15.1625 7.6875 15.5 8.51667 15.5 9.5C15.5 10.4833 15.1625 11.3125 14.4875 11.9875C13.8125 12.6625 12.9833 13 12 13ZM12 22C10.6167 22 9.31667 21.7375 8.1 21.2125C6.88333 20.6875 5.825 19.975 4.925 19.075C4.025 18.175 3.3125 17.1167 2.7875 15.9C2.2625 14.6833 2 13.3833 2 12C2 10.6167 2.2625 9.31667 2.7875 8.1C3.3125 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.3125 8.1 2.7875C9.31667 2.2625 10.6167 2 12 2C13.3833 2 14.6833 2.2625 15.9 2.7875C17.1167 3.3125 18.175 4.025 19.075 4.925C19.975 5.825 20.6875 6.88333 21.2125 8.1C21.7375 9.31667 22 10.6167 22 12C22 13.3833 21.7375 14.6833 21.2125 15.9C20.6875 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6875 15.9 21.2125C14.6833 21.7375 13.3833 22 12 22Z"
+			fill={iconFill(active)}
+		/>
+	</svg>
+);
+
+const IconTypeTab = ({ active }: { active: boolean }) => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+		<path
+			d="M6 14H18V12H6V14ZM6 11H18V9H6V11ZM6 8H18V6H6V8ZM22 22L18 18H4C3.45 18 2.97917 17.8042 2.5875 17.4125C2.19583 17.0208 2 16.55 2 16V4C2 3.45 2.19583 2.97917 2.5875 2.5875C2.97917 2.19583 3.45 2 4 2H20C20.55 2 21.0208 2.19583 21.4125 2.5875C21.8042 2.97917 22 3.45 22 4V22ZM4 16H18.85L20 17.125V4H4V16Z"
+			fill={iconFill(active)}
+		/>
+	</svg>
+);
+
+/** Counselling-centre tab icon (Counselling_Centre_400_24px asset). */
+const IconCentreTab = ({ active }: { active: boolean }) => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+		<path
+			d="M10.8908 17.6584L11.2527 17.8252C11.4871 17.934 11.7402 17.9884 11.9915 17.9884C12.2427 17.9884 12.4949 17.934 12.7293 17.8252L13.0921 17.6574C15.3224 16.6262 16.7295 14.4642 16.6911 12.1365C16.7567 11.3893 16.4633 10.6383 15.898 10.1152C15.1002 9.37646 13.8917 9.19175 12.8915 9.65582C12.5624 9.80863 12.2587 10.0074 11.9915 10.2427C11.7243 10.0074 11.4206 9.80862 11.0915 9.65582C10.0912 9.19269 8.88276 9.37737 8.08503 10.1152C7.51971 10.6383 7.22628 11.3893 7.2919 12.1365C7.25346 14.4643 8.66055 16.6261 10.8908 17.6584ZM9.38897 11.5252C9.53241 11.392 9.73023 11.3227 9.93178 11.3227C10.0518 11.3227 10.1736 11.348 10.2843 11.3995C10.6293 11.5589 10.9115 11.8186 11.0802 12.1298L11.1468 12.2527C11.3146 12.563 11.639 12.7561 11.9915 12.7561C12.344 12.7561 12.6683 12.563 12.8361 12.2527L12.9018 12.1308C13.0705 11.8195 13.3527 11.5599 13.6977 11.4005C13.9949 11.2627 14.3643 11.3142 14.593 11.527C14.7299 11.6536 14.7965 11.8205 14.7768 11.9864C14.7712 12.0333 14.7693 12.0802 14.7702 12.128C14.8133 13.7114 13.8383 15.1993 12.285 15.9173L11.9906 16.0533L11.6962 15.9173C10.1428 15.1983 9.16785 13.7105 9.21105 12.128C9.21292 12.0802 9.21011 12.0333 9.20448 11.9864C9.18573 11.8195 9.2521 11.6517 9.38897 11.5252Z"
+			fill={iconFill(active)}
+		/>
+		<path
+			d="M6.65622 21.4824C7.29184 21.5733 7.93777 21.6427 8.57622 21.6886C9.65154 21.7955 10.769 21.8471 11.9907 21.8471C13.2132 21.8471 14.3298 21.7946 15.4052 21.6886C16.0436 21.6427 16.6896 21.5733 17.3121 21.4843C18.3583 21.3502 19.3305 20.8599 20.1292 20.0602C20.8923 19.283 21.4014 18.2883 21.5992 17.185C21.9217 15.4722 21.9217 13.736 21.601 12.0382L21.4548 11.1944C21.1445 9.51913 20.3917 7.98541 19.2732 6.75445C18.1932 5.57977 17.0036 4.56351 15.7397 3.73669L14.4732 2.90324C12.9422 1.89637 11.04 1.8973 9.50805 2.90324L8.24337 3.73575C6.97682 4.5645 5.78817 5.57982 4.70337 6.75927C3.58869 7.98553 2.83588 9.51927 2.52369 11.2058L2.38307 12.0195C2.22182 12.8492 2.14307 13.6929 2.14307 14.6024C2.14307 15.5164 2.22369 16.3902 2.38025 17.1814C2.57807 18.2877 3.08619 19.2833 3.85774 20.0679C4.65087 20.8601 5.62314 21.3502 6.65622 21.4824ZM4.27216 12.3662L4.41466 11.544C4.66027 10.2193 5.25185 9.01179 6.12185 8.05371C7.09404 6.99622 8.16279 6.08309 9.29705 5.34051L10.5627 4.508C11.0033 4.21832 11.4973 4.07393 11.9914 4.07393C12.4845 4.07393 12.9786 4.21831 13.4192 4.508L14.6877 5.34238C15.8211 6.08393 16.8889 6.99706 17.8573 8.04982C18.7311 9.01169 19.3227 10.2201 19.5664 11.5337L19.7136 12.3811C19.993 13.8586 19.993 15.3567 19.7136 16.8343C19.7127 16.8372 19.7127 16.8409 19.7117 16.8437C19.5823 17.5675 19.2542 18.2153 18.7677 18.7103C18.2783 19.1997 17.6905 19.5015 17.0558 19.5831C16.4595 19.6684 15.8549 19.7331 15.2567 19.7753C15.2473 19.7762 15.2389 19.7771 15.2295 19.7781C14.2142 19.8793 13.1549 19.929 11.9924 19.929C10.83 19.929 9.77054 19.8793 8.75529 19.7781C8.74686 19.7771 8.73748 19.7762 8.72811 19.7753C8.12998 19.7331 7.52436 19.6675 6.91591 19.5812C6.29436 19.5015 5.70747 19.2006 5.22372 18.7168C4.73153 18.2153 4.40247 17.5674 4.27027 16.8268C4.13434 16.1406 4.0659 15.3924 4.0659 14.6021C4.06402 13.8175 4.13059 13.0928 4.27216 12.3662Z"
+			fill={iconFill(active)}
+		/>
+	</svg>
+);
+
+const SelectionCheckbox = ({ selected }: { selected: boolean }) => (
+	<span
+		className={clsx(
+			'sessionsListToolbar__personCheckbox',
+			selected && 'sessionsListToolbar__personCheckbox--selected'
+		)}
+		aria-hidden
+	/>
+);
+
+const SelectionRadio = ({ selected }: { selected: boolean }) => (
+	<span
+		className={clsx(
+			'sessionsListToolbar__personRadio',
+			selected && 'sessionsListToolbar__personRadio--selected'
+		)}
+		aria-hidden
+	/>
+);
+
+const initialsOf = (name: string) =>
+	name
+		.split(' ')
+		.map((part) => part.trim().charAt(0))
+		.join('')
+		.slice(0, 2)
+		.toUpperCase() || 'U';
+
+export const SessionSearchPanel = ({
+	labels,
+	activeTab,
+	onTabChange,
+	archiveOnly,
+	onArchiveOnlyChange,
+	people,
+	selectedPersonIds,
+	onPersonToggle,
+	types,
+	selectedTypeId,
+	onTypeSelect,
+	topics,
+	selectedTopicId,
+	onTopicSelect
+}: SessionSearchPanelProps) => {
+	const contentTabs: {
+		id: SessionSearchTab;
+		label: string;
+		Icon: React.ComponentType<{ active: boolean }>;
+	}[] = [
+		{ id: 'people', label: labels.tabPeople, Icon: IconPeopleTab },
+		{ id: 'type', label: labels.tabType, Icon: IconTypeTab },
+		{ id: 'centre', label: labels.tabCentre, Icon: IconCentreTab }
+	];
+
+	return (
+		<div
+			className="sessionsListToolbar__searchModal"
+			data-cy="session-search-panel"
+		>
+			<div className="sessionsListToolbar__searchRefineHint">
+				{labels.refineHint}
+			</div>
+			<div
+				className="sessionsListToolbar__searchModalTabs"
+				role="tablist"
+				aria-label={labels.refineHint}
+			>
+				{contentTabs.map(({ id, label, Icon }) => {
+					const isActive = activeTab === id;
+					return (
+						<button
+							type="button"
+							key={id}
+							role="tab"
+							aria-selected={isActive}
+							className={clsx(
+								'sessionsListToolbar__searchModalTab',
+								isActive &&
+									'sessionsListToolbar__searchModalTab--active'
+							)}
+							onClick={() => onTabChange(id)}
+							data-cy={`session-search-tab-${id}`}
+						>
+							<span className="sessionsListToolbar__searchModalTabIcon">
+								<Icon active={isActive} />
+							</span>
+							<span className="sessionsListToolbar__searchModalTabLabel">
+								{label}
+							</span>
+						</button>
+					);
+				})}
+				<button
+					type="button"
+					className={clsx(
+						'sessionsListToolbar__searchModalTab',
+						'sessionsListToolbar__searchModalTab--toggle',
+						archiveOnly &&
+							'sessionsListToolbar__searchModalTab--active'
+					)}
+					onClick={() => onArchiveOnlyChange(!archiveOnly)}
+					aria-pressed={archiveOnly}
+					data-cy="session-search-tab-archive-only"
+				>
+					<span className="sessionsListToolbar__searchModalTabIcon">
+						<SelectionCheckbox selected={archiveOnly} />
+					</span>
+					<span className="sessionsListToolbar__searchModalTabLabel">
+						{labels.tabArchiveOnly}
+					</span>
+				</button>
+			</div>
+			<div className="sessionsListToolbar__searchModalBody">
+				{activeTab === 'people' &&
+					(people.length > 0 ? (
+						people.map((person) => {
+							const isSelected = selectedPersonIds.includes(
+								person.id
+							);
+							return (
+								<button
+									type="button"
+									key={person.id}
+									role="checkbox"
+									aria-checked={isSelected}
+									className="sessionsListToolbar__personRow"
+									onClick={() => onPersonToggle(person.id)}
+									data-cy={`session-search-person-${person.id}`}
+								>
+									<div className="sessionsListToolbar__personAvatar">
+										{initialsOf(person.name)}
+									</div>
+									<div className="sessionsListToolbar__personMeta">
+										<div className="sessionsListToolbar__personName">
+											{person.name}
+										</div>
+										<div className="sessionsListToolbar__personSubtitle">
+											{person.subtitle}
+										</div>
+									</div>
+									<SelectionCheckbox selected={isSelected} />
+								</button>
+							);
+						})
+					) : (
+						<div className="sessionsListToolbar__searchEmpty">
+							{labels.emptyPeople}
+						</div>
+					))}
+				{activeTab === 'type' &&
+					(types.length > 0 ? (
+						<div role="radiogroup" aria-label={labels.tabType}>
+							{types.map((type) => {
+								const isSelected = selectedTypeId === type.id;
+								return (
+									<button
+										type="button"
+										key={type.id}
+										role="radio"
+										aria-checked={isSelected}
+										className="sessionsListToolbar__personRow"
+										onClick={() =>
+											onTypeSelect(
+												isSelected ? null : type.id
+											)
+										}
+										data-cy={`session-search-type-${type.id}`}
+									>
+										<div className="sessionsListToolbar__personMeta">
+											<div className="sessionsListToolbar__personName">
+												{type.label}
+											</div>
+										</div>
+										<SelectionRadio selected={isSelected} />
+									</button>
+								);
+							})}
+						</div>
+					) : (
+						<div className="sessionsListToolbar__searchEmpty">
+							{labels.emptyTypes}
+						</div>
+					))}
+				{activeTab === 'centre' &&
+					(topics.length > 0 ? (
+						<div role="radiogroup" aria-label={labels.tabCentre}>
+							{topics.map((topic) => {
+								const isSelected = selectedTopicId === topic.id;
+								return (
+									<button
+										type="button"
+										key={topic.id}
+										role="radio"
+										aria-checked={isSelected}
+										className="sessionsListToolbar__personRow"
+										onClick={() =>
+											onTopicSelect(
+												isSelected ? null : topic.id
+											)
+										}
+										data-cy={`session-search-topic-${topic.id}`}
+									>
+										<div className="sessionsListToolbar__personMeta">
+											<div className="sessionsListToolbar__personName">
+												{topic.label}
+											</div>
+											{topic.subtitle && (
+												<div className="sessionsListToolbar__personSubtitle">
+													{topic.subtitle}
+												</div>
+											)}
+										</div>
+										<SelectionRadio selected={isSelected} />
+									</button>
+								);
+							})}
+						</div>
+					) : (
+						<div className="sessionsListToolbar__searchEmpty">
+							{labels.emptyTopics}
+						</div>
+					))}
+			</div>
+		</div>
+	);
+};

--- a/src/components/sessionsList/SessionsListToolbar.stories.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.stories.tsx
@@ -68,6 +68,9 @@ function SessionsListToolbarPlayground({
 	const [selectedPersonIds, setSelectedPersonIds] = useState<string[]>(
 		initialSelectedPersonIds
 	);
+	const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
+	const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
+	const [archiveOnly, setArchiveOnly] = useState(false);
 
 	return (
 		<div style={shell}>
@@ -78,6 +81,30 @@ function SessionsListToolbarPlayground({
 				searchPeopleResults={searchPeopleResults}
 				selectedPersonIds={selectedPersonIds}
 				onSelectedPersonIdsChange={setSelectedPersonIds}
+				searchTopicResults={[
+					{
+						id: 'schulden',
+						label: 'Schulden',
+						subtitle: 'Mainz 30232'
+					},
+					{
+						id: 'suchtberatung',
+						label: 'Suchtberatung',
+						subtitle: 'Mainz 30232'
+					}
+				]}
+				selectedTopicId={selectedTopicId}
+				onSelectedTopicIdChange={setSelectedTopicId}
+				searchTypeResults={[
+					{ id: 'oneToOne', label: '1-1 Beratung' },
+					{ id: 'liveChat', label: 'Live Chat' },
+					{ id: 'nearby', label: 'Nähe' }
+				]}
+				selectedTypeId={selectedTypeId}
+				onSelectedTypeIdChange={setSelectedTypeId}
+				searchArchiveOnly={archiveOnly}
+				onSearchArchiveOnlyChange={setArchiveOnly}
+				onSearchConfirm={() => {}}
 				activeChip={activeChip}
 				onChipToggle={(chip) =>
 					setActiveChip((prev) => (prev === chip ? null : chip))

--- a/src/components/sessionsList/SessionsListToolbar.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.tsx
@@ -15,8 +15,19 @@ import {
 	UnreadFilterIcon
 } from './SessionToolbarFilterIcons';
 import type { SessionToolbarChipFilter } from './sessionToolbarFilters';
+import {
+	SessionSearchPanel,
+	SessionSearchTab,
+	SessionSearchTopicOption,
+	SessionSearchTypeOption
+} from './SessionSearchPanel';
 
 export type { SessionToolbarChipFilter } from './sessionToolbarFilters';
+export type {
+	SessionSearchTab,
+	SessionSearchTopicOption,
+	SessionSearchTypeOption
+} from './SessionSearchPanel';
 
 interface SessionsListToolbarProps {
 	translate: (key: string) => string;
@@ -25,6 +36,19 @@ interface SessionsListToolbarProps {
 	searchPeopleResults?: SessionSearchPersonResult[];
 	selectedPersonIds?: string[];
 	onSelectedPersonIdsChange?: (ids: string[]) => void;
+	/** Topic options for the "Counselling centre" tab (radio single-select). */
+	searchTopicResults?: SessionSearchTopicOption[];
+	selectedTopicId?: string | null;
+	onSelectedTopicIdChange?: (id: string | null) => void;
+	/** Chat-type options for the "By type" tab (radio single-select). */
+	searchTypeResults?: SessionSearchTypeOption[];
+	selectedTypeId?: string | null;
+	onSelectedTypeIdChange?: (id: string | null) => void;
+	/** "Archive only" toggle in the search panel tab row. */
+	searchArchiveOnly?: boolean;
+	onSearchArchiveOnlyChange?: (archiveOnly: boolean) => void;
+	/** Confirm the current search selection (checkmark button / Enter). */
+	onSearchConfirm?: () => void;
 	activeChip: SessionToolbarChipFilter | null;
 	onChipToggle: (chip: SessionToolbarChipFilter) => void;
 	showConsultantActions: boolean;
@@ -91,47 +115,11 @@ export const IconClose = () => (
 	</svg>
 );
 
-const IconPeople = ({ active }: { active: boolean }) => (
+export const IconCheck = () => (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
 		<path
-			d="M5.85 17.1C6.7 16.45 7.65 15.9375 8.7 15.5625C9.75 15.1875 10.85 15 12 15C13.15 15 14.25 15.1875 15.3 15.5625C16.35 15.9375 17.3 16.45 18.15 17.1C18.7333 16.4167 19.1875 15.6417 19.5125 14.775C19.8375 13.9083 20 12.9833 20 12C20 9.78333 19.2208 7.89583 17.6625 6.3375C16.1042 4.77917 14.2167 4 12 4C9.78333 4 7.89583 4.77917 6.3375 6.3375C4.77917 7.89583 4 9.78333 4 12C4 12.9833 4.1625 13.9083 4.4875 14.775C4.8125 15.6417 5.26667 16.4167 5.85 17.1ZM12 13C11.0167 13 10.1875 12.6625 9.5125 11.9875C8.8375 11.3125 8.5 10.4833 8.5 9.5C8.5 8.51667 8.8375 7.6875 9.5125 7.0125C10.1875 6.3375 11.0167 6 12 6C12.9833 6 13.8125 6.3375 14.4875 7.0125C15.1625 7.6875 15.5 8.51667 15.5 9.5C15.5 10.4833 15.1625 11.3125 14.4875 11.9875C13.8125 12.6625 12.9833 13 12 13ZM12 22C10.6167 22 9.31667 21.7375 8.1 21.2125C6.88333 20.6875 5.825 19.975 4.925 19.075C4.025 18.175 3.3125 17.1167 2.7875 15.9C2.2625 14.6833 2 13.3833 2 12C2 10.6167 2.2625 9.31667 2.7875 8.1C3.3125 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.3125 8.1 2.7875C9.31667 2.2625 10.6167 2 12 2C13.3833 2 14.6833 2.2625 15.9 2.7875C17.1167 3.3125 18.175 4.025 19.075 4.925C19.975 5.825 20.6875 6.88333 21.2125 8.1C21.7375 9.31667 22 10.6167 22 12C22 13.3833 21.7375 14.6833 21.2125 15.9C20.6875 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6875 15.9 21.2125C14.6833 21.7375 13.3833 22 12 22Z"
-			fill={active ? '#A5000A' : '#444748'}
-		/>
-	</svg>
-);
-
-const IconType = ({ active }: { active: boolean }) => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
-		<path
-			d="M6 14H18V12H6V14ZM6 11H18V9H6V11ZM6 8H18V6H6V8ZM22 22L18 18H4C3.45 18 2.97917 17.8042 2.5875 17.4125C2.19583 17.0208 2 16.55 2 16V4C2 3.45 2.19583 2.97917 2.5875 2.5875C2.97917 2.19583 3.45 2 4 2H20C20.55 2 21.0208 2.19583 21.4125 2.5875C21.8042 2.97917 22 3.45 22 4V22ZM4 16H18.85L20 17.125V4H4V16Z"
-			fill={active ? '#A5000A' : '#444748'}
-		/>
-	</svg>
-);
-
-const IconScheduled = ({ active }: { active: boolean }) => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
-		<path
-			d="M12.0001 22C10.7501 22 9.57927 21.7625 8.4876 21.2875C7.39593 20.8125 6.44593 20.1708 5.6376 19.3625C4.82926 18.5541 4.1876 17.6041 3.7126 16.5125C3.2376 15.4208 3.0001 14.25 3.0001 13C3.0001 11.75 3.2376 10.5791 3.7126 9.48748C4.1876 8.39581 4.82926 7.44581 5.6376 6.63748C6.44593 5.82914 7.39593 5.18748 8.4876 4.71248C9.57927 4.23748 10.7501 3.99998 12.0001 3.99998C13.2501 3.99998 14.4209 4.23748 15.5126 4.71248C16.6043 5.18748 17.5543 5.82914 18.3626 6.63748C19.1709 7.44581 19.8126 8.39581 20.2876 9.48748C20.7626 10.5791 21.0001 11.75 21.0001 13C21.0001 14.25 20.7626 15.4208 20.2876 16.5125C19.8126 17.6041 19.1709 18.5541 18.3626 19.3625C17.5543 20.1708 16.6043 20.8125 15.5126 21.2875C14.4209 21.7625 13.2501 22 12.0001 22ZM14.8001 17.2L16.2001 15.8L13.0001 12.6V7.99998H11.0001V13.4L14.8001 17.2ZM5.6001 2.34998L7.0001 3.74998L2.7501 7.99998L1.3501 6.59998L5.6001 2.34998ZM18.4001 2.34998L22.6501 6.59998L21.2501 7.99998L17.0001 3.74998L18.4001 2.34998ZM12.0001 20C13.9501 20 15.6043 19.3208 16.9626 17.9625C18.3209 16.6041 19.0001 14.95 19.0001 13C19.0001 11.05 18.3209 9.39581 16.9626 8.03748C15.6043 6.67914 13.9501 5.99998 12.0001 5.99998C10.0501 5.99998 8.39593 6.67914 7.0376 8.03748C5.67926 9.39581 5.0001 11.05 5.0001 13C5.0001 14.95 5.67926 16.6041 7.0376 17.9625C8.39593 19.3208 10.0501 20 12.0001 20Z"
-			fill={active ? '#A5000A' : '#444748'}
-		/>
-	</svg>
-);
-
-const IconPinned = ({ active }: { active: boolean }) => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
-		<path
-			d="M5 21V5C5 4.45 5.19583 3.97917 5.5875 3.5875C5.97917 3.19583 6.45 3 7 3H17C17.55 3 18.0208 3.19583 18.4125 3.5875C18.8042 3.97917 19 4.45 19 5V21L12 18L5 21ZM7 17.95L12 15.8L17 17.95V5H7V17.95Z"
-			fill={active ? '#A5000A' : '#444748'}
-		/>
-	</svg>
-);
-
-const IconArchivedTab = ({ active }: { active: boolean }) => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
-		<path
-			d="M12 18L16 14L14.6 12.6L13 14.2V10H11V14.2L9.4 12.6L8 14L12 18ZM5 8V19H19V8H5ZM5 21C4.45 21 3.975 20.8083 3.575 20.425C3.19167 20.025 3 19.55 3 19V6.525C3 6.29167 3.03333 6.06667 3.1 5.85C3.18333 5.63333 3.3 5.43333 3.45 5.25L4.7 3.725C4.88333 3.49167 5.10833 3.31667 5.375 3.2C5.65833 3.06667 5.95 3 6.25 3H17.75C18.05 3 18.3333 3.06667 18.6 3.2C18.8833 3.31667 19.1167 3.49167 19.3 3.725L20.55 5.25C20.7 5.43333 20.8083 5.63333 20.875 5.85C20.9583 6.06667 21 6.29167 21 6.525V19C21 19.55 20.8 20.025 20.4 20.425C20.0167 20.8083 19.55 21 19 21H5ZM5.4 6H18.6L17.75 5H6.25L5.4 6Z"
-			fill={active ? '#A5000A' : '#444748'}
+			d="M9.55 18L3.85 12.3L5.275 10.875L9.55 15.15L18.725 5.975L20.15 7.4L9.55 18Z"
+			fill="#ffffff"
 		/>
 	</svg>
 );
@@ -259,6 +247,15 @@ export const SessionsListToolbar = ({
 	searchPeopleResults = [],
 	selectedPersonIds = [],
 	onSelectedPersonIdsChange,
+	searchTopicResults = [],
+	selectedTopicId = null,
+	onSelectedTopicIdChange,
+	searchTypeResults = [],
+	selectedTypeId = null,
+	onSelectedTypeIdChange,
+	searchArchiveOnly = false,
+	onSearchArchiveOnlyChange,
+	onSearchConfirm,
 	activeChip,
 	onChipToggle,
 	showConsultantActions,
@@ -275,9 +272,8 @@ export const SessionsListToolbar = ({
 	const searchRootRef = React.useRef<HTMLDivElement | null>(null);
 	const searchInputRef = React.useRef<HTMLInputElement | null>(null);
 	const [isSearchViewOpen, setIsSearchViewOpen] = React.useState(false);
-	const [searchTab, setSearchTab] = React.useState<
-		'people' | 'type' | 'scheduled' | 'pinned' | 'archived'
-	>('people');
+	const [searchTab, setSearchTab] =
+		React.useState<SessionSearchTab>('people');
 	const setSelectedPersonIds = React.useCallback(
 		(updater: string[] | ((prev: string[]) => string[])) => {
 			if (!onSelectedPersonIdsChange) {
@@ -326,8 +322,34 @@ export const SessionsListToolbar = ({
 		[selectedPersonIds, searchPeopleResults]
 	);
 
+	const filteredTopics = React.useMemo(() => {
+		const needle = searchValue.trim().toLowerCase();
+		if (!needle) {
+			return searchTopicResults;
+		}
+		return searchTopicResults.filter((topic) =>
+			`${topic.label} ${topic.subtitle || ''}`
+				.toLowerCase()
+				.includes(needle)
+		);
+	}, [searchTopicResults, searchValue]);
+
 	const hasTypedQuery = searchValue.trim().length > 0;
 	const hasSelectedPeople = selectedPersonIds.length > 0;
+	const hasSearchSelection =
+		hasSelectedPeople ||
+		Boolean(selectedTopicId) ||
+		Boolean(selectedTypeId) ||
+		searchArchiveOnly;
+	/** Figma Section 07: checkmark hidden while nothing was typed/selected. */
+	const canConfirmSearch = hasTypedQuery || hasSearchSelection;
+	const confirmSearch = React.useCallback(() => {
+		if (!canConfirmSearch) {
+			return;
+		}
+		onSearchConfirm?.();
+		setIsSearchViewOpen(false);
+	}, [canConfirmSearch, onSearchConfirm]);
 	const showSearchDropdown = isSearchViewOpen;
 	const reopenSearchIfActive = React.useCallback(() => {
 		setIsSearchViewOpen(true);
@@ -399,13 +421,20 @@ export const SessionsListToolbar = ({
 					<button
 						type="button"
 						className="sessionsListToolbar__iconButton"
-						aria-label={tr(
-							'sessionList.toolbar.search.toggle',
-							'Open or close search results'
-						)}
+						aria-label={
+							showSearchDropdown
+								? tr(
+										'sessionList.toolbar.search.close',
+										'Close search'
+									)
+								: tr(
+										'sessionList.toolbar.search.toggle',
+										'Open or close search results'
+									)
+						}
 						onClick={() => setIsSearchViewOpen((prev) => !prev)}
 					>
-						<IconMenuDots />
+						{showSearchDropdown ? <IconClose /> : <IconMenuDots />}
 					</button>
 					<div className="sessionsListToolbar__searchFieldWrap">
 						{selectedPeople.length > 0 && (
@@ -457,18 +486,39 @@ export const SessionsListToolbar = ({
 							onChange={(e) => onSearchChange(e.target.value)}
 							onFocus={() => setIsSearchViewOpen(true)}
 							onClick={reopenSearchIfActive}
+							onKeyDown={(event) => {
+								if (event.key === 'Enter') {
+									event.preventDefault();
+									confirmSearch();
+								}
+							}}
 							autoComplete="off"
 							data-cy="sessions-list-search"
 							ref={searchInputRef}
 						/>
 					</div>
-					{hasTypedQuery || hasSelectedPeople ? (
+					{showSearchDropdown && canConfirmSearch ? (
+						<button
+							type="button"
+							className="sessionsListToolbar__searchConfirmButton"
+							onClick={confirmSearch}
+							aria-label={tr(
+								'sessionList.toolbar.search.confirm',
+								'Confirm selection'
+							)}
+							data-cy="sessions-list-search-confirm"
+						>
+							<IconCheck />
+						</button>
+					) : hasTypedQuery || hasSelectedPeople ? (
 						<button
 							type="button"
 							className="sessionsListToolbar__searchActionButton"
 							onClick={() => {
 								onSearchChange('');
 								setSelectedPersonIds([]);
+								onSelectedTopicIdChange?.(null);
+								onSelectedTypeIdChange?.(null);
 								setIsSearchViewOpen(false);
 							}}
 							aria-label={tr(
@@ -488,154 +538,68 @@ export const SessionsListToolbar = ({
 					)}
 				</div>
 				{showSearchDropdown && (
-					<div className="sessionsListToolbar__searchModal">
-						<div className="sessionsListToolbar__searchModalTabs">
-							{[
-								['people', 'People'],
-								['type', 'Type'],
-								['scheduled', 'Scheduled'],
-								['pinned', 'Pinned'],
-								['archived', 'Archived']
-							].map(([id, label]) => {
-								const isActive = searchTab === id;
-								return (
-									<button
-										type="button"
-										key={id}
-										className={clsx(
-											'sessionsListToolbar__searchModalTab',
-											searchTab === id &&
-												'sessionsListToolbar__searchModalTab--active'
-										)}
-										onClick={() =>
-											setSearchTab(
-												id as
-													| 'people'
-													| 'type'
-													| 'scheduled'
-													| 'pinned'
-													| 'archived'
-											)
-										}
-									>
-										<span className="sessionsListToolbar__searchModalTabIcon">
-											{id === 'people' && (
-												<IconPeople active={isActive} />
-											)}
-											{id === 'type' && (
-												<IconType active={isActive} />
-											)}
-											{id === 'scheduled' && (
-												<span className="sessionsListToolbar__searchModalTabIconWithDot">
-													<IconScheduled
-														active={isActive}
-													/>
-													<span className="sessionsListToolbar__searchModalTabDot" />
-												</span>
-											)}
-											{id === 'pinned' && (
-												<IconPinned active={isActive} />
-											)}
-											{id === 'archived' && (
-												<IconArchivedTab
-													active={isActive}
-												/>
-											)}
-										</span>
-										<span className="sessionsListToolbar__searchModalTabLabel">
-											{tr(
-												`sessionList.toolbar.search.tabs.${id}`,
-												label
-											)}
-										</span>
-									</button>
-								);
-							})}
-						</div>
-						<div className="sessionsListToolbar__searchModalBody">
-							{searchTab === 'people' ? (
-								filteredPeople.length > 0 ? (
-									filteredPeople.map((person) => {
-										const isSelected =
-											selectedPersonIds.includes(
-												person.id
-											);
-										return (
-											<button
-												type="button"
-												key={person.id}
-												className="sessionsListToolbar__personRow"
-												onClick={() => {
-													setSelectedPersonIds(
-														(prev) =>
-															prev.includes(
-																person.id
-															)
-																? prev.filter(
-																		(id) =>
-																			id !==
-																			person.id
-																	)
-																: [
-																		...prev,
-																		person.id
-																	]
-													);
-													onSearchChange('');
-													setIsSearchViewOpen(true);
-													requestAnimationFrame(() =>
-														searchInputRef.current?.focus()
-													);
-												}}
-											>
-												<div className="sessionsListToolbar__personAvatar">
-													{person.name
-														.split(' ')
-														.map((part) =>
-															part
-																.trim()
-																.charAt(0)
-														)
-														.join('')
-														.slice(0, 2)
-														.toUpperCase() || 'U'}
-												</div>
-												<div className="sessionsListToolbar__personMeta">
-													<div className="sessionsListToolbar__personName">
-														{person.name}
-													</div>
-													<div className="sessionsListToolbar__personSubtitle">
-														{person.subtitle}
-													</div>
-												</div>
-												<div
-													className={clsx(
-														'sessionsListToolbar__personCheckbox',
-														isSelected &&
-															'sessionsListToolbar__personCheckbox--selected'
-													)}
-												/>
-											</button>
-										);
-									})
-								) : (
-									<div className="sessionsListToolbar__searchEmpty">
-										{tr(
-											'sessionList.toolbar.search.emptyPeople',
-											'No matching people found.'
-										)}
-									</div>
-								)
-							) : (
-								<div className="sessionsListToolbar__searchEmpty">
-									{tr(
-										'sessionList.toolbar.search.emptyTab',
-										'No results for this tab yet.'
-									)}
-								</div>
-							)}
-						</div>
-					</div>
+					<SessionSearchPanel
+						labels={{
+							refineHint: tr(
+								'sessionList.toolbar.search.refineHint',
+								'Refine your search further using filters'
+							),
+							tabPeople: tr(
+								'sessionList.toolbar.search.tabs.people',
+								'People'
+							),
+							tabType: tr(
+								'sessionList.toolbar.search.tabs.type',
+								'By type'
+							),
+							tabCentre: tr(
+								'sessionList.toolbar.search.tabs.centre',
+								'Counseling center'
+							),
+							tabArchiveOnly: tr(
+								'sessionList.toolbar.search.tabs.archiveOnly',
+								'Archive only'
+							),
+							emptyPeople: tr(
+								'sessionList.toolbar.search.emptyPeople',
+								'No matching people found.'
+							),
+							emptyTypes: tr(
+								'sessionList.toolbar.search.emptyTypes',
+								'No chat types available.'
+							),
+							emptyTopics: tr(
+								'sessionList.toolbar.search.emptyTopics',
+								'No topics found for your counseling centers.'
+							)
+						}}
+						activeTab={searchTab}
+						onTabChange={setSearchTab}
+						archiveOnly={searchArchiveOnly}
+						onArchiveOnlyChange={(next) =>
+							onSearchArchiveOnlyChange?.(next)
+						}
+						people={filteredPeople}
+						selectedPersonIds={selectedPersonIds}
+						onPersonToggle={(personId) => {
+							setSelectedPersonIds((prev) =>
+								prev.includes(personId)
+									? prev.filter((id) => id !== personId)
+									: [...prev, personId]
+							);
+							onSearchChange('');
+							setIsSearchViewOpen(true);
+							requestAnimationFrame(() =>
+								searchInputRef.current?.focus()
+							);
+						}}
+						types={searchTypeResults}
+						selectedTypeId={selectedTypeId}
+						onTypeSelect={(id) => onSelectedTypeIdChange?.(id)}
+						topics={filteredTopics}
+						selectedTopicId={selectedTopicId}
+						onTopicSelect={(id) => onSelectedTopicIdChange?.(id)}
+					/>
 				)}
 			</div>
 

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -1167,7 +1167,9 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 	&__searchModalTab {
 		border: none;
 		background: transparent;
-		padding: 10px 12px 6px;
+		flex: 1 1 0;
+		min-width: 0;
+		padding: 10px 8px 6px;
 		font-size: 14px;
 		line-height: 20px;
 		font-weight: 500;
@@ -1200,6 +1202,10 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		font-size: 14px;
 		line-height: 20px;
 		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
 	}
 
 	&__searchModalTabIconWithDot {
@@ -1278,13 +1284,13 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		width: 18px;
 		height: 18px;
 		border-radius: 3px;
-		border: 2px solid #444748;
+		border: 2px solid var(--m3-on-surface-variant, #444748);
 		flex-shrink: 0;
 	}
 
 	&__personCheckbox--selected {
-		background: #a5000a;
-		border-color: #a5000a;
+		background: var(--m3-primary, #a5000a);
+		border-color: var(--m3-primary, #a5000a);
 		position: relative;
 
 		&::after {
@@ -1297,6 +1303,58 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 			border: solid #fff;
 			border-width: 0 2px 2px 0;
 			transform: rotate(45deg);
+		}
+	}
+
+	&__personRadio {
+		width: 20px;
+		height: 20px;
+		border-radius: 999px;
+		border: 2px solid var(--m3-on-surface-variant, #444748);
+		flex-shrink: 0;
+		position: relative;
+	}
+
+	&__personRadio--selected {
+		border-color: var(--m3-primary, #a5000a);
+
+		&::after {
+			content: '';
+			position: absolute;
+			inset: 3px;
+			border-radius: 999px;
+			background: var(--m3-primary, #a5000a);
+		}
+	}
+
+	&__searchRefineHint {
+		padding: 10px 16px 8px;
+		font-size: 13px;
+		line-height: 18px;
+		color: var(--m3-on-surface-variant, #444748);
+		background: var(--m3-surface-container-low, #f5f2f3);
+		border-bottom: 1px solid var(--m3-outline-variant, #d9d6d7);
+	}
+
+	&__searchConfirmButton {
+		width: 40px;
+		height: 40px;
+		border: none;
+		border-radius: 999px;
+		background: var(--m3-primary, #a5000a);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		flex-shrink: 0;
+
+		&:focus-visible {
+			outline: 2px solid var(--m3-on-surface, #1b1b1c);
+			outline-offset: 2px;
+		}
+
+		svg path {
+			fill: var(--m3-on-primary, #ffffff);
 		}
 	}
 

--- a/src/components/storybookDesignLinks.ts
+++ b/src/components/storybookDesignLinks.ts
@@ -4,5 +4,20 @@ export const APP_ORISO_FIGMA_URL =
 // TODO: point to the actual chat-surface Figma frame once available
 export const APP_ORISO_CHAT_FIGMA_URL = APP_ORISO_FIGMA_URL;
 
+/** CARX — Teamberatung Case Handover (search organism, curtain wizard, bulk select). */
+export const CASE_HANDOVER_FIGMA_URL =
+	'https://www.figma.com/design/VGTN5PIN5TNNbMCmECEyZG/CARX---Teamberatung-Case-Handover?node-id=4121-12160&m=dev';
+
+export const CASE_HANDOVER_SEARCH_FIGMA_URL = CASE_HANDOVER_FIGMA_URL;
+
+export const CASE_HANDOVER_BULK_FIGMA_URL =
+	'https://www.figma.com/design/VGTN5PIN5TNNbMCmECEyZG/CARX---Teamberatung-Case-Handover?node-id=4028-7250&m=dev';
+
+export const CASE_HANDOVER_WIZARD_FIGMA_URL =
+	'https://www.figma.com/design/VGTN5PIN5TNNbMCmECEyZG/CARX---Teamberatung-Case-Handover?node-id=4122-14457&m=dev';
+
+export const CASE_HANDOVER_CLIENT_FIGMA_URL =
+	'https://www.figma.com/design/VGTN5PIN5TNNbMCmECEyZG/CARX---Teamberatung-Case-Handover?node-id=4044-15808&m=dev';
+
 export const ORISO_M3_FIGMA_URL =
 	'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=60853-24182&p=f&t=ieIskw4Lz5hlc7iM-0';

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -2758,7 +2758,20 @@
 		"toolbar": {
 			"search": {
 				"label": "Beratungen durchsuchen",
-				"placeholder": "Suche"
+				"placeholder": "Suche",
+				"refineHint": "Verfeinere deine Suche durch Filter weiter",
+				"confirm": "Auswahl bestätigen",
+				"close": "Suche schließen",
+				"clear": "Suche leeren",
+				"emptyPeople": "Keine passenden Personen gefunden.",
+				"emptyTypes": "Keine Chat-Typen verfügbar.",
+				"emptyTopics": "Keine Themen für deine Beratungsstellen gefunden.",
+				"tabs": {
+					"people": "Personen",
+					"type": "Nach Typ",
+					"centre": "Beratungsstelle",
+					"archiveOnly": "Nur Archiv"
+				}
 			},
 			"menu": {
 				"ariaLabel": "Listenoptionen"

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -1073,7 +1073,20 @@
 		"toolbar": {
 			"search": {
 				"label": "Beratungen durchsuchen",
-				"placeholder": "Suche"
+				"placeholder": "Suche",
+				"refineHint": "Verfeinere deine Suche durch Filter weiter",
+				"confirm": "Auswahl bestätigen",
+				"close": "Suche schließen",
+				"clear": "Suche leeren",
+				"emptyPeople": "Keine passenden Personen gefunden.",
+				"emptyTypes": "Keine Chat-Typen verfügbar.",
+				"emptyTopics": "Keine Themen für deine Beratungsstellen gefunden.",
+				"tabs": {
+					"people": "Personen",
+					"type": "Nach Typ",
+					"centre": "Beratungsstelle",
+					"archiveOnly": "Nur Archiv"
+				}
 			},
 			"menu": {
 				"ariaLabel": "Listenoptionen"

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -2701,7 +2701,20 @@
 		"toolbar": {
 			"search": {
 				"label": "Search consultations",
-				"placeholder": "Search"
+				"placeholder": "Search",
+				"refineHint": "Refine your search further using filters",
+				"confirm": "Confirm selection",
+				"close": "Close search",
+				"clear": "Clear search",
+				"emptyPeople": "No matching people found.",
+				"emptyTypes": "No chat types available.",
+				"emptyTopics": "No topics found for your counseling centers.",
+				"tabs": {
+					"people": "People",
+					"type": "By type",
+					"centre": "Counseling center",
+					"archiveOnly": "Archive only"
+				}
 			},
 			"menu": {
 				"ariaLabel": "List options"


### PR DESCRIPTION
## What

Rebuilds the session-list search into the designed Case Handover search organism (Figma "CARX — Teamberatung Case Handover", Section 07 + Section 00 behaviour notes):

- New `SessionSearchPanel` organism: "Refine your search further using filters" hint, filter tabs **People / By type / Counseling center / Archive only**, checkbox multi-select for people, **radio single-select for topics** (a person must never combine two topics, Section 00) and chat types, independent archive-only toggle tab.
- `SessionsListToolbar`: red **confirm checkmark** appears once a query or selection exists (hidden otherwise, per design), **Enter** confirms, X closes the panel; new controlled props for topics, chat types, archive-only and `onSearchConfirm`.
- Replaces the previous placeholder tabs (Scheduled/Pinned/Archived) that had no designed content.
- Design-token pass: checkbox/radio/confirm/hint styles use `--m3-*` variables.
- i18n keys added for de / en / de@informal.

## Storybook

- `Organisms/CaseHandoverSearch/SessionSearchPanel`: people tab (DE+EN), counseling-center tab, by-type tab, archive-only, empty states.
- Interaction tests (`storybook/test`): topic radio exclusivity, people multi-select.
- Figma frames linked via addon-designs.

## Verification

- `vitest` session-list suites: 33/33 green.
- `tsc --noEmit` clean; eslint/stylelint clean on touched files.
- Verified visually in Storybook (worktree instance) against the Figma screenshots.

Part of #491.
Closes #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
