### PR TITLE
feat(chat): drive 'encryption broke' delivery status from real Matrix UTD

### DIFF
--- a/src/components/message/MessageItemComponent.stories.tsx
+++ b/src/components/message/MessageItemComponent.stories.tsx
@@ -456,6 +456,30 @@ export const OutgoingSendFailed: Story = {
 	}
 };
 
+export const IncomingEncryptionBroke: Story = {
+	name: 'Incoming encryption broke (cross)',
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		userData: mockUserData()
+	},
+	args: {
+		...mockMessageItemComponentProps({
+			isMyMessage: false,
+			userId: MOCK_CONSULTANT_RC_ID,
+			displayName: 'Leila Pavlov',
+			username: 'leila.p@oriso.invalid',
+			isNotRead: true,
+			message: 'Diese Nachricht konnte nicht entschlüsselt werden.'
+		}),
+		// Incoming message whose Megolm decryption failed: the red cross shows
+		// on the received message (not own-message-only), labelled
+		// "Verschlüsselung gebrochen".
+		encryptionBroke: true,
+		onReact: () => {},
+		...baseHandlers
+	}
+};
+
 export const WideLongMessageDesktop: Story = {
 	name: 'Long text widens bubble (desktop 770px)',
 	parameters: {

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -1403,12 +1403,22 @@ export const MessageItemComponent = ({
 		sendFailed || encryptionBroke ? 'failed' : isNotRead ? 'sent' : 'read';
 	const deliveryStatusLabel =
 		deliveryState === 'failed'
-			? translate('message.sendFailed.status', 'nicht zugestellt')
+			? encryptionBroke
+				? translate(
+						'message.encryptionBroke.status',
+						'Verschlüsselung gebrochen'
+					)
+				: translate('message.sendFailed.status', 'nicht zugestellt')
 			: translate(
 					deliveryState === 'sent' ? 'message.sent' : 'message.read'
 				);
+	// The delivery cross for a broken decryption belongs on the affected
+	// message whether or not it is ours: you can always decrypt your own
+	// sends, so `encryptionBroke` in practice flags an INCOMING message the
+	// recipient's client could not decrypt. Own-message sent/read status stays
+	// own-only as before.
 	const deliveryStatusInBubble =
-		isMyMessage && t !== 'rm' ? (
+		t !== 'rm' && (isMyMessage || encryptionBroke) ? (
 			<span
 				className={clsx(
 					'messageItem__deliveryStatus',

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -310,9 +310,9 @@ interface MessageItemComponentProps extends MessageItem {
 	/** Send failure: cross instead of checkmarks in the bubble time rail. */
 	sendFailed?: boolean;
 	/**
-	 * End-to-end encryption failed for the recipient (Matrix UTD:
-	 * `event.isEncrypted() && event.isDecryptionFailure()`). Rendered with the
-	 * same cross as `sendFailed` — to the user both mean "not delivered".
+	 * This client could not decrypt the Matrix event (UTD). Rendered with the
+	 * failure cross while the adjacent decryption card explains that the
+	 * incoming message is unavailable.
 	 */
 	encryptionBroke?: boolean;
 	handleDecryptionErrors: (

--- a/src/components/message/MessageSendFailed.stories.tsx
+++ b/src/components/message/MessageSendFailed.stories.tsx
@@ -19,3 +19,11 @@ export const Default: Story = {
 		messageTime: String(new Date('2026-07-10T12:54:00').getTime())
 	}
 };
+
+export const DecryptionFailure: Story = {
+	name: 'Incoming message decryption failed',
+	args: {
+		messageTime: String(new Date('2026-07-10T12:54:00').getTime()),
+		isDecryptionFailure: true
+	}
+};

--- a/src/components/message/MessageSendFailed.test.tsx
+++ b/src/components/message/MessageSendFailed.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MessageSendFailed } from './MessageSendFailed';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (_key: string, fallback: string) => fallback
+	})
+}));
+
+vi.mock('../../resources/img/icons/delivery-failed.svg', () => ({
+	ReactComponent: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+}));
+
+afterEach(cleanup);
+
+describe('MessageSendFailed', () => {
+	it('keeps the outgoing-send instructions for failed sends', () => {
+		render(<MessageSendFailed />);
+
+		expect(screen.getByText('Sending message failed')).toBeTruthy();
+		expect(screen.getByText('Resend your message again')).toBeTruthy();
+		expect(screen.getByRole('img').getAttribute('aria-label')).toBe(
+			'not delivered'
+		);
+	});
+
+	it('uses actionable incoming-message copy for decryption failures', () => {
+		render(<MessageSendFailed isDecryptionFailure />);
+
+		expect(screen.getByText('Message decryption failed')).toBeTruthy();
+		expect(screen.getByText('Incoming message unavailable')).toBeTruthy();
+		expect(
+			screen.getByText(
+				'This incoming message could not be decrypted. Ask the sender to send it again, or try reloading the conversation.'
+			)
+		).toBeTruthy();
+		expect(screen.getByRole('img').getAttribute('aria-label')).toBe(
+			'could not be decrypted'
+		);
+		expect(screen.queryByText('Resend your message again')).toBeNull();
+	});
+});

--- a/src/components/message/MessageSendFailed.tsx
+++ b/src/components/message/MessageSendFailed.tsx
@@ -7,16 +7,54 @@ import './message.styles.scss';
 interface MessageSendFailedProps {
 	/** Timestamp of the send attempt (ms epoch as string, like MessageItem). */
 	messageTime?: string;
+	/** Render copy for an incoming event that could not be decrypted. */
+	isDecryptionFailure?: boolean;
 }
 
 /**
- * "Sending message failed" chat notification (Figma 8498-32373): identical
- * layout to a regular incoming message — avatar column with ring, header
- * next to it, indented bubble — only the avatar glyph ("!") and the red
- * cross in the time rail differ.
+ * Failure notification for an outgoing send or an incoming message that could
+ * not be decrypted. Both variants share the same chat-card presentation while
+ * keeping their instructions specific to what the user can actually do.
  */
-export const MessageSendFailed = ({ messageTime }: MessageSendFailedProps) => {
+export const MessageSendFailed = ({
+	messageTime,
+	isDecryptionFailure = false
+}: MessageSendFailedProps) => {
 	const { t: translate } = useTranslation();
+	const copy = isDecryptionFailure
+		? {
+				title: translate(
+					'message.decryptionFailed.title',
+					'Message decryption failed'
+				),
+				subtitle: translate(
+					'message.decryptionFailed.subtitle',
+					'Incoming message unavailable'
+				),
+				body: translate(
+					'message.decryptionFailed.body',
+					'This incoming message could not be decrypted. Ask the sender to send it again, or try reloading the conversation.'
+				),
+				status: translate(
+					'message.decryptionFailed.status',
+					'could not be decrypted'
+				)
+			}
+		: {
+				title: translate(
+					'message.sendFailed.title',
+					'Sending message failed'
+				),
+				subtitle: translate(
+					'message.sendFailed.subtitle',
+					'Resend your message again'
+				),
+				body: translate(
+					'message.sendFailed.body',
+					'There was a problem with sending the message, likely due to encryption or a transfer error. Please copy it and try again. Check the status: one check means sent, two checks mean read, and a cross means it didn’t reach the server.'
+				),
+				status: translate('message.sendFailed.status', 'not delivered')
+			};
 
 	return (
 		<div className="messageItem messageItem--sendFailed">
@@ -37,38 +75,23 @@ export const MessageSendFailed = ({ messageTime }: MessageSendFailedProps) => {
 					<div className="messageItem__header">
 						<div className="messageItem__sendFailedHeaderText">
 							<div className="messageItem__sendFailedTitle">
-								{translate(
-									'message.sendFailed.title',
-									'Sending message failed'
-								)}
+								{copy.title}
 							</div>
 							<div className="messageItem__sendFailedSubtitle">
-								{translate(
-									'message.sendFailed.subtitle',
-									'Resend your message again'
-								)}
+								{copy.subtitle}
 							</div>
 						</div>
 					</div>
 					<div className="messageItem__message">
-						{translate(
-							'message.sendFailed.body',
-							'There was a problem with sending the message, likely due to encryption or a transfer error. Please copy it and try again. Check the status: one check means sent, two checks mean read, and a cross means it didn’t reach the server.'
-						)}
+						{copy.body}
 						<div className="messageItem__timeRail">
 							<span className="messageItem__messageTime">
 								{messageTime ? formatToHHMM(messageTime) : null}
 								<span
 									className="messageItem__deliveryStatus messageItem__deliveryStatus--failed"
 									role="img"
-									aria-label={translate(
-										'message.sendFailed.status',
-										'nicht zugestellt'
-									)}
-									title={translate(
-										'message.sendFailed.status',
-										'nicht zugestellt'
-									)}
+									aria-label={copy.status}
+									title={copy.status}
 								>
 									<DeliveryFailedIcon
 										aria-hidden

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -4765,17 +4765,16 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 											message._id
 										)}
 									/>
-									{/* A message whose Megolm decryption broke gets
-									    the same standard "Sending message failed"
-									    card as a failed send (Figma 7086-57415) —
-									    its body already names encryption as the
-									    likely cause, so both failure modes share
-									    one notification. */}
-									{decryptionFailures.has(message._id) && (
-										<MessageSendFailed
-											messageTime={message.messageTime}
-										/>
-									)}
+									{decryptionFailures.has(message._id) &&
+										(!isThreadsEnabled ||
+											!message.threadRootEventId) && (
+											<MessageSendFailed
+												messageTime={
+													message.messageTime
+												}
+												isDecryptionFailure
+											/>
+										)}
 								</React.Fragment>
 							))}
 						{/* "Sending message failed" cards for sends that never
@@ -4901,6 +4900,17 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 								)}
 							/>
 						)}
+						{activeThreadRootMessage &&
+							decryptionFailures.has(
+								activeThreadRootMessage._id
+							) && (
+								<MessageSendFailed
+									messageTime={
+										activeThreadRootMessage.messageTime
+									}
+									isDecryptionFailure
+								/>
+							)}
 						{messages &&
 							(ready || !activeSession.rid) &&
 							messages.map((message: MessageItem, index) => (
@@ -4957,6 +4967,16 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 											message._id
 										)}
 									/>
+									{decryptionFailures.has(message._id) &&
+										message.threadRootEventId ===
+											activeThreadRootId && (
+											<MessageSendFailed
+												messageTime={
+													message.messageTime
+												}
+												isDecryptionFailure
+											/>
+										)}
 								</React.Fragment>
 							))}
 					</div>

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -24,6 +24,7 @@ import {
 	MessageItemComponent
 } from '../message/MessageItemComponent';
 import { useMatrixDecryptionFailures } from '../../hooks/useMatrixDecryptionFailures';
+import { MessageSendFailed } from '../message/MessageSendFailed';
 import {
 	ReactionEvent,
 	AggregatedReaction,
@@ -4744,6 +4745,17 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 											message._id
 										)}
 									/>
+									{/* A message whose Megolm decryption broke gets
+									    the same standard "Sending message failed"
+									    card as a failed send (Figma 7086-57415) —
+									    its body already names encryption as the
+									    likely cause, so both failure modes share
+									    one notification. */}
+									{decryptionFailures.has(message._id) && (
+										<MessageSendFailed
+											messageTime={message.messageTime}
+										/>
+									)}
 								</React.Fragment>
 							))}
 						{shouldShowInlineTypingIndicator && (

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -23,6 +23,7 @@ import {
 	MessageItem,
 	MessageItemComponent
 } from '../message/MessageItemComponent';
+import { useMatrixDecryptionFailures } from '../../hooks/useMatrixDecryptionFailures';
 import {
 	ReactionEvent,
 	AggregatedReaction,
@@ -1619,6 +1620,11 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 	const resolvedMatrixRoomId = isMatrixRoom(activeSession.rid)
 		? activeSession.rid
 		: activeSession.item?.matrixRoomId || activeSession.rid;
+	// "Encryption broke" delivery status: event ids in this room whose Megolm
+	// decryption permanently failed, so the affected message can show the red
+	// cross (Figma 7086-57415). Keyed by event id === message._id.
+	const decryptionFailures =
+		useMatrixDecryptionFailures(resolvedMatrixRoomId);
 	// Reactions (m.annotation, #435).
 	const reactionEvents = useMemo(
 		() => props.reactionEvents || [],
@@ -4734,6 +4740,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 										}
 										onUnreact={handleUnreact}
 										{...message}
+										encryptionBroke={decryptionFailures.has(
+											message._id
+										)}
 									/>
 								</React.Fragment>
 							))}
