### PR TITLE
fix: show success after email 2FA activation

### DIFF
--- a/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
@@ -488,6 +488,38 @@ describe('TwoFactorSetupDialog', () => {
 		).toBeTruthy();
 	});
 
+	it('shows email success when refreshed user data is still stale', async () => {
+		apiPutTwoFactorAuthEmailMock.mockResolvedValue(undefined);
+		apiPostTwoFactorAuthEmailWithCodeMock.mockResolvedValue(undefined);
+		apiPatchTwoFactorAuthEncourageMock.mockResolvedValue(undefined);
+		const { onSetupAborted, onSetupComplete } = renderDialog();
+		onSetupComplete.mockRejectedValue(new Error('STALE_USER_DATA'));
+
+		await screen.findByText('twoFactorAuth.setupDialog.decision.email');
+		clickButton('twoFactorAuth.setupDialog.decision.email');
+		clickButton('twoFactorAuth.setupDialog.action.next');
+		await screen.findByLabelText(
+			'twoFactorAuth.setupDialog.email.connect.input'
+		);
+		fireEvent.change(
+			screen.getByLabelText(
+				'twoFactorAuth.setupDialog.email.connect.input'
+			),
+			{ target: { value: '614805' } }
+		);
+		clickButton('twoFactorAuth.setupDialog.action.confirm');
+
+		expect(
+			await screen.findByText(
+				'twoFactorAuth.setupDialog.email.success.title'
+			)
+		).toBeTruthy();
+		expect(onSetupAborted).toHaveBeenCalledTimes(1);
+		expect(
+			screen.queryByText('twoFactorAuth.setupDialog.error.emailSetup')
+		).toBeNull();
+	});
+
 	it('shows success when post-activation encourage fails', async () => {
 		apiPutTwoFactorAuthAppMock.mockResolvedValue(undefined);
 		apiPatchTwoFactorAuthEncourageMock.mockRejectedValue(
@@ -518,7 +550,7 @@ describe('TwoFactorSetupDialog', () => {
 		).toBeNull();
 	});
 
-	it('does not show success when user data refresh fails after app activation', async () => {
+	it('shows app success when user data refresh fails after activation', async () => {
 		apiPutTwoFactorAuthAppMock.mockResolvedValue(undefined);
 		apiPatchTwoFactorAuthEncourageMock.mockResolvedValue(undefined);
 		const onSetupComplete = vi
@@ -540,10 +572,12 @@ describe('TwoFactorSetupDialog', () => {
 
 		await waitFor(() => expect(onSetupAborted).toHaveBeenCalledTimes(1));
 		expect(
-			await screen.findByText('twoFactorAuth.setupDialog.error.appSetup')
+			await screen.findByText(
+				'twoFactorAuth.setupDialog.app.success.title'
+			)
 		).toBeTruthy();
 		expect(
-			screen.queryByText('twoFactorAuth.setupDialog.app.success.title')
+			screen.queryByText('twoFactorAuth.setupDialog.error.appSetup')
 		).toBeNull();
 	});
 

--- a/src/components/twoFactorAuth/TwoFactorSetupDialog.tsx
+++ b/src/components/twoFactorAuth/TwoFactorSetupDialog.tsx
@@ -309,7 +309,7 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 	}, [isRequestInProgress]);
 
 	const finishSetup = useCallback(
-		async (nextStep: TwoFactorSetupStep, syncErrorKey: string) => {
+		async (nextStep: TwoFactorSetupStep) => {
 			setOtp('');
 			setErrorKey('');
 			setHelperKey('');
@@ -322,11 +322,14 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 
 			try {
 				await onSetupComplete();
-				setStep(nextStep);
 			} catch {
+				// The 2FA credential is already active at this point. User data can
+				// still be stale until the next login (especially after changing the
+				// account e-mail), so a failed refresh must not report setup failure.
 				onSetupAborted?.();
-				setErrorKey(syncErrorKey);
 			}
+
+			setStep(nextStep);
 		},
 		[onSetupAborted, onSetupComplete]
 	);
@@ -371,10 +374,7 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 
 		try {
 			await apiPutTwoFactorAuthApp({ secret, otp });
-			await finishSetup(
-				'app-success',
-				'twoFactorAuth.setupDialog.error.appSetup'
-			);
+			await finishSetup('app-success');
 		} catch (error) {
 			onSetupAborted?.();
 			setFetchError(
@@ -397,10 +397,7 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 
 		try {
 			await apiPostTwoFactorAuthEmailWithCode(otp);
-			await finishSetup(
-				'email-success',
-				'twoFactorAuth.setupDialog.error.emailSetup'
-			);
+			await finishSetup('email-success');
 		} catch (error) {
 			onSetupAborted?.();
 			setFetchError(


### PR DESCRIPTION
## What changed

- Treat the immediate user-data refresh as best-effort after the backend has successfully activated a 2FA credential.
- Show the correct App or E-mail success step even when the current login token still contains stale account data.
- Preserve the parent refresh-failure notification without misreporting the already-successful OTP confirmation.
- Add regression coverage for stale refreshes after both E-mail and App activation.

## Root cause

The live E-mail flow successfully validated the code and switched the Keycloak credential to E-mail. The subsequent `reloadUserData()` call failed or returned stale data because the current session still represented the previous account e-mail. The setup dialog treated that secondary refresh problem as an OTP confirmation failure, leaving users on the code screen even though 2FA had already changed.

## User impact

After a valid E-mail code is accepted, users now see the success screen. Updated account data is picked up normally after the session refresh/next login.

## Validation

- `TwoFactorSetupDialog.test.tsx`: 9/9 tests passed.
- ESLint, Prettier, and `git diff --check` passed for both changed files.
- Full repository gates were attempted. They remain blocked by unrelated checkout/repository issues: missing installed OpenTelemetry/Joyride/TipTap packages, existing `localStorage` test-environment failures, and dependency resolution conflict between React 19 and `@cypress/react` during `npm ci`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved two-factor authentication setup behavior when account information refreshes fail after activation.
  * Setup now continues to the appropriate success confirmation instead of displaying an incorrect setup error.
  * Ensures setup-aborted handling is triggered consistently in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->