### PR TITLE
fix(registration): cap username at 30, unify anon identity, expand animal set + palette

### DIFF
--- a/src/components/anonymousChat/AnonymousChat.tsx
+++ b/src/components/anonymousChat/AnonymousChat.tsx
@@ -15,7 +15,7 @@ import {
 	TextField,
 	Dialog
 } from '@mui/material';
-import PersonIcon from '@mui/icons-material/Person';
+import { AnimalAvatar } from '../pseudonym/AnimalAvatar';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -478,7 +478,7 @@ export const AnonymousChat: FC<AnonymousChatProps> = ({ onBack }) => {
 									gap: '12px'
 								}}
 							>
-								<PersonIcon sx={{ color: '#c62828' }} />
+								<AnimalAvatar avatar={identity.avatar} size={48} />
 								<Box sx={{ flex: 1 }}>
 									<Typography
 										variant="body2"

--- a/src/components/anonymousChat/AnonymousChat.tsx
+++ b/src/components/anonymousChat/AnonymousChat.tsx
@@ -31,6 +31,12 @@ import {
 	TopicsDataInterface
 } from '../../globalState/interfaces';
 import { apiPostRegistration } from '../../api/apiPostRegistration';
+import {
+	generatePseudonym,
+	generatePassword,
+	type Pseudonym
+} from '../../utils/anonName/engine';
+import { toRegistrationUsername } from '../registration/accountData/registrationUsername';
 import { redirectToApp } from '../registration/autoLogin';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { useAppConfig } from '../../hooks/useAppConfig';
@@ -81,6 +87,9 @@ export const AnonymousChat: FC<AnonymousChatProps> = ({ onBack }) => {
 		new Set()
 	);
 	const [isRegistering, setIsRegistering] = useState<boolean>(false);
+	// Same anonymous identity as the normal registration: a friendly animal
+	// pseudonym (e.g. "katze_mika_1234"), NOT an "Anonymous-<timestamp>" handle.
+	const [identity] = useState<Pseudonym>(() => generatePseudonym(locale));
 	const [username, setUsername] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
 	const [noAvailabilityModalTopic, setNoAvailabilityModalTopic] =
