### PR TITLE
feat(team-discussion): deep-link ?teamDiscussion=1 opens the panel expanded and joins the room

### DIFF
--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -984,6 +984,7 @@ export const SessionStream = ({
 		<div className="session__wrapper">
 			{showTeamDiscussion && (
 				<TeamDiscussionPanel
+					key={activeSession.item.id}
 					sessionId={activeSession.item.id}
 					allowCreate={activeSession.isEnquiry}
 					initiallyOpen={teamDiscussionParam === '1'}

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -81,6 +81,9 @@ export const SessionStream = ({
 	const { userData } = useContext(UserDataContext);
 	const { matrixClientService } = useMatrixClient();
 	const sessionListTab = useSearchParam<SESSION_LIST_TAB>('sessionListTab');
+	// FE#514 follow-up: `team.discussion.new` notifications deep-link with
+	// ?teamDiscussion=1 — the panel then opens expanded instead of collapsed.
+	const teamDiscussionParam = useSearchParam<string>('teamDiscussion');
 
 	// MATRIX MIGRATION: Track component mount/unmount
 	useEffect(() => {
@@ -983,6 +986,7 @@ export const SessionStream = ({
 				<TeamDiscussionPanel
 					sessionId={activeSession.item.id}
 					allowCreate={activeSession.isEnquiry}
+					initiallyOpen={teamDiscussionParam === '1'}
 				/>
 			)}
 			<SessionItemComponent

--- a/src/components/teamDiscussion/TeamDiscussionPanel.tsx
+++ b/src/components/teamDiscussion/TeamDiscussionPanel.tsx
@@ -12,7 +12,7 @@
  * exercises every state without network.
  */
 import * as React from 'react';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
 	apiGetTeamDiscussion,
@@ -63,7 +63,7 @@ export const TeamDiscussionPanel = ({
 	const { t: translate } = useTranslation();
 	const { userData } = useContext(UserDataContext);
 
-	const [isOpen, setIsOpen] = useState(initiallyOpen);
+	const [isOpen, setIsOpen] = useState(false);
 	const [discussion, setDiscussion] = useState<TeamDiscussion | null>(null);
 	const [discussionLoaded, setDiscussionLoaded] = useState(false);
 	const [messages, setMessages] = useState<TeamDiscussionMessage[]>([]);
@@ -77,21 +77,9 @@ export const TeamDiscussionPanel = ({
 		let cancelled = false;
 		apiGetTeamDiscussion(sessionId)
 			.then((result) => {
-				if (cancelled) {
-					return;
-				}
-				setDiscussion(result);
-				setDiscussionLoaded(true);
-				// Deep-link (?teamDiscussion=1): the panel starts expanded, so
-				// join the room right away — otherwise the feed stays empty
-				// until the first manual toggle. Idempotent on the backend.
-				if (result && initiallyOpen) {
-					apiOpenTeamDiscussion(sessionId)
-						.then(
-							(joined) =>
-								!cancelled && joined && setDiscussion(joined)
-						)
-						.catch(() => undefined);
+				if (!cancelled) {
+					setDiscussion(result);
+					setDiscussionLoaded(true);
 				}
 			})
 			.catch(() => {
@@ -102,8 +90,31 @@ export const TeamDiscussionPanel = ({
 		return () => {
 			cancelled = true;
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- initiallyOpen is a mount-time deep-link signal
 	}, [sessionId]);
+
+	// Deep-link (?teamDiscussion=1): reactive, not mount-time only — a
+	// notification click while already viewing the session updates the URL
+	// without remounting. Opens the panel and joins the room; join failures
+	// surface as the regular open error instead of being swallowed.
+	const deepLinkHandledRef = useRef(false);
+	useEffect(() => {
+		deepLinkHandledRef.current = false;
+	}, [sessionId]);
+	useEffect(() => {
+		if (
+			!initiallyOpen ||
+			!discussionLoaded ||
+			!discussion ||
+			deepLinkHandledRef.current
+		) {
+			return;
+		}
+		deepLinkHandledRef.current = true;
+		setIsOpen(true);
+		apiOpenTeamDiscussion(sessionId)
+			.then((joined) => joined && setDiscussion(joined))
+			.catch(() => setError(translate('teamDiscussion.error.open')));
+	}, [initiallyOpen, discussionLoaded, discussion, sessionId, translate]);
 
 	const refreshMessages = useCallback((matrixRoomId: string) => {
 		const ownMatrixUserId =

--- a/src/components/teamDiscussion/TeamDiscussionPanel.tsx
+++ b/src/components/teamDiscussion/TeamDiscussionPanel.tsx
@@ -77,9 +77,21 @@ export const TeamDiscussionPanel = ({
 		let cancelled = false;
 		apiGetTeamDiscussion(sessionId)
 			.then((result) => {
-				if (!cancelled) {
-					setDiscussion(result);
-					setDiscussionLoaded(true);
+				if (cancelled) {
+					return;
+				}
+				setDiscussion(result);
+				setDiscussionLoaded(true);
+				// Deep-link (?teamDiscussion=1): the panel starts expanded, so
+				// join the room right away — otherwise the feed stays empty
+				// until the first manual toggle. Idempotent on the backend.
+				if (result && initiallyOpen) {
+					apiOpenTeamDiscussion(sessionId)
+						.then(
+							(joined) =>
+								!cancelled && joined && setDiscussion(joined)
+						)
+						.catch(() => undefined);
 				}
 			})
 			.catch(() => {
@@ -90,6 +102,7 @@ export const TeamDiscussionPanel = ({
 		return () => {
 			cancelled = true;
 		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- initiallyOpen is a mount-time deep-link signal
 	}, [sessionId]);
 
 	const refreshMessages = useCallback((matrixRoomId: string) => {


### PR DESCRIPTION
## Why

Follow-up to #519: the `team.discussion.new` notification deep-links with `?teamDiscussion=1`, but the panel ignored the parameter — the recipient landed on the enquiry with the discussion collapsed and, not yet being a room member, an empty feed after opening it manually.

## What

- `SessionStream` reads the `teamDiscussion` search param and passes `initiallyOpen` to `TeamDiscussionPanel`.
- On deep-link the container joins the room immediately (idempotent `POST /team-discussion`) so the feed is populated without a manual toggle.

## Verification

`tsc`, `eslint --max-warnings=0` clean; teamDiscussion + session test suites green (122 tests).

Refs OpenResilienceInitiative/ORISO-Frontend#514 · OpenResilienceInitiative/ORISO-Frontend#512

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening the Team Discussion panel directly through a URL link.
  * Deep-linked discussions now automatically join the relevant discussion room when available.

* **Bug Fixes**
  * Improved handling when discussion data loads after opening through a deep link.
  * Prevented state updates when the panel is no longer mounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->