### PR TITLE
feat(tour): profile tutorial carousel with versioned progress integration (TOUR-04)

### DIFF
--- a/src/api/apiTutorialProgress.test.ts
+++ b/src/api/apiTutorialProgress.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetTutorialProgress,
+	apiUpsertTutorialProgress
+} from './apiTutorialProgress';
+import { fetchData } from './fetchData';
+
+vi.mock('./fetchData', async () => {
+	const actual: any = await vi.importActual('./fetchData');
+	return {
+		...actual,
+		fetchData: vi.fn(() => Promise.resolve([]))
+	};
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('apiTutorialProgress', () => {
+	it('reads the own progress list for a surface', async () => {
+		await apiGetTutorialProgress('frontend');
+
+		const call = vi.mocked(fetchData).mock.calls[0][0] as any;
+		expect(call.url).toContain('/service/users/tutorials/progress');
+		expect(call.url).toContain('surface=frontend');
+		expect(call.method).toBe('GET');
+	});
+
+	it('upserts progress with the versioned scope payload', async () => {
+		vi.mocked(fetchData).mockResolvedValueOnce({ status: 'completed' });
+
+		await apiUpsertTutorialProgress({
+			surface: 'frontend',
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'completed',
+			currentStepId: 'profile'
+		});
+
+		const call = vi.mocked(fetchData).mock.calls[0][0] as any;
+		expect(call.url).toContain('/service/users/tutorials/progress');
+		expect(call.method).toBe('PUT');
+		expect(JSON.parse(call.bodyData)).toMatchObject({
+			surface: 'frontend',
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'completed'
+		});
+	});
+
+	it('propagates upsert failures so callers never fake completion', async () => {
+		vi.mocked(fetchData).mockRejectedValueOnce(new Error('down'));
+
+		await expect(
+			apiUpsertTutorialProgress({
+				surface: 'frontend',
+				tourId: 'consultant-walkthrough',
+				tourVersion: 1,
+				status: 'completed'
+			})
+		).rejects.toThrow('down');
+	});
+});

--- a/src/api/apiTutorialProgress.ts
+++ b/src/api/apiTutorialProgress.ts
@@ -1,0 +1,49 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+
+export type TutorialProgressStatus =
+	| 'not_started'
+	| 'in_progress'
+	| 'completed'
+	| 'skipped';
+
+export interface ITutorialProgressItem {
+	tourId: string;
+	tourVersion: number;
+	surface: 'frontend' | 'admin';
+	status: TutorialProgressStatus;
+	currentStepId?: string | null;
+	startedAt?: string | null;
+	completedAt?: string | null;
+}
+
+export interface IUpsertTutorialProgressRequest {
+	surface: 'frontend' | 'admin';
+	tourId: string;
+	tourVersion: number;
+	status: TutorialProgressStatus;
+	currentStepId?: string;
+}
+
+export const apiGetTutorialProgress = async (
+	surface: 'frontend' | 'admin'
+): Promise<ITutorialProgressItem[]> =>
+	fetchData({
+		url: `${endpoints.tutorialProgress}?surface=${surface}`,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_SUCCESS.CONTENT]
+	});
+
+/**
+ * Upserts the caller's own versioned tutorial progress. Failures reject so
+ * the UI never reports a completion the server has not accepted.
+ */
+export const apiUpsertTutorialProgress = async (
+	request: IUpsertTutorialProgressRequest
+): Promise<ITutorialProgressItem> =>
+	fetchData({
+		url: endpoints.tutorialProgress,
+		method: FETCH_METHODS.PUT,
+		bodyData: JSON.stringify(request),
+		responseHandling: [FETCH_SUCCESS.CONTENT]
+	});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -47,3 +47,4 @@ export * from './apiUpdatePassword';
 export * from './apiMatrixUpload';
 export * from './fetchData';
 export * from './apiDeleteUserFromRoom';
+export * from './apiTutorialProgress';

--- a/src/components/productTour/TourOverviewCarousel.component.test.tsx
+++ b/src/components/productTour/TourOverviewCarousel.component.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TourOverviewCarousel } from './TourOverviewCarousel';
+import type { TourDefinition } from './types';
+
+const translations: Record<string, string> = {
+	'walkthrough.title': 'Rundgang',
+	'walkthrough.subtitle': 'Kurzer Rundgang durch die Anwendung.',
+	'walkthrough.overview.title': 'Meine Rundgänge',
+	'walkthrough.overview.subtitle': 'Tutorials starten und fortsetzen.',
+	'walkthrough.overview.empty': 'Keine Rundgänge verfügbar.',
+	'walkthrough.overview.status.not_started': 'Nicht gestartet',
+	'walkthrough.overview.status.in_progress': 'In Bearbeitung',
+	'walkthrough.overview.status.completed': 'Abgeschlossen',
+	'walkthrough.overview.status.skipped': 'Übersprungen',
+	'walkthrough.overview.action.start': 'Starten',
+	'walkthrough.overview.action.continue': 'Fortsetzen',
+	'walkthrough.overview.action.restart': 'Neu starten'
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => translations[key] ?? key,
+		i18n: { language: 'de', resolvedLanguage: 'de' }
+	})
+}));
+
+// The globalState barrel pulls lottie (crashes in jsdom): stub the player.
+vi.mock('lottie-react', () => ({ default: () => null }));
+
+const consultantTour: TourDefinition = {
+	id: 'consultant-walkthrough',
+	version: 1,
+	surface: 'frontend',
+	audiences: ['consultant'],
+	titleKey: 'walkthrough.title',
+	summaryKey: 'walkthrough.subtitle',
+	steps: [
+		{ id: 'a', target: '', titleKey: 't', contentKey: 'c' },
+		{ id: 'b', target: 'x', titleKey: 't', contentKey: 'c' }
+	]
+};
+
+const askerTour: TourDefinition = {
+	...consultantTour,
+	id: 'asker-tour',
+	audiences: ['asker']
+};
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('TourOverviewCarousel', () => {
+	it('lists only tours matching the audience with their progress status', async () => {
+		render(
+			<TourOverviewCarousel
+				tours={[consultantTour, askerTour]}
+				audience="consultant"
+				loadProgress={() =>
+					Promise.resolve([
+						{
+							tourId: 'consultant-walkthrough',
+							tourVersion: 1,
+							status: 'completed'
+						}
+					])
+				}
+				onStartTour={() => {}}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText('Abgeschlossen')).toBeTruthy()
+		);
+		expect(screen.getAllByText('Rundgang')).toHaveLength(1);
+		expect(screen.getByText('Neu starten')).toBeTruthy();
+	});
+
+	it('offers start for fresh tours and continue for in-progress ones', async () => {
+		const onStartTour = vi.fn();
+		render(
+			<TourOverviewCarousel
+				tours={[consultantTour]}
+				audience="consultant"
+				loadProgress={() =>
+					Promise.resolve([
+						{
+							tourId: 'consultant-walkthrough',
+							tourVersion: 1,
+							status: 'in_progress',
+							currentStepId: 'b'
+						}
+					])
+				}
+				onStartTour={onStartTour}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText('Fortsetzen')).toBeTruthy()
+		);
+		fireEvent.click(screen.getByText('Fortsetzen'));
+		expect(onStartTour).toHaveBeenCalledWith(consultantTour, 'continue');
+	});
+
+	it('treats a newer tour version as a fresh scope', async () => {
+		render(
+			<TourOverviewCarousel
+				tours={[{ ...consultantTour, version: 2 }]}
+				audience="consultant"
+				loadProgress={() =>
+					Promise.resolve([
+						{
+							tourId: 'consultant-walkthrough',
+							tourVersion: 1,
+							status: 'completed'
+						}
+					])
+				}
+				onStartTour={() => {}}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText('Nicht gestartet')).toBeTruthy()
+		);
+		expect(screen.getByText('Starten')).toBeTruthy();
+	});
+
+	it('shows the empty state when no tour matches the audience', async () => {
+		render(
+			<TourOverviewCarousel
+				tours={[askerTour]}
+				audience="consultant"
+				loadProgress={() => Promise.resolve([])}
+				onStartTour={() => {}}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText('Keine Rundgänge verfügbar.')).toBeTruthy()
+		);
+	});
+});