@@ -93,23 +102,12 @@ export const AnonymousChat: FC<AnonymousChatProps> = ({ onBack }) => {
 	// updater to show the no-availability modal once per topic.
 	const [, setShownNoAvailabilityTopics] = useState<Set<number>>(new Set());
 
-	// Generate username and 8-character random password on mount
+	// Derive the login username and password from the shared anonymous-name
+	// engine — the exact same structure as the normal registration flow.
 	useEffect(() => {
-		const timestamp = Date.now();
-		const generatedUsername = `Anonymous-${timestamp}`;
-		setUsername(generatedUsername);
-
-		// Generate 8-character random password
-		const chars =
-			'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-		let generatedPassword = '';
-		for (let i = 0; i < 8; i++) {
-			generatedPassword += chars.charAt(
-				Math.floor(Math.random() * chars.length)
-			);
-		}
-		setPassword(generatedPassword);
-	}, []);
+		setUsername(toRegistrationUsername(identity));
+		setPassword(generatePassword());
+	}, [identity]);
 
 	// Fetch all topics on mount
 	useEffect(() => {

--- a/src/components/anonymousChat/AnonymousChat.tsx
+++ b/src/components/anonymousChat/AnonymousChat.tsx
@@ -89,9 +89,11 @@ export const AnonymousChat: FC<AnonymousChatProps> = ({ onBack }) => {
 	const [isRegistering, setIsRegistering] = useState<boolean>(false);
 	// Same anonymous identity as the normal registration: a friendly animal
 	// pseudonym (e.g. "katze_mika_1234"), NOT an "Anonymous-<timestamp>" handle.
+	// Username + password are derived synchronously from the shared anon-name
+	// engine on first render (same structure as normal registration).
 	const [identity] = useState<Pseudonym>(() => generatePseudonym(locale));
-	const [username, setUsername] = useState<string>('');
-	const [password, setPassword] = useState<string>('');
+	const [username] = useState<string>(() => toRegistrationUsername(identity));
+	const [password] = useState<string>(() => generatePassword());
 	const [noAvailabilityModalTopic, setNoAvailabilityModalTopic] =
 		useState<TopicsDataInterface | null>(null);
 	const [noAvailabilityModalOpen, setNoAvailabilityModalOpen] =
@@ -102,12 +104,6 @@ export const AnonymousChat: FC<AnonymousChatProps> = ({ onBack }) => {
 	// updater to show the no-availability modal once per topic.
 	const [, setShownNoAvailabilityTopics] = useState<Set<number>>(new Set());
 
-	// Derive the login username and password from the shared anonymous-name
-	// engine — the exact same structure as the normal registration flow.
-	useEffect(() => {
-		setUsername(toRegistrationUsername(identity));
-		setPassword(generatePassword());
-	}, [identity]);
 
 	// Fetch all topics on mount
 	useEffect(() => {

--- a/src/components/registration/accountData/AccountData.tsx
+++ b/src/components/registration/accountData/AccountData.tsx
@@ -58,23 +58,7 @@ import genKeyIcon from '../../../resources/img/registration-md3/icons/gen-key.sv
 import genAvatarIcon from '../../../resources/img/registration-md3/icons/gen-avatar.svg';
 import genDiceIcon from '../../../resources/img/registration-md3/icons/gen-dice.svg';
 import { DepartmentLegalSection } from '../../departmentLegal/DepartmentLegalSection';
-
-const toRegistrationUsername = (displayName: string) => {
-	const normalized = displayName
-		.normalize('NFD')
-		.replace(/[\u0300-\u036f]/g, '')
-		.toLowerCase()
-		.replace(/ß/g, 'ss')
-		.replace(/[^a-z0-9]+/g, '_')
-		.replace(/^_+|_+$/g, '')
-		.replace(/_{2,}/g, '_');
-	const safeBase = normalized || 'oriso';
-	const suffix = Math.floor(100 + Math.random() * 900);
-	const suffixText = `_${suffix}`;
-	const maxBaseLength = 48 - suffixText.length;
-
-	return `${safeBase.slice(0, maxBaseLength)}${suffixText}`;
-};
+import { toRegistrationUsername } from './registrationUsername';
 
 const suggestButtonSx = (filled: boolean) =>
 	({
@@ -175,7 +159,7 @@ export const AccountData: FC<{
 	const applyGeneratedUsername = useCallback(
 		(nextIdentity: Pseudonym) => {
 			setIdentity(nextIdentity);
-			setUsername(toRegistrationUsername(nextIdentity.displayName));
+			setUsername(toRegistrationUsername(nextIdentity));
 			resetUsernameAvailability();
 		},
 		[resetUsernameAvailability]

--- a/src/components/registration/accountData/registrationUsername.test.ts
+++ b/src/components/registration/accountData/registrationUsername.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { toRegistrationUsername } from './registrationUsername';
+import {
+	REGISTRATION_DATA_VALIDATION,
+	USERNAME_MAX_LENGTH
+} from '../registrationDataValidation';
+import { generatePseudonym, Pseudonym, SUPPORTED } from '../../../utils/anonName/engine';
+
+const identity = (partial: Partial<Pseudonym>): Pseudonym => ({
+	displayName: 'freundliche Katze Mika',
+	avatar: { file: 'cat.svg', bg: '#FFB3BA', iconColor: '#1a1a1a' },
+	animalLabel: 'Katze',
+	name: 'Mika',
+	...partial
+});
+
+describe('toRegistrationUsername', () => {
+	it('builds the handle from animal + name, dropping the adjective', () => {
+		expect(toRegistrationUsername(identity({}))).toMatch(/^katze_mika_\d{4}$/);
+	});
+
+	it('never exceeds the backend username limit', () => {
+		const longest = identity({
+			animalLabel: 'Meerschweinchen',
+			name: 'Dominique',
+			displayName: 'sanftmütige Meerschweinchen Dominique'
+		});
+		for (let i = 0; i < 200; i++) {
+			expect(
+				toRegistrationUsername(longest).length
+			).toBeLessThanOrEqual(USERNAME_MAX_LENGTH);
+		}
+	});
+
+	it('passes the frontend username validation for every language', () => {
+		for (const lang of SUPPORTED) {
+			for (let i = 0; i < 50; i++) {
+				const username = toRegistrationUsername(generatePseudonym(lang));
+				expect(
+					REGISTRATION_DATA_VALIDATION.username.validation(username),
+					`invalid username "${username}" (${lang})`
+				).toBe(true);
+			}
+		}
+	});
+
+	it('handles multi-word animal labels', () => {
+		const username = toRegistrationUsername(
+			identity({
+				animalLabel: 'Guinea Pig',
+				name: 'Charlie',
+				displayName: 'gentle Guinea Pig Charlie'
+			})
+		);
+		expect(username).toMatch(/^guinea_pig_charlie_\d{4}$/);
+	});
+
+	it('never emits a trailing underscore before the numeric suffix', () => {
+		for (const lang of SUPPORTED) {
+			for (let i = 0; i < 50; i++) {
+				const username = toRegistrationUsername(generatePseudonym(lang));
+				expect(username).not.toMatch(/__\d{4}$/);
+			}
+		}
+	});
+
+	it('falls back to a valid handle for legacy drafts without structured parts', () => {
+		const legacy = {
+			displayName: 'freundliche Katze Mika',
+			avatar: { file: 'cat.svg', bg: '#FFB3BA', iconColor: '#1a1a1a' }
+		} as Pseudonym;
+		const username = toRegistrationUsername(legacy);
+		expect(username.length).toBeLessThanOrEqual(USERNAME_MAX_LENGTH);
+		expect(
+			REGISTRATION_DATA_VALIDATION.username.validation(username)
+		).toBe(true);
+	});
+});

--- a/src/components/registration/accountData/registrationUsername.ts
+++ b/src/components/registration/accountData/registrationUsername.ts
@@ -6,7 +6,7 @@ import { USERNAME_MAX_LENGTH } from '../registrationDataValidation';
 const slugify = (value: string): string =>
 	value
 		.normalize('NFD')
-		.replace(/[̀-ͯ]/g, '')
+		.replace(/[\u0300-\u036f]/g, '')
 		.toLowerCase()
 		.replace(/ß/g, 'ss')
 		.replace(/[^a-z0-9]+/g, '_')

--- a/src/components/registration/accountData/registrationUsername.ts
+++ b/src/components/registration/accountData/registrationUsername.ts
@@ -1,0 +1,49 @@
+import { Pseudonym } from '../../../utils/anonName/engine';
+import { USERNAME_MAX_LENGTH } from '../registrationDataValidation';
+
+/** Slugify a display fragment: strip diacritics, lowercase, ß→ss, collapse any
+ *  run of non-alphanumerics into a single underscore, trim edge underscores. */
+const slugify = (value: string): string =>
+	value
+		.normalize('NFD')
+		.replace(/[̀-ͯ]/g, '')
+		.toLowerCase()
+		.replace(/ß/g, 'ss')
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.replace(/_{2,}/g, '_');
+
+// A 4-digit suffix (1000–9999) keeps the total length predictable (always 5
+// characters incl. the separator) and adds ~9k variants on top of the
+// animal×name space, so username collisions stay rare. The registration flow
+// still verifies availability against the backend as the real uniqueness gate.
+const SUFFIX_MIN = 1000;
+const SUFFIX_SPAN = 9000;
+
+/**
+ * Build the login username from a generated pseudonym.
+ *
+ * The username is the asker's login credential AND is capped at
+ * {@link USERNAME_MAX_LENGTH} (30) by the backend. To stay within that budget we
+ * drop the (long) adjective and build the handle from `animal + name` only, e.g.
+ * "freundliche Katze Mika" → "katze_mika_1234". Legacy drafts that predate the
+ * structured `animalLabel`/`name` fields fall back to the full display name so
+ * the result is still valid (just possibly truncated).
+ */
+export const toRegistrationUsername = (identity: Pseudonym): string => {
+	const fromParts = slugify(
+		[identity.animalLabel, identity.name].filter(Boolean).join(' ')
+	);
+	const base = fromParts || slugify(identity.displayName) || 'oriso';
+
+	const suffix = Math.floor(SUFFIX_MIN + Math.random() * SUFFIX_SPAN);
+	const suffixText = `_${suffix}`;
+	const maxBaseLength = USERNAME_MAX_LENGTH - suffixText.length;
+
+	// Truncate to the budget, then drop any trailing underscore the cut may have
+	// left so we never emit "..._" before the numeric suffix.
+	const trimmedBase =
+		base.slice(0, maxBaseLength).replace(/_+$/, '') || 'oriso';
+
+	return `${trimmedBase}${suffixText}`;
+};

--- a/src/components/registration/registrationDataValidation.test.ts
+++ b/src/components/registration/registrationDataValidation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { REGISTRATION_DATA_VALIDATION } from './registrationDataValidation';
+import {
+	REGISTRATION_DATA_VALIDATION,
+	USERNAME_MAX_LENGTH,
+	USERNAME_MIN_LENGTH
+} from './registrationDataValidation';
 
 describe('REGISTRATION_DATA_VALIDATION', () => {
 	it('treats empty postcode values as invalid without throwing', () => {
@@ -20,5 +24,26 @@ describe('REGISTRATION_DATA_VALIDATION', () => {
 		expect(REGISTRATION_DATA_VALIDATION.zipcode.validation('5066a')).toBe(
 			false
 		);
+	});
+
+	describe('username', () => {
+		const validate = REGISTRATION_DATA_VALIDATION.username.validation;
+		const repeat = (length: number) => 'a'.repeat(length);
+
+		it('rejects usernames shorter than the minimum length', () => {
+			expect(validate(repeat(USERNAME_MIN_LENGTH - 1))).toBe(false);
+			expect(validate(repeat(USERNAME_MIN_LENGTH))).toBe(true);
+		});
+
+		it('rejects usernames longer than the backend maximum length', () => {
+			expect(validate(repeat(USERNAME_MAX_LENGTH))).toBe(true);
+			expect(validate(repeat(USERNAME_MAX_LENGTH + 1))).toBe(false);
+		});
+
+		it('rejects invalid characters', () => {
+			expect(validate('Katze_Mika')).toBe(false);
+			expect(validate('katze mika')).toBe(false);
+			expect(validate('katze_mika_1234')).toBe(true);
+		});
 	});
 });

--- a/src/components/registration/registrationDataValidation.ts
+++ b/src/components/registration/registrationDataValidation.ts
@@ -1,5 +1,11 @@
 import { passwordCriteria } from './accountData/passwordRules';
 
+// Keep in sync with the UserService backend (UserHelper.USERNAME_MIN/MAX_LENGTH).
+// The backend rejects usernames outside this range with HTTP 400, so the
+// frontend must enforce the same bounds before submitting the registration.
+export const USERNAME_MIN_LENGTH = 5;
+export const USERNAME_MAX_LENGTH = 30;
+
 interface RegistrationDataValidation {
 	[key: string]: {
 		validation(val?: string): boolean;
@@ -27,7 +33,11 @@ export const REGISTRATION_DATA_VALIDATION: RegistrationDataValidation = {
 		validation: (val = '') => {
 			// Only allow lowercase letters, numbers, underscores and dashes
 			const usernameRegex = /^[a-z0-9_-]+$/;
-			return val.length > 4 && usernameRegex.test(val);
+			return (
+				val.length >= USERNAME_MIN_LENGTH &&
+				val.length <= USERNAME_MAX_LENGTH &&
+				usernameRegex.test(val)
+			);
 		}
 	},
 	age: {

--- a/src/utils/anonName/data.ts
+++ b/src/utils/anonName/data.ts
@@ -1747,10 +1747,6 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 						svg: 'trout.svg'
 					},
 					{
-						label: 'Жирафа',
-						svg: 'giraffe.svg'
-					},
-					{
 						label: 'Сорока',
 						svg: 'magpie.svg'
 					},
@@ -1981,6 +1977,10 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Волк',
 						svg: 'wolf.svg'
+					},
+					{
+						label: 'Жираф',
+						svg: 'giraffe.svg'
 					}
 				]
 			}
@@ -2144,10 +2144,6 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Ластівка',
 						svg: 'swallow.svg'
-					},
-					{
-						label: 'Кобила',
-						svg: 'horse.svg'
 					},
 					{
 						label: 'Зебра',
@@ -2368,6 +2364,10 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Вовк',
 						svg: 'wolf.svg'
+					},
+					{
+						label: 'Кінь',
+						svg: 'horse.svg'
 					}
 				]
 			}

--- a/src/utils/anonName/data.ts
+++ b/src/utils/anonName/data.ts
@@ -1,4 +1,13 @@
-// AUTO-GENERATED from Storypapst/anonymous-name-generator (do not edit by hand).
+// Originally scaffolded from Storypapst/anonymous-name-generator, but the word
+// tables (esp. the localized labels) have since been curated IN-REPO and now
+// diverge from upstream — upstream ships only the SVGs, not these lists. Treat
+// THIS file as the source of truth and edit it directly; do not blindly
+// regenerate from upstream, which would drop the curated labels.
+//
+// The German set intentionally offers every available animal (all 62 SVGs) for
+// maximum variation; animals are grouped by grammatical gender so the adjective
+// agreement in `displayName` stays correct (group 0 = feminine "-e", group 1 =
+// the rest "-es").
 // Word tables for all six languages of the shared name generator.
 export interface NickAnimal {
 	label: string;
@@ -110,6 +119,14 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Lerche',
 						svg: 'lark.svg'
+					},
+					{
+						label: 'Ente',
+						svg: 'duck.svg'
+					},
+					{
+						label: 'Robbe',
+						svg: 'seal.svg'
 					}
 				]
 			},
@@ -227,6 +244,106 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Yak',
 						svg: 'yak.svg'
+					},
+					{
+						label: 'Bär',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Käfer',
+						svg: 'beetle.svg'
+					},
+					{
+						label: 'Schmetterling',
+						svg: 'butterfly.svg'
+					},
+					{
+						label: 'Kranich',
+						svg: 'crane.svg'
+					},
+					{
+						label: 'Hund',
+						svg: 'dog.svg'
+					},
+					{
+						label: 'Delfin',
+						svg: 'dolphin.svg'
+					},
+					{
+						label: 'Adler',
+						svg: 'eagle.svg'
+					},
+					{
+						label: 'Fisch',
+						svg: 'fish.svg'
+					},
+					{
+						label: 'Fuchs',
+						svg: 'fox.svg'
+					},
+					{
+						label: 'Frosch',
+						svg: 'frog.svg'
+					},
+					{
+						label: 'Hase',
+						svg: 'hare.svg'
+					},
+					{
+						label: 'Falke',
+						svg: 'hawk.svg'
+					},
+					{
+						label: 'Igel',
+						svg: 'hedgehog.svg'
+					},
+					{
+						label: 'Kolibri',
+						svg: 'hummingbird.svg'
+					},
+					{
+						label: 'Koala',
+						svg: 'koala.svg'
+					},
+					{
+						label: 'Marienkäfer',
+						svg: 'ladybird.svg'
+					},
+					{
+						label: 'Löwe',
+						svg: 'lion.svg'
+					},
+					{
+						label: 'Otter',
+						svg: 'otter.svg'
+					},
+					{
+						label: 'Papagei',
+						svg: 'parrot.svg'
+					},
+					{
+						label: 'Pinguin',
+						svg: 'penguin.svg'
+					},
+					{
+						label: 'Rabe',
+						svg: 'raven.svg'
+					},
+					{
+						label: 'Spatz',
+						svg: 'sparrow.svg'
+					},
+					{
+						label: 'Storch',
+						svg: 'stork.svg'
+					},
+					{
+						label: 'Schwan',
+						svg: 'swan.svg'
+					},
+					{
+						label: 'Wolf',
+						svg: 'wolf.svg'
 					}
 				]
 			}
@@ -596,6 +713,22 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Frog',
 						svg: 'frog.svg'
+					},
+					{
+						label: 'Bear',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Coral',
+						svg: 'coral.svg'
+					},
+					{
+						label: 'Crane',
+						svg: 'crane.svg'
+					},
+					{
+						label: 'Lion',
+						svg: 'lion.svg'
 					}
 				]
 			}
