### PR TITLE
feat(notifications): register session Matrix rooms with the backend sync listener

### DIFF
--- a/src/api/apiMatrixSyncRegister.test.ts
+++ b/src/api/apiMatrixSyncRegister.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchDataMock = vi.fn();
+vi.mock('./fetchData', () => ({
+	fetchData: (args: unknown) => fetchDataMock(args),
+	FETCH_METHODS: { POST: 'POST' }
+}));
+
+import {
+	apiRegisterMatrixRoomForSync,
+	__resetMatrixSyncRegistrationCache
+} from './apiMatrixSyncRegister';
+
+describe('apiRegisterMatrixRoomForSync', () => {
+	beforeEach(() => {
+		fetchDataMock.mockReset();
+		fetchDataMock.mockResolvedValue({});
+		__resetMatrixSyncRegistrationCache();
+	});
+
+	it('POSTs the session id to the matrix sync register endpoint', async () => {
+		await apiRegisterMatrixRoomForSync(103293);
+
+		expect(fetchDataMock).toHaveBeenCalledTimes(1);
+		const call = fetchDataMock.mock.calls[0][0];
+		expect(call.url).toContain('/service/matrix/sync/register/103293');
+		expect(call.method).toBe('POST');
+	});
+
+	it('registers each session only once per app lifetime', async () => {
+		await apiRegisterMatrixRoomForSync(1);
+		await apiRegisterMatrixRoomForSync(1);
+		await apiRegisterMatrixRoomForSync(2);
+
+		expect(fetchDataMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('ignores missing session ids', async () => {
+		await apiRegisterMatrixRoomForSync(undefined);
+		await apiRegisterMatrixRoomForSync(null);
+
+		expect(fetchDataMock).not.toHaveBeenCalled();
+	});
+
+	it('allows a retry after a failed registration and never throws', async () => {
+		fetchDataMock.mockRejectedValueOnce(new Error('offline'));
+
+		await expect(apiRegisterMatrixRoomForSync(7)).resolves.toBeUndefined();
+		await apiRegisterMatrixRoomForSync(7);
+
+		expect(fetchDataMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/api/apiMatrixSyncRegister.test.ts
+++ b/src/api/apiMatrixSyncRegister.test.ts
@@ -1,16 +1,15 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const fetchDataMock = vi.fn();
-vi.mock('./fetchData', () => ({
-	fetchData: (args: unknown) => fetchDataMock(args),
-	FETCH_METHODS: { POST: 'POST' }
-}));
-
 import {
 	apiRegisterMatrixRoomForSync,
 	__resetMatrixSyncRegistrationCache
 } from './apiMatrixSyncRegister';
+
+const { fetchDataMock } = vi.hoisted(() => ({ fetchDataMock: vi.fn() }));
+vi.mock('./fetchData', () => ({
+	fetchData: (args: unknown) => fetchDataMock(args),
+	FETCH_METHODS: { POST: 'POST' }
+}));
 
 describe('apiRegisterMatrixRoomForSync', () => {
 	beforeEach(() => {

--- a/src/api/apiMatrixSyncRegister.ts
+++ b/src/api/apiMatrixSyncRegister.ts
@@ -1,0 +1,36 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS } from './fetchData';
+
+/**
+ * Registers a session's Matrix room with the backend event listener
+ * (`POST /service/matrix/sync/register/{sessionId}`). The listener's /sync
+ * loop only receives events for rooms its technical admin has joined; the
+ * backend heals that membership on every registration, so this call is what
+ * makes message notifications work for a session at all.
+ *
+ * Fire-and-forget: failures are swallowed (the next open retries) and each
+ * session is registered at most once per app lifetime.
+ */
+const registeredSessionIds = new Set<number>();
+
+export const __resetMatrixSyncRegistrationCache = () => {
+	registeredSessionIds.clear();
+};
+
+export const apiRegisterMatrixRoomForSync = async (
+	sessionId?: number | null
+): Promise<void> => {
+	if (!sessionId || registeredSessionIds.has(sessionId)) {
+		return;
+	}
+	registeredSessionIds.add(sessionId);
+	try {
+		await fetchData({
+			url: endpoints.matrixSyncRegister(sessionId),
+			method: FETCH_METHODS.POST
+		});
+	} catch (_error) {
+		// Best-effort: allow a retry the next time the session is opened.
+		registeredSessionIds.delete(sessionId);
+	}
+};

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -61,6 +61,7 @@ import { MessageSubmitErrorBoundary } from '../messageSubmitInterface/MessageSub
 import { EncryptionBanner } from './EncryptionBanner';
 import { apiGetSessionSupervisors } from '../../api/apiGetSessionSupervisors';
 import { apiPatchNotificationActiveView } from '../../api/apiPatchNotificationActiveView';
+import { apiRegisterMatrixRoomForSync } from '../../api/apiMatrixSyncRegister';
 import { apiPatchUserData } from '../../api/apiPatchUserData';
 import { apiGetUserData } from '../../api/apiGetUserData';
 import { apiGetAnonymousEnquiryDetails } from '../../api/apiGetAnonymousEnquiryDetails';
@@ -2933,6 +2934,19 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 			handleCloseThread();
 		}
 	}, [isThreadsEnabled, activeThreadRootId, handleCloseThread]);
+
+	// Register the session's Matrix room with the backend event listener
+	// (fire-and-forget, deduped per app lifetime). The listener syncs as its
+	// technical admin and only sees rooms it has joined — the backend heals
+	// that membership on registration, which is what makes message
+	// notifications work for this session at all.
+	useEffect(() => {
+		const sessionId = activeSession.item?.id;
+		if (!sessionId || activeSession.isGroup) {
+			return;
+		}
+		apiRegisterMatrixRoomForSync(sessionId);
+	}, [activeSession.item?.id, activeSession.isGroup]);
 
 	useEffect(() => {
 		if (isAskerUser && !isConsultantUser) {

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -99,6 +99,8 @@ export const endpoints = {
 	magicLinkRequest: userServiceOrigin + '/service/users/magic-link/request',
 	magicLinkConsume: userServiceOrigin + '/service/users/magic-link/consume',
 	matrixAccessToken: userServiceOrigin + '/service/matrix/me/token',
+	matrixSyncRegister: (sessionId: number) =>
+		userServiceOrigin + `/service/matrix/sync/register/${sessionId}`,
 	messages: {
 		get: userServiceOrigin + '/service/messages',
 		delete: userServiceOrigin + '/service/messages/:messageId'


### PR DESCRIPTION
## Why

Companion to OpenResilienceInitiative/ORISO-UserService#474. The backend's `POST /matrix/sync/register/{sessionId}` endpoint existed but had **zero callers** in the frontend — the listener's room registry stayed empty, and the new admin-membership heal (which makes message notifications work at all for existing E2EE rooms) never runs without it.

## What

- `apiRegisterMatrixRoomForSync(sessionId)` — fire-and-forget, deduped per app lifetime, allows retry after a failed attempt.
- Called from `SessionItemComponent` when a 1:1 session is opened (group chats skipped — the endpoint is session-based).

## Tests

TDD: `src/api/apiMatrixSyncRegister.test.ts` (4 tests, red first). `tsc --noEmit` clean.

Refs #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)