### PR TITLE
fix(group-chat): declutter scheduled waiting area to fit the room container

### DIFF
--- a/src/components/groupChat/JoinGroupChatView.tsx
+++ b/src/components/groupChat/JoinGroupChatView.tsx
@@ -328,10 +328,16 @@ export const JoinGroupChatView = ({
 				bannedUsers={bannedUsers}
 			/>
 			<div className="joinChat__content session__content">
-				<Headline
-					text={translate('groupChat.join.content.headline')}
-					semanticLevel="4"
-				/>
+				{/* The scheduled-chat countdown carries its own headline
+				    ("Dein Gruppen-Chat beginnt in …"); a second static heading
+				    above it just repeats the frame. Only show the standalone
+				    "Spielregeln"-headline in the no-countdown (hint message) view. */}
+				{!plannedStart && (
+					<Headline
+						text={translate('groupChat.join.content.headline')}
+						semanticLevel="4"
+					/>
+				)}
 				{!!authorContent.hintMessage && !plannedStart && (
 					<Text text={authorContent.hintMessage} type="standard" />
 				)}

--- a/src/components/groupChat/joinChat.styles.scss
+++ b/src/components/groupChat/joinChat.styles.scss
@@ -42,15 +42,14 @@
 		}
 	}
 
-	// The ORISO Design waiting box (variant 4a/4b): the white card that hosts
-	// the clock-made-of-clocks countdown (WaitingAreaCountdown).
+	// The ORISO Design waiting box (variant 4a/4b) hosts the clock-made-of-clocks
+	// countdown (WaitingAreaCountdown). It is a transparent spacing wrapper only —
+	// the surrounding room container already supplies the white surface and the
+	// #ffb4aa outline, so drawing our own card here would double the frame.
 	&__waitingBox {
 		width: min(100%, $grid-base * 96);
 		margin: $grid-base-two 0;
-		padding: $grid-base-four $grid-base-four $grid-base-two;
-		background: var(--m3-surface-container-lowest, #fff);
-		border: 1px solid var(--m3-primary-fixed-dim, #ffb4aa);
-		border-radius: 20px;
+		padding: $grid-base-two 0;
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
## Problem

The scheduled group-chat waiting view (`JoinGroupChatView`, ORISO Design 4a/4b) added two things on top of the `WaitingAreaCountdown` that duplicated the frame it already lives in:

1. **A redundant card wrapper** — `.joinChat__waitingBox` drew its own white surface + `#ffb4aa` outline + `border-radius`. The surrounding room container (`session.styles.scss`) already provides exactly that white + salmon frame, so the countdown ended up double-boxed.
2. **A second static headline** — a standalone `"Spielregeln" des Chats` heading sat above the countdown, which already renders its own headline (`Dein Gruppen-Chat beginnt in …`). In the countdown state it just repeated the frame.

Reference: Figma `App.Oriso` node `8509-27745` (Chat Room Desktop) — the room panel is a single white `#ffb4aa`-outlined `rounded-32` container; the waiting content should sit inside it without its own card.

## Change

- `joinChat.styles.scss` → `.joinChat__waitingBox`: drop `background` / `border` / `border-radius`; keep it as a transparent spacing wrapper so the countdown sits directly in the room surface.
- `JoinGroupChatView.tsx`: render the standalone headline **only** in the no-countdown (hint-message) view (`!plannedStart`).

**The clock-of-clocks countdown and its animation are untouched** — no changes to `WaitingAreaCountdown`.

## Verification

Verified live in Storybook (`GroupChat/JoinGroupChatView` → *Waiting Future* and *Waiting Overdue*): the extra heading and the double frame are gone; the animated clock, flip cards, add-to-calendar, overdue count-up and netiquette rules all render unchanged. No unit tests reference the removed heading/box.

## Scope

2 files, additive/subtractive CSS + one conditional render. No API, i18n key, or component-contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)