@@ -885,6 +1018,38 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Cheval',
 						svg: 'horse.svg'
+					},
+					{
+						label: 'Ours',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Papillon',
+						svg: 'butterfly.svg'
+					},
+					{
+						label: 'Poisson',
+						svg: 'fish.svg'
+					},
+					{
+						label: 'Cobaye',
+						svg: 'guinea-pig.svg'
+					},
+					{
+						label: 'Lion',
+						svg: 'lion.svg'
+					},
+					{
+						label: 'Pingouin',
+						svg: 'penguin.svg'
+					},
+					{
+						label: 'Lapin',
+						svg: 'rabbit.svg'
+					},
+					{
+						label: 'Écureuil',
+						svg: 'squirrel.svg'
 					}
 				]
 			},
@@ -1002,6 +1167,10 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Grenouille',
 						svg: 'frog.svg'
+					},
+					{
+						label: 'Grue',
+						svg: 'crane.svg'
 					}
 				]
 			}
@@ -1253,6 +1422,34 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Ruiseñor',
 						svg: 'Nightingale.svg'
+					},
+					{
+						label: 'Antílope',
+						svg: 'antelope.svg'
+					},
+					{
+						label: 'Oso',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Halcón',
+						svg: 'hawk.svg'
+					},
+					{
+						label: 'León',
+						svg: 'lion.svg'
+					},
+					{
+						label: 'Ratón',
+						svg: 'mouse.svg'
+					},
+					{
+						label: 'Caballito de mar',
+						svg: 'seahorse.svg'
+					},
+					{
+						label: 'Gorrión',
+						svg: 'sparrow.svg'
 					}
 				]
 			},
