### PR TITLE
feat(session-header): honest disabled state for the supervisor '+' + single-avatar 1:1 stack

### DIFF
--- a/src/components/sessionHeader/ChatroomMainInteractionIcon.stories.tsx
+++ b/src/components/sessionHeader/ChatroomMainInteractionIcon.stories.tsx
@@ -1,0 +1,62 @@
+/**
+ * FE#513 — the 1:1 header "+" (add-supervisor entry) never renders as a dead
+ * decorative element: interactive when it can act, otherwise a disabled
+ * button with an honest tooltip (house rule: disable, don't hide — including
+ * for askers).
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ChatroomMainInteractionIcon } from './ChatroomMainInteractionIcon';
+import './sessionHeader.styles.scss';
+
+const meta: Meta<typeof ChatroomMainInteractionIcon> = {
+	title: 'Components/Session/ChatroomMainInteractionIcon',
+	component: ChatroomMainInteractionIcon
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatroomMainInteractionIcon>;
+
+export const InteractiveDesktopConsultant: Story = {
+	name: 'Interactive (desktop consultant, supervision enabled)',
+	args: {
+		type: 'nearby',
+		showAddIcon: true,
+		addLabel: 'Supervisor verwalten',
+		onAddClick: () => {}
+	}
+};
+
+export const DisabledAsker: Story = {
+	name: 'Disabled — asker (grey out, never hide)',
+	args: {
+		type: 'nearby',
+		showAddIcon: true,
+		addLabel: 'Supervision wird vom Beratungsteam verwaltet'
+	}
+};
+
+export const DisabledMobileConsultant: Story = {
+	name: 'Disabled — consultant on mobile',
+	args: {
+		type: 'nearby',
+		showAddIcon: true,
+		addLabel: 'Supervisor hinzufügen – am Desktop verfügbar'
+	}
+};
+
+export const DisabledSupervisionUnavailable: Story = {
+	name: 'Disabled — supervision not enabled for this chat',
+	args: {
+		type: 'live',
+		showAddIcon: true,
+		addLabel: 'Supervisor hinzufügen – hier nicht verfügbar'
+	}
+};
+
+export const NoAddAffordance: Story = {
+	name: 'No add affordance (enquiry)',
+	args: {
+		type: 'nearby',
+		showAddIcon: false
+	}
+};

--- a/src/components/sessionHeader/ChatroomMainInteractionIcon.test.tsx
+++ b/src/components/sessionHeader/ChatroomMainInteractionIcon.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+/**
+ * FE#513 — the "+" add affordance must never render as a dead decorative
+ * element: it is either an interactive button or a real disabled button with
+ * an honest tooltip/label.
+ */
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ChatroomMainInteractionIcon } from './ChatroomMainInteractionIcon';
+
+describe('ChatroomMainInteractionIcon', () => {
+	afterEach(cleanup);
+
+	it('renders an interactive add button when a click handler is provided', () => {
+		const onAddClick = vi.fn();
+		render(
+			<ChatroomMainInteractionIcon
+				type="nearby"
+				showAddIcon
+				addLabel="Supervisor verwalten"
+				onAddClick={onAddClick}
+			/>
+		);
+		const button = screen.getByRole('button', {
+			name: 'Supervisor verwalten'
+		});
+		expect(button.hasAttribute('disabled')).toBe(false);
+		fireEvent.click(button);
+		expect(onAddClick).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders a disabled button with an honest tooltip when no handler is provided', () => {
+		render(
+			<ChatroomMainInteractionIcon
+				type="nearby"
+				showAddIcon
+				addLabel="Supervision wird vom Beratungsteam verwaltet"
+			/>
+		);
+		const button = screen.getByRole('button', {
+			name: 'Supervision wird vom Beratungsteam verwaltet'
+		});
+		expect(button.hasAttribute('disabled')).toBe(true);
+		expect(button.getAttribute('title')).toBe(
+			'Supervision wird vom Beratungsteam verwaltet'
+		);
+	});
+
+	it('renders no add affordance at all when showAddIcon is false', () => {
+		render(<ChatroomMainInteractionIcon type="nearby" />);
+		expect(screen.queryByRole('button')).toBeNull();
+	});
+});

