### PR TITLE
Resolve /media legal-text image URLs against the tenant origin

### DIFF
--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -10,7 +10,7 @@ import {
 
 export const apiUrl = getApiBaseUrl();
 const userServiceOrigin = getUserServiceOrigin(apiUrl);
-const tenantServiceOrigin = getTenantServiceOrigin(apiUrl);
+export const tenantServiceOrigin = getTenantServiceOrigin(apiUrl);
 const agencyServiceOrigin = getAgencyServiceOrigin(apiUrl);
 const consultingTypeServiceOrigin = getConsultingTypeServiceOrigin(apiUrl);
 const keycloakOrigin = getKeycloakOrigin(apiUrl);

--- a/src/resources/scripts/util/htmlParser.test.tsx
+++ b/src/resources/scripts/util/htmlParser.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// The media origin the parser resolves against (mirror the split-host prod case).
+vi.mock('../endpoints', () => ({
+	tenantServiceOrigin: 'https://api.oriso-dev.site'
+}));
+
+import htmlParser from './htmlParser';
+
+describe('htmlParser media rewrite', () => {
+	it('rewrites a root-relative /media img src to the tenant origin', () => {
+		const { container } = render(
+			<div>{htmlParser('<p>Impressum</p><img src="/media/abc-1">')}</div>
+		);
+		const img = container.querySelector('img');
+		expect(img?.getAttribute('src')).toBe(
+			'https://api.oriso-dev.site/media/abc-1'
+		);
+	});
+
+	it('leaves absolute and non-media srcs untouched, still strips class="remove"', () => {
+		const { container } = render(
+			<div>
+				{htmlParser(
+					'<img src="https://cdn/x.png"><span class="remove">x</span><b>keep</b>'
+				)}
+			</div>
+		);
+		expect(container.querySelector('img')?.getAttribute('src')).toBe(
+			'https://cdn/x.png'
+		);
+		expect(container.querySelector('span.remove')).toBeNull();
+		expect(container.querySelector('b')?.textContent).toBe('keep');
+	});
+});

--- a/src/resources/scripts/util/htmlParser.test.tsx
+++ b/src/resources/scripts/util/htmlParser.test.tsx
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import htmlParser from './htmlParser';
 
 // The media origin the parser resolves against (mirror the split-host prod case).
+// vitest hoists vi.mock above the htmlParser import at runtime.
 vi.mock('../endpoints', () => ({
 	tenantServiceOrigin: 'https://api.oriso-dev.site'
 }));
-
-import htmlParser from './htmlParser';
 
 describe('htmlParser media rewrite', () => {
 	it('rewrites a root-relative /media img src to the tenant origin', () => {

--- a/src/resources/scripts/util/htmlParser.tsx
+++ b/src/resources/scripts/util/htmlParser.tsx
@@ -1,15 +1,35 @@
-import parse, { Element } from 'html-react-parser';
+import parse, { DOMNode, Element } from 'html-react-parser';
 import React from 'react';
+import { tenantServiceOrigin } from '../endpoints';
+import { resolveTenantMediaUrl } from '../../../utils/resolveTenantMediaUrl';
 
+// Structural tag check — more robust than `instanceof Element`, which can fail
+// when html-react-parser is loaded as more than one module instance.
+const isTag = (node: DOMNode): node is Element =>
+	(node as Element).type === 'tag' &&
+	typeof (node as Element).attribs === 'object';
+
+// Legal/tenant rich-text (imprint/privacy/DPP) is authored in the Admin editor
+// and may embed <img src="/media/{id}"> (WP-3a/3b). Rendered on the frontend
+// origin, that root-relative path would not reach the TenantService in a split
+// api/app host topology — so rewrite it to the tenant origin here, the single
+// choke point every legal HTML string passes through.
 const htmlParser = (input: string) =>
 	parse(input, {
 		replace: (domNode) => {
-			if (
-				domNode instanceof Element &&
-				domNode.attribs.class === 'remove'
-			) {
+			if (!isTag(domNode)) {
+				return undefined;
+			}
+			if (domNode.attribs.class === 'remove') {
 				return <></>;
 			}
+			if (domNode.name === 'img' && domNode.attribs.src) {
+				domNode.attribs.src = resolveTenantMediaUrl(
+					domNode.attribs.src,
+					tenantServiceOrigin
+				) as string;
+			}
+			return undefined;
 		}
 	});
 

--- a/src/utils/resolveTenantMediaUrl.test.ts
+++ b/src/utils/resolveTenantMediaUrl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTenantMediaUrl } from './resolveTenantMediaUrl';
+
+const ORIGIN = 'https://api.oriso-dev.site';
+
+describe('resolveTenantMediaUrl', () => {
+	it('prefixes a root-relative /media path with the tenant origin', () => {
+		expect(resolveTenantMediaUrl('/media/abc-123', ORIGIN)).toBe(
+			'https://api.oriso-dev.site/media/abc-123'
+		);
+	});
+
+	it('strips a trailing slash on the origin so the result has one slash', () => {
+		expect(resolveTenantMediaUrl('/media/x', 'https://api.test/')).toBe(
+			'https://api.test/media/x'
+		);
+	});
+
+	it('leaves the path relative when the origin is empty (dev proxy)', () => {
+		expect(resolveTenantMediaUrl('/media/x', '')).toBe('/media/x');
+	});
+
+	it('never touches absolute, data, blob or non-media sources', () => {
+		expect(resolveTenantMediaUrl('https://cdn/x.png', ORIGIN)).toBe(
+			'https://cdn/x.png'
+		);
+		expect(
+			resolveTenantMediaUrl('data:image/png;base64,AAAA', ORIGIN)
+		).toBe('data:image/png;base64,AAAA');
+		expect(resolveTenantMediaUrl('/static/logo.png', ORIGIN)).toBe(
+			'/static/logo.png'
+		);
+		// guards against a naive contains-check hijacking an unrelated path
+		expect(resolveTenantMediaUrl('/x/media/y', ORIGIN)).toBe('/x/media/y');
+	});
+
+	it('is safe on undefined src', () => {
+		expect(resolveTenantMediaUrl(undefined, ORIGIN)).toBeUndefined();
+	});
+});

--- a/src/utils/resolveTenantMediaUrl.ts
+++ b/src/utils/resolveTenantMediaUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolves a root-relative tenant media reference (`/media/{id}`, produced by
+ * the admin editor upload, WP-3a/3b) against the TenantService origin.
+ *
+ * Legal-text HTML (imprint/privacy/DPP) is authored in the Admin and rendered
+ * on the frontend origin, which — in a split api/app host topology — does not
+ * route `/media/{id}` to the TenantService. Rewriting the src to the tenant
+ * origin at render time makes the image load wherever the HTML is shown, while
+ * the stored HTML stays origin-independent (relative).
+ *
+ * Only bare `/media/...` paths are rewritten. Absolute URLs, data/blob URIs,
+ * and anything else pass through untouched. When the origin is empty (dev
+ * same-origin proxy) the path is left relative on purpose.
+ */
+export const resolveTenantMediaUrl = (
+	src: string | undefined,
+	tenantMediaOrigin: string
+): string | undefined => {
+	if (!src || !tenantMediaOrigin) {
+		return src;
+	}
+	if (!src.startsWith('/media/')) {
+		return src;
+	}
+	return `${tenantMediaOrigin.replace(/\/$/, '')}${src}`;
+};


### PR DESCRIPTION
## Problem
Legal texts (imprint/privacy/DPP) authored in the Admin editor may embed `<img src="/media/{id}">` (WP-3a/3b). They render on the **frontend** origin, which in the split api/app host topology does **not** route `/media/{id}` to the TenantService — so an anonymous imprint visitor gets the SPA `index.html` (200 HTML) instead of the image. Found via a read-only Pre-Dev probe (`app.oriso-dev.site/media/…` → text/html; the endpoint lives on the api host).

## What changed (render-time resolution — Frank's call)
- `resolveTenantMediaUrl(src, origin)`: prefixes only bare `/media/…` paths with the tenant origin; absolute/data/blob/other srcs and an empty (dev same-origin) base pass through unchanged
- `htmlParser` — the single choke point all legal HTML flows through (`LegalContentRenderer` + `LegalLinkModal`) — rewrites `/media` img srcs to `getTenantServiceOrigin()` (= `REACT_APP_API_URL`); stored HTML stays origin-independent
- hardened the tag check to a structural test instead of `instanceof Element` (which can silently no-op across module instances — it was also skipping the existing `class="remove"` strip in tests)

Admin editor preview gets the same treatment in a separate Admin PR.

## Verification
- `npm run test:unit` — 1164/1164 (7 new: resolver matrix + htmlParser rewrite/passthrough/strip)
- `tsc --noEmit`, ESLint zero-warnings, production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of tenant-scoped media images in rich content: root-relative `/media/...` URLs are now correctly rewritten to include the tenant origin.
  - Absolute URLs, `data:` URIs, and development proxy paths are preserved without modification.
  - Elements marked for removal are consistently omitted.

- **Tests**
  - Added new unit and HTML parsing test coverage for media URL rewriting, URL preservation, and parser-environment compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #601