### PR TITLE
chore(styles): fix stylelint violations in untouched scss files

### DIFF
--- a/src/components/call/FloatingCallWidget.scss
+++ b/src/components/call/FloatingCallWidget.scss
@@ -22,6 +22,7 @@
 
 	&.normal {
 		width: min(460px, calc(100vw - 32px));
+
 		/* Height is driven by inline stageSize; avoid min-height fighting auto-fit/resize */
 		min-height: 0;
 		height: auto;
@@ -351,10 +352,11 @@
 	}
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
 	.floating-call-widget.normal {
 		width: calc(100vw - 16px) !important;
 		max-width: calc(100vw - 16px);
+
 		/* Keep JS-driven height; only constrain width on narrow screens */
 
 		.call-video-area {

--- a/src/components/message/appointment.styles.scss
+++ b/src/components/message/appointment.styles.scss
@@ -70,7 +70,7 @@
 			width: 18px;
 			height: 18px;
 
-			@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+			@media (resolution >= 1.5dppx), (width >= 1920px) {
 				width: 22px;
 				height: 22px;
 			}
@@ -86,7 +86,7 @@
 			width: 24px;
 			height: 23px;
 
-			@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+			@media (resolution >= 1.5dppx), (width >= 1920px) {
 				width: 28px;
 				height: 27px;
 			}

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -4,6 +4,7 @@ $message-lineheight: 21px;
 $message-attachment-color: $secondary !default;
 $message-avatar-ring: #ebe2e2;
 $message-incoming-bg: var(--m3-surface-container-high, #eae7e8);
+
 // Use the always-light `primary-fixed` (tonal palette tone 90) rather than
 // `on-primary-container`. The latter is a foreground/contrast role whose
 // lightness flips with the tenant seed brightness, so bright-red tenants
@@ -640,7 +641,7 @@ $message-outgoing-text: var(--m3-on-surface, #1a1c1e);
 		width: 15px;
 		height: 15px;
 
-		@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+		@media (resolution >= 1.5dppx), (width >= 1920px) {
 			width: 19px;
 			height: 19px;
 		}

--- a/src/components/pseudonym/PseudonymCard.styles.scss
+++ b/src/components/pseudonym/PseudonymCard.styles.scss
@@ -60,7 +60,7 @@
 		width: 25px;
 		height: 25px;
 
-		@media (min-resolution: 1.5dppx), (min-width: 1920px) {
+		@media (resolution >= 1.5dppx), (width >= 1920px) {
 			width: 29px;
 			height: 29px;
 		}

--- a/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.styles.scss
+++ b/src/features/keyboard-shortcuts/components/KeyboardShortcutsSettings.styles.scss
@@ -115,7 +115,7 @@
 			background: color-mix(in srgb, currentColor 4%, transparent);
 		}
 
-		@media (max-width: 560px) {
+		@media (width <= 560px) {
 			grid-template-columns: 1fr;
 			gap: 0.45rem;
 			padding: 0.75rem 0.45rem;


### PR DESCRIPTION
## Problem

`npx stylelint "src/**/*.scss"` failed with 13 pre-existing errors in files untouched by current feature work, so any branch running the style gate inherited the noise.

## What changed

- `stylelint --fix` across the five affected files: `@media (max-width: X)` → `(width <= X)` / `(min-resolution: …)` → `(resolution >= …)` (media-feature-range-notation) and required blank lines before comments.
- No selector, value, or visual changes — mechanical notation fixes only.

## Verification

- `npx stylelint "src/**/*.scss"` exits clean (0 problems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