--- a/src/components/sessionHeader/ChatroomMainInteractionIcon.tsx
+++ b/src/components/sessionHeader/ChatroomMainInteractionIcon.tsx
@@ -67,12 +67,17 @@ export const ChatroomMainInteractionIcon = ({
 						{addContent}
 					</button>
 				) : (
-					<span
-						className="chatroomMainInteractionIcon__add"
-						aria-hidden="true"
+					/* FE#513: never a dead decorative element — a real
+					   disabled button with an honest tooltip. */
+					<button
+						type="button"
+						className="chatroomMainInteractionIcon__add chatroomMainInteractionIcon__add--disabled"
+						aria-label={addLabel}
+						title={addLabel}
+						disabled
 					>
 						{addContent}
-					</span>
+					</button>
 				))}
 			<span
 				className="chatroomMainInteractionIcon__type"

--- a/src/components/sessionHeader/SessionHeaderComponent.tsx
+++ b/src/components/sessionHeader/SessionHeaderComponent.tsx
@@ -83,6 +83,7 @@ import {
 	ChatroomConversationIconType,
 	ChatroomMainInteractionIcon
 } from './ChatroomMainInteractionIcon';
+import { getSupervisorAddState } from './getSupervisorAddState';
 export interface SessionHeaderProps {
 	consultantAbsent?: SessionConsultantInterface;
 	hasUserInitiatedStopOrLeaveRequest?: React.MutableRefObject<boolean>;
@@ -976,19 +977,30 @@ export const SessionHeaderComponent = (props: SessionHeaderProps) => {
 					{(() => {
 						/* The Figma pill always carries the conversation
 						   type. When supervision management is available,
-						   the plus part remains the only clickable area. */
-						const canOpenSupervisorModal =
-							isSupervisionEnabledForCurrentChat &&
-							hasUserAuthority(
+						   the plus part remains the only clickable area.
+						   FE#513: when it cannot act, the plus renders as a
+						   disabled button with an honest label — for every
+						   role, including askers (grey out, never hide). */
+						const supervisorAddState = getSupervisorAddState({
+							isAsker: hasUserAuthority(
+								AUTHORITIES.ASKER_DEFAULT,
+								userData
+							),
+							isConsultant: hasUserAuthority(
 								AUTHORITIES.CONSULTANT_DEFAULT,
 								userData
-							) &&
-							!activeSession.isGroup &&
-							!isSupervisor &&
-							!activeSession.isEnquiry &&
-							!untilL;
+							),
+							isSupervisionEnabled:
+								isSupervisionEnabledForCurrentChat &&
+								!activeSession.isGroup &&
+								!activeSession.isEnquiry,
+							isSupervisor,
+							isMobile: untilL
+						});
+						const canOpenSupervisorModal =
+							supervisorAddState.mode === 'interactive';
 						return (
-							<div className="sessionInfo__memberStack">
+							<div className="sessionInfo__memberStack sessionInfo__memberStack--single">
 								<ChatroomMainInteractionIcon
 									type={sessionHeaderConversationIconType}
 									showAddIcon={
@@ -996,8 +1008,7 @@ export const SessionHeaderComponent = (props: SessionHeaderProps) => {
 										!activeSession.isEnquiry
 									}
 									addLabel={translate(
-										'sessionHeader.supervisor.modal.title',
-										'Supervisor hinzufügen'
+										supervisorAddState.labelKey
 									)}
 									onAddClick={
 										canOpenSupervisorModal

--- a/src/components/sessionHeader/getSupervisorAddState.test.ts
+++ b/src/components/sessionHeader/getSupervisorAddState.test.ts
@@ -1,0 +1,95 @@
+/**
+ * FE#513 — the "+" in the 1:1 header is the add-supervisor entry point.
+ * Visibility used to be broader than clickability, leaving a dead decorative
+ * element for askers/mobile/supervisors. Decision (2026-07-18): the control is
+ * always rendered as a real button; when it cannot act it is DISABLED with an
+ * honest label — including for askers (explicit product decision: grey out,
+ * never hide).
+ */
+import { describe, expect, it } from 'vitest';
+import { getSupervisorAddState } from './getSupervisorAddState';
+
+const consultantDefaults = {
+	isAsker: false,
+	isConsultant: true,
+	isSupervisionEnabled: true,
+	isSupervisor: false,
+	isMobile: false
+};
+
+describe('getSupervisorAddState', () => {
+	it('is interactive for a desktop consultant with supervision enabled', () => {
+		expect(getSupervisorAddState(consultantDefaults)).toEqual({
+			mode: 'interactive',
+			labelKey: 'sessionHeader.supervisor.modal.title'
+		});
+	});
+
+	it('is disabled with the asker label for askers (grey out, never hide)', () => {
+		expect(
+			getSupervisorAddState({
+				...consultantDefaults,
+				isAsker: true,
+				isConsultant: false
+			})
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledAsker'
+		});
+	});
+
+	it('is disabled with the mobile label for a consultant below the L breakpoint', () => {
+		expect(
+			getSupervisorAddState({ ...consultantDefaults, isMobile: true })
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledMobile'
+		});
+	});
+
+	it('is disabled when supervision is not enabled for the chat', () => {
+		expect(
+			getSupervisorAddState({
+				...consultantDefaults,
+				isSupervisionEnabled: false
+			})
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledUnavailable'
+		});
+	});
+
+	it('is disabled for a read-only supervisor observer', () => {
+		expect(
+			getSupervisorAddState({ ...consultantDefaults, isSupervisor: true })
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledUnavailable'
+		});
+	});
+
+	it('falls back to disabled/unavailable for roles that are neither asker nor consultant', () => {
+		expect(
+			getSupervisorAddState({
+				...consultantDefaults,
+				isConsultant: false
+			})
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledUnavailable'
+		});
+	});
+
+	it('prefers the mobile reason over generic unavailability only when supervision could otherwise act', () => {
+		expect(
+			getSupervisorAddState({
+				...consultantDefaults,
+				isMobile: true,
+				isSupervisionEnabled: false
+			})
+		).toEqual({
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledUnavailable'
+		});
+	});
+});

--- a/src/components/sessionHeader/getSupervisorAddState.ts
+++ b/src/components/sessionHeader/getSupervisorAddState.ts
@@ -1,0 +1,58 @@
+/**
+ * FE#513 — single source of truth for the 1:1 header's add-supervisor "+"
+ * affordance. Product decision 2026-07-18: the control is always a real
+ * button; when it cannot act it is disabled with an honest label — including
+ * for askers (grey out, never hide).
+ */
+
+export type SupervisorAddMode = 'interactive' | 'disabled';
+
+export interface SupervisorAddState {
+	mode: SupervisorAddMode;
+	labelKey: string;
+}
+
+export interface SupervisorAddInput {
+	isAsker: boolean;
+	isConsultant: boolean;
+	isSupervisionEnabled: boolean;
+	isSupervisor: boolean;
+	isMobile: boolean;
+}
+
+export const getSupervisorAddState = ({
+	isAsker,
+	isConsultant,
+	isSupervisionEnabled,
+	isSupervisor,
+	isMobile
+}: SupervisorAddInput): SupervisorAddState => {
+	if (isAsker) {
+		return {
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledAsker'
+		};
+	}
+
+	const couldManageSupervision =
+		isConsultant && isSupervisionEnabled && !isSupervisor;
+
+	if (!couldManageSupervision) {
+		return {
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledUnavailable'
+		};
+	}
+
+	if (isMobile) {
+		return {
+			mode: 'disabled',
+			labelKey: 'sessionHeader.supervisor.add.disabledMobile'
+		};
+	}
+
+	return {
+		mode: 'interactive',
+		labelKey: 'sessionHeader.supervisor.modal.title'
+	};
+};

--- a/src/components/sessionHeader/sessionHeader.styles.scss
+++ b/src/components/sessionHeader/sessionHeader.styles.scss
@@ -546,6 +546,12 @@ $iconSize: 24px;
 		flex: 0 0 auto;
 	}
 
+	// FE#513: a 1:1 conversation must not borrow the group facepile look —
+	// the single avatar stands free of the type pill instead of overlapping it.
+	&__memberStack--single &__memberBubble {
+		margin-left: 6px;
+	}
+
 	// Figma #430: collapsed "+N people" badge shown for groups with >4 members.
 	&__memberCount {
 		display: inline-flex;
@@ -628,6 +634,12 @@ $iconSize: 24px;
 				box-shadow: 0 0 0 2px #fff;
 			}
 		}
+	}
+
+	// FE#513: house rule "disable, don't hide" — light-grey, honest tooltip.
+	&__add--disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
 	}
 
 	&__addContent {

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -3630,6 +3630,11 @@
 			},
 			"remove": {
 				"confirm": "Möchten Sie diesen Supervisor wirklich entfernen?"
+			},
+			"add": {
+				"disabledAsker": "Supervision wird vom Beratungsteam verwaltet",
+				"disabledMobile": "Supervisor hinzufügen – am Desktop verfügbar",
+				"disabledUnavailable": "Supervisor hinzufügen – hier nicht verfügbar"
 			}
 		}
 	},

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -1544,6 +1544,11 @@
 			},
 			"remove": {
 				"confirm": "Möchtest du diesen Supervisor wirklich entfernen?"
+			},
+			"add": {
+				"disabledAsker": "Supervision wird vom Beratungsteam verwaltet",
+				"disabledMobile": "Supervisor hinzufügen – am Desktop verfügbar",
+				"disabledUnavailable": "Supervisor hinzufügen – hier nicht verfügbar"
 			}
 		}
 	},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -3532,6 +3532,11 @@
 			},
 			"remove": {
 				"confirm": "Are you sure you want to remove this supervisor?"
+			},
+			"add": {
+				"disabledAsker": "Supervision is managed by the counselling team",
+				"disabledMobile": "Add supervisor – available on desktop",
+				"disabledUnavailable": "Add supervisor – not available here"
 			}
 		}
 	},


