### PR TITLE
feat(sessions): bulk flow through curtain wizard, search wiring, client handover cards

### DIFF
--- a/src/components/caseHandover/CaseHandoverClientCards.stories.tsx
+++ b/src/components/caseHandover/CaseHandoverClientCards.stories.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useTranslation } from 'react-i18next';
+import {
+	CaseHandoverAcceptedCard,
+	CaseHandoverSystemMessageCard
+} from './CaseHandoverClientCards';
+import {
+	CASE_HANDOVER_CLIENT_FIGMA_URL,
+	ORISO_M3_FIGMA_URL
+} from '../storybookDesignLinks';
+import './caseHandoverClientCards.styles.scss';
+
+const shell: React.CSSProperties = {
+	backgroundColor: '#4a4a4a',
+	padding: 32,
+	display: 'flex',
+	justifyContent: 'center'
+};
+
+const meta: Meta = {
+	title: 'Organisms/CaseHandover/ClientCards',
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		design: [
+			{
+				type: 'figma',
+				name: 'CARX Case Handover — client view (Section 04 / Screen 01)',
+				url: CASE_HANDOVER_CLIENT_FIGMA_URL
+			},
+			{
+				type: 'figma',
+				name: 'Design System M3 ORISO',
+				url: ORISO_M3_FIGMA_URL
+			}
+		],
+		docs: {
+			description: {
+				component:
+					'Client-facing case-handover surfaces: the **acceptance card** ("Your inquiry has been accepted by a consultant." + View conversation, Screen 01) and the **in-chat system notification card** (takeover with reason/explanation, important notification, supervision activated — Sections 03/04). Copy source: vault doc "Case Handover — System-Benachrichtigungen & Rechtstexte (Entwurf)".'
+			}
+		}
+	}
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InquiryAccepted: Story = {
+	render: () => (
+		<div style={shell}>
+			<CaseHandoverAcceptedCard
+				advisorName="Kim G."
+				organisationName="Caritas Mainz"
+				onViewConversation={() => {}}
+			/>
+		</div>
+	)
+};
+
+export const InquiryAcceptedMobile: Story = {
+	render: () => (
+		<div style={{ ...shell, maxWidth: 420, margin: '0 auto' }}>
+			<CaseHandoverAcceptedCard
+				advisorName="Kim G."
+				organisationName="Caritas Mainz"
+				onViewConversation={() => {}}
+				compact
+			/>
+		</div>
+	)
+};
+
+function TookOverCard() {
+	const { t } = useTranslation();
+	return (
+		<CaseHandoverSystemMessageCard
+			title={t('caseHandover.systemMessage.tookOverTitle')}
+			subtitle={t('caseHandover.systemMessage.noActionNeeded')}
+			reasonLabel="Other emergency"
+			explanation="My colleague's kids are ill, so I decided it is better if I take care of this client."
+			timestamp="14:22"
+		/>
+	);
+}
+
+export const NewCounsellorTookOver: Story = {
+	render: () => (
+		<div style={{ ...shell, backgroundColor: '#f7f2f1' }}>
+			<TookOverCard />
+		</div>
+	)
+};
+
+function SupervisionCard() {
+	const { t } = useTranslation();
+	return (
+		<CaseHandoverSystemMessageCard
+			title={t('caseHandover.systemMessage.supervisionTitle')}
+		>
+			<p style={{ margin: 0 }}>
+				{t('caseHandover.systemMessage.supervisionBody', {
+					advisor: 'Shazia Kausar'
+				})}
+			</p>
+		</CaseHandoverSystemMessageCard>
+	);
+}
+
+export const SupervisionActivated: Story = {
+	render: () => (
+		<div style={{ ...shell, backgroundColor: '#f7f2f1' }}>
+			<SupervisionCard />
+		</div>
+	)
+};
+
+function ImportantNotificationCard() {
+	const { t } = useTranslation();
+	return (
+		<CaseHandoverSystemMessageCard
+			title={t('caseHandover.systemMessage.importantTitle')}
+			subtitle={t('caseHandover.systemMessage.noActionNeeded')}
+			reasonLabel="Counsellor is ill"
+			explanation="Your case was handed over so you don't have to wait."
+			timestamp="09:32"
+		/>
+	);
+}
+
+export const ImportantNotification: Story = {
+	render: () => (
+		<div style={{ ...shell, backgroundColor: '#f7f2f1' }}>
+			<ImportantNotificationCard />
+		</div>
+	)
+};

