### PR TITLE
test(observability): named #412 regression for UTD grace period (#440 task 5)

### DIFF
--- a/src/utils/observability/utdTracker.test.ts
+++ b/src/utils/observability/utdTracker.test.ts
@@ -495,4 +495,69 @@ describe('initUtdTracking', () => {
 			expect(event.listenerCount()).toBe(1);
 		});
 	});
+
+	// #440 task 5 — a named, executable guard for the incident that motivated
+	// this tracker (#412): a Megolm key that arrives seconds late made messages
+	// briefly undecryptable, then self-healed. That transient must NOT register
+	// as a UTD, or the SigNoz signal drowns in false positives; but a key that
+	// genuinely never arrives MUST register. The grace-period logic already
+	// covers both, this pins it to the concrete incident narrative + timing.
+	describe('#412 regression: delayed Megolm key self-heals within the grace period', () => {
+		it('does not count a key that arrives ~30s late (well inside the 5-minute grace)', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$delayed-key');
+			client.emit('Room.timeline', event);
+
+			// #412 symptom: the inbound Megolm session isn't known yet.
+			event.simulateFailure(
+				DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			);
+			// The key shows up 30 seconds later — the SDK re-decrypts and the
+			// event type is promoted away from the encrypted envelope.
+			vi.advanceTimersByTime(30 * 1000);
+			event.simulateSuccess();
+			// Let the full grace window elapse to prove the permanent timer was
+			// cancelled, not merely not-yet-fired.
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).not.toHaveBeenCalledWith(
+				1,
+				expect.objectContaining({ outcome: 'permanent' })
+			);
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'transient_resolved',
+				cause: DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			});
+		});
+
+		it('still counts the evil twin — a key that never arrives — as a permanent bug', async () => {
+			const { initUtdTracking, setMatrixClientServiceRef } =
+				await loadModules();
+			initUtdTracking();
+
+			const client = createFakeMatrixClient();
+			setMatrixClientServiceRef({ getClient: () => client } as any);
+			flushClientPoll();
+
+			const event = createFakeEncryptedEvent('$lost-key');
+			client.emit('Room.timeline', event);
+			event.simulateFailure(
+				DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID
+			);
+			vi.advanceTimersByTime(GRACE_PERIOD_MS);
+
+			expect(mockAdd).toHaveBeenCalledWith(1, {
+				outcome: 'permanent',
+				cause: DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID,
+				category: 'bug'
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Context — #440 is already ~90% done
Auditing #440 before building: the UTD tracker landed earlier as **commit `aba5fca` (OBS-P9)** and is wired in `initApp.tsx`. It already covers:
- **Task 1** (tracker core: 5-min grace period + cause classification on SDK `Event.decrypted`) ✅
- **Task 2** (aggregated `decryption_failure` counter via OTel → SigNoz `meterProvider`) ✅
- **Task 4** (MSC4153 "intentionally withheld" split — `category: 'withheld' | 'bug'`) ✅

29 existing tests, all green (once `@opentelemetry/*` deps are installed — they were missing from my checkout's `node_modules`).

## What this PR adds — Task 5
A **named** regression guard for the incident that motivated the tracker (#412): a Megolm key arriving ~30s late must self-heal to `transient_resolved` and never register as a permanent UTD; its evil twin — a key that never arrives — must still count as a permanent `bug`. The generic grace-period tests cover the behaviour, but this pins it to the concrete incident + realistic timing so a future change to the grace logic trips a clearly-named test.

2 new tests → **31 green**.

## Still open on #440 (not FE)
- **Task 3** — SigNoz dashboard (UTD rate per cause) + post-deploy regression alert. This is ops/infra, belongs to the observability rollout epic **ORISO-Helm#62** (OBS track), not this repo.

Refs #440, #412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)