### PR TITLE
fix: prevent bootstrap errors from hijacking invite redemption

### DIFF
--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	handleTokenRefresh,
 	hasActiveAuthSession,
+	isInviteRoute,
 	isPublicAuthRoute,
 	setTokens
 } from './auth';
@@ -40,6 +41,16 @@ vi.mock('../../utils/appConfig', () => ({
 }));
 
 describe('auth helpers', () => {
+	it.each([
+		['/invite/token', true],
+		['/invite/token/U25%20Suizidpr%C3%A4vention', true],
+		['/invited', false],
+		['/login', false]
+	])('detects invite route %s', (path, expected) => {
+		window.history.replaceState({}, '', path);
+		expect(isInviteRoute()).toBe(expected);
+	});
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		window.history.replaceState({}, '', '/login');

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -9,6 +9,9 @@ import { appConfig } from '../../utils/appConfig';
 
 export const RENEW_BEFORE_EXPIRY_IN_MS = 10 * 1000; // seconds
 
+export const isInviteRoute = (): boolean =>
+	/^\/invite(?:\/|$)/.test(window.location.pathname);
+
 export const isPublicAuthRoute = (): boolean => {
 	const { pathname } = window.location;
 	return (

--- a/src/components/error/errorHandling.test.ts
+++ b/src/components/error/errorHandling.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { redirectToErrorPage, ERROR_TYPES } from './errorHandling';
+import { apiPostError } from '../../api/apiPostError';
+
+vi.mock('../../api/apiPostError', () => ({
+	apiPostError: vi.fn(),
+	ERROR_LEVEL_ERROR: 'ERROR'
+}));
+
+vi.mock('../../utils/appConfig', () => ({
+	appConfig: {
+		urls: {
+			error401: '/error.401.html',
+			error404: '/error.404.html',
+			error500: '/error.500.html'
+		},
+		requestCollector: { showCorrelationId: {} }
+	}
+}));
+
+vi.mock('../../utils/requestCollector', () => ({
+	requestCollector: { get: vi.fn(() => []) }
+}));
+
+vi.mock('../sessionCookie/accessSessionCookie', () => ({
+	getValueFromCookie: vi.fn()
+}));
+
+vi.mock('../logout/logout', () => ({ logout: vi.fn() }));
+
+describe('redirectToErrorPage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each([
+		ERROR_TYPES.UNAUTHORIZED,
+		ERROR_TYPES.FORBIDDEN,
+		ERROR_TYPES.NOT_FOUND,
+		ERROR_TYPES.SERVER
+	])(
+		'does not redirect or report bootstrap error %s on an invite route',
+		(error) => {
+			window.history.replaceState({}, '', '/invite/token/U25');
+
+			redirectToErrorPage(error);
+
+			expect(apiPostError).not.toHaveBeenCalled();
+			expect(window.location.pathname).toBe('/invite/token/U25');
+		}
+	);
+});

--- a/src/components/error/errorHandling.ts
+++ b/src/components/error/errorHandling.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { isPublicAuthRoute } from '../auth/auth';
+import { isInviteRoute, isPublicAuthRoute } from '../auth/auth';
 import { logout } from '../logout/logout';
 import { appConfig } from '../../utils/appConfig';
 import { apiPostError, ERROR_LEVEL_ERROR } from '../../api/apiPostError';
@@ -26,6 +26,13 @@ export const getErrorCaseForStatus = (status: number) => {
 };
 
 export const redirectToErrorPage = (error: number) => {
+	// The invite landing page owns its redemption lifecycle and renders its
+	// errors inline. Unrelated bootstrap requests must not replace it with a
+	// generic error page before the redeem request can complete.
+	if (isInviteRoute()) {
+		return;
+	}
+
 	if (error === ERROR_TYPES.UNAUTHORIZED && isPublicAuthRoute()) {
 		return;
 	}


### PR DESCRIPTION
## What changed

- identify invite landing routes explicitly
- prevent unrelated global bootstrap failures from redirecting `/invite/...` to a generic error page
- keep redemption failures owned and rendered by the invite component
- add regression coverage for invite-route detection and all global error classes

## Root cause

A valid U25 external inbound link reached the frontend, and the UserService redemption endpoint returned HTTP 200 when called directly. However, a separate application bootstrap request could invoke the global error redirect while the invite landing page was loading. That replaced the redemption flow with `/error.404.html` before the invite component completed.

## User impact

Users opening external inbound links can remain on the invite landing flow and redeem the link instead of being sent to the generic 404 page.

## Validation

- `npm run test:unit -- src/components/auth/auth.test.ts src/components/error/errorHandling.test.ts` (20 tests passed)
- `npm run lint:scripts` (ESLint and TypeScript passed)
- reproduced with a newly generated active U25 link on oriso-dev
- verified the UserService redeem endpoint returns HTTP 200 for the generated link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invite links now remain on the invite redemption page when bootstrap errors occur.
  * Invite-specific errors are no longer redirected to a generic error page, preserving inline error handling.
* **Tests**
  * Added coverage for invite route detection, including encoded invite paths and non-invite routes.
  * Added coverage confirming invite-route errors do not trigger redirects or error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->