### PR TITLE
feat(chat): surface failed sends in the timeline

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -194,6 +194,13 @@ export interface MessageSubmitInterfaceComponentProps {
 	onLocalMessageEdit?: (messageId: string, newText: string) => void;
 	/** Prefer Matrix-aware ownership from SessionItem when provided. */
 	isOwnMessage?: (userId: string) => boolean;
+	/**
+	 * Called when a send attempt fails (the message never reached the server /
+	 * encryption broke). The parent surfaces a "Sending message failed"
+	 * notification in the timeline. The composer keeps the typed text so the
+	 * user can simply resend.
+	 */
+	onSendError?: (message: string, ts: number) => void;
 }
 
 export const MessageSubmitInterfaceComponent = ({
@@ -222,7 +229,8 @@ export const MessageSubmitInterfaceComponent = ({
 	messages,
 	onCloseThread,
 	onLocalMessageEdit,
-	isOwnMessage
+	isOwnMessage,
+	onSendError
 }: MessageSubmitInterfaceComponentProps) => {
 	const ComposerMobileBackIcon = () => (
 		<svg
@@ -1387,6 +1395,10 @@ export const MessageSubmitInterfaceComponent = ({
 					})
 					.catch((error) => {
 						setIsRequestInProgress(false);
+						// Surface the failure in the timeline ("Sending message
+						// failed"); the composer keeps the text so the user can
+						// resend without retyping.
+						onSendError?.(message, Date.now());
 						apiPostError({
 							name: error?.name || 'MatrixMessageSendError',
 							message:
@@ -1415,6 +1427,7 @@ export const MessageSubmitInterfaceComponent = ({
 			isSupervisor,
 			matrixClientService,
 			onSendButton,
+			onSendError,
 			resolvedChatSession,
 			setE2EEState,
 			supervisionRoomId,

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -23,6 +23,7 @@ import {
 	MessageItem,
 	MessageItemComponent
 } from '../message/MessageItemComponent';
+import { MessageSendFailed } from '../message/MessageSendFailed';
 import {
 	ReactionEvent,
 	AggregatedReaction,
@@ -2993,8 +2994,28 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		onDragLeave();
 	};
 
+	// "Sending message failed" notifications (Figma 7086-57415): a send that
+	// never reached the server surfaces a card at the bottom of the timeline.
+	// They are cleared once a later send succeeds (the composer keeps the text,
+	// so a successful resend means the failures are resolved).
+	const [failedSends, setFailedSends] = useState<
+		{ id: string; ts: number }[]
+	>([]);
+	const handleSendError = useCallback((_message: string, ts: number) => {
+		setFailedSends((previous) => [
+			...previous,
+			{ id: `send-failed-${ts}`, ts }
+		]);
+	}, []);
+
+	// Drop stale failure cards when the conversation changes.
+	useEffect(() => {
+		setFailedSends([]);
+	}, [activeSession?.rid]);
+
 	const handleMessageSendSuccess = () => {
 		setDraggedFile(null);
+		setFailedSends([]);
 
 		if (props.refreshMessages) {
 			setTimeout(() => {
@@ -4737,6 +4758,14 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 									/>
 								</React.Fragment>
 							))}
+						{/* "Sending message failed" cards for sends that never
+						    reached the server (Figma 7086-57415). */}
+						{failedSends.map((failed) => (
+							<MessageSendFailed
+								key={failed.id}
+								messageTime={String(failed.ts)}
+							/>
+						))}
 						{shouldShowInlineTypingIndicator && (
 							<div className="messageItem session__inlineTypingIndicator">
 								<div className="messageItem__messageWrap">
@@ -4915,6 +4944,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 							)}
 							typingUsers={props.typingUsers}
 							handleMessageSendSuccess={handleMessageSendSuccess}
+							onSendError={handleSendError}
 							isSupervisor={isSupervisor}
 							supervisionRoomId={supervisionRoomId}
 							threadRootId={activeThreadRootId}
@@ -5055,6 +5085,7 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 									handleMessageSendSuccess={
 										handleMessageSendSuccess
 									}
+									onSendError={handleSendError}
 									isSupervisor={isSupervisor}
 									supervisionRoomId={supervisionRoomId}
 									replyTo={replyTo}


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Frontend#541 · Parent #537

Wires the "Sending message failed" card (Figma 7086-57415) to real send failures. Until now a rejected send only logged to the error API and nothing appeared in the conversation.

- `messageSubmitInterface`: new `onSendError(message, ts)`, fired from the text-send `.catch`; composer keeps the text so the user can resend.
- `SessionItemComponent`: `failedSends` state renders a `MessageSendFailed` card per failure at the bottom of the timeline; cleared on the next successful send and on conversation change.
- Attachment sends keep their existing size/format error UI.

Verified: `tsc --noEmit` 0 errors, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible failure notifications when sending a message doesn’t succeed.
  * Preserved failed message text in the composer so it can be resubmitted.
  * Automatically clears failed-send notices after a successful send or when switching sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->