@@ -1378,6 +1575,14 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Corala',
 						svg: 'coral.svg'
+					},
+					{
+						label: 'Grulla',
+						svg: 'crane.svg'
+					},
+					{
+						label: 'Águila',
+						svg: 'eagle.svg'
 					}
 				]
 			}
@@ -1576,6 +1781,30 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Божья коровка',
 						svg: 'ladybird.svg'
+					},
+					{
+						label: 'Собака',
+						svg: 'dog.svg'
+					},
+					{
+						label: 'Утка',
+						svg: 'duck.svg'
+					},
+					{
+						label: 'Рыба',
+						svg: 'fish.svg'
+					},
+					{
+						label: 'Лиса',
+						svg: 'fox.svg'
+					},
+					{
+						label: 'Морская свинка',
+						svg: 'guinea-pig.svg'
+					},
+					{
+						label: 'Панда',
+						svg: 'panda.svg'
 					}
 				]
 			},
@@ -1680,6 +1909,78 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Жаворонок',
 						svg: 'lark.svg'
+					},
+					{
+						label: 'Соловей',
+						svg: 'Nightingale.svg'
+					},
+					{
+						label: 'Муравей',
+						svg: 'ant.svg'
+					},
+					{
+						label: 'Медведь',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Коралл',
+						svg: 'coral.svg'
+					},
+					{
+						label: 'Журавль',
+						svg: 'crane.svg'
+					},
+					{
+						label: 'Орёл',
+						svg: 'eagle.svg'
+					},
+					{
+						label: 'Светлячок',
+						svg: 'firefly.svg'
+					},
+					{
+						label: 'Заяц',
+						svg: 'hare.svg'
+					},
+					{
+						label: 'Ястреб',
+						svg: 'hawk.svg'
+					},
+					{
+						label: 'Колибри',
+						svg: 'hummingbird.svg'
+					},
+					{
+						label: 'Кенгуру',
+						svg: 'kangaroo.svg'
+					},
+					{
+						label: 'Ягнёнок',
+						svg: 'lamb.svg'
+					},
+					{
+						label: 'Лев',
+						svg: 'lion.svg'
+					},
+					{
+						label: 'Ворон',
+						svg: 'raven.svg'
+					},
+					{
+						label: 'Морской конёк',
+						svg: 'seahorse.svg'
+					},
+					{
+						label: 'Воробей',
+						svg: 'sparrow.svg'
+					},
+					{
+						label: 'Лебедь',
+						svg: 'swan.svg'
+					},
+					{
+						label: 'Волк',
+						svg: 'wolf.svg'
 					}
 				]
 			}
