### PR TITLE
docs(chat): correct the stale 'unencrypted' Matrix send comment

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -1483,8 +1483,14 @@ export const MessageSubmitInterfaceComponent = ({
 		if (prefixParts.length && message.length > 0) {
 			message = `${prefixParts.join(' ')} ${message}`;
 		}
-		// Legacy Rocket.Chat client-side message encryption is removed;
-		// Matrix messages go through the SDK path unencrypted (ADR-004).
+		// Legacy Rocket.Chat client-side message encryption is removed. This
+		// `isEncrypted` flag is the vestigial remnant of that path and no
+		// longer controls Matrix encryption: with Rust crypto initialized
+		// unconditionally (matrixClientService.initRustCrypto) and rooms
+		// created with `m.room.encryption`, the SDK Megolm-encrypts every send
+		// automatically (ADR-004, durable since the ADR-005 homeserver
+		// rebuild). The flag is a no-op pass-through kept only for the
+		// chatTransportService signature.
 		const isEncrypted = false;
 
 		if (isAskerEnquiry) {


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Frontend#543 · Refs #436, ADR-004 (amendment 2026-07-19)

Corrects a stale comment claiming "Matrix messages go through the SDK path unencrypted (ADR-004)". Not true: `matrixClientService` initializes Rust crypto unconditionally and rooms carry `m.room.encryption`, so the SDK Megolm-encrypts every send. `isEncrypted = false` is the vestigial legacy Rocket.Chat flag, a no-op pass-through into `chatTransportService`. Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
