### PR TITLE
fix: contain Matrix sync startup failures

### DIFF
--- a/src/api/apiMatrixSyncRegister.test.ts
+++ b/src/api/apiMatrixSyncRegister.test.ts
@@ -8,7 +8,8 @@ import {
 const { fetchDataMock } = vi.hoisted(() => ({ fetchDataMock: vi.fn() }));
 vi.mock('./fetchData', () => ({
 	fetchData: (args: unknown) => fetchDataMock(args),
-	FETCH_METHODS: { POST: 'POST' }
+	FETCH_METHODS: { POST: 'POST' },
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' }
 }));
 
 describe('apiRegisterMatrixRoomForSync', () => {
@@ -25,6 +26,7 @@ describe('apiRegisterMatrixRoomForSync', () => {
 		const call = fetchDataMock.mock.calls[0][0];
 		expect(call.url).toContain('/service/matrix/sync/register/103293');
 		expect(call.method).toBe('POST');
+		expect(call.responseHandling).toEqual(['CATCH_ALL']);
 	});
 
 	it('registers each session only once per app lifetime', async () => {

--- a/src/api/apiMatrixSyncRegister.ts
+++ b/src/api/apiMatrixSyncRegister.ts
@@ -1,5 +1,5 @@
 import { endpoints } from '../resources/scripts/endpoints';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
 
 /**
  * Registers a session's Matrix room with the backend event listener
@@ -27,7 +27,11 @@ export const apiRegisterMatrixRoomForSync = async (
 	try {
 		await fetchData({
 			url: endpoints.matrixSyncRegister(sessionId),
-			method: FETCH_METHODS.POST
+			method: FETCH_METHODS.POST,
+			// A newly redeemed session can be rendered before its Matrix room is
+			// available. Registration is best-effort, so keep that expected 404
+			// local instead of letting fetchData redirect the whole app.
+			responseHandling: [FETCH_ERRORS.CATCH_ALL]
 		});
 	} catch (_error) {
 		// Best-effort: allow a retry the next time the session is opened.


### PR DESCRIPTION
## What changed

- handle Matrix sync registration failures locally in the best-effort registration helper
- prevent an expected startup 404 from invoking the application's global error-page redirect
- extend the existing unit test to verify catch-all response handling

## Root cause

External inbound redemption succeeds and redirects the anonymous user to the newly created session. The session view immediately performs best-effort Matrix sync registration. At that moment the new session can legitimately have no Matrix room ID yet, so UserService returns 404. Although the helper catches the rejected promise, `fetchData` had already redirected the entire application to `/error.404.html`.

## User impact

Newly redeemed U25 external inbound sessions remain on the session page while Matrix room initialization completes instead of being replaced by the generic 404 page.

## Validation

- reproduced the complete URL sequence: invite URL → `/sessions/user/view/session/103375` → `/error.404.html`
- confirmed invite redemption and asker session bootstrap endpoints return HTTP 200
- confirmed a new session can initially have no Matrix room ID
- `npm run test:unit -- src/api/apiMatrixSyncRegister.test.ts src/components/error/errorHandling.test.ts` (8 tests passed)
- `npm run lint:scripts` (ESLint and TypeScript passed)