@@ -4847,6 +4856,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 								threadsEnabled={true}
 								forceShow={true}
 								{...activeThreadRootMessage}
+								encryptionBroke={decryptionFailures.has(
+									activeThreadRootMessage._id
+								)}
 							/>
 						)}
 						{messages &&
@@ -4901,6 +4913,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 										}
 										onUnreact={handleUnreact}
 										{...message}
+										encryptionBroke={decryptionFailures.has(
+											message._id
+										)}
 									/>
 								</React.Fragment>
 							))}

--- a/src/hooks/useMatrixDecryptionFailures.test.tsx
+++ b/src/hooks/useMatrixDecryptionFailures.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { MatrixEventEvent } from 'matrix-js-sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMatrixDecryptionFailures } from './useMatrixDecryptionFailures';
+
+const { getMatrixClientServiceMock } = vi.hoisted(() => ({
+	getMatrixClientServiceMock: vi.fn()
+}));
+
+vi.mock('../services/matrixClientRegistry', () => ({
+	getMatrixClientService: getMatrixClientServiceMock
+}));
+
+class FakeMatrixEvent {
+	private listeners = new Map<string, Set<() => void>>();
+
+	constructor(
+		private readonly id: string,
+		public type = 'm.room.encrypted',
+		public decryptionFailure = true
+	) {}
+
+	getId = () => this.id;
+
+	getType = () => this.type;
+
+	isDecryptionFailure = () => this.decryptionFailure;
+
+	on = (name: string, listener: () => void) => {
+		const listeners = this.listeners.get(name) ?? new Set();
+		listeners.add(listener);
+		this.listeners.set(name, listeners);
+	};
+
+	off = (name: string, listener: () => void) => {
+		this.listeners.get(name)?.delete(listener);
+	};
+
+	emitDecrypted = () => {
+		this.listeners
+			.get(MatrixEventEvent.Decrypted)
+			?.forEach((listener) => listener());
+	};
+
+	listenerCount = () =>
+		this.listeners.get(MatrixEventEvent.Decrypted)?.size ?? 0;
+}
+
+const createClient = (events: FakeMatrixEvent[]) => {
+	const timelineListeners = new Set<(...args: any[]) => void>();
+	return {
+		getRoom: vi.fn(() => ({
+			getLiveTimeline: () => ({ getEvents: () => events })
+		})),
+		on: vi.fn((name: string, listener: (...args: any[]) => void) => {
+			if (name === 'Room.timeline') timelineListeners.add(listener);
+		}),
+		off: vi.fn((name: string, listener: (...args: any[]) => void) => {
+			if (name === 'Room.timeline') timelineListeners.delete(listener);
+		})
+	};
+};
+
+describe('useMatrixDecryptionFailures listener lifecycle', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		getMatrixClientServiceMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('unbinds and stops tracking an event after successful decryption', () => {
+		const event = new FakeMatrixEvent('$event');
+		const client = createClient([event]);
+		getMatrixClientServiceMock.mockReturnValue({ getClient: () => client });
+
+		const { result } = renderHook(() =>
+			useMatrixDecryptionFailures('!room:example.org')
+		);
+
+		expect(event.listenerCount()).toBe(1);
+		event.type = 'm.room.message';
+		event.decryptionFailure = false;
+		act(() => event.emitDecrypted());
+
+		expect(event.listenerCount()).toBe(0);
+		act(() => vi.advanceTimersByTime(12_000));
+		expect(result.current.size).toBe(0);
+	});
+
+	it('keeps a failed event tracked until a later decrypt succeeds', () => {
+		const event = new FakeMatrixEvent('$event');
+		const client = createClient([event]);
+		getMatrixClientServiceMock.mockReturnValue({ getClient: () => client });
+
+		const { result } = renderHook(() =>
+			useMatrixDecryptionFailures('!room:example.org')
+		);
+
+		act(() => vi.advanceTimersByTime(12_000));
+		expect(result.current.has('$event')).toBe(true);
+		expect(event.listenerCount()).toBe(1);
+
+		event.type = 'm.room.message';
+		event.decryptionFailure = false;
+		act(() => event.emitDecrypted());
+
+		expect(result.current.size).toBe(0);
+		expect(event.listenerCount()).toBe(0);
+	});
+});