### PR DESCRIPTION
## Why

The "+" in the 1:1 session header is the add-supervisor entry point (Figma #430), but its visibility (`!isEnquiry`) was far broader than its clickability (desktop consultant + supervision enabled). Askers, mobile users and read-only supervisors saw a dead decorative element inside a group-style member stack — the "who am I talking to?" confusion reported by the team.

Design decided 2026-07-18 (grill session): the control is **always a real button**; when it cannot act it is **disabled with an honest tooltip** — explicitly including askers (grey out, never hide). The 1:1 avatar stops borrowing the group facepile look.

## What

- `getSupervisorAddState()` — pure helper as single source of truth: role/state → `interactive` | `disabled` + honest i18n label (`disabledAsker` / `disabledMobile` / `disabledUnavailable`); enquiry stage maps to `disabledUnavailable`.
- `ChatroomMainInteractionIcon` — no-handler branch renders a real `<button disabled>` with `title`/`aria-label` instead of an `aria-hidden` span; new `--disabled` style (light grey, `not-allowed`).
- `SessionHeaderComponent` — wires the helper; `sessionInfo__memberStack--single` removes the −10px facepile overlap so the single avatar stands free of the type pill.
- i18n keys in `de`, `de@informal`, `en`.

## Verification

- TDD: 7 unit tests for the helper, 3 for the icon (red → green); full `test:unit` suite 857/857 green; `tsc`, `eslint --max-warnings=0`, `stylelint` clean.
- Storybook: 5 new stories (interactive / disabled-asker / disabled-mobile / disabled-unavailable / no-affordance); verified in the built Storybook that the disabled variant renders as a disabled button with tooltip and the ActiveConversation header shows the free-standing avatar.

Closes OpenResilienceInitiative/ORISO-Frontend#513
Refs OpenResilienceInitiative/ORISO-Frontend#512 (Team-Besprechung epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