--- a/src/components/productTour/TourOverviewCarousel.stories.tsx
+++ b/src/components/productTour/TourOverviewCarousel.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TourOverviewCarousel } from './TourOverviewCarousel';
+import { consultantWalkthroughTour } from './tourDefinitions';
+import { APP_ORISO_FIGMA_URL } from '../storybookDesignLinks';
+import type { ITutorialProgressItem } from '../../api/apiTutorialProgress';
+import type { TourDefinition } from './types';
+import './productTour.styles.scss';
+
+const secondTour: TourDefinition = {
+	...consultantWalkthroughTour,
+	id: 'archive-deep-dive',
+	titleKey: 'walkthrough.step.4.title',
+	summaryKey: 'walkthrough.step.4.intro'
+};
+
+const thirdTour: TourDefinition = {
+	...consultantWalkthroughTour,
+	id: 'profile-deep-dive',
+	titleKey: 'walkthrough.step.6.title',
+	summaryKey: 'walkthrough.step.6.intro'
+};
+
+type ProgressFixture = Pick<
+	ITutorialProgressItem,
+	'tourId' | 'tourVersion' | 'status' | 'currentStepId'
+>[];
+
+const meta = {
+	title: 'Organisms/TourOverviewCarousel',
+	component: TourOverviewCarousel,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'padded',
+		design: {
+			type: 'figma',
+			url: APP_ORISO_FIGMA_URL
+		},
+		docs: {
+			description: {
+				component:
+					'Profile overview of the tutorials available to the signed-in user: versioned progress state and a Start/Continue/Restart action per tour, backed by the versioned UserService progress API.'
+			}
+		}
+	},
+	args: {
+		tours: [consultantWalkthroughTour],
+		audience: 'consultant',
+		loadProgress: () => Promise.resolve([]),
+		onStartTour: () => {}
+	}
+} satisfies Meta<typeof TourOverviewCarousel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotStarted: Story = {};
+
+export const MixedStatuses: Story = {
+	args: {
+		tours: [consultantWalkthroughTour, secondTour, thirdTour],
+		loadProgress: () =>
+			Promise.resolve<ProgressFixture>([
+				{
+					tourId: 'consultant-walkthrough',
+					tourVersion: 1,
+					status: 'completed'
+				},
+				{
+					tourId: 'archive-deep-dive',
+					tourVersion: 1,
+					status: 'in_progress',
+					currentStepId: 'archive'
+				}
+			])
+	}
+};
+
+export const NewTourVersionOffersRestartAsFresh: Story = {
+	args: {
+		tours: [{ ...consultantWalkthroughTour, version: 2 }],
+		loadProgress: () =>
+			Promise.resolve<ProgressFixture>([
+				{
+					tourId: 'consultant-walkthrough',
+					tourVersion: 1,
+					status: 'completed'
+				}
+			])
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'A newer tour version is a fresh progress scope: the completed v1 progress does not mark v2 as completed.'
+			}
+		}
+	}
+};
+
+export const Empty: Story = {
+	args: {
+		tours: [],
+		loadProgress: () => Promise.resolve([])
+	}
+};
+
+export const MobileViewport: Story = {
+	args: {
+		tours: [consultantWalkthroughTour, secondTour, thirdTour],
+		loadProgress: () =>
+			Promise.resolve<ProgressFixture>([
+				{
+					tourId: 'consultant-walkthrough',
+					tourVersion: 1,
+					status: 'skipped'
+				}
+			])
+	},
+	globals: { viewport: { value: 'mobile1', isRotated: false } }
+};

