### PR TITLE
feat(chat): render case-handover system messages as designed cards

### DIFF
--- a/src/components/message/MessageItemComponent.mocks.ts
+++ b/src/components/message/MessageItemComponent.mocks.ts
@@ -245,3 +245,15 @@ export const mockSystemNotificationMessage = `[SYSTEM_NOTIFICATION]${JSON.string
 		type: 'INFO'
 	}
 )}`;
+
+export const mockCaseHandoverGrantedMessage = `[SYSTEM_NOTIFICATION]${JSON.stringify(
+	{
+		type: 'CASE_HANDOVER_GRANTED',
+		username: 'Kim G.',
+		description:
+			'Deine bisherige Berater:in ist leider erkrankt. Damit du nicht warten musst, hat Kim G. deinen Fall übernommen.',
+		reasonLabel: 'Counsellor is ill',
+		explanation:
+			'My colleague is ill, so I decided it is better if I take care of this client.'
+	}
+)}`;

--- a/src/components/message/MessageItemComponent.stories.tsx
+++ b/src/components/message/MessageItemComponent.stories.tsx
@@ -24,6 +24,7 @@ import {
 	mockLongGermanMessage,
 	mockMessageItemComponentProps,
 	mockServerSettingsContext,
+	mockCaseHandoverGrantedMessage,
 	mockSystemNotificationMessage,
 	mockUserData,
 	mockVisibilityMessage
@@ -225,6 +226,24 @@ export const SystemNotification: Story = {
 			displayName: 'system',
 			username: 'system',
 			message: mockSystemNotificationMessage
+		}),
+		...baseHandlers
+	}
+};
+
+export const CaseHandoverGranted: Story = {
+	name: 'Case handover granted (system card)',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: 'system',
+			displayName: 'system',
+			username: 'system',
+			message: mockCaseHandoverGrantedMessage
 		}),
 		...baseHandlers
 	}

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -69,8 +69,10 @@ import { MessageAvatar } from './MessageAvatar';
 import clsx from 'clsx';
 import {
 	parseMessagePrefixes,
-	SYSTEM_NOTIFICATION_USER_LEFT_CHAT
+	SYSTEM_NOTIFICATION_USER_LEFT_CHAT,
+	SYSTEM_NOTIFICATION_CASE_HANDOVER_GRANTED
 } from './messageConstants';
+import { CaseHandoverSystemMessageCard } from '../caseHandover/CaseHandoverClientCards';
 import { createPortal } from 'react-dom';
 import { ReactComponent as NotificationBellIcon } from '../../resources/img/icons/notification_bell.svg';
 import { ReactComponent as StackVerticalIcon } from '../../resources/img/icons/stack-vertical.svg';
