### PR TITLE
Fix consultant acceptance gaps for chat and language

### DIFF
--- a/src/components/app/acceptanceLayout.styles.test.ts
+++ b/src/components/app/acceptanceLayout.styles.test.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const navigationStyles = () =>
+	fs.readFileSync(
+		path.join(process.cwd(), 'src/components/app/navigation.styles.scss'),
+		'utf8'
+	);
+
+describe('mobile navigation acceptance layout', () => {
+	it('keeps language pinned immediately left of sticky logout', () => {
+		const scss = navigationStyles();
+		const mobileBlock = scss.slice(
+			scss.indexOf('@media screen and (width < 900px)')
+		);
+
+		expect(mobileBlock).toContain('.navigation__item--nav-language');
+		expect(mobileBlock).toMatch(
+			/\.navigation__item--nav-language\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?right:\s*72px;/
+		);
+		expect(mobileBlock).toMatch(
+			/\.navigation__item--nav-logout\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?right:\s*0;/
+		);
+	});
+});

--- a/src/components/app/navigation.styles.scss
+++ b/src/components/app/navigation.styles.scss
@@ -1014,6 +1014,13 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 			display: flex !important;
 		}
 
+		.navigation__item--nav-language {
+			position: sticky;
+			right: 72px;
+			z-index: 2;
+			background: var(--oriso-nav-bar-background, #f0edee) !important;
+		}
+
 		.navigation__item--nav-logout {
 			position: sticky;
 			right: 0;
@@ -1035,11 +1042,16 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 		}
 
 		.navigation__item,
-		.navigation__item--nav-logout {
+		.navigation__item--nav-logout,
+		.navigation__item--nav-language {
 			flex-basis: 80px;
 			width: 80px;
 			min-width: 80px;
 			max-width: 80px;
+		}
+
+		.navigation__item--nav-language {
+			right: 80px;
 		}
 	}
 

--- a/src/components/sessionsList/ResizableHandle.test.ts
+++ b/src/components/sessionsList/ResizableHandle.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getToggledSidebarWidth } from './ResizableHandle';
+
+describe('session-list collapse control', () => {
+	it('collapses an expanded list to the compact rail', () => {
+		expect(getToggledSidebarWidth(420, 80, 397)).toBe(80);
+	});
+
+	it('restores the complete expanded minimum instead of a truncated width', () => {
+		expect(getToggledSidebarWidth(80, 80, 397)).toBe(397);
+	});
+});

--- a/src/components/sessionsList/ResizableHandle.tsx
+++ b/src/components/sessionsList/ResizableHandle.tsx
@@ -12,6 +12,12 @@ interface ResizableHandleProps {
 	maxWidth?: number;
 }
 
+export const getToggledSidebarWidth = (
+	currentWidth: number,
+	minWidth: number,
+	expandedMinWidth: number
+) => (currentWidth <= minWidth + 1 ? expandedMinWidth : minWidth);
+
 export const ResizableHandle: React.FC<ResizableHandleProps> = ({
 	onResize,
 	currentWidth,
@@ -177,10 +183,15 @@ export const ResizableHandle: React.FC<ResizableHandleProps> = ({
 	);
 
 	const toggleCollapsed = useCallback(() => {
-		const next =
-			currentWidth <= minWidth + 1 ? ICON_ONLY_THRESHOLD : minWidth;
+		const next = getToggledSidebarWidth(
+			currentWidth,
+			minWidth,
+			EXPANDED_MIN_WIDTH
+		);
 		onResize(normalizeWidth(next));
-	}, [ICON_ONLY_THRESHOLD, currentWidth, minWidth, normalizeWidth, onResize]);
+	}, [EXPANDED_MIN_WIDTH, currentWidth, minWidth, normalizeWidth, onResize]);
+
+	const isCollapsed = currentWidth <= minWidth + 1;
 
 	const handlePointerUp = useCallback(() => {
 		pointerIdRef.current = null;
@@ -448,6 +459,26 @@ export const ResizableHandle: React.FC<ResizableHandleProps> = ({
 			}}
 		>
 			<span className="sessionsList__resizeHandlePill" />
+			<button
+				type="button"
+				className="sessionsList__resizeToggle"
+				aria-label={t(
+					isCollapsed
+						? 'sessionList.resizeHandle.expand'
+						: 'sessionList.resizeHandle.collapse',
+					isCollapsed
+						? 'Expand chat list'
+						: 'Collapse chat list to enlarge the chat room'
+				)}
+				onPointerDown={(event) => event.stopPropagation()}
+				onClick={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					toggleCollapsed();
+				}}
+			>
+				<span aria-hidden>{isCollapsed ? '›' : '‹'}</span>
+			</button>
 		</div>
 	);
 };