--- a/src/components/productTour/TourOverviewCarousel.tsx
+++ b/src/components/productTour/TourOverviewCarousel.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, BUTTON_TYPES } from '../button/Button';
+import { Headline } from '../headline/Headline';
+import { Text } from '../text/Text';
+import type { ITutorialProgressItem } from '../../api/apiTutorialProgress';
+import type { TourAudience, TourDefinition, TourStatus } from './types';
+import './productTour.styles.scss';
+
+export type TourStartMode = 'start' | 'continue' | 'restart';
+
+export interface TourOverviewCarouselProps {
+	tours: TourDefinition[];
+	audience: TourAudience;
+	/** Loads the signed-in user's versioned progress for this surface. */
+	loadProgress: () => Promise<
+		Pick<
+			ITutorialProgressItem,
+			'tourId' | 'tourVersion' | 'status' | 'currentStepId'
+		>[]
+	>;
+	onStartTour: (tour: TourDefinition, mode: TourStartMode) => void;
+}
+
+const actionForStatus = (status: TourStatus): TourStartMode => {
+	if (status === 'in_progress') {
+		return 'continue';
+	}
+	if (status === 'completed' || status === 'skipped') {
+		return 'restart';
+	}
+	return 'start';
+};
+
+/**
+ * Profile overview of the tutorials available to the signed-in user: title,
+ * summary, versioned progress state and a Start/Continue/Restart action.
+ * A newer tour version is a fresh progress scope and is offered again.
+ */
+export const TourOverviewCarousel = ({
+	tours,
+	audience,
+	loadProgress,
+	onStartTour
+}: TourOverviewCarouselProps) => {
+	const { t: translate } = useTranslation();
+	const [progress, setProgress] = useState<
+		Pick<
+			ITutorialProgressItem,
+			'tourId' | 'tourVersion' | 'status' | 'currentStepId'
+		>[]
+	>([]);
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+		loadProgress()
+			.then((items) => {
+				if (!cancelled) {
+					setProgress(items);
+				}
+			})
+			.catch(() => {
+				// Without progress data every tour is offered as not started.
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setIsLoading(false);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [loadProgress]);
+
+	const eligibleTours = tours.filter(
+		(tour) =>
+			tour.surface === 'frontend' && tour.audiences.includes(audience)
+	);
+
+	const statusFor = (tour: TourDefinition): TourStatus =>
+		progress.find(
+			(item) =>
+				item.tourId === tour.id && item.tourVersion === tour.version
+		)?.status ?? 'not_started';
+
+	if (isLoading) {
+		return null;
+	}
+
+	return (
+		<div className="tourOverview">
+			<div className="profile__content__title">
+				<Headline
+					text={translate('walkthrough.overview.title')}
+					semanticLevel="5"
+				/>
+				<Text
+					text={translate('walkthrough.overview.subtitle')}
+					type="standard"
+					className="tertiary"
+				/>
+			</div>
+			{eligibleTours.length === 0 ? (
+				<Text
+					text={translate('walkthrough.overview.empty')}
+					type="standard"
+				/>
+			) : (
+				<ul
+					className="tourOverview__list"
+					aria-label={translate('walkthrough.overview.title')}
+				>
+					{eligibleTours.map((tour) => {
+						const status = statusFor(tour);
+						const mode = actionForStatus(status);
+						return (
+							<li className="tourOverview__card" key={tour.id}>
+								<span
+									className={`tourOverview__status tourOverview__status--${status}`}
+								>
+									{translate(
+										`walkthrough.overview.status.${status}`
+									)}
+								</span>
+								<h3 className="tourOverview__cardTitle">
+									{translate(tour.titleKey)}
+								</h3>
+								<p className="tourOverview__cardSummary">
+									{translate(tour.summaryKey)}
+								</p>
+								<Button
+									item={{
+										label: translate(
+											`walkthrough.overview.action.${mode}`
+										),
+										type:
+											mode === 'restart'
+												? BUTTON_TYPES.SECONDARY
+												: BUTTON_TYPES.PRIMARY
+									}}
+									buttonHandle={() => onStartTour(tour, mode)}
+									className="tourOverview__action"
+								/>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+};

--- a/src/components/productTour/TourOverviewSection.tsx
+++ b/src/components/productTour/TourOverviewSection.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import { useSetAtom } from 'jotai';
+import { TourOverviewCarousel } from './TourOverviewCarousel';
+import { frontendTours } from './tourDefinitions';
+import { tourLaunchRequestAtom } from './tourLaunchState';
+import { versionedTourProgressRepository } from './versionedTourProgressRepository';
+import type { TourDefinition } from './types';
+import type { TourStartMode } from './TourOverviewCarousel';
+
+/**
+ * Profile section wiring the tutorial carousel to the versioned progress API
+ * and the tour host. Consultant-only for now — the consultant walkthrough is
+ * the only shipped frontend tour.
+ */
+export const TourOverviewSection = () => {
+	const requestTourLaunch = useSetAtom(tourLaunchRequestAtom);
+
+	const loadProgress = useCallback(
+		() => versionedTourProgressRepository.getProgress(),
+		[]
+	);
+
+	const handleStartTour = useCallback(
+		(tour: TourDefinition, mode: TourStartMode) => {
+			requestTourLaunch({
+				tourId: tour.id,
+				mode,
+				requestedAt: Date.now()
+			});
+		},
+		[requestTourLaunch]
+	);
+
+	return (
+		<TourOverviewCarousel
+			tours={frontendTours}
+			audience="consultant"
+			loadProgress={loadProgress}
+			onStartTour={handleStartTour}
+		/>
+	);
+};

--- a/src/components/productTour/productTour.styles.scss
+++ b/src/components/productTour/productTour.styles.scss
@@ -124,3 +124,61 @@
 		}
 	}
 }
+
+.tourOverview {
+	&__list {
+		display: flex;
+		gap: $grid-base-two;
+		margin: $grid-base-two 0 0;
+		padding: 0 0 $grid-base;
+		list-style: none;
+		overflow-x: auto;
+		scroll-snap-type: x proximity;
+	}
+
+	&__card {
+		display: flex;
+		flex-direction: column;
+		flex: 0 0 min(260px, 80vw);
+		gap: $grid-base;
+		padding: $grid-base-two;
+		border: 1px solid var(--m3-surface-variant, $form-input-border);
+		border-radius: $button-border-radius;
+		background-color: var(--m3-surface, $white);
+		scroll-snap-align: start;
+	}
+
+	&__status {
+		align-self: flex-start;
+		padding: 2px $grid-base;
+		border-radius: $button-border-radius;
+		font-size: $font-size-secondary;
+		background-color: var(--m3-surface-variant, $form-input-border);
+		color: var(--m3-on-surface, $primary);
+
+		&--completed {
+			background-color: var(--m3-primary, $primary);
+			color: var(--m3-on-primary, $white);
+		}
+	}
+
+	&__cardTitle {
+		margin: 0;
+		font-size: $font-size-h5;
+		font-weight: $font-weight-bold;
+	}
+
+	&__cardSummary {
+		margin: 0;
+		flex: 1 1 auto;
+		font-size: $font-size-primary;
+		line-height: $line-height-primary;
+	}
+
+	&__action {
+		.button__item {
+			min-width: 0;
+			width: 100%;
+		}
+	}
+}

--- a/src/components/productTour/productTour.styles.scss
+++ b/src/components/productTour/productTour.styles.scss
@@ -142,7 +142,7 @@
 		flex: 0 0 min(260px, 80vw);
 		gap: $grid-base;
 		padding: $grid-base-two;
-		border: 1px solid var(--m3-surface-variant, $form-input-border);
+		border: 1px solid var(--m3-outline-variant, $form-input-border);
 		border-radius: $button-border-radius;
 		background-color: var(--m3-surface, $white);
 		scroll-snap-align: start;

--- a/src/components/productTour/tourLaunchState.ts
+++ b/src/components/productTour/tourLaunchState.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai';
+import type { TourStartMode } from './TourOverviewCarousel';
+
+export interface TourLaunchRequest {
+	tourId: string;
+	mode: TourStartMode;
+	/** Monotonic marker so an identical re-request still remounts the tour. */
+	requestedAt: number;
+}
+
+/**
+ * Cross-surface signal from the profile carousel to the tour host: the
+ * carousel requests a run, the host (Walkthrough) renders it.
+ */
+export const tourLaunchRequestAtom = atom(null as TourLaunchRequest | null);

--- a/src/components/productTour/versionedTourProgressRepository.test.ts
+++ b/src/components/productTour/versionedTourProgressRepository.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetTutorialProgress,
+	apiUpsertTutorialProgress
+} from '../../api/apiTutorialProgress';
+import { versionedTourProgressRepository } from './versionedTourProgressRepository';
+
+vi.mock('../../api/apiTutorialProgress', () => ({
+	apiGetTutorialProgress: vi.fn(() => Promise.resolve([])),
+	apiUpsertTutorialProgress: vi.fn(() => Promise.resolve({}))
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('versionedTourProgressRepository', () => {
+	it('persists progress through the versioned userservice api', async () => {
+		await versionedTourProgressRepository.saveProgress({
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'in_progress',
+			currentStepId: 'enquiries'
+		});
+
+		expect(apiUpsertTutorialProgress).toHaveBeenCalledWith({
+			surface: 'frontend',
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'in_progress',
+			currentStepId: 'enquiries'
+		});
+	});
+
+	it('reads the frontend-surface progress list', async () => {
+		vi.mocked(apiGetTutorialProgress).mockResolvedValueOnce([
+			{
+				tourId: 'consultant-walkthrough',
+				tourVersion: 1,
+				surface: 'frontend',
+				status: 'completed'
+			} as any
+		]);
+
+		const items = await versionedTourProgressRepository.getProgress();
+
+		expect(apiGetTutorialProgress).toHaveBeenCalledWith('frontend');
+		expect(items[0]).toMatchObject({
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'completed'
+		});
+	});
+
+	it('rejects on write failure instead of swallowing it', async () => {
+		vi.mocked(apiUpsertTutorialProgress).mockRejectedValueOnce(
+			new Error('offline')
+		);
+
+		await expect(
+			versionedTourProgressRepository.saveProgress({
+				tourId: 'consultant-walkthrough',
+				tourVersion: 1,
+				status: 'completed'
+			})
+		).rejects.toThrow('offline');
+	});
+});

--- a/src/components/productTour/versionedTourProgressRepository.ts
+++ b/src/components/productTour/versionedTourProgressRepository.ts
@@ -1,0 +1,32 @@
+import {
+	apiGetTutorialProgress,
+	apiUpsertTutorialProgress,
+	ITutorialProgressItem
+} from '../../api/apiTutorialProgress';
+import type { TourProgress } from './types';
+
+export interface VersionedTourProgressRepository {
+	/**
+	 * Persists tour progress through the versioned UserService API. Rejects
+	 * on write failure so callers never report an unaccepted completion.
+	 */
+	saveProgress(progress: TourProgress): Promise<void>;
+	getProgress(): Promise<ITutorialProgressItem[]>;
+}
+
+/** Frontend-surface repository backed by /users/tutorials/progress (TOUR-03). */
+export const versionedTourProgressRepository: VersionedTourProgressRepository =
+	{
+		async saveProgress(progress: TourProgress): Promise<void> {
+			await apiUpsertTutorialProgress({
+				surface: 'frontend',
+				tourId: progress.tourId,
+				tourVersion: progress.tourVersion,
+				status: progress.status,
+				currentStepId: progress.currentStepId
+			});
+		},
+		async getProgress(): Promise<ITutorialProgressItem[]> {
+			return apiGetTutorialProgress('frontend');
+		}
+	};

--- a/src/components/profile/profile.routes.ts
+++ b/src/components/profile/profile.routes.ts
@@ -9,6 +9,7 @@ import { ConsultantStatistics } from './ConsultantStatistics';
 import { AbsenceFormular } from './AbsenceFormular';
 import { LiveChatAvailability } from './LiveChatAvailability';
 import { EnableWalkthrough } from './EnableWalkthrough';
+import { TourOverviewSection } from '../productTour/TourOverviewSection';
 import { COLUMN_LEFT, COLUMN_RIGHT, TabsType } from '../../utils/tabsHelper';
 import { isDesktop } from 'react-device-detect';
 import { OverviewBookings } from './OverviewMobile/Bookings';
@@ -105,6 +106,15 @@ const profileRoutes = (
 									userData
 								) && settings.enableWalkthrough,
 							component: EnableWalkthrough,
+							column: COLUMN_RIGHT
+						},
+						{
+							condition: (userData) =>
+								hasUserAuthority(
+									AUTHORITIES.CONSULTANT_DEFAULT,
+									userData
+								) && settings.enableWalkthrough,
+							component: TourOverviewSection,
 							column: COLUMN_RIGHT
 						},
 						{

--- a/src/components/walkthrough/Walkthrough.component.test.tsx
+++ b/src/components/walkthrough/Walkthrough.component.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { cleanup, render, waitFor } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { apiPatchConsultantData } from '../../api';
 import { UserDataContext } from '../../globalState';
+import { tourLaunchRequestAtom } from '../productTour/tourLaunchState';
+import { versionedTourProgressRepository } from '../productTour/versionedTourProgressRepository';
 import { Walkthrough } from './Walkthrough';
 
 let adapterProps: any = null;
@@ -19,6 +22,13 @@ vi.mock('../../api', () => ({
 	apiPatchConsultantData: vi.fn(() => Promise.resolve())
 }));
 
+vi.mock('../productTour/versionedTourProgressRepository', () => ({
+	versionedTourProgressRepository: {
+		saveProgress: vi.fn(() => Promise.resolve()),
+		getProgress: vi.fn(() => Promise.resolve([]))
+	}
+}));
+
 // The globalState barrel pulls lottie (crashes in jsdom): stub the player.
 vi.mock('lottie-react', () => ({ default: () => null }));
 
@@ -27,19 +37,28 @@ vi.mock('../../hooks/useAppConfig', () => ({
 	useAppConfig: () => appConfig
 }));
 
-const renderWalkthrough = (userDataOver: Record<string, any> = {}) => {
+const renderWalkthrough = (
+	userDataOver: Record<string, any> = {},
+	launchRequest: any = null
+) => {
 	const reloadUserData = vi.fn();
 	const userData = {
 		isWalkThroughEnabled: true,
 		twoFactorAuth: { isShown: false },
 		...userDataOver
 	};
+	const store = createStore();
+	store.set(tourLaunchRequestAtom, launchRequest);
 	const utils = render(
-		<UserDataContext.Provider value={{ userData, reloadUserData } as any}>
-			<Walkthrough />
-		</UserDataContext.Provider>
+		<Provider store={store}>
+			<UserDataContext.Provider
+				value={{ userData, reloadUserData } as any}
+			>
+				<Walkthrough />
+			</UserDataContext.Provider>
+		</Provider>
 	);
-	return { reloadUserData, ...utils };
+	return { reloadUserData, store, ...utils };
 };
 
 afterEach(() => {
@@ -57,7 +76,7 @@ describe('Walkthrough', () => {
 		expect(queryByTestId('product-tour-adapter')).toBeNull();
 	});
 
-	it('renders nothing when the user has the walkthrough disabled', () => {
+	it('renders nothing without auto-run or a carousel launch request', () => {
 		const { queryByTestId } = renderWalkthrough({
 			isWalkThroughEnabled: false
 		});
@@ -65,7 +84,7 @@ describe('Walkthrough', () => {
 		expect(queryByTestId('product-tour-adapter')).toBeNull();
 	});
 
-	it('runs the consultant walkthrough tour when both gates are open', () => {
+	it('runs the consultant walkthrough tour when the legacy gate is open', () => {
 		renderWalkthrough();
 
 		expect(adapterProps).not.toBeNull();
@@ -74,14 +93,74 @@ describe('Walkthrough', () => {
 		expect(adapterProps.paused).toBe(false);
 	});
 
+	it('runs on a carousel launch request even when the legacy switch is off', () => {
+		renderWalkthrough(
+			{ isWalkThroughEnabled: false },
+			{
+				tourId: 'consultant-walkthrough',
+				mode: 'restart',
+				requestedAt: 1
+			}
+		);
+
+		expect(adapterProps).not.toBeNull();
+		expect(adapterProps.active).toBe(true);
+	});
+
 	it('pauses the tour while the two-factor-authentication dialog is shown', () => {
 		renderWalkthrough({ twoFactorAuth: { isShown: true } });
 
 		expect(adapterProps.paused).toBe(true);
 	});
 
-	it('disables the legacy boolean and reloads user data on terminal status', async () => {
-		const { reloadUserData } = renderWalkthrough();
+	it('persists step progress through the versioned api while running', () => {
+		renderWalkthrough();
+
+		adapterProps.onEvent('step_completed', { id: 'enquiries' });
+
+		expect(
+			versionedTourProgressRepository.saveProgress
+		).toHaveBeenCalledWith({
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'in_progress',
+			currentStepId: 'enquiries'
+		});
+	});
+
+	it('skips the step-progress write for the final step so it cannot race the terminal write', () => {
+		renderWalkthrough();
+
+		adapterProps.onEvent('step_completed', { id: 'profile' });
+
+		expect(
+			versionedTourProgressRepository.saveProgress
+		).not.toHaveBeenCalled();
+	});
+
+	it('re-opens the versioned scope when a restart run starts', () => {
+		renderWalkthrough(
+			{ isWalkThroughEnabled: false },
+			{
+				tourId: 'consultant-walkthrough',
+				mode: 'restart',
+				requestedAt: 2
+			}
+		);
+
+		adapterProps.onEvent('tour_started', undefined);
+
+		expect(
+			versionedTourProgressRepository.saveProgress
+		).toHaveBeenCalledWith({
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'in_progress'
+		});
+	});
+
+	it('persists terminal progress via the versioned api and syncs the legacy boolean', async () => {
+		const { reloadUserData, store } = renderWalkthrough();
 
 		await adapterProps.onTerminalStatus({
 			tourId: 'consultant-walkthrough',
@@ -89,9 +168,34 @@ describe('Walkthrough', () => {
 			status: 'completed'
 		});
 
+		expect(
+			versionedTourProgressRepository.saveProgress
+		).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 'completed' })
+		);
 		expect(apiPatchConsultantData).toHaveBeenCalledWith({
 			walkThroughEnabled: false
 		});
 		await waitFor(() => expect(reloadUserData).toHaveBeenCalled());
+		expect(store.get(tourLaunchRequestAtom)).toBeNull();
+	});
+
+	it('does not touch the legacy boolean for carousel-only runs', async () => {
+		renderWalkthrough(
+			{ isWalkThroughEnabled: false },
+			{
+				tourId: 'consultant-walkthrough',
+				mode: 'restart',
+				requestedAt: 3
+			}
+		);
+
+		await adapterProps.onTerminalStatus({
+			tourId: 'consultant-walkthrough',
+			tourVersion: 1,
+			status: 'skipped'
+		});
+
+		expect(apiPatchConsultantData).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/walkthrough/Walkthrough.tsx
+++ b/src/components/walkthrough/Walkthrough.tsx
@@ -1,40 +1,96 @@
 import * as React from 'react';
 import { useCallback, useContext } from 'react';
+import { useAtom } from 'jotai';
 import { UserDataContext } from '../../globalState';
 import { useAppConfig } from '../../hooks/useAppConfig';
+import { apiPatchConsultantData } from '../../api';
 import { ProductTourAdapter } from '../productTour/ProductTourAdapter';
 import { ProductTourTooltip } from '../productTour/ProductTourTooltip';
 import { consultantWalkthroughTour } from '../productTour/tourDefinitions';
-import { legacyWalkthroughProgressRepository } from '../productTour/tourProgressRepository';
-import type { TourProgress } from '../productTour/types';
+import { tourLaunchRequestAtom } from '../productTour/tourLaunchState';
+import { versionedTourProgressRepository } from '../productTour/versionedTourProgressRepository';
+import type { TourEvent, TourProgress, TourStep } from '../productTour/types';
 
 /**
- * Consultant walkthrough, rendered through the React Joyride product-tour
- * adapter. Gated by the app config flag and the user's walkthrough setting;
- * paused while the two-factor-authentication dialog is shown.
+ * Consultant walkthrough host. Runs either through the legacy auto-start
+ * gate (app-config flag + the user's walkthrough switch) or on demand from
+ * the profile tutorial carousel. Progress is persisted through the versioned
+ * UserService API; the legacy boolean is kept in sync so the auto-start
+ * behavior stays unchanged.
  */
 export const Walkthrough = () => {
 	const settings = useAppConfig();
 	const { userData, reloadUserData } = useContext(UserDataContext);
+	const [launchRequest, setLaunchRequest] = useAtom(tourLaunchRequestAtom);
+
+	const isLaunchRequested =
+		launchRequest?.tourId === consultantWalkthroughTour.id;
+	const isAutoRun = !!userData.isWalkThroughEnabled;
+
+	const lastStepId =
+		consultantWalkthroughTour.steps[
+			consultantWalkthroughTour.steps.length - 1
+		].id;
+
+	const persistStepProgress = useCallback(
+		(event: TourEvent, step?: TourStep) => {
+			if (event === 'step_completed' && step && step.id !== lastStepId) {
+				// Fire-and-forget: step progress powers the carousel's
+				// continue state but must never block the tour.
+				versionedTourProgressRepository
+					.saveProgress({
+						tourId: consultantWalkthroughTour.id,
+						tourVersion: consultantWalkthroughTour.version,
+						status: 'in_progress',
+						currentStepId: step.id
+					})
+					.catch(() => {});
+			}
+			if (event === 'tour_started' && launchRequest?.mode === 'restart') {
+				// A restart of a terminal tour re-opens the versioned scope.
+				versionedTourProgressRepository
+					.saveProgress({
+						tourId: consultantWalkthroughTour.id,
+						tourVersion: consultantWalkthroughTour.version,
+						status: 'in_progress'
+					})
+					.catch(() => {});
+			}
+		},
+		[lastStepId, launchRequest?.mode]
+	);
 
 	const handleTerminalStatus = useCallback(
 		async (progress: TourProgress) => {
-			await legacyWalkthroughProgressRepository.saveProgress(progress);
-			reloadUserData();
+			try {
+				await versionedTourProgressRepository.saveProgress(progress);
+			} finally {
+				if (userData.isWalkThroughEnabled) {
+					// Keep the legacy auto-start boolean in sync so the tour
+					// does not re-open on the next app view.
+					await apiPatchConsultantData({
+						walkThroughEnabled: false
+					}).catch(() => {});
+					reloadUserData();
+				}
+				setLaunchRequest(null);
+			}
 		},
-		[reloadUserData]
+		[reloadUserData, setLaunchRequest, userData.isWalkThroughEnabled]
 	);
 
-	if (!userData.isWalkThroughEnabled || !settings.enableWalkthrough) {
+	if (!settings.enableWalkthrough || (!isAutoRun && !isLaunchRequested)) {
 		return null;
 	}
 
 	return (
 		<ProductTourAdapter
+			key={launchRequest?.requestedAt ?? 'auto'}
 			tour={consultantWalkthroughTour}
 			active={true}
 			paused={!!userData.twoFactorAuth?.isShown}
 			tooltipComponent={ProductTourTooltip}
+			onEvent={persistStepProgress}
 			onTerminalStatus={handleTerminalStatus}
 		/>
 	);

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -3513,6 +3513,22 @@
 	},
 	"walkthrough": {
 		"close": "Rundgang schließen",
+		"overview": {
+			"title": "Meine Rundgänge",
+			"subtitle": "Starten Sie Rundgänge durch die Anwendung oder setzen Sie sie fort.",
+			"empty": "Aktuell sind keine Rundgänge für Sie verfügbar.",
+			"status": {
+				"not_started": "Nicht gestartet",
+				"in_progress": "In Bearbeitung",
+				"completed": "Abgeschlossen",
+				"skipped": "Übersprungen"
+			},
+			"action": {
+				"start": "Starten",
+				"continue": "Fortsetzen",
+				"restart": "Neu starten"
+			}
+		},
 		"step": {
 			"0": {
 				"intro": "Um Ihnen die einzelnen Funktionen zu erklären, haben wir einen kurzen Rundgang für Sie vorbereitet. <br /><br /> Sie können ihn jederzeit abbrechen oder in ihrem Profil erneut starten.",

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -1401,6 +1401,22 @@
 	},
 	"walkthrough": {
 		"close": "Rundgang schließen",
+		"overview": {
+			"title": "Meine Rundgänge",
+			"subtitle": "Starte Rundgänge durch die Anwendung oder setze sie fort.",
+			"empty": "Aktuell sind keine Rundgänge für dich verfügbar.",
+			"status": {
+				"not_started": "Nicht gestartet",
+				"in_progress": "In Bearbeitung",
+				"completed": "Abgeschlossen",
+				"skipped": "Übersprungen"
+			},
+			"action": {
+				"start": "Starten",
+				"continue": "Fortsetzen",
+				"restart": "Neu starten"
+			}
+		},
 		"step": {
 			"0": {
 				"intro": "Um Dir die einzelnen Funktionen zu erklären, haben wir einen kurzen Rundgang für Dich vorbereitet. <br /><br /> Du kannst ihn jederzeit abbrechen oder in Deinem Profil erneut starten."

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -3455,6 +3455,22 @@
 	},
 	"walkthrough": {
 		"close": "Close tour",
+		"overview": {
+			"title": "My tours",
+			"subtitle": "Start or continue guided tours through the application.",
+			"empty": "There are currently no tours available for you.",
+			"status": {
+				"not_started": "Not started",
+				"in_progress": "In progress",
+				"completed": "Completed",
+				"skipped": "Skipped"
+			},
+			"action": {
+				"start": "Start",
+				"continue": "Continue",
+				"restart": "Restart"
+			}
+		},
 		"step": {
 			"0": {
 				"intro": "To explain the individual functions, we have prepared a short tour for you. <br /><br /> They can cancel it at any time or start it again in their profile.",

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -80,6 +80,7 @@ export const endpoints = {
 	deleteAskerAccount: userServiceOrigin + '/service/users/account',
 	draftMessages: userServiceOrigin + '/service/messages/draft',
 	userDrafts: userServiceOrigin + '/service/users/drafts',
+	tutorialProgress: userServiceOrigin + '/service/users/tutorials/progress',
 	email: userServiceOrigin + '/service/users/email',
 	// logstash intake was retired; client crash reports now go to UserService's
 	// OBS-P3 error-intake endpoint, which logs them into SigNoz (ORISO-Helm#62).


### PR DESCRIPTION
Closes #523

Part of epic #521. Builds on the merged TOUR-01 (#524) and TOUR-03 (OpenResilienceInitiative/ORISO-UserService#491, deployed to PreDev).

**Problem:** users could only toggle the walkthrough boolean; there was no way to see tutorial state or start/continue/restart tours from the profile, and progress was not persisted per step/version.

**What changed**

- `TourOverviewCarousel` ("Meine Rundgänge") in the consultant profile: audience/surface-filtered tour cards with translated title/summary, versioned status badge and a Start/Continue/Restart action; horizontal scroll-snap list, `--m3-*` tokens.
- `apiTutorialProgress` client + `versionedTourProgressRepository` against `/users/tutorials/progress` (TOUR-03).
- Carousel → tour host launch signal via a jotai atom; a launch runs the tour even when the auto-start switch is off.
- The walkthrough host persists per-step `in_progress` (with `currentStepId`) and terminal progress through the versioned API; the final-step write is skipped so it cannot race the terminal write (bug found by the real-browser run). Legacy `walkThroughEnabled` stays in sync for unchanged auto-start behavior; a restart of a terminal tour re-opens the versioned scope.
- New `walkthrough.overview.*` i18n keys (DE/EN/de@informal); 5 carousel Storybook stories.

**Verification:** red-first TDD — 27 new tests (api client, repository, carousel incl. version-scoping, host wiring incl. race guard); full gates green (`test:unit` 1044, eslint+tsc, stylelint, `typecheck:storybook`, build). Real browser (dev server + live PreDev API): carousel from real progress data, full five-step run started from the carousel at 1440x900 and 390x844 (mobile drill-in via "Öffentliche Daten"), 6× progress PUT 200 per run, badge flips to "Abgeschlossen" after reload; Start/Continue/Restart all exercised. Settings intercept overrides only PreDev's `enableWalkthrough=false` flag; the 2FA nag was dismissed via the dev-only duty switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tutorial overview to eligible consultant profiles, showing available tours, progress, and actions to start, continue, or restart.
  * Added version-aware tutorial progress tracking and persistence.
  * Walkthroughs can now be launched directly from the tutorial overview.
  * Added responsive layouts, localized labels, and empty-state messaging.

* **Bug Fixes**
  * Improved walkthrough progress handling across restarts and completions.
  * Prevented progress updates after a walkthrough has finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->