@@ -904,6 +906,9 @@ export const MessageItemComponent = ({
 	const isUserLeftChatEvent =
 		parsedMessage.systemNotificationType ===
 		SYSTEM_NOTIFICATION_USER_LEFT_CHAT;
+	const isCaseHandoverGrantedEvent =
+		parsedMessage.systemNotificationType ===
+		SYSTEM_NOTIFICATION_CASE_HANDOVER_GRANTED;
 	const userLeftChatEventText = hasUserAuthority(
 		AUTHORITIES.CONSULTANT_DEFAULT,
 		userData
@@ -916,6 +921,12 @@ export const MessageItemComponent = ({
 	const systemNotificationDescription =
 		parsedMessage.systemNotificationDescription ||
 		parsedMessage.cleanedMessage;
+	const systemNotificationReasonLabel =
+		parsedMessage.systemNotificationReasonLabel;
+	const systemNotificationExplanation =
+		parsedMessage.systemNotificationExplanation;
+	const systemNotificationRawDescription =
+		parsedMessage.systemNotificationDescription;
 	const renderedMessageWithoutPrefix = renderedMessage;
 
 	const hasRenderedMessage =
@@ -1408,24 +1419,52 @@ export const MessageItemComponent = ({
 									: 'messageItem__message'
 							} ${isSystemNotification ? 'messageItem__message--systemNotification' : ''}`}
 						>
-							{isSystemNotification && (
-								<>
-									<div className="messageItem__systemNotificationTag">
-										{translate(
-											'message.systemNotification',
-											'System Notification'
+							{isSystemNotification &&
+								isCaseHandoverGrantedEvent && (
+									<CaseHandoverSystemMessageCard
+										title={translate(
+											'caseHandover.systemMessage.tookOverTitle'
 										)}
-									</div>
-									<div className="messageItem__systemNotificationTitle">
-										{systemNotificationTitle}
-									</div>
-									{systemNotificationDescription && (
-										<div className="messageItem__systemNotificationDescription">
-											{systemNotificationDescription}
+										subtitle={translate(
+											'caseHandover.systemMessage.noActionNeeded'
+										)}
+										reasonLabel={
+											systemNotificationReasonLabel ||
+											undefined
+										}
+										explanation={
+											systemNotificationExplanation ||
+											undefined
+										}
+									>
+										{systemNotificationRawDescription && (
+											<p className="messageItem__systemNotificationDescription">
+												{
+													systemNotificationRawDescription
+												}
+											</p>
+										)}
+									</CaseHandoverSystemMessageCard>
+								)}
+							{isSystemNotification &&
+								!isCaseHandoverGrantedEvent && (
+									<>
+										<div className="messageItem__systemNotificationTag">
+											{translate(
+												'message.systemNotification',
+												'System Notification'
+											)}
 										</div>
-									)}
-								</>
-							)}
+										<div className="messageItem__systemNotificationTitle">
+											{systemNotificationTitle}
+										</div>
+										{systemNotificationDescription && (
+											<div className="messageItem__systemNotificationDescription">
+												{systemNotificationDescription}
+											</div>
+										)}
+									</>
+								)}
 							{isSupervisorFeedback && (
 								<div className="messageItem__feedbackTag">
 									{translate(

--- a/src/components/message/messageConstants.ts
+++ b/src/components/message/messageConstants.ts
@@ -1,6 +1,8 @@
 export const SUPERVISOR_FEEDBACK_PREFIX = '[SUPERVISOR_FEEDBACK]';
 export const SYSTEM_NOTIFICATION_PREFIX = '[SYSTEM_NOTIFICATION]';
 export const SYSTEM_NOTIFICATION_USER_LEFT_CHAT = 'USER_LEFT_CHAT';
+export const SYSTEM_NOTIFICATION_CASE_HANDOVER_GRANTED =
+	'CASE_HANDOVER_GRANTED';
 export const VISIBLE_TO_PREFIX = '[VISIBLE_TO:';
 export const THREAD_PREFIX = '[THREAD:';
 export const THREAD_SUFFIX = ']';
@@ -21,6 +23,8 @@ export const parseMessagePrefixes = (message?: string | null) => {
 			systemNotificationDescription: '',
 			systemNotificationType: null as string | null,
 			systemNotificationUsername: '',
+			systemNotificationReasonLabel: '',
+			systemNotificationExplanation: '',
 			visibleToUserIds: [] as string[],
 			isThreadMessage: false,
 			threadRootId: null as string | null
@@ -34,6 +38,8 @@ export const parseMessagePrefixes = (message?: string | null) => {
 	let systemNotificationDescription = '';
 	let systemNotificationType: string | null = null;
 	let systemNotificationUsername = '';
+	let systemNotificationReasonLabel = '';
+	let systemNotificationExplanation = '';
 	let visibleToUserIds: string[] = [];
 	let threadRootId: string | null = null;
 
@@ -97,11 +103,15 @@ export const parseMessagePrefixes = (message?: string | null) => {
 				description?: string;
 				type?: string;
 				username?: string;
+				reasonLabel?: string;
+				explanation?: string;
 			};
 			systemNotificationType = parsed?.type?.trim() || null;
 			systemNotificationUsername = parsed?.username?.trim() || '';
 			systemNotificationTitle = parsed?.title?.trim() || '';
 			systemNotificationDescription = parsed?.description?.trim() || '';
+			systemNotificationReasonLabel = parsed?.reasonLabel?.trim() || '';
+			systemNotificationExplanation = parsed?.explanation?.trim() || '';
 		} catch (_error) {
 			const lines = payload
 				.split('\n')
@@ -122,6 +132,8 @@ export const parseMessagePrefixes = (message?: string | null) => {
 		systemNotificationDescription,
 		systemNotificationType,
 		systemNotificationUsername,
+		systemNotificationReasonLabel,
+		systemNotificationExplanation,
 		visibleToUserIds,
 		isThreadMessage: !!threadRootId,
 		threadRootId


### PR DESCRIPTION
## What

Renders the case-handover system notifications inside the chat stream (Figma Sections 03/04), consuming the `[SYSTEM_NOTIFICATION]{"type":"CASE_HANDOVER_GRANTED",…}` envelope that UserService emits on grant (OpenResilienceInitiative/ORISO-UserService#465):

- `parseMessagePrefixes` now surfaces `reasonLabel` and `explanation` from the payload.
- `MessageItemComponent` renders the existing `CaseHandoverSystemMessageCard` for these events — badge, "New counsellor took over your case" + "you don't need to take any action" (localized client-side), the admin-configured template text, selected reason and explanation. All other system notifications keep their current inline layout (incl. USER_LEFT_CHAT).

## Verification

- New story `Components/Chat/MessageItem → Case handover granted (system card)` verified visually in Storybook (renders inside the real message-stream layout with bell avatar).
- vitest message/session suites: 160/160 green; tsc/eslint clean.
- Works with plaintext server-sent events in encrypted rooms (no UTD warning path; verified against the formatter behaviour).

Part of #491.
Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
