### PR TITLE
fix: make 2FA enrollment optional

### DIFF
--- a/src/components/twoFactorAuth/TwoFactorAuth.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.test.tsx
@@ -14,7 +14,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('react-router-dom', () => ({
 	useLocation: () => ({
-		state: { isEditMode: true, openTwoFactor: true }
+		state: { openTwoFactor: true }
 	})
 }));
 
@@ -28,9 +28,7 @@ vi.mock('../../globalState', async () => {
 	const ReactModule = await import('react');
 
 	return {
-		AUTHORITIES: { CONSULTANT_DEFAULT: 'CONSULTANT_DEFAULT' },
-		UserDataContext: ReactModule.createContext(undefined),
-		hasUserAuthority: () => true
+		UserDataContext: ReactModule.createContext(undefined)
 	};
 });
 
@@ -55,7 +53,7 @@ describe('TwoFactorAuth', () => {
 		setupDialogMock.mockClear();
 	});
 
-	it('allows an active consultant to disable mandatory two-factor authentication', () => {
+	it('keeps mandatory two-factor authentication setup dismissible', () => {
 		const contextValue = {
 			userData: {
 				email: 'consultant@example.org',
@@ -76,6 +74,7 @@ describe('TwoFactorAuth', () => {
 		expect(setupDialogMock).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				canDisable: true,
+				canClose: true,
 				open: true
 			})
 		);

--- a/src/components/twoFactorAuth/TwoFactorAuth.tsx
+++ b/src/components/twoFactorAuth/TwoFactorAuth.tsx
@@ -3,11 +3,7 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { apiDeleteTwoFactorAuth } from '../../api';
-import {
-	AUTHORITIES,
-	hasUserAuthority,
-	UserDataContext
-} from '../../globalState';
+import { UserDataContext } from '../../globalState';
 import { Button, BUTTON_TYPES } from '../button/Button';
 import { Headline } from '../headline/Headline';
 import { Switch } from '../Switch';
@@ -26,26 +22,17 @@ export const TwoFactorAuth = () => {
 	// v7 dropped the useLocation<T>() generic; cast the nav state back to a
 	// known shape so these reads stay type-checked.
 	const locationState = (location.state ?? {}) as {
-		isEditMode?: boolean;
 		openTwoFactor?: boolean;
 	};
 	const { userData, reloadUserData } = useContext(UserDataContext);
 	const settings = useAppConfig();
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
-	const [isEditMode, setIsEditMode] = useState(
-		locationState.isEditMode ?? false
-	);
 	const [isSwitchChecked, setIsSwitchChecked] = useState<boolean>(
 		userData.twoFactorAuth.isActive
 	);
 
-	const isConsultant = hasUserAuthority(
-		AUTHORITIES.CONSULTANT_DEFAULT,
-		userData
-	);
 	const isTwoFactorBinding =
 		new Date() >= settings.twofactor.dateTwoFactorObligatory;
-	const isForcedSetup = isTwoFactorBinding && !isEditMode && isConsultant;
 	const canDisable = userData.twoFactorAuth.isActive;
 
 	useEffect(() => {
@@ -60,7 +47,6 @@ export const TwoFactorAuth = () => {
 
 	const closeDialog = useCallback(() => {
 		setIsDialogOpen(false);
-		setIsEditMode(false);
 		setIsSwitchChecked(userData.twoFactorAuth.isActive);
 	}, [userData.twoFactorAuth.isActive]);
 
@@ -78,7 +64,6 @@ export const TwoFactorAuth = () => {
 		await reloadUserData();
 		setIsSwitchChecked(false);
 		setIsDialogOpen(false);
-		setIsEditMode(false);
 	}, [reloadUserData]);
 
 	const handleSwitchChange = () => {
@@ -96,7 +81,6 @@ export const TwoFactorAuth = () => {
 
 	const handleEditButton = () => {
 		setIsDialogOpen(true);
-		setIsEditMode(true);
 	};
 
 	return (
@@ -169,7 +153,7 @@ export const TwoFactorAuth = () => {
 					</p>
 				)}
 			<TwoFactorSetupDialog
-				canClose={!isForcedSetup}
+				canClose
 				canDisable={canDisable}
 				currentType={userData.twoFactorAuth.type}
 				email={userData.email}

--- a/src/components/twoFactorAuth/TwoFactorNag.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorNag.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserDataContext } from '../../globalState';
+import { OVERLAY_FUNCTIONS } from '../overlay/Overlay';
+import { TwoFactorNag } from './TwoFactorNag';
+
+const overlayMock = vi.fn();
+const stableMocks = vi.hoisted(() => ({
+	appConfig: {
+		twofactor: {
+			startObligatoryHint: new Date(0),
+			dateTwoFactorObligatory: new Date(0),
+			messages: [
+				{
+					title: 'reminder-title',
+					copy: 'reminder-copy',
+					showClose: true
+				},
+				{
+					title: 'mandatory-title',
+					copy: 'mandatory-copy',
+					showClose: false
+				}
+			]
+		}
+	},
+	getDevToolbarOption: vi.fn(() => '1'),
+	location: { state: {} }
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('react-router-dom', () => ({
+	useLocation: () => stableMocks.location
+}));
+
+vi.mock('../../hooks/useOpenTwoFactorSettings', () => ({
+	useOpenTwoFactorSettings: () => vi.fn()
+}));
+
+vi.mock('../../hooks/useAppConfig', () => ({
+	useAppConfig: () => stableMocks.appConfig
+}));
+
+vi.mock('../../globalState', async () => {
+	const ReactModule = await import('react');
+
+	return {
+		UserDataContext: ReactModule.createContext(undefined)
+	};
+});
+
+vi.mock('../devToolbar/DevToolbar', () => ({
+	STORAGE_KEY_2FA: '2fa',
+	useDevToolbar: () => ({
+		getDevToolbarOption: stableMocks.getDevToolbarOption
+	})
+}));
+
+vi.mock('../overlay/Overlay', () => ({
+	OVERLAY_FUNCTIONS: { CLOSE: 'CLOSE', REDIRECT: 'REDIRECT' },
+	Overlay: (props: unknown) => {
+		overlayMock(props);
+		return null;
+	}
+}));
+
+vi.mock('./twoFactorNag.styles', () => ({}));
+
+describe('TwoFactorNag', () => {
+	beforeEach(() => {
+		overlayMock.mockClear();
+	});
+
+	it('allows the mandatory login reminder to be dismissed', async () => {
+		const contextValue = {
+			userData: {
+				twoFactorAuth: { isActive: false, isEnabled: true }
+			}
+		} as React.ContextType<typeof UserDataContext>;
+
+		render(
+			<UserDataContext.Provider value={contextValue}>
+				<TwoFactorNag />
+			</UserDataContext.Provider>
+		);
+
+		await waitFor(() => expect(overlayMock).toHaveBeenCalled());
+
+		const props = overlayMock.mock.lastCall?.[0] as {
+			handleOverlayClose: unknown;
+			item: { buttonSet: { function: string }[] };
+		};
+		expect(props.handleOverlayClose).toEqual(expect.any(Function));
+		expect(props.item.buttonSet).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ function: OVERLAY_FUNCTIONS.CLOSE })
+			])
+		);
+	});
+});

--- a/src/components/twoFactorAuth/TwoFactorNag.tsx
+++ b/src/components/twoFactorAuth/TwoFactorNag.tsx
@@ -7,11 +7,7 @@ import { Overlay, OVERLAY_FUNCTIONS } from '../overlay/Overlay';
 import './twoFactorNag.styles';
 import { useTranslation } from 'react-i18next';
 import { useAppConfig } from '../../hooks/useAppConfig';
-import {
-	STORAGE_KEY_2FA,
-	STORAGE_KEY_DISABLE_2FA_DUTY,
-	useDevToolbar
-} from '../devToolbar/DevToolbar';
+import { STORAGE_KEY_2FA, useDevToolbar } from '../devToolbar/DevToolbar';
 import { OVERLAY_TWO_FACTOR_NAG } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 
 interface TwoFactorNagProps {}
@@ -44,12 +40,11 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 			getDevToolbarOption(STORAGE_KEY_2FA) === '1'
 		) {
 			setIsShownTwoFactorNag(true);
-			todaysDate >= settings.twofactor.dateTwoFactorObligatory &&
-			(process.env.NODE_ENV !== 'production'
-				? getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY)
-				: '0') === '0'
-				? setMessage(settings.twofactor.messages[1])
-				: setMessage(settings.twofactor.messages[0]);
+			const configuredMessage =
+				todaysDate >= settings.twofactor.dateTwoFactorObligatory
+					? settings.twofactor.messages[1]
+					: settings.twofactor.messages[0];
+			setMessage({ ...configuredMessage, showClose: true });
 		} else {
 			setIsShownTwoFactorNag(false);
 		}
@@ -63,23 +58,9 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 		location
 	]);
 
-	// Prevent hiding 2fa nag if it has a duty
-	const handleTwoFactorNag = useCallback(
-		(val) => {
-			let todaysDate = new Date(Date.now());
-			if (
-				todaysDate >= settings.twofactor.dateTwoFactorObligatory &&
-				(process.env.NODE_ENV !== 'production'
-					? getDevToolbarOption(STORAGE_KEY_DISABLE_2FA_DUTY)
-					: '0') === '0'
-			) {
-				setForceHideTwoFactorNag(false);
-				return;
-			}
-			setForceHideTwoFactorNag(val);
-		},
-		[getDevToolbarOption, settings.twofactor.dateTwoFactorObligatory]
-	);
+	const handleTwoFactorNag = useCallback((val) => {
+		setForceHideTwoFactorNag(val);
+	}, []);
 
 	const closeTwoFactorNag = async () => {
 		handleTwoFactorNag(true);


### PR DESCRIPTION
## What changed

- Keep the login-time 2FA reminder dismissible after the configured obligation date.
- Show the existing secondary “Later” action and close control on the mandatory reminder.
- Keep the 2FA setup dialog closable when opened from the login reminder.
- Remove obsolete mandatory-enrollment state and development-toolbar override logic.
- Add regression coverage for the login reminder and setup dialog.

## Why

After 2FA was disabled in Settings, the next login immediately displayed a mandatory, non-dismissible enrollment overlay. That behavior made the newly added disable action ineffective because users were forced to configure 2FA again before continuing.

## User impact

Users can dismiss the login reminder with “Later” and can close the setup dialog if they do not want to configure 2FA at that time.

## Validation

- 10 focused two-factor authentication tests pass across `TwoFactorAuth`, `TwoFactorNag`, and `TwoFactorSetupDialog`.
- ESLint passes for all changed files.
- Prettier and `git diff --check` pass.
- The full repository gates remain affected by the unrelated pre-existing dependency, localStorage, and SCSS failures documented in PR #533.