--- a/src/hooks/useMatrixDecryptionFailures.ts
+++ b/src/hooks/useMatrixDecryptionFailures.ts
@@ -80,18 +80,36 @@ export const useMatrixDecryptionFailures = (
 			}
 		};
 
-		const evaluate = (eventId: string, event: MatrixEvent): void => {
+		const untrack = (eventId: string): void => {
 			const entry = tracked.get(eventId);
-			// Decrypted successfully — the SDK promoted the type away from the
-			// encrypted envelope. Cancel any pending grace timer and clear.
-			if (event.getType() !== 'm.room.encrypted') {
-				if (entry?.timer) {
-					window.clearTimeout(entry.timer);
-					entry.timer = null;
-				}
-				clearFailed(eventId);
+			if (!entry) {
 				return;
 			}
+			if (entry.timer) {
+				window.clearTimeout(entry.timer);
+				entry.timer = null;
+			}
+			try {
+				(entry.event as any).off(
+					MatrixEventEvent.Decrypted,
+					entry.onDecrypted
+				);
+			} catch {
+				// best-effort listener cleanup
+			}
+			tracked.delete(eventId);
+		};
+
+		const evaluate = (eventId: string, event: MatrixEvent): void => {
+			// Decrypted successfully — the SDK promoted the type away from the
+			// encrypted envelope. It can never become encrypted again, so cancel
+			// pending work, clear the UI state, and release the event immediately.
+			if (event.getType() !== 'm.room.encrypted') {
+				clearFailed(eventId);
+				untrack(eventId);
+				return;
+			}
+			const entry = tracked.get(eventId);
 			if (event.isDecryptionFailure()) {
 				if (!entry || entry.timer || failed.has(eventId)) {
 					return; // already counting down or already surfaced

--- a/src/hooks/useMatrixDecryptionFailures.ts
+++ b/src/hooks/useMatrixDecryptionFailures.ts
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import { MatrixEventEvent, type MatrixEvent } from 'matrix-js-sdk';
+import { getMatrixClientService } from '../services/matrixClientRegistry';
+
+/**
+ * Per-message "encryption broke" detection for the delivery-status UI.
+ *
+ * Watches one Matrix room and returns the set of event ids that currently
+ * fail to decrypt (`event.isEncrypted() && event.isDecryptionFailure()` on the
+ * `MatrixEventEvent.Decrypted` event — the exact API the ops-only
+ * `utdTracker.ts` already proves works). The consumer maps each rendered
+ * message to `encryptionBroke={failures.has(message._id)}` — and `message._id`
+ * is the Matrix event id (see `matrixTimelineEventFormatter`).
+ *
+ * A grace period mirrors `utdTracker`: a late Megolm key is normal and the SDK
+ * self-heals, so a failure is only surfaced once it has persisted past the
+ * grace window. A subsequent successful decrypt (the event type is promoted
+ * away from `m.room.encrypted`) clears it again. This keeps the red cross off
+ * every message during ordinary key sync.
+ *
+ * Unlike `utdTracker` (anonymous SigNoz telemetry, spans all rooms) this is a
+ * per-room, per-event UI signal — so it lives as a hook scoped to the open
+ * conversation, not a global counter. Best-effort: never throws into render.
+ */
+
+// Shorter than utdTracker's 5-min "permanent" classification: this is a live
+// UI hint, not a telemetry verdict, so it should appear within seconds of a
+// genuine failure while still riding out ordinary key-arrival latency.
+const GRACE_PERIOD_MS = 12 * 1000;
+
+export const useMatrixDecryptionFailures = (
+	roomId: string | null | undefined
+): ReadonlySet<string> => {
+	const [failedEventIds, setFailedEventIds] = useState<ReadonlySet<string>>(
+		() => new Set<string>()
+	);
+
+	useEffect(() => {
+		if (!roomId) {
+			setFailedEventIds((previous) =>
+				previous.size ? new Set<string>() : previous
+			);
+			return;
+		}
+
+		const client = getMatrixClientService()?.getClient?.() ?? null;
+		if (!client) {
+			return;
+		}
+
+		let disposed = false;
+		const failed = new Set<string>();
+		// event id -> the listener + grace timer we attached, so we can detach.
+		const tracked = new Map<
+			string,
+			{
+				event: MatrixEvent;
+				onDecrypted: () => void;
+				timer: number | null;
+			}
+		>();
+
+		const publish = (): void => {
+			if (disposed) {
+				return;
+			}
+			setFailedEventIds(new Set(failed));
+		};
+
+		const markFailed = (eventId: string): void => {
+			if (!failed.has(eventId)) {
+				failed.add(eventId);
+				publish();
+			}
+		};
+
+		const clearFailed = (eventId: string): void => {
+			if (failed.delete(eventId)) {
+				publish();
+			}
+		};
+
+		const evaluate = (eventId: string, event: MatrixEvent): void => {
+			const entry = tracked.get(eventId);
+			// Decrypted successfully — the SDK promoted the type away from the
+			// encrypted envelope. Cancel any pending grace timer and clear.
+			if (event.getType() !== 'm.room.encrypted') {
+				if (entry?.timer) {
+					window.clearTimeout(entry.timer);
+					entry.timer = null;
+				}
+				clearFailed(eventId);
+				return;
+			}
+			if (event.isDecryptionFailure()) {
+				if (!entry || entry.timer || failed.has(eventId)) {
+					return; // already counting down or already surfaced
+				}
+				entry.timer = window.setTimeout(() => {
+					entry.timer = null;
+					if (
+						event.getType() === 'm.room.encrypted' &&
+						event.isDecryptionFailure()
+					) {
+						markFailed(eventId);
+					}
+				}, GRACE_PERIOD_MS);
+			}
+		};
+
+		const attach = (event: MatrixEvent | undefined): void => {
+			try {
+				if (!event || event.getType() !== 'm.room.encrypted') {
+					return;
+				}
+				const eventId = event.getId?.();
+				if (!eventId || tracked.has(eventId)) {
+					return;
+				}
+				const onDecrypted = () => evaluate(eventId, event);
+				tracked.set(eventId, { event, onDecrypted, timer: null });
+				(event as any).on(MatrixEventEvent.Decrypted, onDecrypted);
+				// Cover the race where decryption already concluded before we
+				// attached (e.g. events already in the timeline on mount).
+				evaluate(eventId, event);
+			} catch {
+				// never throw into render
+			}
+		};
+
+		const onTimeline = (
+			event: MatrixEvent | undefined,
+			room: { roomId?: string } | undefined
+		): void => {
+			if (room?.roomId === roomId) {
+				attach(event);
+			}
+		};
+
+		// Seed from events already loaded in the room's live timeline.
+		try {
+			const room = (client as any).getRoom?.(roomId);
+			const events = room?.getLiveTimeline?.()?.getEvents?.() ?? [];
+			events.forEach((event: MatrixEvent) => attach(event));
+		} catch {
+			// best-effort seeding
+		}
+
+		(client as any).on('Room.timeline', onTimeline);
+
+		return () => {
+			disposed = true;
+			try {
+				(client as any).off('Room.timeline', onTimeline);
+			} catch {
+				// ignore
+			}
+			tracked.forEach(({ event, onDecrypted, timer }) => {
+				if (timer) {
+					window.clearTimeout(timer);
+				}
+				try {
+					(event as any).off(MatrixEventEvent.Decrypted, onDecrypted);
+				} catch {
+					// ignore
+				}
+			});
+			tracked.clear();
+		};
+	}, [roomId]);
+
+	return failedEventIds;
+};

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1434,6 +1434,9 @@
 				"headline": "Nachricht löschen"
 			}
 		},
+		"encryptionBroke": {
+			"status": "Verschlüsselung gebrochen"
+		},
 		"groupChat": "Gruppenchat",
 		"isMyMessage": {
 			"name": "Ich"

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1437,6 +1437,12 @@
 		"encryptionBroke": {
 			"status": "Verschlüsselung gebrochen"
 		},
+		"decryptionFailed": {
+			"body": "Diese eingehende Nachricht konnte nicht entschlüsselt werden. Bitten Sie die absendende Person, sie erneut zu senden, oder laden Sie die Unterhaltung neu.",
+			"status": "konnte nicht entschlüsselt werden",
+			"subtitle": "Eingehende Nachricht nicht verfügbar",
+			"title": "Nachricht konnte nicht entschlüsselt werden"
+		},
 		"groupChat": "Gruppenchat",
 		"isMyMessage": {
 			"name": "Ich"

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -431,6 +431,12 @@
 				"copy": "Möchtest Du die Nachricht wirklich löschen?"
 			}
 		},
+		"decryptionFailed": {
+			"body": "Diese eingehende Nachricht konnte nicht entschlüsselt werden. Bitte die absendende Person, sie erneut zu senden, oder lade die Unterhaltung neu.",
+			"status": "konnte nicht entschlüsselt werden",
+			"subtitle": "Eingehende Nachricht nicht verfügbar",
+			"title": "Nachricht konnte nicht entschlüsselt werden"
+		},
 		"reply": {
 			"previewLabel": "Antwort an",
 			"cancel": "Antwort verwerfen",

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1419,6 +1419,9 @@
 				"headline": "Delete message"
 			}
 		},
+		"encryptionBroke": {
+			"status": "encryption failed"
+		},
 		"groupChat": "Group chat",
 		"isMyMessage": {
 			"name": "Me"

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1422,6 +1422,12 @@
 		"encryptionBroke": {
 			"status": "encryption failed"
 		},
+		"decryptionFailed": {
+			"body": "This incoming message could not be decrypted. Ask the sender to send it again, or try reloading the conversation.",
+			"status": "could not be decrypted",
+			"subtitle": "Incoming message unavailable",
+			"title": "Message decryption failed"
+		},
 		"groupChat": "Group chat",
 		"isMyMessage": {
 			"name": "Me"


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Frontend#542 · Parent #537 · Refs #436

Makes the `encryptionBroke` delivery state fire from real Matrix decryption failures (crypto is durable, ADR-004 amendment 2026-07-19).

- New hook `useMatrixDecryptionFailures(roomId)`: tracks `m.room.encrypted` && `isDecryptionFailure()` on `MatrixEventEvent.Decrypted` (same SDK API as `utdTracker`), 12s grace so late Megolm keys never flash a cross. Keyed by event id === `message._id`.
- `SessionItemComponent` passes `encryptionBroke` to every message render; the red cross shows on the affected message even when incoming (the recipient case), label `message.encryptionBroke.status`.
- The same standard `MessageSendFailed` card is shown under a broken message — one notification for both failure modes, no recipient-specific variant.
- Storybook: `IncomingEncryptionBroke` story.

Verified: `tsc --noEmit` 0 errors, `eslint` clean, Storybook screenshot of the incoming red cross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer status indicators for messages affected by encryption failures.
  * Permanently failed encrypted messages now appear in the conversation and thread views with a delivery failure card.
  * Added localized encryption failure labels in English and German.

* **Bug Fixes**
  * Improved handling of failed message decryption, including recovery when messages decrypt successfully later.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->