--- a/src/components/caseHandover/CaseHandoverClientCards.tsx
+++ b/src/components/caseHandover/CaseHandoverClientCards.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { ReactComponent as CaseAcceptedIcon } from '../../resources/img/icons/case-handover/case-accepted.svg';
+import './caseHandoverClientCards.styles';
+
+/**
+ * Client-facing case-handover surfaces (Figma "CARX — Teamberatung Case
+ * Handover", Screen 01 + Sections 03/04):
+ *
+ * - CaseHandoverAcceptedCard — "Your inquiry has been accepted by a
+ *   consultant." with the View-conversation action (desktop + mobile).
+ * - CaseHandoverSystemMessageCard — in-chat system notification (takeover,
+ *   supervision activated, important notification) with reason/explanation.
+ */
+
+const IconOpenConversation = () => (
+	<svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+		<path
+			d="M4 20V15H6V16.6L9.6 13L11 14.4L7.4 18H9V20H4ZM15 20V18H16.6L13 14.4L14.4 13L18 16.6V15H20V20H15ZM9 11L5.4 7.4V9H3.4V4H8.4V6H6.8L10.4 9.6L9 11ZM14.4 11L13 9.6L16.6 6H15V4H20V9H18V7.4L14.4 11Z"
+			fill="currentColor"
+		/>
+	</svg>
+);
+
+const IconBell = () => (
+	<svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+		<path
+			d="M4 19V17H6V10C6 8.61667 6.41667 7.39583 7.25 6.3375C8.08333 5.27917 9.16667 4.58333 10.5 4.25V3.5C10.5 3.08333 10.6458 2.72917 10.9375 2.4375C11.2292 2.14583 11.5833 2 12 2C12.4167 2 12.7708 2.14583 13.0625 2.4375C13.3542 2.72917 13.5 3.08333 13.5 3.5V4.25C14.8333 4.58333 15.9167 5.27917 16.75 6.3375C17.5833 7.39583 18 8.61667 18 10V17H20V19H4ZM12 22C11.45 22 10.9792 21.8042 10.5875 21.4125C10.1958 21.0208 10 20.55 10 20H14C14 20.55 13.8042 21.0208 13.4125 21.4125C13.0208 21.8042 12.55 22 12 22ZM8 17H16V10C16 8.9 15.6083 7.95833 14.825 7.175C14.0417 6.39167 13.1 6 12 6C10.9 6 9.95833 6.39167 9.175 7.175C8.39167 7.95833 8 8.9 8 10V17Z"
+			fill="currentColor"
+		/>
+	</svg>
+);
+
+interface CaseHandoverAcceptedCardProps {
+	/** Counsellor display name for the body copy. */
+	advisorName?: string;
+	organisationName?: string;
+	onViewConversation: () => void;
+	/** Compact layout (mobile card, Screen 01 right variant). */
+	compact?: boolean;
+}
+
+export const CaseHandoverAcceptedCard = ({
+	advisorName,
+	organisationName,
+	onViewConversation,
+	compact = false
+}: CaseHandoverAcceptedCardProps) => {
+	const { t: translate } = useTranslation();
+	return (
+		<div
+			className={clsx(
+				'caseHandoverAccepted',
+				compact && 'caseHandoverAccepted--compact'
+			)}
+			data-cy="case-handover-accepted-card"
+		>
+			<div className="caseHandoverAccepted__hero">
+				<CaseAcceptedIcon
+					className="caseHandoverAccepted__icon"
+					aria-hidden
+				/>
+				<h2 className="caseHandoverAccepted__title">
+					{translate('caseHandover.accepted.title')}
+				</h2>
+			</div>
+			<p className="caseHandoverAccepted__copy">
+				{translate('caseHandover.accepted.copy', {
+					advisor:
+						advisorName ||
+						translate('caseHandover.accepted.advisorFallback'),
+					organisation:
+						organisationName ||
+						translate('caseHandover.accepted.organisationFallback')
+				})}
+			</p>
+			<div className="caseHandoverAccepted__actions">
+				<button
+					type="button"
+					className="caseHandoverAccepted__cta"
+					onClick={onViewConversation}
+					data-cy="case-handover-accepted-view-conversation"
+				>
+					<IconOpenConversation />
+					{translate('caseHandover.accepted.cta')}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+interface CaseHandoverSystemMessageCardProps {
+	title: string;
+	/** e.g. "You don't need to take any action" */
+	subtitle?: string;
+	children?: React.ReactNode;
+	/** Reason label ("Selected reason: …"). */
+	reasonLabel?: string;
+	explanation?: string;
+	timestamp?: string;
+}
+
+export const CaseHandoverSystemMessageCard = ({
+	title,
+	subtitle,
+	children,
+	reasonLabel,
+	explanation,
+	timestamp
+}: CaseHandoverSystemMessageCardProps) => {
+	const { t: translate } = useTranslation();
+	return (
+		<div
+			className="caseHandoverSystemMessage"
+			role="note"
+			data-cy="case-handover-system-message"
+		>
+			<div className="caseHandoverSystemMessage__head">
+				<span
+					className="caseHandoverSystemMessage__bellIcon"
+					aria-hidden
+				>
+					<IconBell />
+				</span>
+				<div>
+					<span className="caseHandoverSystemMessage__badge">
+						{translate('caseHandover.systemMessage.badge')}
+					</span>
+					<h4 className="caseHandoverSystemMessage__title">
+						{title}
+					</h4>
+					{subtitle && (
+						<p className="caseHandoverSystemMessage__subtitle">
+							{subtitle}
+						</p>
+					)}
+				</div>
+			</div>
+			{(reasonLabel || explanation || children) && (
+				<div className="caseHandoverSystemMessage__body">
+					{reasonLabel && (
+						<p className="caseHandoverSystemMessage__reason">
+							{translate(
+								'caseHandover.systemMessage.selectedReason',
+								{ reason: reasonLabel }
+							)}
+						</p>
+					)}
+					{explanation && (
+						<p className="caseHandoverSystemMessage__explanation">
+							{translate(
+								'caseHandover.systemMessage.explanation',
+								{ explanation }
+							)}
+						</p>
+					)}
+					{children}
+				</div>
+			)}
+			{timestamp && (
+				<span className="caseHandoverSystemMessage__timestamp">
+					{timestamp}
+				</span>
+			)}
+		</div>
+	);
+};

--- a/src/components/caseHandover/caseHandoverClientCards.styles.scss
+++ b/src/components/caseHandover/caseHandoverClientCards.styles.scss
@@ -1,0 +1,165 @@
+.caseHandoverAccepted {
+	width: min(720px, 100%);
+	padding: 40px 48px;
+	border-radius: 24px;
+	background: var(--m3-surface, #ffffff);
+	box-shadow: 0 2px 10px rgba(45, 34, 33, 0.08);
+	box-sizing: border-box;
+}
+
+.caseHandoverAccepted__hero {
+	display: flex;
+	align-items: center;
+	gap: 18px;
+	margin-bottom: 18px;
+}
+
+.caseHandoverAccepted__icon {
+	width: 72px;
+	height: 72px;
+	flex-shrink: 0;
+}
+
+.caseHandoverAccepted__title {
+	margin: 0;
+	font-size: 26px;
+	line-height: 33px;
+	font-weight: 500;
+	color: var(--m3-on-surface, #1b1b1c);
+}
+
+.caseHandoverAccepted__copy {
+	margin: 0 0 26px;
+	font-size: 15px;
+	line-height: 23px;
+	color: var(--m3-on-surface-variant, #4b515a);
+}
+
+.caseHandoverAccepted__actions {
+	display: flex;
+	justify-content: center;
+}
+
+.caseHandoverAccepted__cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 52px;
+	padding: 0 28px;
+	border: 0;
+	border-radius: 26px;
+	background: var(--m3-primary, #a5000a);
+	color: var(--m3-on-primary, #ffffff);
+	font-size: 16px;
+	font-weight: 600;
+	cursor: pointer;
+
+	&:focus-visible {
+		outline: 2px solid var(--m3-on-surface, #1b1b1c);
+		outline-offset: 2px;
+	}
+}
+
+.caseHandoverAccepted--compact {
+	padding: 24px;
+
+	.caseHandoverAccepted__hero {
+		align-items: flex-start;
+	}
+
+	.caseHandoverAccepted__icon {
+		width: 56px;
+		height: 56px;
+	}
+
+	.caseHandoverAccepted__title {
+		font-size: 22px;
+		line-height: 28px;
+	}
+
+	.caseHandoverAccepted__cta {
+		width: 100%;
+		justify-content: center;
+	}
+}
+
+.caseHandoverSystemMessage {
+	position: relative;
+	width: min(560px, 100%);
+	padding: 16px 18px;
+	border-radius: 16px;
+	border: 1px solid var(--m3-primary-fixed-dim, #ffd8d4);
+	background: var(--m3-surface-container-lowest, #fff8f7);
+	box-sizing: border-box;
+}
+
+.caseHandoverSystemMessage__head {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.caseHandoverSystemMessage__bellIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: 999px;
+	background: var(--m3-primary-container, #ffdad6);
+	color: var(--m3-primary, #a5000a);
+	flex-shrink: 0;
+}
+
+.caseHandoverSystemMessage__badge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	padding: 2px 10px;
+	border-radius: 999px;
+	background: var(--m3-secondary, #4b515a);
+	color: var(--m3-on-primary, #ffffff);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.3px;
+}
+
+.caseHandoverSystemMessage__title {
+	margin: 8px 0 0;
+	font-size: 18px;
+	line-height: 24px;
+	font-weight: 700;
+	color: var(--m3-on-surface, #1b1b1c);
+}
+
+.caseHandoverSystemMessage__subtitle {
+	margin: 2px 0 0;
+	font-size: 12px;
+	line-height: 16px;
+	color: var(--m3-on-surface-variant, #6d747d);
+}
+
+.caseHandoverSystemMessage__body {
+	margin-top: 10px;
+	padding-left: 48px;
+	font-size: 14px;
+	line-height: 20px;
+	color: var(--m3-on-surface, #2d3135);
+}
+
+.caseHandoverSystemMessage__reason {
+	margin: 0 0 6px;
+	font-weight: 600;
+}
+
+.caseHandoverSystemMessage__explanation {
+	margin: 0;
+}
+
+.caseHandoverSystemMessage__timestamp {
+	position: absolute;
+	right: 14px;
+	bottom: 10px;
+	font-size: 12px;
+	color: var(--m3-on-surface-variant, #6d747d);
+}

--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -49,7 +49,7 @@ import {
 	isMatrixRoomIdHeuristic
 } from '../../utils/matrixRoomUtils';
 import { Button } from '../button/Button';
-import { OrisoTextarea } from '../form/OrisoTextarea';
+import { CaseHandoverCurtainView } from '../session/CaseHandoverCurtain';
 import './sessionsList.styles';
 import { SCROLL_PAGINATE_THRESHOLD } from './sessionsListConfig';
 import clsx from 'clsx';
@@ -389,6 +389,8 @@ export const SessionsList = ({
 	const [isRequestInProgress, setIsRequestInProgress] = useState(false);
 	const abortController = useRef<AbortController>(null);
 	const [sessionToolbarSearch, setSessionToolbarSearch] = useState('');
+	const [sessionToolbarSelectedTopic, setSessionToolbarSelectedTopic] =
+		useState<string | null>(null);
 	const [sessionToolbarSelectedPeople, setSessionToolbarSelectedPeople] =
 		useState<string[]>([]);
 	const [caseHandoverCandidateSessions, setCaseHandoverCandidateSessions] =
@@ -396,6 +398,9 @@ export const SessionsList = ({
 	const [userDrafts, setUserDrafts] = useState<IUserDraftItem[]>([]);
 	const [caseHandoverBatchMode, setCaseHandoverBatchMode] = useState(false);
 	const [caseHandoverReviewOpen, setCaseHandoverReviewOpen] = useState(false);
+	const [caseHandoverWizardStep, setCaseHandoverWizardStep] = useState<
+		'reason' | 'describe'
+	>('reason');
 	const [caseHandoverSelectedIds, setCaseHandoverSelectedIds] = useState<
 		number[]
 	>([]);
@@ -1590,6 +1595,21 @@ export const SessionsList = ({
 			})),
 		[finalSessionsList, groupIdFromParam]
 	);
+	const toolbarSearchTopicResults = React.useMemo(() => {
+		const byId = new Map<string, { id: string; label: string }>();
+		sessionToolbarPairs.forEach(({ extended }) => {
+			const topic = extended?.item?.topic as TopicSessionInterface | null;
+			if (topic?.id !== undefined && topic?.name) {
+				byId.set(String(topic.id), {
+					id: String(topic.id),
+					label: topic.name
+				});
+			}
+		});
+		return Array.from(byId.values()).sort((a, b) =>
+			a.label.localeCompare(b.label)
+		);
+	}, [sessionToolbarPairs]);
 	const sessionToolbarFilteredPairs = sessionToolbarPairs.filter(
 		({ raw, extended }) =>
 			sessionMatchesToolbar(
@@ -1600,7 +1620,12 @@ export const SessionsList = ({
 				sessionToolbarSelectedPeople,
 				visibleUserDrafts,
 				userData?.userId
-			)
+			) &&
+			(!sessionToolbarSelectedTopic ||
+				String(
+					(extended?.item?.topic as TopicSessionInterface | null)
+						?.id ?? ''
+				) === sessionToolbarSelectedTopic)
 	);
 	const sortedSessions = sessionToolbarFilteredPairs
 		.map(({ extended }) => extended)
@@ -1657,6 +1682,8 @@ export const SessionsList = ({
 					})
 				);
 				setCaseHandoverSelectedIds([]);
+				setCaseHandoverReviewOpen(false);
+				setCaseHandoverWizardStep('reason');
 				void refetchSessionList();
 			})
 			.catch(() => {
@@ -1831,6 +1858,54 @@ export const SessionsList = ({
 					}
 					createGroupChatActive={isCreateChatActive}
 					chipCounts={toolbarChipCounts}
+					searchTopicResults={toolbarSearchTopicResults}
+					selectedTopicId={sessionToolbarSelectedTopic}
+					onSelectedTopicIdChange={setSessionToolbarSelectedTopic}
+					searchTypeResults={[
+						{
+							id: 'nearby',
+							label: translate('sessionList.toolbar.chips.nearby')
+						},
+						{
+							id: 'liveChat',
+							label: translate(
+								'sessionList.toolbar.chips.liveChat'
+							)
+						},
+						{
+							id: 'internalGroup',
+							label: translate(
+								'sessionList.toolbar.chips.internalGroup'
+							)
+						},
+						{
+							id: 'groups',
+							label: translate('sessionList.toolbar.chips.groups')
+						},
+						{
+							id: 'supervision',
+							label: translate(
+								'sessionList.toolbar.chips.supervision'
+							)
+						}
+					]}
+					selectedTypeId={sessionToolbarChip}
+					onSelectedTypeIdChange={(id) =>
+						handleToolbarChipToggle(
+							(id ||
+								sessionToolbarChip) as SessionToolbarChipFilter
+						)
+					}
+					searchArchiveOnly={
+						sessionListTab === SESSION_LIST_TAB_ARCHIVE
+					}
+					onSearchArchiveOnlyChange={(archiveOnly) =>
+						navigate(
+							archiveOnly
+								? buildArchiveTabPath()
+								: '/sessions/consultant/sessionView'
+						)
+					}
 				/>
 			)}
 			{showMySessionToolbar && futureTimelineSeries.length > 0 && (
@@ -1843,10 +1918,29 @@ export const SessionsList = ({
 			)}
 			{showCaseHandoverBatchUi &&
 				caseHandoverBatchMode &&
-				caseHandoverReviewOpen && (
+				caseHandoverBatchSummary &&
+				!caseHandoverReviewOpen && (
 					<div className="sessionsList__caseHandoverBatch">
-						<div className="sessionsList__caseHandoverBatchPanel">
-							<div className="sessionsList__caseHandoverBatchHeader">
+						<div
+							className="sessionsList__caseHandoverBatchSummary"
+							role="status"
+							aria-live="polite"
+						>
+							{caseHandoverBatchSummary}
+						</div>
+					</div>
+				)}
+			{showCaseHandoverBatchUi &&
+				caseHandoverBatchMode &&
+				caseHandoverReviewOpen && (
+					<div
+						className="sessionsList__caseHandoverWizardOverlay"
+						role="dialog"
+						aria-modal="true"
+						aria-label={translate('caseHandover.batch.title')}
+					>
+						<div className="sessionsList__caseHandoverWizardShell">
+							<div className="sessionsList__caseHandoverWizardBar">
 								<strong>
 									{translate('caseHandover.batch.title')}
 								</strong>
@@ -1858,84 +1952,42 @@ export const SessionsList = ({
 										}
 									)}
 								</span>
-							</div>
-							<div
-								className="sessionsList__caseHandoverBatchReasons"
-								role="radiogroup"
-								aria-label={translate(
-									'caseHandover.batch.title'
-								)}
-							>
-								{caseHandoverReasons.map((reason) => (
-									<label key={reason.code}>
-										<input
-											type="radio"
-											name="case-handover-batch-reason"
-											checked={
-												caseHandoverReasonCode ===
-												reason.code
-											}
-											onChange={() =>
-												setCaseHandoverReasonCode(
-													reason.code
-												)
-											}
-										/>
-										<span>{reason.label}</span>
-									</label>
-								))}
-							</div>
-							<OrisoTextarea
-								className="sessionsList__caseHandoverBatchExplanation"
-								value={caseHandoverExplanation}
-								onChange={(event) =>
-									setCaseHandoverExplanation(
-										event.target.value
-									)
-								}
-								label={translate(
-									'caseHandover.explanation.placeholder'
-								)}
-								aria-label={translate(
-									'caseHandover.explanation.placeholder'
-								)}
-							/>
-							<div className="sessionsList__caseHandoverBatchActions">
 								<button
 									type="button"
-									onClick={handleCloseCaseHandoverBatch}
+									className="sessionsList__caseHandoverWizardClose"
+									onClick={() => {
+										setCaseHandoverReviewOpen(false);
+										setCaseHandoverWizardStep('reason');
+									}}
 								>
 									{translate('caseHandover.batch.cancel')}
 								</button>
-								<button
-									type="button"
-									className="sessionsList__caseHandoverBatchSubmit"
-									onClick={handleSubmitCaseHandoverBatch}
-									disabled={
-										caseHandoverBatchSubmitting ||
-										caseHandoverSelectedIds.length === 0 ||
-										!caseHandoverReasonCode ||
-										!caseHandoverExplanation.trim()
-									}
-								>
-									{caseHandoverBatchSubmitting
-										? translate(
-												'caseHandover.submitSending'
-											)
-										: translate(
-												'caseHandover.batch.confirm'
-											)}
-								</button>
 							</div>
-							{caseHandoverBatchSummary && (
-								<div
-									className="sessionsList__caseHandoverBatchSummary"
-									role="status"
-									aria-live="polite"
-								>
-									{caseHandoverBatchSummary}
-								</div>
-							)}
+							<CaseHandoverCurtainView
+								step={caseHandoverWizardStep}
+								reasons={caseHandoverReasons}
+								reasonCode={caseHandoverReasonCode}
+								explanation={caseHandoverExplanation}
+								isSubmitting={caseHandoverBatchSubmitting}
+								error={
+									caseHandoverReviewOpen &&
+									caseHandoverBatchSummary
+										? caseHandoverBatchSummary
+										: undefined
+								}
+								onStart={() =>
+									setCaseHandoverWizardStep('reason')
+								}
+								onBack={() =>
+									setCaseHandoverWizardStep('reason')
+								}
+								onNext={() =>
+									setCaseHandoverWizardStep('describe')
+								}
+								onReasonSelect={setCaseHandoverReasonCode}
+								onExplanationChange={setCaseHandoverExplanation}
+								onSubmit={handleSubmitCaseHandoverBatch}
+							/>
 						</div>
 					</div>
 				)}

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -212,6 +212,65 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		}
 	}
 
+	&__caseHandoverWizardOverlay {
+		position: fixed;
+		inset: 0;
+		z-index: 120;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 16px;
+		background: rgba(27, 27, 28, 0.4);
+	}
+
+	&__caseHandoverWizardShell {
+		width: min(720px, 100%);
+		max-height: min(86vh, 780px);
+		display: flex;
+		flex-direction: column;
+		border-radius: 24px;
+		overflow: hidden auto;
+		background: var(--m3-surface, #ffffff);
+		box-shadow: 0 12px 40px rgba(0, 0, 0, 0.24);
+
+		.caseHandoverCurtain {
+			padding: 0;
+			background: transparent;
+		}
+
+		.caseHandoverCurtain__card {
+			box-shadow: none;
+			border-radius: 0;
+		}
+	}
+
+	&__caseHandoverWizardBar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 14px 20px 0;
+		color: var(--m3-on-surface, #1b1b1c);
+		font-size: 14px;
+
+		span {
+			color: var(--m3-on-surface-variant, #6d747d);
+		}
+	}
+
+	&__caseHandoverWizardClose {
+		margin-left: auto;
+		border: 0;
+		background: transparent;
+		color: var(--m3-primary, #a5000a);
+		font-weight: 700;
+		cursor: pointer;
+
+		&:focus-visible {
+			outline: 2px solid var(--m3-primary, #a5000a);
+			outline-offset: 2px;
+		}
+	}
+
 	&__caseHandoverBatchSummary {
 		margin-top: 10px;
 		color: $caseHandoverTextMuted;

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -2497,6 +2497,23 @@
 			"back": "Zurück",
 			"next": "Weiter",
 			"consentPending": "Klient:innen-Zustimmung ist erforderlich, bevor der Zugriff aktiviert wird."
+		},
+		"accepted": {
+			"title": "Deine Anfrage wurde von einer Berater:in angenommen.",
+			"copy": "{{advisor}} aus der Beratungsstelle {{organisation}} kümmert sich ab jetzt um dein Anliegen. Alle Nachrichten bleiben Ende-zu-Ende verschlüsselt und nur für die an deiner Beratung beteiligten Personen sichtbar.",
+			"cta": "Zum Gespräch",
+			"advisorFallback": "Eine Berater:in",
+			"organisationFallback": "deiner Beratungsstelle"
+		},
+		"systemMessage": {
+			"badge": "System-Benachrichtigung",
+			"selectedReason": "Ausgewählter Grund: {{reason}}",
+			"explanation": "Erläuterung: {{explanation}}",
+			"tookOverTitle": "Neue Berater:in hat deinen Fall übernommen",
+			"noActionNeeded": "Du musst nichts weiter tun",
+			"importantTitle": "Wichtige Mitteilung",
+			"supervisionTitle": "Supervision aktiviert!",
+			"supervisionBody": "{{advisor}} wurde diesem Chat als beratende Supervisor:in hinzugefügt."
 		}
 	},
 	"session": {

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -2437,6 +2437,23 @@
 			"back": "Back",
 			"next": "Next",
 			"consentPending": "Client consent is required before access is activated."
+		},
+		"accepted": {
+			"title": "Your inquiry has been accepted by a consultant.",
+			"copy": "{{advisor}} from the counselling centre {{organisation}} is now taking care of your request. All messages remain end-to-end encrypted and visible only to the people involved in your counselling.",
+			"cta": "View conversation",
+			"advisorFallback": "A consultant",
+			"organisationFallback": "your counselling centre"
+		},
+		"systemMessage": {
+			"badge": "System notification",
+			"selectedReason": "Selected reason: {{reason}}",
+			"explanation": "Explanation: {{explanation}}",
+			"tookOverTitle": "New counsellor took over your case",
+			"noActionNeeded": "You don't need to take any action",
+			"importantTitle": "Important notification",
+			"supervisionTitle": "Supervision activated!",
+			"supervisionBody": "{{advisor}} has been added to this chat as a supervising advisor."
 		}
 	},
 	"session": {


### PR DESCRIPTION
## What

Completes the functional wiring of the new handover UI and adds the client-facing surfaces:

**Wiring (#496)**
- Bulk confirm ("Confirm selection" from the card menu / search checkmark) now opens the **curtain wizard in a modal overlay** (reason → describe) and submits through `apiRequestCaseHandoverBatchAccess`; per-session result summary appears above the list. The legacy inline batch reason panel is removed.
- Search organism wired in `SessionsList`: topic options are derived from the visible (own + candidate) sessions and the topic radio narrows the list; the "By type" tab maps onto the existing toolbar chip filters; "Archive only" routes to the archive tab; people/candidate search stays department-scoped via the candidates endpoint (`archived` flag included).

**Client surfaces (#495)**
- `CaseHandoverAcceptedCard` (Figma Screen 01): "Your inquiry has been accepted by a consultant." + **View conversation**, desktop and compact/mobile variants — final copy from the reviewed notification/legal draft doc (vault, CAR-CHO-01), no lorem ipsum.
- `CaseHandoverSystemMessageCard` (Sections 03/04): in-chat system notification with badge, title, "you don't need to take any action", selected reason and explanation; variants for takeover, important notification and supervision-activated.
- Client consent decision (agree/decline) already ships via the NotificationsCenter timeline cards and stays as is.
- i18n `caseHandover.accepted.*` / `caseHandover.systemMessage.*` (de/en).

## Known follow-up (backend)

UserService currently emits handover events to the activity timeline only — there is no in-chat system-message emission. The system-message card is ready; emitting `case.handover.*` chat messages (or rendering them from timeline events inside the room) is a backend/bridge follow-up tracked on the epic.

## Verification

- vitest session/sessionsList/sessionsListItem suites: 93/93 green.
- `tsc --noEmit`, eslint, stylelint clean.
- Storybook: `Organisms/CaseHandover/ClientCards` (accepted desktop/mobile, took-over, supervision, important) visually verified against Screen 01 / Sections 03–04.

Stacked on #499.

Part of #491.
Closes #495.
Refs #496 (pre-dev end-to-end business-rule verification remains after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
