### PR TITLE
test: assert topicsData endpoint origin

### DIFF
--- a/src/resources/scripts/endpoints.test.ts
+++ b/src/resources/scripts/endpoints.test.ts
@@ -43,6 +43,9 @@ describe('endpoints service origins', () => {
 		expect(endpoints.tenantServiceBase).toBe(
 			'https://api.oriso.org/service/tenant'
 		);
+		expect(endpoints.topicsData).toBe(
+			'https://api.oriso.org/service/topic/public'
+		);
 	});
 
 	it('falls back to the broad API origin when service origins are absent', async () => {


### PR DESCRIPTION
**Handover to @Shirloin — please analyse carefully before merging.**

**What:** Adds a 3-line assertion to the existing `endpoints.test.ts` verifying `endpoints.topicsData === https://api.oriso.org/service/topic/public`. Pure test coverage; no source change.

**Why it's still needed:** the endpoint already exists in source (`src/resources/scripts/endpoints.ts:126`) but has NO test assertion on `pre-dev`.

**Concerns / things to check:**
- Branch is ~139 commits behind `pre-dev`; merges clean but **rebase first**.
- Recovered-WIP origin.
- Trivial, low risk.
- Do not self-merge — required gates apply.

_Opened by Claude during 2026-07-17 branch reconciliation; content-verified against pre-dev._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected topic data requests to use the configured service-specific public URL when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->