### PR TITLE
fix: don't drop live-chat enquiries when the registered feed is empty

### DIFF
--- a/src/api/apiGetConsultantSessionList.test.ts
+++ b/src/api/apiGetConsultantSessionList.test.ts
@@ -65,6 +65,67 @@ describe('apiGetConsultantSessionList', () => {
 		expect(result.sessions.map((s: any) => s.session.id)).toEqual([7]);
 	});
 
+	it('keeps live-chat enquiries when the registered feed is empty (204/EMPTY)', async () => {
+		vi.mocked(fetchData).mockImplementation((async ({ url }: any) => {
+			if (url.includes('/registered')) {
+				throw new Error('EMPTY');
+			}
+			return {
+				sessions: [{ session: { id: 42 } }],
+				offset: 0,
+				count: 1,
+				total: 1
+			};
+		}) as any);
+
+		const result = await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.ENQUIRY
+		});
+
+		// Regression: an empty registered feed must not discard the anonymous
+		// live-chat queue ("Aktuell liegen keine Erstanfragen vor" bug).
+		expect(result.sessions.map((s: any) => s.session.id)).toEqual([42]);
+		expect(result.total).toBe(1);
+	});
+
+	it('keeps registered enquiries when the anonymous feed is empty (204/EMPTY)', async () => {
+		vi.mocked(fetchData).mockImplementation((async ({ url }: any) => {
+			if (url.includes('/anonymous')) {
+				throw new Error('EMPTY');
+			}
+			return { sessions: [{ session: { id: 7 } }], total: 1 };
+		}) as any);
+
+		const result = await apiGetConsultantSessionList({
+			type: SESSION_LIST_TYPES.ENQUIRY
+		});
+
+		expect(result.sessions.map((s: any) => s.session.id)).toEqual([7]);
+	});
+
+	it('rethrows EMPTY only when both enquiry feeds are empty', async () => {
+		vi.mocked(fetchData).mockImplementation((async () => {
+			throw new Error('EMPTY');
+		}) as any);
+
+		await expect(
+			apiGetConsultantSessionList({ type: SESSION_LIST_TYPES.ENQUIRY })
+		).rejects.toThrow('EMPTY');
+	});
+
+	it('propagates hard failures of the registered feed', async () => {
+		vi.mocked(fetchData).mockImplementation((async ({ url }: any) => {
+			if (url.includes('/registered')) {
+				throw new Error('Internal Server Error');
+			}
+			return { sessions: [{ session: { id: 2 } }] };
+		}) as any);
+
+		await expect(
+			apiGetConsultantSessionList({ type: SESSION_LIST_TYPES.ENQUIRY })
+		).rejects.toThrow('Internal Server Error');
+	});
+
 	it('loads consultant sessions with pagination', async () => {
 		vi.mocked(fetchData).mockResolvedValue({ sessions: [] });
 

--- a/src/api/apiGetConsultantSessionList.ts
+++ b/src/api/apiGetConsultantSessionList.ts
@@ -64,28 +64,47 @@ export const apiGetConsultantSessionList = async ({
 	const registeredUrl = `${endpoints.consultantEnquiriesBase}registered?${query}`;
 	const anonymousUrl = `${endpoints.consultantEnquiriesBase}anonymous?${query}`;
 
+	/*
+	 * Each feed answers 204 (rejected as FETCH_ERRORS.EMPTY) when IT is empty.
+	 * One empty feed must not fail the merge: a consultant with zero
+	 * registered enquiries but a filled live-chat topic queue would otherwise
+	 * see "no enquiries" although the anonymous feed returned sessions.
+	 * Only when BOTH feeds are empty the merged list is genuinely empty and
+	 * the EMPTY error is re-thrown so the existing empty-state handling runs.
+	 */
 	const [registered, anonymous] = await Promise.all([
-		fetchListUrl(registeredUrl, signal),
+		fetchListUrl(registeredUrl, signal).catch((error) => {
+			if (error?.message === FETCH_ERRORS.EMPTY) {
+				return null;
+			}
+			throw error;
+		}),
 		// The anonymous queue is best-effort: a failure there must not hide the
 		// registered enquiries a consultant is responsible for. It must be
 		// loud, though — a silent empty result is indistinguishable from
 		// "no live chat enquiries" and hides backend 500s from diagnosis.
 		fetchListUrl(anonymousUrl, signal).catch((error) => {
-			console.error(
-				'Anonymous enquiry feed failed — live chat enquiries may be missing from the list:',
-				error
-			);
-			return { sessions: [] } as ListItemsResponseInterface;
+			if (error?.message !== FETCH_ERRORS.EMPTY) {
+				console.error(
+					'Anonymous enquiry feed failed — live chat enquiries may be missing from the list:',
+					error
+				);
+			}
+			return null;
 		})
 	]);
+
+	if (!registered && !anonymous) {
+		throw new Error(FETCH_ERRORS.EMPTY);
+	}
 
 	return mergeEnquiryFeeds(registered, anonymous);
 };
 
 /** Merge two enquiry feeds, de-duplicating by session id (registered wins on conflict). */
 const mergeEnquiryFeeds = (
-	registered: ListItemsResponseInterface,
-	anonymous: ListItemsResponseInterface
+	registered: ListItemsResponseInterface | null,
+	anonymous: ListItemsResponseInterface | null
 ): ListItemsResponseInterface => {
 	const registeredSessions = registered?.sessions ?? [];
 	const anonymousSessions = anonymous?.sessions ?? [];
@@ -96,5 +115,9 @@ const mergeEnquiryFeeds = (
 		...registeredSessions,
 		...anonymousSessions.filter((item: any) => !seen.has(item?.session?.id))
 	];
-	return { ...registered, sessions: merged };
+	/* Base the pagination envelope (offset/count/total) on whichever feed
+	 * actually answered — with an empty registered feed the anonymous feed
+	 * carries the only valid envelope. */
+	const base = registered ?? anonymous ?? ({} as ListItemsResponseInterface);
+	return { ...base, sessions: merged };
 };


### PR DESCRIPTION
## Problem

A consultant with **zero registered enquiries** always sees *"Aktuell liegen keine Erstanfragen vor"*, even when the anonymous live-chat topic queue has waiting sessions. This is one of the root causes of "consultant does not see the live-chat request" reported on pre-dev (Slack, Shazia 2026-07-19).

## Root cause

The enquiry tab merges two feeds:

- `GET /conversations/consultants/enquiries/registered`
- `GET /conversations/consultants/enquiries/anonymous`

Both endpoints answer **204 No Content** when they are empty (the backend throws `NoContentException` for an empty list), which `fetchData` rejects as `FETCH_ERRORS.EMPTY`. Only the anonymous fetch had a `.catch`; an EMPTY rejection of the **registered** feed failed the whole `Promise.all` and discarded the already-fetched anonymous sessions. `SessionsList` treats the EMPTY rejection as "list is empty".

## Evidence (pre-dev reproduction)

- `GET …/enquiries/anonymous?count=15&filter=all&offset=0` → `200` with session `103387` (invite-link live chat, topic 3)
- `GET …/enquiries/registered?count=15&filter=all&offset=0` → `204`
- UI: "Aktuell liegen keine Erstanfragen vor", zero session cards

## Fix

- Catch `EMPTY` per feed and treat it as an empty list.
- Merge whatever answered (registered first, de-duplicated by session id, pagination envelope from the feed that answered).
- Re-throw `EMPTY` only when **both** feeds are empty, so the existing empty-state handling still runs.
- Hard (non-EMPTY) failures of the registered feed still propagate; the anonymous feed stays best-effort with loud logging.

## Tests

- `apiGetConsultantSessionList.test.ts` extended: empty-registered keeps live-chat sessions (regression), empty-anonymous keeps registered, both-empty rethrows EMPTY, hard registered failure propagates. 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enquiry session retrieval when one feed is empty or unavailable.
  * Results from the available feed are now displayed correctly, including accurate pagination totals.
  * Empty results are reported only when both enquiry feeds contain no sessions.
  * Non-empty feed errors no longer prevent available enquiry sessions from being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->