### PR TITLE
fix(navigation): keep consultant logout inside desktop rail

### DIFF
--- a/src/components/app/NavigationSidebar.stories.tsx
+++ b/src/components/app/NavigationSidebar.stories.tsx
@@ -293,15 +293,19 @@ export const RuntimeConsultantRail: Story = {
 
 		const navigationRail = canvasElement.querySelector(
 			'.navigation__wrapper--figma-consultant'
-		) as HTMLElement;
+		);
+		await expect(navigationRail).not.toBeNull();
+
 		const bottomActions = canvasElement.querySelector(
 			'.navigation__item__bottom'
-		) as HTMLElement;
-		await expect(getComputedStyle(bottomActions).flexDirection).toBe(
-			'column'
 		);
+		await expect(bottomActions).not.toBeNull();
 
-		const railBounds = navigationRail.getBoundingClientRect();
+		await expect(
+			getComputedStyle(bottomActions as Element).flexDirection
+		).toBe('column');
+
+		const railBounds = (navigationRail as Element).getBoundingClientRect();
 		const logoutBounds = (
 			logoutAction as HTMLElement
 		).getBoundingClientRect();

--- a/src/components/app/NavigationSidebar.stories.tsx
+++ b/src/components/app/NavigationSidebar.stories.tsx
@@ -290,6 +290,24 @@ export const RuntimeConsultantRail: Story = {
 			'.navigation__item--nav-logout'
 		);
 		await expect(logoutAction).not.toBeNull();
+
+		const navigationRail = canvasElement.querySelector(
+			'.navigation__wrapper--figma-consultant'
+		) as HTMLElement;
+		const bottomActions = canvasElement.querySelector(
+			'.navigation__item__bottom'
+		) as HTMLElement;
+		await expect(getComputedStyle(bottomActions).flexDirection).toBe(
+			'column'
+		);
+
+		const railBounds = navigationRail.getBoundingClientRect();
+		const logoutBounds = (
+			logoutAction as HTMLElement
+		).getBoundingClientRect();
+		await expect(logoutBounds.left).toBeGreaterThanOrEqual(railBounds.left);
+		await expect(logoutBounds.right).toBeLessThanOrEqual(railBounds.right);
+
 		await userEvent.click(logoutAction as HTMLElement);
 		await expect(storyShell).toHaveAttribute('data-logout-clicked', 'true');
 	}

--- a/src/components/app/navigation.styles.scss
+++ b/src/components/app/navigation.styles.scss
@@ -792,6 +792,7 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 		flex-direction: row;
 
 		@include breakpoint($fromLarge) {
+			flex-direction: column;
 			flex: 0 0 auto;
 			margin-top: auto !important;
 			padding-top: 12px;


### PR DESCRIPTION
## Why

Consultant logout is rendered but sits outside the 73px desktop navigation rail, making it appear missing. The regression arrived with the mobile M3 navigation work and affects the deployed Pre-Dev consultant surface.

## Root cause

`.navigation__item__bottom` is mobile-first with `flex-direction: row`, but the desktop breakpoint did not restore the rail's column layout. The deployed logout action is therefore rendered at x=134..183 while the rail ends at x=73.

## What changed

- Restore `flex-direction: column` at the desktop breakpoint.
- Extend the real consultant-rail Storybook play test to assert the desktop layout and logout bounds.
- Keep the existing logout interaction assertion and mobile navigation behavior.

## Impact

The desktop consultant logout action stays visible and usable inside the rail. Mobile consultant navigation remains unchanged.

## Verification

- Regression test failed with `row` before the fix and passed with `column` after it.
- Desktop browser measurement after the fix: rail x=0..73, logout x=12..61.
- Mobile consultant logout remains visible.
- `npm run typecheck:storybook`
- `npm run lint:scripts`
- `npm run lint:style`
- `npm run test:unit` — 163 files / 1075 tests passed.
- `npm run build`
- `git diff --check`

Closes OpenResilienceInitiative/ORISO-Frontend#530
Refs OpenResilienceInitiative/ORISO-Frontend#529

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop navigation rail layout by stacking bottom actions vertically.
  * Ensured the logout control remains properly positioned within the navigation rail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->