### PR TITLE
fix: allow consultants to disable 2FA

### DIFF
--- a/src/components/twoFactorAuth/TwoFactorAuth.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserDataContext } from '../../globalState';
+import { TwoFactorAuth } from './TwoFactorAuth';
+
+const setupDialogMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('react-router-dom', () => ({
+	useLocation: () => ({
+		state: { isEditMode: true, openTwoFactor: true }
+	})
+}));
+
+vi.mock('../../hooks/useAppConfig', () => ({
+	useAppConfig: () => ({
+		twofactor: { dateTwoFactorObligatory: new Date(0) }
+	})
+}));
+
+vi.mock('../../globalState', async () => {
+	const ReactModule = await import('react');
+
+	return {
+		AUTHORITIES: { CONSULTANT_DEFAULT: 'CONSULTANT_DEFAULT' },
+		UserDataContext: ReactModule.createContext(undefined),
+		hasUserAuthority: () => true
+	};
+});
+
+vi.mock('../button/Button', () => ({
+	BUTTON_TYPES: { LINK_INLINE: 'LINK_INLINE' },
+	Button: () => null
+}));
+vi.mock('../headline/Headline', () => ({ Headline: () => null }));
+vi.mock('../Switch', () => ({ Switch: () => null }));
+vi.mock('../text/Text', () => ({ Text: () => null }));
+vi.mock('../../resources/img/icons', () => ({ PenIcon: () => null }));
+vi.mock('./twoFactorAuth.styles', () => ({}));
+vi.mock('./TwoFactorSetupDialog', () => ({
+	TwoFactorSetupDialog: (props: unknown) => {
+		setupDialogMock(props);
+		return null;
+	}
+}));
+
+describe('TwoFactorAuth', () => {
+	beforeEach(() => {
+		setupDialogMock.mockClear();
+	});
+
+	it('allows an active consultant to disable mandatory two-factor authentication', () => {
+		const contextValue = {
+			userData: {
+				email: 'consultant@example.org',
+				twoFactorAuth: {
+					isActive: true,
+					type: 'APP'
+				}
+			},
+			reloadUserData: vi.fn()
+		} as React.ContextType<typeof UserDataContext>;
+
+		render(
+			<UserDataContext.Provider value={contextValue}>
+				<TwoFactorAuth />
+			</UserDataContext.Provider>
+		);
+
+		expect(setupDialogMock).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				canDisable: true,
+				open: true
+			})
+		);
+	});
+});

--- a/src/components/twoFactorAuth/TwoFactorAuth.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.tsx
@@ -14,10 +14,6 @@ import { Switch } from '../Switch';
 import { Text } from '../text/Text';
 import { PenIcon } from '../../resources/img/icons';
 import { useAppConfig } from '../../hooks/useAppConfig';
-import {
-	STORAGE_KEY_DISABLE_2FA_DUTY,
-	useDevToolbar
-} from '../devToolbar/DevToolbar';
 import { TwoFactorSetupDialog } from './TwoFactorSetupDialog';
 import { TWO_FACTOR_TYPES } from './twoFactorAuthConstants';
 import './twoFactorAuth.styles';
@@ -35,7 +31,6 @@ export const TwoFactorAuth = () => {
 	};
 	const { userData, reloadUserData } = useContext(UserDataContext);
 	const settings = useAppConfig();
-	const { getDevToolbarOption } = useDevToolbar();
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 	const [isEditMode, setIsEditMode] = useState(
 		locationState.isEditMode ?? false
@@ -51,11 +46,7 @@ export const TwoFactorAuth = () => {
 	const isTwoFactorBinding =
 		new Date() >= settings.twofactor.dateTwoFactorObligatory;
 	const isForcedSetup = isTwoFactorBinding && !isEditMode && isConsultant;
-	const canDisable =
-		(!isConsultant ||
-			(process.env.NODE_ENV !== 'production' &&
-				getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY) === '1')) &&
-		userData.twoFactorAuth.isActive;
+	const canDisable = userData.twoFactorAuth.isActive;
 
 	useEffect(() => {
 		if (locationState.openTwoFactor) {


### PR DESCRIPTION
## What changed

- Allow consultants with active two-factor authentication to disable it from the security settings dialog.
- Remove the development-toolbar-only exception that previously controlled the disable action after mandatory 2FA became active.
- Add regression coverage for an active consultant editing mandatory 2FA settings.

## Why

The security page showed the current second factor and allowed editing the authentication method, but hid the disable action for consultants after the mandatory-2FA date. This left consultants unable to turn off 2FA through the UI.

## Validation

- `npm run test:unit -- --run src/components/twoFactorAuth/TwoFactorAuth.test.tsx` — passed
- ESLint and Prettier checks for both changed files — passed
- `git diff --check` — passed
- Full repository gates were also attempted. They remain blocked by unrelated existing issues: missing TipTap/emoji packages, broken `localStorage` test setup, and existing SCSS lint violations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified two-factor authentication disable controls so they accurately reflect whether two-factor authentication is active.

* **Tests**
  * Added coverage verifying that active two-factor authentication opens the setup dialog with disabling enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->