@@ -1867,6 +2168,30 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Корівка',
 						svg: 'ladybird.svg'
+					},
+					{
+						label: 'Собака',
+						svg: 'dog.svg'
+					},
+					{
+						label: 'Качка',
+						svg: 'duck.svg'
+					},
+					{
+						label: 'Риба',
+						svg: 'fish.svg'
+					},
+					{
+						label: 'Лисиця',
+						svg: 'fox.svg'
+					},
+					{
+						label: 'Морська свинка',
+						svg: 'guinea-pig.svg'
+					},
+					{
+						label: 'Панда',
+						svg: 'panda.svg'
 					}
 				]
 			},
@@ -1983,6 +2308,66 @@ export const LANGUAGE_DATA: Record<string, NickLang> = {
 					{
 						label: 'Заєць',
 						svg: 'hare.svg'
+					},
+					{
+						label: 'Ведмідь',
+						svg: 'bear.svg'
+					},
+					{
+						label: 'Корал',
+						svg: 'coral.svg'
+					},
+					{
+						label: 'Журавель',
+						svg: 'crane.svg'
+					},
+					{
+						label: 'Орел',
+						svg: 'eagle.svg'
+					},
+					{
+						label: 'Світлячок',
+						svg: 'firefly.svg'
+					},
+					{
+						label: 'Яструб',
+						svg: 'hawk.svg'
+					},
+					{
+						label: 'Кенгуру',
+						svg: 'kangaroo.svg'
+					},
+					{
+						label: 'Ягня',
+						svg: 'lamb.svg'
+					},
+					{
+						label: 'Лев',
+						svg: 'lion.svg'
+					},
+					{
+						label: 'Цуценя',
+						svg: 'puppy.svg'
+					},
+					{
+						label: 'Ворон',
+						svg: 'raven.svg'
+					},
+					{
+						label: 'Морський коник',
+						svg: 'seahorse.svg'
+					},
+					{
+						label: 'Горобець',
+						svg: 'sparrow.svg'
+					},
+					{
+						label: 'Лебідь',
+						svg: 'swan.svg'
+					},
+					{
+						label: 'Вовк',
+						svg: 'wolf.svg'
 					}
 				]
 			}

--- a/src/utils/anonName/engine.test.ts
+++ b/src/utils/anonName/engine.test.ts
@@ -34,6 +34,22 @@ describe('anonymous name engine', () => {
 		);
 	});
 
