### PR TITLE
fix: allow anonymous invite redemption

### DIFF
--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -53,6 +53,8 @@ describe('auth helpers', () => {
 		['/login', true],
 		['/registration', true],
 		['/tenant-a/registration', true],
+		['/invite/token', true],
+		['/invite/token/U25%20Suizidpr%C3%A4vention', true],
 		['/error.401.html', true],
 		['/sessions/consultant/sessionView', false]
 	])('detects public auth route %s', (path, expected) => {

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -12,7 +12,7 @@ export const RENEW_BEFORE_EXPIRY_IN_MS = 10 * 1000; // seconds
 export const isPublicAuthRoute = (): boolean => {
 	const { pathname } = window.location;
 	return (
-		/^\/(?:login|registration|error\.401\.html|error\.404\.html|error\.500\.html)(?:\/|$)/.test(
+		/^\/(?:login|registration|invite|error\.401\.html|error\.404\.html|error\.500\.html)(?:\/|$)/.test(
 			pathname
 		) || /^\/[^/]+\/registration(?:\/|$)/.test(pathname)
 	);


### PR DESCRIPTION
## What changed

- Classify `/invite/:token` and `/invite/:token/:topicSlug` as public authentication routes.
- Add regression coverage for token-only and URL-encoded topic-slug invite paths.

## Root cause

The React router exposed the invite landing page, but the shared authentication/error handling did not consider `/invite/...` public. During anonymous initialization, a provider request could therefore redirect the browser to `/error.404.html` before the invite redemption flow completed.

## Impact

Anonymous external-inbound links can redeem without requiring an existing login, including links containing encoded topic labels such as `U25%20Suizidpr%C3%A4vention`.

## Validation

- Reproduced the deployed redirect to `/error.404.html` with the supplied encoded invite URL.
- Confirmed token-only redemption reaches the generated session, showing the redemption backend is functional.
- `npx vitest run src/components/auth/auth.test.ts --maxWorkers=2 --minWorkers=1` — 12 tests passed.
- `npm run build` — successful (existing warnings only).