--- a/src/components/sessionsList/SessionsListToolbar.test.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.test.tsx
@@ -69,11 +69,23 @@ describe('SessionsListToolbar group-chat feature gate', () => {
 	it('shows Create when the tenant enables the feature', () => {
 		renderToolbar(true);
 
+		const createLink = screen.getByRole('link', {
+			name: 'sessionList.createChat.buttonTitle'
+		});
+
+		expect(createLink).toBeTruthy();
+		expect(createLink.classList).not.toContain(
+			'sessionsListToolbar__chip--iconOnly'
+		);
 		expect(
-			screen.getByRole('link', {
-				name: 'sessionList.createChat.buttonTitle'
-			})
-		).toBeTruthy();
+			createLink.querySelector('.sessionsListToolbar__chipLabel')
+				?.textContent
+		).toBe('Create');
+		expect(
+			createLink
+				.querySelector('.sessionsListToolbar__chipLabel')
+				?.hasAttribute('aria-hidden')
+		).toBe(false);
 	});
 
 	it('hides group filters when their tenant modules are disabled', () => {

--- a/src/components/sessionsList/SessionsListToolbar.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.tsx
@@ -628,8 +628,6 @@ export const SessionsListToolbar = ({
 					{showCreateGroupChatAction && (
 						<Link
 							className={clsx('sessionsListToolbar__chip', {
-								'sessionsListToolbar__chip--iconOnly':
-									!createGroupChatActive,
 								'sessionsListToolbar__chip--active':
 									createGroupChatActive
 							})}
@@ -643,10 +641,7 @@ export const SessionsListToolbar = ({
 							data-cy="sessions-list-chip-create"
 						>
 							<CreateChatFilterIcon className="sessionsListToolbar__chipIconSvg" />
-							<span
-								className="sessionsListToolbar__chipLabel"
-								aria-hidden={!createGroupChatActive}
-							>
+							<span className="sessionsListToolbar__chipLabel">
 								{tr(
 									'sessionList.toolbar.chips.create',
 									'Create'

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -406,6 +406,39 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		transition: box-shadow 140ms ease;
 	}
 
+	&__resizeToggle {
+		position: absolute;
+		right: -14px;
+		top: 18px;
+		z-index: 3;
+		width: 28px;
+		height: 28px;
+		padding: 0;
+		border: 1px solid var(--m3-outline-variant, #c9c5c7);
+		border-radius: 999px;
+		background: var(--m3-surface-container-highest, #e1dddf);
+		color: var(--m3-on-surface, #1d1b1c);
+		font-size: 22px;
+		line-height: 24px;
+		cursor: pointer;
+		display: none;
+		align-items: center;
+		justify-content: center;
+
+		@include breakpoint($fromLarge) {
+			display: flex;
+		}
+
+		&:hover {
+			background: var(--m3-secondary-container, #ffdad5);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--m3-primary, #a5000a);
+			outline-offset: 2px;
+		}
+	}
+
 	&__resizeHandle:hover &__resizeHandlePill {
 		box-shadow:
 			0 0 0 1px rgba(165, 0, 10, 0.22),


### PR DESCRIPTION
Closes #558\n\n## What\n- keeps the authorized create-chat action visibly labelled\n- adds an accessible collapse/expand button to the existing session-list resizer\n- pins the mobile language selector beside logout\n- adds focused regression coverage\n\n## Verification\n- 179 test files / 1,160 unit tests passed\n- ESLint + TypeScript passed\n- changed SCSS files passed Stylelint\n- production build passed\n- full Stylelint still has one pre-existing failure in messageSubmitInterface.styles.scss:1670