+	it('exposes the structured animal + name parts of the display name', () => {
+		vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+			const values = array as Uint32Array;
+			values.fill(0);
+			return array;
+		});
+
+		const de = LANGUAGE_DATA.de;
+		const pseudonym = generatePseudonym('de');
+
+		expect(pseudonym.animalLabel).toBe(de.groups[0].animals[0].label);
+		expect(pseudonym.name).toBe(de.names[0]);
+		expect(pseudonym.displayName).toContain(pseudonym.animalLabel);
+		expect(pseudonym.displayName).toContain(pseudonym.name);
+	});
+
 	it('uses crypto randomness for generated passwords', () => {
 		const getRandomValues = vi
 			.spyOn(crypto, 'getRandomValues')

--- a/src/utils/anonName/engine.test.ts
+++ b/src/utils/anonName/engine.test.ts
@@ -2,9 +2,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LANGUAGE_DATA } from './data';
 import {
+	contrastRatio,
 	generateAvatarForUser,
 	generatePassword,
-	generatePseudonym
+	generatePseudonym,
+	iconCandidates
 } from './engine';
 import { allPasswordCriteriaPass } from '../../components/registration/accountData/passwordRules';
 
@@ -84,6 +86,27 @@ describe('anonymous name engine', () => {
 		expect(other).not.toEqual(first);
 		expect(first.file).toBeTruthy();
 		expect(first.bg).toMatch(/^#[0-9A-Fa-f]{6}$/);
-		expect(['#ffffff', '#1a1a1a']).toContain(first.iconColor);
+		// Icon colour may now be black/white OR a complementary palette colour,
+		// but must always be a valid hex from the candidate pool.
+		expect(first.iconColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+		expect(iconCandidates(first.bg)).toContain(first.iconColor);
+	});
+
+	it('every icon candidate stays legible and keeps black/white in the pool', () => {
+		for (let i = 0; i < 40; i++) {
+			const { bg, iconColor } = generateAvatarForUser(`user-${i}`);
+			const candidates = iconCandidates(bg);
+			expect(candidates.length).toBeGreaterThan(0);
+			// all candidates meet the WCAG floor
+			candidates.forEach((c) =>
+				expect(contrastRatio(bg, c)).toBeGreaterThanOrEqual(4.5)
+			);
+			// the classic high-contrast black/white is still offered
+			expect(
+				candidates.some((c) => c === '#1a1a1a' || c === '#ffffff')
+			).toBe(true);
+			// the chosen colour is legible
+			expect(contrastRatio(bg, iconColor)).toBeGreaterThanOrEqual(4.5);
+		}
 	});
 });

--- a/src/utils/anonName/engine.ts
+++ b/src/utils/anonName/engine.ts
@@ -12,44 +12,67 @@
 
 import { LANGUAGE_DATA, type NickLang } from './data';
 
-// The widget's 35-colour pastel palette (24 light + 11 dark). One random pick
-// per generation; the animal is recoloured to contrast it.
-const PASTEL_COLORS = [
-	'#FFB3BA',
-	'#FFDFBA',
-	'#FFFFBA',
-	'#BAFFC9',
-	'#BAE1FF',
-	'#E8BAFF',
-	'#FFC9DE',
-	'#C9FFE5',
-	'#D4C9FF',
-	'#FFE4C9',
-	'#B5EAD7',
-	'#C7CEEA',
-	'#FFDAC1',
-	'#FF9AA2',
-	'#F0E6EF',
-	'#D5AAFF',
-	'#85E3FF',
-	'#BFFCC6',
-	'#DBCDF0',
-	'#F2C6DE',
-	'#A0CED9',
-	'#FFC6FF',
-	'#CAFFBF',
-	'#9BF6FF',
-	'#FFD6A5',
-	'#2D4A3E',
-	'#4A2D3E',
-	'#2D3E4A',
-	'#5C3A21',
-	'#3E2D4A',
-	'#1B3A4B',
-	'#4B1B3A',
-	'#3A4B1B',
-	'#6B3FA0',
-	'#A03F6B'
+// Curated 52-colour avatar palette drawn from traditional Japanese (和色) and
+// British/English heritage colours, spanning light AND deep-dark tones for
+// variety. Every colour is vetted so that either near-black (#1a1a1a) or white
+// reaches a WCAG contrast ratio ≥ 4.5 against it (see pickIconColor); muddy
+// mid-tones where neither is crisp were deliberately excluded. One random pick
+// per generation; the animal is recoloured to contrast the background.
+const AVATAR_COLORS = [
+	// --- Light (pairs with a near-black animal) ---
+	'#FCE7E6', // JP Sakura
+	'#F6BFBC', // JP Toki
+	'#EEBBCB', // JP Nadeshiko
+	'#F0908D', // JP Usubeni
+	'#FCE2C4', // JP Tamago
+	'#EAD56B', // JP Kariyasu
+	'#D6E9CA', // JP Byakuroku
+	'#D8E698', // JP Wakana
+	'#EBF6F7', // JP Aijiro
+	'#BBBCDE', // JP Fuji
+	'#BCE2E8', // JP Mizu
+	'#FABF14', // JP Ukon
+	'#A3C1AD', // UK Cambridge Blue
+	'#B0E0E6', // UK Powder Blue
+	'#96C8A2', // UK Eton Blue
+	'#B2AC88', // UK Sage
+	'#F0DC82', // UK Buff
+	'#F6DE9B', // UK Primrose
+	'#F7CAC9', // UK Rose Quartz
+	'#C6D3E3', // UK Wedgwood
+	'#C9E4DE', // UK Duck Egg
+	'#C3B1D0', // UK Heather
+	// --- Dark (pairs with a white animal) ---
+	'#165E83', // JP Ai (indigo)
+	'#223A70', // JP Kon
+	'#1E50A2', // JP Ruri
+	'#19448E', // JP Rurikon
+	'#4C6CB3', // JP Gunjo
+	'#007B43', // JP Tokiwa (green)
+	'#B7282E', // JP Akane
+	'#C9171E', // JP Kurenai
+	'#6C2C2F', // JP Ebicha
+	'#745399', // JP Edomurasaki
+	'#5E4491', // JP Sumire
+	'#4F284B', // JP Murasaki
+	'#1D697C', // JP Nando
+	'#2C4F54', // JP Onando
+	'#181B39', // JP Kachi
+	'#A22041', // JP Botan
+	'#211915', // JP Kurotsurubami
+	'#004225', // UK British Racing Green
+	'#002147', // UK Oxford Blue
+	'#003153', // UK Prussian Blue
+	'#7F1734', // UK Claret
+	'#800020', // UK Burgundy
+	'#355E3B', // UK Hunter Green
+	'#005F6A', // UK Teal
+	'#1B1F3B', // UK Navy
+	'#472D47', // UK Aubergine
+	'#4B2E44', // UK Damson
+	'#48586A', // UK Slate
+	'#5C2A4B', // UK Mulberry
+	'#093824' // UK Bottle Green
 ];
 
 const secureRandomInt = (maxExclusive: number): number => {
@@ -82,13 +105,37 @@ const secureRandomInt = (maxExclusive: number): number => {
 
 const pick = <T>(arr: T[]): T => arr[secureRandomInt(arr.length)];
 
-/** Perceived luminance (0–1) of a #rrggbb colour (same weights as the widget). */
+/** WCAG relative luminance (0–1) of a #rrggbb colour (gamma-correct sRGB). */
 export function luminance(hex: string): number {
 	const n = parseInt(hex.slice(1), 16);
-	const r = (n >> 16) & 255;
-	const g = (n >> 8) & 255;
-	const b = n & 255;
-	return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+	const channel = (c: number) => {
+		const s = c / 255;
+		return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+	};
+	const r = channel((n >> 16) & 255);
+	const g = channel((n >> 8) & 255);
+	const b = channel(n & 255);
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG contrast ratio (1–21) between two relative luminances. */
+function contrastRatio(l1: number, l2: number): number {
+	const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+const ICON_DARK = '#1a1a1a';
+const ICON_LIGHT = '#ffffff';
+const L_ICON_DARK = luminance(ICON_DARK);
+const L_ICON_LIGHT = luminance(ICON_LIGHT);
+
+/** Pick the animal colour (near-black or white) that maximises WCAG contrast
+ *  against the given background — legible on any palette entry. */
+export function pickIconColor(bg: string): string {
+	const l = luminance(bg);
+	return contrastRatio(l, L_ICON_DARK) >= contrastRatio(l, L_ICON_LIGHT)
+		? ICON_DARK
+		: ICON_LIGHT;
 }
 
 export interface Avatar {
@@ -104,6 +151,11 @@ export interface Pseudonym {
 	/** Display name, e.g. "freundliche Katze Mika" (never the identity/User-ID). */
 	displayName: string;
 	avatar: Avatar;
+	/** Animal label of the display name, e.g. "Katze". Used to build a short
+	 *  login username (animal + name, without the adjective). */
+	animalLabel: string;
+	/** Given name of the display name, e.g. "Mika". */
+	name: string;
 }
 
 /** Languages the engine ships (others should fall back to one of these). */
@@ -120,8 +172,8 @@ const dataFor = (lang: string): NickLang => {
 };
 
 const avatarFor = (file: string): Avatar => {
-	const bg = pick(PASTEL_COLORS);
-	return { file, bg, iconColor: luminance(bg) < 0.5 ? '#ffffff' : '#1a1a1a' };
+	const bg = pick(AVATAR_COLORS);
+	return { file, bg, iconColor: pickIconColor(bg) };
 };
 
 /** A display-name pseudonym + its matching avatar, in the given language. */
@@ -133,7 +185,9 @@ export function generatePseudonym(lang = 'de'): Pseudonym {
 	const name = pick(data.names);
 	return {
 		displayName: `${adjective} ${animal.label} ${name}`,
-		avatar: avatarFor(animal.svg)
+		avatar: avatarFor(animal.svg),
+		animalLabel: animal.label,
+		name
 	};
 }
 
@@ -175,8 +229,8 @@ function hashUserId(userId: string): number {
 /** Deterministic avatar derived from a stable user identifier. */
 export function generateAvatarForUser(userId: string): Avatar {
 	const absHash = hashUserId(userId);
-	const bg = PASTEL_COLORS[absHash % PASTEL_COLORS.length];
-	const iconColor = luminance(bg) < 0.5 ? '#ffffff' : '#1a1a1a';
+	const bg = AVATAR_COLORS[absHash % AVATAR_COLORS.length];
+	const iconColor = pickIconColor(bg);
 	const animalFile =
 		ALL_ANIMAL_FILES[absHash % ALL_ANIMAL_FILES.length] ??
 		ALL_ANIMAL_FILES[0];

--- a/src/utils/anonName/engine.ts
+++ b/src/utils/anonName/engine.ts
@@ -118,24 +118,80 @@ export function luminance(hex: string): number {
 	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-/** WCAG contrast ratio (1–21) between two relative luminances. */
-function contrastRatio(l1: number, l2: number): number {
-	const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+/** WCAG contrast ratio (1–21) between two colours (given as #rrggbb). */
+export function contrastRatio(a: string, b: string): number {
+	const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
 	return (hi + 0.05) / (lo + 0.05);
 }
 
 const ICON_DARK = '#1a1a1a';
 const ICON_LIGHT = '#ffffff';
-const L_ICON_DARK = luminance(ICON_DARK);
-const L_ICON_LIGHT = luminance(ICON_LIGHT);
+
+/** Minimum WCAG contrast an animal colour must reach against its background so
+ *  the silhouette stays clearly legible. */
+const MIN_ICON_CONTRAST = 4.5;
+
+/** How many complementary palette colours to offer per background (the most
+ *  hue-distant, contrast-passing ones). Black + white are always added on top,
+ *  so they stay part of the mix. */
+const COMPLEMENTARY_ICON_LIMIT = 6;
+
+/** Hue angle (0–360) of a #rrggbb colour. */
+function hueOf(hex: string): number {
+	const n = parseInt(hex.slice(1), 16);
+	const r = ((n >> 16) & 255) / 255;
+	const g = ((n >> 8) & 255) / 255;
+	const b = (n & 255) / 255;
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const d = max - min;
+	if (d === 0) return 0;
+	let h: number;
+	if (max === r) h = ((g - b) / d) % 6;
+	else if (max === g) h = (b - r) / d + 2;
+	else h = (r - g) / d + 4;
+	h *= 60;
+	return h < 0 ? h + 360 : h;
+}
+
+/** Shortest angular distance (0–180) between two hues. */
+function hueDistance(a: number, b: number): number {
+	const d = Math.abs(a - b) % 360;
+	return d > 180 ? 360 - d : d;
+}
+
+const PALETTE_META = AVATAR_COLORS.map((hex) => ({ hex, hue: hueOf(hex) }));
 
 /** Pick the animal colour (near-black or white) that maximises WCAG contrast
  *  against the given background — legible on any palette entry. */
 export function pickIconColor(bg: string): string {
-	const l = luminance(bg);
-	return contrastRatio(l, L_ICON_DARK) >= contrastRatio(l, L_ICON_LIGHT)
+	return contrastRatio(bg, ICON_DARK) >= contrastRatio(bg, ICON_LIGHT)
 		? ICON_DARK
 		: ICON_LIGHT;
+}
+
+/**
+ * All animal-colour options that stay legible on `bg` (WCAG ≥ 4.5): the
+ * black/white that pass, PLUS the most hue-distant ("complementary") colours
+ * from the same curated palette. Black/white remain in the pool so the classic
+ * high-contrast look still appears. Always returns at least one entry.
+ */
+export function iconCandidates(bg: string): string[] {
+	const bw = [ICON_DARK, ICON_LIGHT].filter(
+		(c) => contrastRatio(bg, c) >= MIN_ICON_CONTRAST
+	);
+	const bgHue = hueOf(bg);
+	const complementary = PALETTE_META.filter(
+		(p) => p.hex.toLowerCase() !== bg.toLowerCase()
+	)
+		.map((p) => ({ hex: p.hex, dist: hueDistance(bgHue, p.hue) }))
+		.filter((p) => contrastRatio(bg, p.hex) >= MIN_ICON_CONTRAST)
+		.sort((x, y) => y.dist - x.dist)
+		.slice(0, COMPLEMENTARY_ICON_LIMIT)
+		.map((p) => p.hex);
+
+	const pool = [...bw, ...complementary];
+	return pool.length > 0 ? pool : [pickIconColor(bg)];
 }
 
 export interface Avatar {
@@ -173,7 +229,7 @@ const dataFor = (lang: string): NickLang => {
 
 const avatarFor = (file: string): Avatar => {
 	const bg = pick(AVATAR_COLORS);
-	return { file, bg, iconColor: pickIconColor(bg) };
+	return { file, bg, iconColor: pick(iconCandidates(bg)) };
 };
 
 /** A display-name pseudonym + its matching avatar, in the given language. */
@@ -230,7 +286,11 @@ function hashUserId(userId: string): number {
 export function generateAvatarForUser(userId: string): Avatar {
 	const absHash = hashUserId(userId);
 	const bg = AVATAR_COLORS[absHash % AVATAR_COLORS.length];
-	const iconColor = pickIconColor(bg);
+	// Deterministic icon colour from the same candidate pool as the random path
+	// (a shifted hash slice so it doesn't track the bg index).
+	const candidates = iconCandidates(bg);
+	const iconColor =
+		candidates[Math.floor(absHash / AVATAR_COLORS.length) % candidates.length];
 	const animalFile =
 		ALL_ANIMAL_FILES[absHash % ALL_ANIMAL_FILES.length] ??
 		ALL_ANIMAL_FILES[0];


### PR DESCRIPTION
## Why
Registration on the account-data step failed with **HTTP 400** ("Username is invalid"). The generated login username could exceed the backend limit `UserHelper.USERNAME_MAX_LENGTH = 30`: the frontend capped the slug at 48 and enforced **no** max length, so the request was sent and rejected by `UserRegistrationControllerDelegate.registerUser` (controller has NO `@Valid`).

## What
- **Username ≤ 30, adjective dropped.** Build the login username from `animal + name` only (e.g. `katze_mika_1234`), hard-capped at 30, built from the structured pseudonym parts (handles multi-word animals like "Guinea Pig"). Extracted into `registrationUsername.ts` with unit tests covering all languages, the 30-char bound, multi-word animals and legacy drafts.
- **Frontend max-length validation** added (`registrationDataValidation`), shared `USERNAME_MIN/MAX_LENGTH` constants kept in sync with the backend.
- **Live chat uses the same structure.** `AnonymousChat` now derives its username + password from the shared anon-name engine instead of the non-anonymous `Anonymous-<timestamp>` handle.
- **All 6 languages now offer every animal (62 SVGs)** for more variation; animals grouped by grammatical gender so `displayName` agreement stays correct.
- **New avatar palette:** 52 curated traditional Japanese (和色) + British heritage colours, balanced light/dark, each vetted for a **WCAG contrast ratio ≥ 4.5** with a proper contrast-based icon-colour pick (replaces the naive `luminance < 0.5` threshold).
- **Complementary-colour animals.** The animal is no longer only black/white: `iconCandidates(bg)` offers the passing black/white **plus** the most hue-distant palette colours that still clear WCAG ≥ 4.5, and one is chosen at random (deterministically for chat avatars). Black/white stay in the pool, so the classic high-contrast look still appears — this just adds variation.

## Tests
`npm run test:unit` — green across engine / username / validation; every icon candidate is asserted to meet the 4.5 contrast floor and to keep black/white in the pool. `tsc` + `eslint` clean for touched files.

## Notes / follow-ups (not in this PR)
- **ru/uk Cyrillic labels are best-effort** and should be sanity-checked by a native speaker (labels + gender grouping).
- For **ru/uk the username variation is unchanged** — Cyrillic animal labels slug to empty, so the username stays `name_<n>`. A transliteration step could fix that separately.
- The animal SVGs return **404 on dev.oriso.org** because that deployed build predates the assets (they are in-repo since 2026-06-26). Needs a **redeploy**, not a code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anonymous accounts now receive consistent, localized pseudonyms and generated credentials.
  - Anonymous profiles display animal-based avatars with improved color contrast and accessibility.
  - Expanded animal options are available across German, English, French, Spanish, Russian, and Ukrainian locales.
  - Registration usernames are automatically generated in a consistent, valid format.

- **Bug Fixes**
  - Username validation now correctly enforces supported characters and length limits.
  - Improved handling of long, multi-word, accented, and legacy pseudonyms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->