### PR TITLE
Fix pre-send image thumbnail broken under StrictMode

### DIFF
--- a/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
+++ b/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StrictMode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { MessageSubmitInterfaceComponent } from './messageSubmitInterfaceComponent';
@@ -116,7 +117,13 @@ export const ReadyToSend: Story = {
  *  and the pre-send card shows a real thumbnail instead of a file icon. */
 export const ImageAttachmentPreview: Story = {
 	name: 'Image attachment preview (pasted)',
-	render: () => <ComposerShell />,
+	// Wrapped in StrictMode: the pre-send thumbnail must survive the
+	// mount → cleanup → mount object-URL cycle (the 1146 KB broken-thumb fix).
+	render: () => (
+		<StrictMode>
+			<ComposerShell />
+		</StrictMode>
+	),
 	play: async ({ canvasElement }) => {
 		const editor = await waitFor(() => {
 			const node = canvasElement.querySelector<HTMLElement>(

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -1667,6 +1667,9 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			object-fit: cover;
 			border-radius: 8px;
 			flex-shrink: 0;
+			// Clip the alt text if an image ever fails to load, so it can
+			// never spill out of the thumbnail box.
+			overflow: hidden;
 		}
 
 		&__attachmentModeIcon {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -96,6 +96,7 @@ import {
 } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { getIconForAttachmentType } from '../message/messageHelpers';
 import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
+import { useImagePreviewUrl } from './useImagePreviewUrl';
 import { HIGHLIGHT_SNIPPET_SELECTED_EVENT } from './highlightSnippetEvents';
 import { isMyMessage } from '../session/sessionHelpers';
 import { transportMarkupToComposerHtml } from './transportMarkupToComposerHtml';
@@ -1680,21 +1681,10 @@ export const MessageSubmitInterfaceComponent = ({
 		};
 	}, [cleanupVoiceRecorder]);
 
-	// Image thumbnail for the pre-send attachment card (revoked on change/unmount).
-	const attachmentPreviewUrl = useMemo(
-		() =>
-			attachmentSelected?.type?.startsWith('image/')
-				? URL.createObjectURL(attachmentSelected)
-				: null,
-		[attachmentSelected]
-	);
-	useEffect(() => {
-		return () => {
-			if (attachmentPreviewUrl) {
-				URL.revokeObjectURL(attachmentPreviewUrl);
-			}
-		};
-	}, [attachmentPreviewUrl]);
+	// Image thumbnail for the pre-send attachment card. Create/revoke are paired
+	// inside the hook's effect so StrictMode's mount → cleanup → mount recreates
+	// a fresh URL instead of leaving the <img> on a revoked blob (broken thumb).
+	const attachmentPreviewUrl = useImagePreviewUrl(attachmentSelected);
 
 	const handleAttachmentRemoval = useCallback(() => {
 		if (uploadProgress && attachmentUpload) {

--- a/src/components/messageSubmitInterface/useImagePreviewUrl.test.tsx
+++ b/src/components/messageSubmitInterface/useImagePreviewUrl.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { StrictMode } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useImagePreviewUrl } from './useImagePreviewUrl';
+
+const Thumb = ({ file }: { file: File | null }) => {
+	const url = useImagePreviewUrl(file);
+	return url ? (
+		<img data-testid="thumb" src={url} alt="preview" />
+	) : (
+		<span data-testid="no-thumb" />
+	);
+};
+
+describe('useImagePreviewUrl', () => {
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
+	});
+
+	it('keeps the shown object URL alive under StrictMode double-mount', () => {
+		const revoked = new Set<string>();
+		let counter = 0;
+		vi.stubGlobal('URL', {
+			createObjectURL: vi.fn(() => `blob:mock-${(counter += 1)}`),
+			revokeObjectURL: vi.fn((url: string) => revoked.add(url))
+		});
+
+		const file = new File(['x'], 'photo.png', { type: 'image/png' });
+		render(
+			<StrictMode>
+				<Thumb file={file} />
+			</StrictMode>
+		);
+
+		const shownUrl = screen
+			.getByTestId('thumb')
+			.getAttribute('src') as string;
+		// The URL the <img> currently shows must NOT have been revoked — the
+		// old useMemo pattern revoked it on the StrictMode cleanup and left a
+		// broken thumbnail (the 1146 KB paste regression).
+		expect(revoked.has(shownUrl)).toBe(false);
+	});
+
+	it('renders nothing for non-image files', () => {
+		vi.stubGlobal('URL', {
+			createObjectURL: vi.fn(() => 'blob:should-not-be-called'),
+			revokeObjectURL: vi.fn()
+		});
+		render(
+			<Thumb
+				file={new File(['x'], 'a.pdf', { type: 'application/pdf' })}
+			/>
+		);
+		expect(screen.queryByTestId('thumb')).toBeNull();
+		expect(URL.createObjectURL).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/messageSubmitInterface/useImagePreviewUrl.ts
+++ b/src/components/messageSubmitInterface/useImagePreviewUrl.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Object URL for a selected image file, for the pre-send attachment thumbnail.
+ * Create and revoke live in the SAME effect so they are always paired: under
+ * React StrictMode (mount → cleanup → mount) a fresh URL is created on remount
+ * instead of the <img> pointing at an already-revoked blob (broken thumbnail).
+ * Returns null for non-images or no selection.
+ */
+export const useImagePreviewUrl = (
+	file: File | null | undefined
+): string | null => {
+	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!file?.type?.startsWith('image/')) {
+			setPreviewUrl(null);
+			return undefined;
+		}
+		const objectUrl = URL.createObjectURL(file);
+		setPreviewUrl(objectUrl);
+		return () => URL.revokeObjectURL(objectUrl);
+	}, [file]);
+
+	return previewUrl;
+};


### PR DESCRIPTION
## Problem
The composer's pre-send attachment card shows a broken-image icon (with overflowing alt text) instead of the image thumbnail — reproduced with a real 1146 KB paste. Root cause: the preview object URL was created in `useMemo` (render phase) and revoked in a separate cleanup effect. Under React StrictMode (mount → cleanup → mount, which the real app uses but Storybook does not) the cleanup revokes the URL while `useMemo` does not recreate it, so `<img>` points at a revoked blob. Shipped in #547 (WP-4) because it was only checked in non-StrictMode Storybook.

## What changed
- `useImagePreviewUrl` hook: create + revoke paired inside one effect, so StrictMode's remount produces a fresh URL
- Composer card uses the hook instead of the useMemo/effect pair
- StrictMode regression test (asserts the shown URL is never revoked) + the composer image story wrapped in StrictMode so it's caught visually
- Thumbnail overflow clipped defensively

Touches only composer files — orthogonal to the receive-side hardening in `fix: harden composer image safety flow` already on pre-dev.

## Verification
- `npm run test:unit` — 1117/1117 (2 new StrictMode tests)
- `tsc --noEmit`, ESLint zero-warnings, production build + build-storybook clean
- Visually verified in a StrictMode-wrapped Storybook (real browser): thumbnail loads (naturalWidth 120, not broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)