### PR TITLE
Show DPA contract and transfer encrypted handover history

### DIFF
--- a/src/api/apiDpaSignature.test.ts
+++ b/src/api/apiDpaSignature.test.ts
@@ -1,14 +1,48 @@
 import { describe, expect, it, vi } from 'vitest';
-import { apiConfirmDpaSignature, DPA_SIGN_ERRORS } from './apiDpaSignature';
+import {
+	apiConfirmDpaSignature,
+	apiGetDpaSignPreview,
+	DPA_SIGN_ERRORS
+} from './apiDpaSignature';
 
 vi.mock('../resources/scripts/endpoints', () => ({
 	endpoints: {
 		dpaSignatureConfirm: (token: string) =>
+			`https://api.oriso-dev.site/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`,
+		dpaSignaturePreview: (token: string) =>
 			`https://api.oriso-dev.site/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`
 	}
 }));
 
 describe('apiConfirmDpaSignature', () => {
+	it('loads the exact contract preview before the signer can confirm', async () => {
+		const preview = {
+			tenantName: 'Träger Nord',
+			dpaVersion: '2026-07-20T12:30:00',
+			content: '{"de":"<p>Vertragstext</p>"}',
+			expiresAt: '2026-08-03T12:30:00'
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(preview), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(apiGetDpaSignPreview('signed token')).resolves.toEqual(
+			preview
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.oriso-dev.site/service/tenant/public/dpa/confirm/signed%20token',
+			{
+				method: 'GET',
+				headers: { Accept: 'application/json' },
+				credentials: 'include'
+			}
+		);
+	});
+
 	it('posts the public DPA signature payload to the token endpoint', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ status: 'SIGNED' }), {

--- a/src/api/apiDpaSignature.test.ts
+++ b/src/api/apiDpaSignature.test.ts
@@ -14,7 +14,7 @@ vi.mock('../resources/scripts/endpoints', () => ({
 	}
 }));
 
-describe('apiConfirmDpaSignature', () => {
+describe('apiGetDpaSignPreview', () => {
 	it('loads the exact contract preview before the signer can confirm', async () => {
 		const preview = {
 			tenantName: 'Träger Nord',
@@ -42,7 +42,9 @@ describe('apiConfirmDpaSignature', () => {
 			}
 		);
 	});
+});
 
+describe('apiConfirmDpaSignature', () => {
 	it('posts the public DPA signature payload to the token endpoint', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ status: 'SIGNED' }), {

--- a/src/api/apiDpaSignature.ts
+++ b/src/api/apiDpaSignature.ts
@@ -31,6 +31,33 @@ export interface DpaSignatureResponse {
 	signedAt?: string;
 }
 
+export interface DpaSignPreviewResponse {
+	tenantName: string;
+	dpaVersion: string;
+	content: string;
+	expiresAt: string;
+}
+
+export const apiGetDpaSignPreview = async (
+	token: string
+): Promise<DpaSignPreviewResponse> => {
+	const response = await fetch(endpoints.dpaSignaturePreview(token), {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+		credentials: 'include'
+	});
+
+	if (!response.ok) {
+		if (response.status === 404 || response.status === 410) {
+			throw new Error(DPA_SIGN_ERRORS.INVALID_OR_EXPIRED_TOKEN);
+		}
+
+		throw new Error(DPA_SIGN_ERRORS.FAILED);
+	}
+
+	return response.json();
+};
+
 export const apiConfirmDpaSignature = async (
 	token: string,
 	request: DpaSignatureRequest

--- a/src/components/conversationCreate/CreateConversationView.editmode.test.tsx
+++ b/src/components/conversationCreate/CreateConversationView.editmode.test.tsx
@@ -117,7 +117,10 @@ const editSeriesItem = {
 	sourceLanguage: 'de',
 	hintMessageTranslations: { de: 'Welcome' },
 	groupChatRulesTranslations: { de: ['Be kind'] },
-	participants: [{ consultantId: 'c-9' }],
+	participants: [
+		{ consultantId: 'me', role: 'OWNER' },
+		{ consultantId: 'c-9', role: 'CO_MODERATOR' }
+	],
 	assignedAgencies: [{ id: 5 }]
 };
 
@@ -218,6 +221,9 @@ describe('CreateConversationView edit mode (finding 1)', () => {
 		expect(apiUpdateGroupChat.mock.calls[0][1]).toMatchObject({
 			consultantIds: ['c-9', 'c-2']
 		});
+		expect(
+			screen.queryByText('me', { selector: '.personChip__name' })
+		).toBeNull();
 	});
 
 	it('shows a loading state until the series has hydrated', () => {

--- a/src/components/conversationCreate/CreateConversationView.tsx
+++ b/src/components/conversationCreate/CreateConversationView.tsx
@@ -137,14 +137,18 @@ const CreateConversationFlow = () => {
 				interval: draft.seriesFields.interval,
 				modality: draft.seriesFields.modality,
 				authorContent: draft.authorContent,
-				consultantIds: draft.consultantIds,
+				// The API returns the OWNER in the participant list as well. The
+				// co-moderator picker must never render or submit the current owner.
+				consultantIds: draft.consultantIds.filter(
+					(consultantId) => consultantId !== userData?.userId
+				),
 				agencyId: draft.agencyId
 			};
 		} catch {
 			// Invalid persisted start etc. — keep the form gated (no prefill).
 			return undefined;
 		}
-	}, [isEditMode, editSession]);
+	}, [isEditMode, editSession, userData?.userId]);
 
 	const [step, setStep] = useState<CreateStep>(() =>
 		isEditMode

--- a/src/components/dpaSign/DpaSign.test.tsx
+++ b/src/components/dpaSign/DpaSign.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiConfirmDpaSignature,
+	apiGetDpaSignPreview,
+	DPA_SIGN_ERRORS
+} from '../../api/apiDpaSignature';
+import { DpaSign } from './DpaSign';
+
+const translate = (_key: string, fallback?: string) => fallback ?? _key;
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: translate,
+		i18n: { language: 'de' }
+	})
+}));
+
+vi.mock('../../api/apiDpaSignature', () => ({
+	DPA_SIGN_ERRORS: {
+		INVALID_OR_EXPIRED_TOKEN: 'DPA_SIGN_INVALID_OR_EXPIRED_TOKEN',
+		INVALID_REQUEST: 'DPA_SIGN_INVALID_REQUEST',
+		FAILED: 'DPA_SIGN_FAILED'
+	},
+	apiGetDpaSignPreview: vi.fn(),
+	apiConfirmDpaSignature: vi.fn()
+}));
+
+const previewMock = vi.mocked(apiGetDpaSignPreview);
+const confirmMock = vi.mocked(apiConfirmDpaSignature);
+
+const renderPage = () =>
+	render(
+		<MemoryRouter initialEntries={['/dpa-sign/valid-token']}>
+			<Routes>
+				<Route path="/dpa-sign/:token" element={<DpaSign />} />
+			</Routes>
+		</MemoryRouter>
+	);
+
+describe('DpaSign', () => {
+	beforeEach(() => {
+		previewMock.mockResolvedValue({
+			tenantName: 'Träger Nord',
+			dpaVersion: '2026-07-20T12:30:00',
+			content:
+				'{"de":"<h2>Vereinbarung</h2><p>Dieser konkrete Vertragstext ist verbindlich.</p>","en":"<h2>Agreement</h2><p>This exact contract applies.</p>"}',
+			expiresAt: '2026-08-03T12:30:00'
+		});
+		confirmMock.mockResolvedValue({ status: 'SIGNED' });
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('shows the exact contract and version before the signer confirmation form', async () => {
+		renderPage();
+
+		expect(
+			await screen.findByText(
+				'Dieser konkrete Vertragstext ist verbindlich.'
+			)
+		).toBeDefined();
+		expect(screen.getByText('Träger Nord')).toBeDefined();
+		expect(
+			screen.getByRole('heading', {
+				name: 'Auftragsverarbeitungsvereinbarung'
+			})
+		).toBeDefined();
+		expect(
+			screen.getByRole('heading', {
+				name: 'Bestätigung der vertretungsberechtigten Person'
+			})
+		).toBeDefined();
+		expect(
+			screen.getByText(
+				/Ich habe die oben angezeigte Vereinbarung gelesen/
+			)
+		).toBeDefined();
+		expect(previewMock).toHaveBeenCalledWith('valid-token');
+	});
+
+	it('confirms only after the visible contract and explicit checkbox', async () => {
+		renderPage();
+		await screen.findByText(
+			'Dieser konkrete Vertragstext ist verbindlich.'
+		);
+
+		fireEvent.change(screen.getByLabelText('Name *'), {
+			target: { value: 'Marge Simpson' }
+		});
+		fireEvent.change(screen.getByLabelText('Position *'), {
+			target: { value: 'Geschäftsführerin' }
+		});
+		fireEvent.change(screen.getByLabelText('E-Mail *'), {
+			target: { value: 'marge.simpson@dreambau.com' }
+		});
+		fireEvent.change(screen.getByLabelText('Organisation *'), {
+			target: { value: 'Träger Nord' }
+		});
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Ich habe die oben angezeigte Vereinbarung gelesen/
+			})
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Verbindlich bestätigen' })
+		);
+
+		await waitFor(() =>
+			expect(confirmMock).toHaveBeenCalledWith(
+				'valid-token',
+				expect.objectContaining({
+					signerName: 'Marge Simpson',
+					signerEmail: 'marge.simpson@dreambau.com',
+					accepted: true
+				})
+			)
+		);
+		expect(
+			await screen.findByText('Die AVV-Bestätigung wurde gespeichert.')
+		).toBeDefined();
+	});
+
+	it('does not render a confirmation form for an invalid or expired token', async () => {
+		previewMock.mockRejectedValue(
+			new Error(DPA_SIGN_ERRORS.INVALID_OR_EXPIRED_TOKEN)
+		);
+		renderPage();
+
+		expect(
+			await screen.findByText(
+				'Dieser Signaturlink ist ungültig, abgelaufen oder wurde bereits verwendet.'
+			)
+		).toBeDefined();
+		expect(screen.queryByLabelText('Name *')).toBeNull();
+		expect(confirmMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/dpaSign/DpaSign.tsx
+++ b/src/components/dpaSign/DpaSign.tsx
@@ -44,6 +44,8 @@ const INITIAL_FORM_STATE: FormState = {
 	accepted: false
 };
 
+const DPA_DATE_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+
 export const DpaSign = () => {
 	const { token } = useParams<{ token: string }>();
 	const { t } = useTranslation();
@@ -434,10 +436,17 @@ const formatDpaDate = (value: string, language: string) => {
 		return value;
 	}
 
-	return new Intl.DateTimeFormat(language === 'en' ? 'en-GB' : 'de-DE', {
-		dateStyle: 'long',
-		timeStyle: 'short'
-	}).format(date);
+	const locale = language === 'en' ? 'en-GB' : 'de-DE';
+	let formatter = DPA_DATE_FORMATTERS.get(locale);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(locale, {
+			dateStyle: 'long',
+			timeStyle: 'short'
+		});
+		DPA_DATE_FORMATTERS.set(locale, formatter);
+	}
+
+	return formatter.format(date);
 };
 
 const resolveErrorMessage = (

--- a/src/components/dpaSign/DpaSign.tsx
+++ b/src/components/dpaSign/DpaSign.tsx
@@ -4,6 +4,8 @@ import {
 	Box,
 	Button,
 	Checkbox,
+	CircularProgress,
+	Divider,
 	FormControlLabel,
 	MenuItem,
 	Paper,
@@ -11,13 +13,16 @@ import {
 	Typography
 } from '@mui/material';
 import * as React from 'react';
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
 	apiConfirmDpaSignature,
+	apiGetDpaSignPreview,
+	DpaSignPreviewResponse,
 	DPA_SIGN_ERRORS
 } from '../../api/apiDpaSignature';
+import { LegalContentRenderer } from '../legalContent/LegalContentRenderer';
 
 type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -45,11 +50,54 @@ export const DpaSign = () => {
 	const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
 	const [submitState, setSubmitState] = useState<SubmitState>('idle');
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [preview, setPreview] = useState<DpaSignPreviewResponse | null>(null);
+	const [previewLoading, setPreviewLoading] = useState(true);
 
 	const decodedToken = useMemo(
 		() => (token ? decodeURIComponent(token) : ''),
 		[token]
 	);
+
+	useEffect(() => {
+		let active = true;
+		setPreview(null);
+		setPreviewLoading(true);
+		setErrorMessage(null);
+
+		if (!decodedToken) {
+			setPreviewLoading(false);
+			setErrorMessage(
+				t(
+					'dpaSign.error.missingToken',
+					'Der Signaturlink ist unvollständig.'
+				)
+			);
+			return () => {
+				active = false;
+			};
+		}
+
+		apiGetDpaSignPreview(decodedToken)
+			.then((result) => {
+				if (active) {
+					setPreview(result);
+				}
+			})
+			.catch((error) => {
+				if (active) {
+					setErrorMessage(resolveErrorMessage(error, t));
+				}
+			})
+			.finally(() => {
+				if (active) {
+					setPreviewLoading(false);
+				}
+			});
+
+		return () => {
+			active = false;
+		};
+	}, [decodedToken, t]);
 
 	const updateField = <K extends keyof FormState>(
 		field: K,
@@ -65,12 +113,12 @@ export const DpaSign = () => {
 		event.preventDefault();
 		setErrorMessage(null);
 
-		if (!decodedToken) {
+		if (!decodedToken || !preview) {
 			setSubmitState('error');
 			setErrorMessage(
 				t(
-					'dpaSign.error.missingToken',
-					'Der Signaturlink ist unvollständig.'
+					'dpaSign.error.previewRequired',
+					'Die Vereinbarung muss vollständig geladen sein, bevor Sie sie bestätigen können.'
 				)
 			);
 			return;
@@ -107,12 +155,12 @@ export const DpaSign = () => {
 			component="main"
 			sx={{
 				minHeight: '100vh',
-				background: 'var(--m3-surface, #f8faf9)',
+				background: 'var(--m3-surface-container-lowest, #f7f5f4)',
 				display: 'flex',
-				alignItems: 'center',
+				alignItems: 'flex-start',
 				justifyContent: 'center',
 				px: 2,
-				py: 4
+				py: { xs: 2, md: 6 }
 			}}
 		>
 			<Paper
@@ -121,12 +169,13 @@ export const DpaSign = () => {
 				onSubmit={handleSubmit}
 				sx={{
 					width: '100%',
-					maxWidth: 560,
-					border: '1px solid var(--m3-outline-variant, #dce5df)',
+					maxWidth: 1120,
+					border: '1px solid var(--m3-outline-variant, #cac7c5)',
 					borderRadius: 2,
-					p: { xs: 3, sm: 4 },
+					background: 'var(--m3-surface, #ffffff)',
+					p: { xs: 2.5, sm: 4 },
 					display: 'grid',
-					gap: 2
+					gap: 3
 				}}
 			>
 				<Box>
@@ -136,117 +185,259 @@ export const DpaSign = () => {
 					<Typography color="text.secondary">
 						{t(
 							'dpaSign.subtitle',
-							'Bitte prüfen und bestätigen Sie die Angaben zur unterzeichnenden Person.'
+							'Bitte lesen Sie die Vereinbarung vollständig und bestätigen Sie anschließend die Angaben zur unterzeichnenden Person.'
 						)}
 					</Typography>
 				</Box>
 
-				{submitState === 'success' ? (
-					<Alert severity="success">
-						{t(
-							'dpaSign.success',
-							'Die AVV-Signatur wurde gespeichert.'
-						)}
+				{previewLoading ? (
+					<Box
+						role="status"
+						sx={{
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							gap: 2,
+							minHeight: 240,
+							color: 'text.secondary'
+						}}
+					>
+						<CircularProgress size={24} />
+						<Typography>
+							{t(
+								'dpaSign.loadingContract',
+								'Vereinbarung wird geladen...'
+							)}
+						</Typography>
+					</Box>
+				) : !preview ? (
+					<Alert severity="error">
+						{errorMessage ??
+							t(
+								'dpaSign.error.generic',
+								'Die Vereinbarung konnte gerade nicht geladen werden.'
+							)}
 					</Alert>
 				) : (
-					<>
-						<TextField
-							label={t('dpaSign.signerName', 'Name')}
-							value={formState.signerName}
-							onChange={(event) =>
-								updateField('signerName', event.target.value)
-							}
-							required
-							fullWidth
-						/>
-						<TextField
-							label={t('dpaSign.signerPosition', 'Position')}
-							value={formState.signerPosition}
-							onChange={(event) =>
-								updateField(
-									'signerPosition',
-									event.target.value
-								)
-							}
-							required
-							fullWidth
-						/>
-						<TextField
-							label={t('dpaSign.signerEmail', 'E-Mail')}
-							type="email"
-							value={formState.signerEmail}
-							onChange={(event) =>
-								updateField('signerEmail', event.target.value)
-							}
-							required
-							fullWidth
-						/>
-						<TextField
-							label={t(
-								'dpaSign.signerOrganisation',
-								'Organisation'
-							)}
-							value={formState.signerOrganisation}
-							onChange={(event) =>
-								updateField(
-									'signerOrganisation',
-									event.target.value
-								)
-							}
-							required
-							fullWidth
-						/>
-						<TextField
-							label={t('dpaSign.language', 'Sprache')}
-							value={formState.language}
-							onChange={(event) =>
-								updateField('language', event.target.value)
-							}
-							required
-							fullWidth
-							select
+					<Box
+						sx={{
+							display: 'grid',
+							gridTemplateColumns: {
+								xs: 'minmax(0, 1fr)',
+								md: 'minmax(0, 1.2fr) minmax(360px, 0.8fr)'
+							},
+							gap: { xs: 3, md: 4 },
+							alignItems: 'start'
+						}}
+					>
+						<Box
+							component="section"
+							aria-labelledby="dpa-contract-heading"
+							sx={{
+								background:
+									'var(--m3-surface-container-low, #f3f1f0)',
+								border: '1px solid var(--m3-outline-variant, #d7d3d1)',
+								borderRadius: 2,
+								p: { xs: 2, sm: 3 }
+							}}
 						>
-							<MenuItem value="de">Deutsch</MenuItem>
-							<MenuItem value="en">English</MenuItem>
-						</TextField>
-						<FormControlLabel
-							control={
-								<Checkbox
-									checked={formState.accepted}
-									onChange={(event) =>
-										updateField(
-											'accepted',
-											event.target.checked
-										)
-									}
-									required
+							<Typography
+								variant="overline"
+								color="text.secondary"
+							>
+								{preview.tenantName}
+							</Typography>
+							<Typography
+								id="dpa-contract-heading"
+								variant="h5"
+								component="h2"
+							>
+								{t(
+									'dpaSign.contractHeading',
+									'Auftragsverarbeitungsvereinbarung'
+								)}
+							</Typography>
+							<Typography variant="body2" color="text.secondary">
+								{t('dpaSign.version', 'Vertragsversion')}{' '}
+								{formatDpaDate(
+									preview.dpaVersion,
+									formState.language
+								)}
+							</Typography>
+							<Divider sx={{ my: 2 }} />
+							<Box
+								sx={{
+									maxHeight: { xs: 300, md: 520 },
+									overflowY: 'auto',
+									pr: 1
+								}}
+							>
+								<LegalContentRenderer
+									content={preview.content}
+									language={formState.language}
 								/>
-							}
-							label={t(
-								'dpaSign.accept',
-								'Ich bestätige die Vereinbarung verbindlich.'
-							)}
-						/>
-						{errorMessage && (
-							<Alert severity="error">{errorMessage}</Alert>
-						)}
-						<Button
-							type="submit"
-							variant="contained"
-							size="large"
-							startIcon={<CheckRoundedIcon />}
-							disabled={submitState === 'submitting'}
-							sx={{ justifySelf: 'start' }}
+							</Box>
+						</Box>
+
+						<Box
+							component="section"
+							aria-labelledby="dpa-signer-heading"
+							sx={{ display: 'grid', gap: 2 }}
 						>
-							{submitState === 'submitting'
-								? t('dpaSign.submitting', 'Speichern...')
-								: t('dpaSign.submit', 'Unterzeichnen')}
-						</Button>
-					</>
+							<Typography
+								id="dpa-signer-heading"
+								variant="h5"
+								component="h2"
+							>
+								{t(
+									'dpaSign.signerHeading',
+									'Bestätigung der vertretungsberechtigten Person'
+								)}
+							</Typography>
+							{submitState === 'success' ? (
+								<Alert severity="success">
+									{t(
+										'dpaSign.success',
+										'Die AVV-Bestätigung wurde gespeichert.'
+									)}
+								</Alert>
+							) : (
+								<>
+									<TextField
+										label={t('dpaSign.signerName', 'Name')}
+										value={formState.signerName}
+										onChange={(event) =>
+											updateField(
+												'signerName',
+												event.target.value
+											)
+										}
+										required
+										fullWidth
+									/>
+									<TextField
+										label={t(
+											'dpaSign.signerPosition',
+											'Position'
+										)}
+										value={formState.signerPosition}
+										onChange={(event) =>
+											updateField(
+												'signerPosition',
+												event.target.value
+											)
+										}
+										required
+										fullWidth
+									/>
+									<TextField
+										label={t(
+											'dpaSign.signerEmail',
+											'E-Mail'
+										)}
+										type="email"
+										value={formState.signerEmail}
+										onChange={(event) =>
+											updateField(
+												'signerEmail',
+												event.target.value
+											)
+										}
+										required
+										fullWidth
+									/>
+									<TextField
+										label={t(
+											'dpaSign.signerOrganisation',
+											'Organisation'
+										)}
+										value={formState.signerOrganisation}
+										onChange={(event) =>
+											updateField(
+												'signerOrganisation',
+												event.target.value
+											)
+										}
+										required
+										fullWidth
+									/>
+									<TextField
+										label={t('dpaSign.language', 'Sprache')}
+										value={formState.language}
+										onChange={(event) =>
+											updateField(
+												'language',
+												event.target.value
+											)
+										}
+										required
+										fullWidth
+										select
+									>
+										<MenuItem value="de">Deutsch</MenuItem>
+										<MenuItem value="en">English</MenuItem>
+									</TextField>
+									<FormControlLabel
+										control={
+											<Checkbox
+												checked={formState.accepted}
+												onChange={(event) =>
+													updateField(
+														'accepted',
+														event.target.checked
+													)
+												}
+												required
+											/>
+										}
+										label={t(
+											'dpaSign.accept',
+											'Ich habe die oben angezeigte Vereinbarung gelesen und bestätige sie verbindlich.'
+										)}
+									/>
+									{errorMessage && (
+										<Alert severity="error">
+											{errorMessage}
+										</Alert>
+									)}
+									<Button
+										type="submit"
+										variant="contained"
+										size="large"
+										startIcon={<CheckRoundedIcon />}
+										disabled={submitState === 'submitting'}
+										sx={{ justifySelf: 'start' }}
+									>
+										{submitState === 'submitting'
+											? t(
+													'dpaSign.submitting',
+													'Speichern...'
+												)
+											: t(
+													'dpaSign.submit',
+													'Verbindlich bestätigen'
+												)}
+									</Button>
+								</>
+							)}
+						</Box>
+					</Box>
 				)}
 			</Paper>
 		</Box>
 	);
+};
+
+const formatDpaDate = (value: string, language: string) => {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return value;
+	}
+
+	return new Intl.DateTimeFormat(language === 'en' ? 'en-GB' : 'de-DE', {
+		dateStyle: 'long',
+		timeStyle: 'short'
+	}).format(date);
 };
 
 const resolveErrorMessage = (

--- a/src/components/legalContent/LegalContentRenderer.test.tsx
+++ b/src/components/legalContent/LegalContentRenderer.test.tsx
@@ -94,4 +94,19 @@ describe('LegalContentRenderer', () => {
 		expect(container.textContent).not.toContain('src');
 		expect(screen.getByText('Hallo')).toBeDefined();
 	});
+
+	it('uses an explicit public-flow language instead of the global UI language', () => {
+		render(
+			<LegalContentRenderer
+				language="en"
+				content={map({
+					de: '<p>Deutscher Vertrag</p>',
+					en: '<p>English contract</p>'
+				})}
+			/>
+		);
+
+		expect(screen.getByText('English contract')).toBeDefined();
+		expect(screen.queryByText('Deutscher Vertrag')).toBeNull();
+	});
 });

--- a/src/components/legalContent/LegalContentRenderer.test.tsx
+++ b/src/components/legalContent/LegalContentRenderer.test.tsx
@@ -109,4 +109,29 @@ describe('LegalContentRenderer', () => {
 		expect(screen.getByText('English contract')).toBeDefined();
 		expect(screen.queryByText('Deutscher Vertrag')).toBeNull();
 	});
+
+	it('removes active markup while preserving legal formatting', () => {
+		const { container } = render(
+			<LegalContentRenderer
+				content={map({
+					de: [
+						'<h2>Vertrag</h2>',
+						'<p onclick="window.__xss = true"><strong>Sicherer Text</strong></p>',
+						'<script>window.__xss = true</script>',
+						'<a href="javascript:alert(1)">Unsicher</a>',
+						'<a href="https://oriso.org/legal">Sicher</a>'
+					].join('')
+				})}
+			/>
+		);
+
+		expect(screen.getByRole('heading', { name: 'Vertrag' })).toBeDefined();
+		expect(screen.getByText('Sicherer Text').tagName).toBe('STRONG');
+		expect(container.querySelector('script')).toBeNull();
+		expect(container.querySelector('[onclick]')).toBeNull();
+		expect(screen.getByText('Unsicher').getAttribute('href')).toBeNull();
+		expect(screen.getByText('Sicher').getAttribute('href')).toBe(
+			'https://oriso.org/legal'
+		);
+	});
 });

--- a/src/components/legalContent/LegalContentRenderer.tsx
+++ b/src/components/legalContent/LegalContentRenderer.tsx
@@ -16,6 +16,8 @@ export interface LegalContentRendererProps {
 	 */
 	content: string | null | undefined;
 	className?: string;
+	/** Optional explicit language for public legal flows that provide their own selector. */
+	language?: string;
 }
 
 /**
@@ -29,12 +31,13 @@ export interface LegalContentRendererProps {
  */
 export const LegalContentRenderer = ({
 	content,
-	className
+	className,
+	language
 }: LegalContentRendererProps) => {
 	const { t, i18n } = useTranslation();
 	const [showOriginal, setShowOriginal] = useState(false);
 
-	const uiLang = normalizeLegalLang(i18n?.language);
+	const uiLang = normalizeLegalLang(language ?? i18n?.language);
 	const resolved = useMemo(
 		() => resolveLegalContent(content, uiLang),
 		[content, uiLang]

--- a/src/components/legalContent/LegalContentRenderer.tsx
+++ b/src/components/legalContent/LegalContentRenderer.tsx
@@ -2,12 +2,27 @@ import * as React from 'react';
 import { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
+import sanitizeHtml from 'sanitize-html';
 import htmlParser from '../../resources/scripts/util/htmlParser';
 import {
 	normalizeLegalLang,
 	resolveLegalContent
 } from '../../utils/legalContent';
 import './legalContent.styles.scss';
+
+const LEGAL_HTML_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+	allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img'],
+	allowedAttributes: {
+		'*': ['class'],
+		'a': ['href', 'name', 'target', 'rel'],
+		'img': ['src', 'alt', 'title', 'width', 'height', 'loading']
+	},
+	allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+	allowedSchemesByTag: {
+		img: ['http', 'https']
+	},
+	allowProtocolRelative: false
+};
 
 export interface LegalContentRendererProps {
 	/**
@@ -48,6 +63,13 @@ export const LegalContentRenderer = ({
 				? resolveLegalContent(content, resolved.originalLang)
 				: resolved,
 		[showOriginal, resolved, content]
+	);
+	const sanitizedHtml = useMemo(
+		() =>
+			displayed
+				? sanitizeHtml(displayed.html, LEGAL_HTML_SANITIZE_OPTIONS)
+				: '',
+		[displayed]
 	);
 
 	if (!displayed) {
@@ -103,7 +125,7 @@ export const LegalContentRenderer = ({
 				</p>
 			)}
 			<div className="legalContentRenderer__content">
-				{htmlParser(displayed.html)}
+				{htmlParser(sanitizedHtml)}
 			</div>
 		</div>
 	);

--- a/src/components/session/SessionStream.test.tsx
+++ b/src/components/session/SessionStream.test.tsx
@@ -33,6 +33,15 @@ const mocks = vi.hoisted(() => {
 		detachLifecycle: vi.fn(),
 		getMatrixRoomMessages: vi.fn(() => []),
 		getSessionSupervisors: vi.fn(() => Promise.resolve([])),
+		getCaseHandoverStatus: vi.fn(() =>
+			Promise.resolve({
+				sessionId: 1,
+				status: 'GRANTED',
+				canViewContent: true,
+				clientConsentRequired: false,
+				auditOutcome: 'ACCESS_GRANTED'
+			})
+		),
 		resolveSession: vi.fn(() => ({
 			isMatrixSession: true,
 			matrixRoomId: ROOM_ID,
@@ -50,7 +59,8 @@ const mocks = vi.hoisted(() => {
 						mocks.clientChangeListeners.splice(index, 1);
 				};
 			}
-		} as any
+		} as any,
+		requestHistoryKeys: vi.fn(() => Promise.resolve(true))
 	};
 });
 
@@ -69,15 +79,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 vi.mock('../../api', () => ({
 	apiGetAgencyConsultantList: vi.fn(() => Promise.resolve([])),
 	apiGetSessionSupervisors: mocks.getSessionSupervisors,
-	apiGetCaseHandoverStatus: vi.fn(() =>
-		Promise.resolve({
-			sessionId: 1,
-			status: 'GRANTED',
-			canViewContent: true,
-			clientConsentRequired: false,
-			auditOutcome: 'ACCESS_GRANTED'
-		})
-	),
+	apiGetCaseHandoverStatus: mocks.getCaseHandoverStatus,
 	FETCH_ERRORS: { ABORT: 'ABORT' }
 }));
 
@@ -108,6 +110,19 @@ vi.mock('../../services/chatTransportService', () => ({
 		)
 	}
 }));
+
+vi.mock(
+	'../../services/matrixRoomHistoryKeyTransfer',
+	async (importOriginal) => {
+		const actual = await importOriginal<any>();
+		return {
+			...actual,
+			matrixRoomHistoryKeyTransfer: {
+				requestKeys: mocks.requestHistoryKeys
+			}
+		};
+	}
+);
 
 // The globalState barrel drags in the entire registration UI; provide just
 // the contexts and helpers SessionStream consumes.
@@ -239,6 +254,13 @@ describe('SessionStream Matrix room lifecycle', () => {
 		mocks.timelineListeners.length = 0;
 		mocks.clientChangeListeners.length = 0;
 		mocks.sessionItemProps = null;
+		mocks.getCaseHandoverStatus.mockResolvedValue({
+			sessionId: 1,
+			status: 'GRANTED',
+			canViewContent: true,
+			clientConsentRequired: false,
+			auditOutcome: 'ACCESS_GRANTED'
+		});
 	});
 
 	afterEach(() => {
@@ -409,6 +431,7 @@ describe('SessionStream Matrix room lifecycle', () => {
 				mocks.getMatrixRoomMessages.mock.calls.length
 			).toBeGreaterThan(callsAtAttach)
 		);
+		expect(mocks.requestHistoryKeys).toHaveBeenCalledWith(ROOM_ID);
 	});
 
 	it('does not curtain a backend-authorized session supervisor', async () => {
@@ -475,5 +498,77 @@ describe('SessionStream Matrix room lifecycle', () => {
 			expect(screen.getByTestId('session-item')).toBeDefined()
 		);
 		expect(screen.queryByTestId('case-handover-curtain')).toBeNull();
+		await waitFor(() => {
+			expect(mocks.requestHistoryKeys).toHaveBeenCalledWith(ROOM_ID);
+			expect(mocks.requestHistoryKeys).toHaveBeenCalledWith(
+				'!supervision:matrix.oriso.org'
+			);
+		});
+	});
+
+	it('does not attach or request history before case handover is granted', async () => {
+		mocks.getCaseHandoverStatus.mockResolvedValueOnce({
+			sessionId: 1,
+			status: 'PENDING',
+			canViewContent: false,
+			clientConsentRequired: true,
+			auditOutcome: 'CONSENT_REQUIRED'
+		});
+		const activeSession = {
+			rid: ROOM_ID,
+			isGroup: false,
+			isSession: true,
+			consultant: { id: 'owner-2' },
+			item: { id: 1, matrixRoomId: ROOM_ID, active: true, status: 2 }
+		} as any;
+		const consultantUserData = {
+			userId: 'consultant-1',
+			grantedAuthorities: ['AUTHORIZATION_CONSULTANT_DEFAULT']
+		} as any;
+
+		render(
+			<MemoryRouter>
+				<UserDataContext.Provider
+					value={{ userData: consultantUserData } as any}
+				>
+					<SessionTypeContext.Provider
+						value={{
+							type: SESSION_LIST_TYPES.MY_SESSION,
+							path: LIST_PATH
+						}}
+					>
+						<ConsultantListContext.Provider
+							value={
+								{
+									consultantList: [],
+									setConsultantList: () => {}
+								} as any
+							}
+						>
+							<ActiveSessionContext.Provider
+								value={
+									{
+										activeSession,
+										readActiveSession: () => {}
+									} as any
+								}
+							>
+								<SessionStream
+									readonly={false}
+									checkMutedUserForThisSession={() => {}}
+									bannedUsers={[]}
+								/>
+							</ActiveSessionContext.Provider>
+						</ConsultantListContext.Provider>
+					</SessionTypeContext.Provider>
+				</UserDataContext.Provider>
+			</MemoryRouter>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByTestId('case-handover-curtain')).toBeDefined()
+		);
+		expect(mocks.requestHistoryKeys).not.toHaveBeenCalled();
+		expect(chatTransportService.onMatrixTimeline).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/session/SessionStream.test.tsx
+++ b/src/components/session/SessionStream.test.tsx
@@ -391,6 +391,26 @@ describe('SessionStream Matrix room lifecycle', () => {
 		);
 	});
 
+	it('hydrates the initial timeline after its listener attaches', async () => {
+		let callsAtAttach = -1;
+		vi.mocked(chatTransportService.onMatrixTimeline).mockImplementationOnce(
+			(_roomId: string, listener: any) => {
+				callsAtAttach = mocks.getMatrixRoomMessages.mock.calls.length;
+				mocks.timelineListeners.push(listener);
+				return () => undefined;
+			}
+		);
+
+		renderSessionStream({ isGroup: true });
+
+		await waitFor(() => expect(callsAtAttach).toBeGreaterThanOrEqual(0));
+		await waitFor(() =>
+			expect(
+				mocks.getMatrixRoomMessages.mock.calls.length
+			).toBeGreaterThan(callsAtAttach)
+		);
+	});
+
 	it('does not curtain a backend-authorized session supervisor', async () => {
 		mocks.getSessionSupervisors.mockResolvedValueOnce([
 			{

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -220,6 +220,9 @@ export const SessionStream = ({
 	);
 	const caseHandoverCurtainNeeded =
 		caseHandoverGateNeeded && !hasSupervisionAccess;
+	const mayRequestHistoryKeys =
+		!caseHandoverCurtainNeeded ||
+		caseHandoverStatus?.canViewContent === true;
 
 	// ADR-008: resolve the per-session supervision side room id for members.
 	// The backend only returns supervisor entries (with the side room id) to
@@ -326,23 +329,27 @@ export const SessionStream = ({
 				};
 
 				const clientEvents = loadRoomEvents(resolvedMatrixRoomId);
-				const hasUndecryptedHistory = clientEvents.some(
-					isUndecryptedRoomEvent
-				);
-				if (hasUndecryptedHistory && resolvedMatrixRoomId) {
-					// A newly-authorised case owner joined after the old Megolm
-					// sessions were created. Ask existing member devices for only
-					// this room's keys over encrypted to-device messages.
-					void matrixRoomHistoryKeyTransfer.requestKeys(
-						resolvedMatrixRoomId
-					);
-				}
 				// ADR-008: merge the supervision side room's asides so they
 				// render for members. The client is never a member of the side
 				// room, so it never loads these.
 				const supervisionEvents = supervisionRoomId
 					? loadRoomEvents(supervisionRoomId)
 					: [];
+				if (mayRequestHistoryKeys) {
+					[
+						[resolvedMatrixRoomId, clientEvents],
+						[supervisionRoomId, supervisionEvents]
+					].forEach(([roomId, events]) => {
+						if (
+							roomId &&
+							(events as any[]).some(isUndecryptedRoomEvent)
+						) {
+							void matrixRoomHistoryKeyTransfer.requestKeys(
+								roomId as string
+							);
+						}
+					});
+				}
 				const formattedMessages = mergeMatrixMessages(
 					formatRoomMessages(clientEvents, resolvedMatrixRoomId),
 					formatRoomMessages(supervisionEvents, supervisionRoomId)
@@ -373,6 +380,7 @@ export const SessionStream = ({
 		[
 			caseHandoverCurtainNeeded,
 			caseHandoverStatus?.canViewContent,
+			mayRequestHistoryKeys,
 			resolvedChatSession,
 			supervisionRoomId,
 			translate
@@ -383,7 +391,11 @@ export const SessionStream = ({
 	useEffect(() => {
 		const onHistoryKeysImported = (rawEvent: Event) => {
 			const importedRoomId = (rawEvent as CustomEvent)?.detail?.roomId;
-			if (importedRoomId === resolvedChatSession.matrixRoomId) {
+			if (
+				[resolvedChatSession.matrixRoomId, supervisionRoomId].includes(
+					importedRoomId
+				)
+			) {
 				void fetchSessionMessagesRef.current(true);
 			}
 		};
@@ -396,7 +408,11 @@ export const SessionStream = ({
 				MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
 				onHistoryKeysImported
 			);
-	}, [fetchSessionMessagesRef, resolvedChatSession.matrixRoomId]);
+	}, [
+		fetchSessionMessagesRef,
+		resolvedChatSession.matrixRoomId,
+		supervisionRoomId
+	]);
 
 	const setSessionRead = useCallback(() => {
 		if (readonly) {
@@ -494,6 +510,9 @@ export const SessionStream = ({
 		if (!clientRoomId) {
 			return;
 		}
+		if (!mayRequestHistoryKeys) {
+			return;
+		}
 
 		// ADR-008: listen on the client room AND (for members) the supervision
 		// side room, so newly-sent asides appear live for authorized viewers.
@@ -576,7 +595,10 @@ export const SessionStream = ({
 				// time React sees it. Request this room's existing keys once per
 				// client generation instead of depending on a particular failure
 				// event shape.
-				void matrixRoomHistoryKeyTransfer.requestKeys(clientRoomId);
+				watchedRoomIds.forEach(
+					(roomId) =>
+						void matrixRoomHistoryKeyTransfer.requestKeys(roomId)
+				);
 				refreshMessages();
 			}
 			return true;
@@ -624,7 +646,8 @@ export const SessionStream = ({
 		supervisionRoomId,
 		fetchSessionMessages,
 		matrixRoomId,
-		matrixClientGeneration
+		matrixClientGeneration,
+		mayRequestHistoryKeys
 	]);
 
 	const groupChatStoppedOverlay: OverlayItem = useMemo(

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -59,6 +59,11 @@ import {
 import { applyMessageEdits } from '../../utils/messageRelations';
 import { CaseHandoverCurtain } from './CaseHandoverCurtain';
 import { isCaseHandoverAccessControlled } from './caseHandoverHelpers';
+import {
+	MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
+	isUndecryptedRoomEvent,
+	matrixRoomHistoryKeyTransfer
+} from '../../services/matrixRoomHistoryKeyTransfer';
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -98,6 +103,7 @@ export const SessionStream = ({
 	// instance got removeAllListeners(), so every effect holding room
 	// listeners depends on this generation to re-attach to the new client.
 	const [matrixClientGeneration, setMatrixClientGeneration] = useState(0);
+	const initialTimelineHydrationKeyRef = useRef('');
 	const [messagesItem, setMessagesItem] = useState(null);
 	const [overlayItem, setOverlayItem] = useState<OverlayItem>(null);
 	const [isOverlayActive, setIsOverlayActive] = useState(false);
@@ -320,6 +326,17 @@ export const SessionStream = ({
 				};
 
 				const clientEvents = loadRoomEvents(resolvedMatrixRoomId);
+				const hasUndecryptedHistory = clientEvents.some(
+					isUndecryptedRoomEvent
+				);
+				if (hasUndecryptedHistory && resolvedMatrixRoomId) {
+					// A newly-authorised case owner joined after the old Megolm
+					// sessions were created. Ask existing member devices for only
+					// this room's keys over encrypted to-device messages.
+					void matrixRoomHistoryKeyTransfer.requestKeys(
+						resolvedMatrixRoomId
+					);
+				}
 				// ADR-008: merge the supervision side room's asides so they
 				// render for members. The client is never a member of the side
 				// room, so it never loads these.
@@ -362,6 +379,24 @@ export const SessionStream = ({
 		]
 	);
 	const fetchSessionMessagesRef = useUpdatingRef(fetchSessionMessages);
+
+	useEffect(() => {
+		const onHistoryKeysImported = (rawEvent: Event) => {
+			const importedRoomId = (rawEvent as CustomEvent)?.detail?.roomId;
+			if (importedRoomId === resolvedChatSession.matrixRoomId) {
+				void fetchSessionMessagesRef.current(true);
+			}
+		};
+		window.addEventListener(
+			MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
+			onHistoryKeysImported
+		);
+		return () =>
+			window.removeEventListener(
+				MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
+				onHistoryKeysImported
+			);
+	}, [fetchSessionMessagesRef, resolvedChatSession.matrixRoomId]);
 
 	const setSessionRead = useCallback(() => {
 		if (readonly) {
@@ -465,6 +500,7 @@ export const SessionStream = ({
 		const watchedRoomIds = supervisionRoomId
 			? [clientRoomId, supervisionRoomId]
 			: [clientRoomId];
+		const initialHydrationKey = `${matrixClientGeneration}:${watchedRoomIds.join('|')}`;
 
 		let retryTimer: number | null = null;
 		let detachTimelineListeners: Array<() => void> = [];
@@ -528,6 +564,21 @@ export const SessionStream = ({
 			}
 
 			detachTimelineListeners = detachers;
+			// Initial-sync events arrive with toStartOfTimeline=true and are
+			// intentionally ignored by the live handler. Hydrate once after every
+			// successful attachment so late-join decryption failures can trigger
+			// their room-key request after the Matrix room actually exists.
+			if (
+				initialTimelineHydrationKeyRef.current !== initialHydrationKey
+			) {
+				initialTimelineHydrationKeyRef.current = initialHydrationKey;
+				// The initial timeline can be empty or already SDK-normalised by the
+				// time React sees it. Request this room's existing keys once per
+				// client generation instead of depending on a particular failure
+				// event shape.
+				void matrixRoomHistoryKeyTransfer.requestKeys(clientRoomId);
+				refreshMessages();
+			}
 			return true;
 		};
 

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -132,6 +132,9 @@ export const endpoints = {
 	dpaSignatureConfirm: (token: string) =>
 		tenantServiceOrigin +
 		`/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`,
+	dpaSignaturePreview: (token: string) =>
+		tenantServiceOrigin +
+		`/service/tenant/public/dpa/confirm/${encodeURIComponent(token)}`,
 	topicGroups: consultingTypeServiceOrigin + '/service/topic-groups',
 	topicsData: consultingTypeServiceOrigin + '/service/topic/public',
 	twoFactorAuth: userServiceOrigin + '/service/users/2fa',

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -11,6 +11,7 @@ import { applyDeviceIsolationMode } from './matrixDeviceIsolation';
 import { appConfig } from '../utils/appConfig';
 import { matrixLiveEventBridge } from './matrixLiveEventBridge';
 import { startDeviceDehydration } from './matrixDeviceDehydration';
+import { matrixRoomHistoryKeyTransfer } from './matrixRoomHistoryKeyTransfer';
 import { encryptMatrixAttachment } from '../utils/matrixEncryptedAttachment';
 import { buildMatrixRoomEncryptionInitialState } from '../utils/matrixRoomEncryption';
 import {
@@ -496,6 +497,7 @@ export class MatrixClientService {
 
 		matrixCallService.initialize(client);
 		matrixLiveEventBridge.initialize(client);
+		matrixRoomHistoryKeyTransfer.initialize(client);
 		this.initializedServicesClient = client;
 
 		// #439 MSC3814: rehydrate the parked device (reads Megolm keys sent
@@ -565,6 +567,7 @@ export class MatrixClientService {
 		this.initializedServicesClient = null;
 		matrixLiveEventBridge.detach();
 		matrixCallService.detach();
+		matrixRoomHistoryKeyTransfer.detach();
 		this.notifySyncStateListeners();
 	}
 

--- a/src/services/matrixDeviceIsolation.ts
+++ b/src/services/matrixDeviceIsolation.ts
@@ -4,6 +4,12 @@ import {
 	OnlySignedDevicesIsolationMode
 } from 'matrix-js-sdk/lib/crypto-api';
 
+const invisibleCryptoClients = new WeakSet<MatrixClient>();
+
+export const isInvisibleCryptoEnabledForClient = (
+	client: MatrixClient
+): boolean => invisibleCryptoClients.has(client);
+
 /**
  * #438 MSC4153 "invisible crypto". When enabled, the SDK shares Megolm keys
  * only with cross-signed devices (`OnlySignedDevicesIsolationMode`): an
@@ -39,8 +45,14 @@ export const applyDeviceIsolationMode = (
 				? new OnlySignedDevicesIsolationMode()
 				: new AllDevicesIsolationMode(false)
 		);
+		if (invisibleCryptoEnabled) {
+			invisibleCryptoClients.add(client);
+		} else {
+			invisibleCryptoClients.delete(client);
+		}
 		return true;
 	} catch {
+		invisibleCryptoClients.delete(client);
 		// Only supported by the rust crypto stack; never break startup on it.
 		return false;
 	}

--- a/src/services/matrixRoomHistoryKeyTransfer.test.ts
+++ b/src/services/matrixRoomHistoryKeyTransfer.test.ts
@@ -2,10 +2,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClientEvent } from 'matrix-js-sdk';
 import {
+	MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT,
 	MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
 	MatrixRoomHistoryKeyTransfer,
 	isUndecryptedRoomEvent
 } from './matrixRoomHistoryKeyTransfer';
+import { applyDeviceIsolationMode } from './matrixDeviceIsolation';
 
 const ROOM_ID = '!case:matrix';
 const ME = '@new:matrix';
@@ -32,6 +34,10 @@ const buildHarness = () => {
 		)
 	};
 	const crypto = {
+		setDeviceIsolationMode: vi.fn(),
+		getDeviceVerificationStatus: vi.fn().mockResolvedValue({
+			isVerified: () => true
+		}),
 		getUserDeviceInfo: vi
 			.fn()
 			.mockResolvedValue(
@@ -95,6 +101,16 @@ describe('MatrixRoomHistoryKeyTransfer', () => {
 				requester_device_id: 'NEW1'
 			})
 		);
+	});
+
+	it('throttles repeated outgoing room-key requests', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		expect(await service.requestKeys(ROOM_ID)).toBe(true);
+		expect(await service.requestKeys(ROOM_ID)).toBe(false);
+		expect(harness.client.encryptAndSendToDevice).toHaveBeenCalledTimes(1);
 	});
 
 	it('still requests from valid devices when another device has no Olm session', async () => {
@@ -205,6 +221,116 @@ describe('MatrixRoomHistoryKeyTransfer', () => {
 		);
 	});
 
+	it('rejects an unverified requester device when invisible crypto is enabled', async () => {
+		const harness = buildHarness();
+		harness.crypto.getDeviceVerificationStatus.mockResolvedValue({
+			isVerified: () => false
+		});
+		applyDeviceIsolationMode(harness.client as any, true);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'unverified-request',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+		await vi.waitFor(() =>
+			expect(
+				harness.crypto.getDeviceVerificationStatus
+			).toHaveBeenCalledWith(PEER, 'ASKER1')
+		);
+
+		expect(harness.crypto.exportRoomKeys).not.toHaveBeenCalled();
+	});
+
+	it('throttles repeated incoming requests before exporting all account keys', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		const request = event('org.oriso.room_history_key_request', PEER, {
+			room_id: ROOM_ID,
+			request_id: 'request-1',
+			requester_user_id: PEER,
+			requester_device_id: 'ASKER1'
+		});
+
+		harness.emitToDevice(request);
+		await vi.waitFor(() =>
+			expect(harness.crypto.exportRoomKeys).toHaveBeenCalledTimes(1)
+		);
+		harness.emitToDevice(request);
+		await Promise.resolve();
+
+		expect(harness.crypto.exportRoomKeys).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not send an oversized exported key bundle', async () => {
+		const harness = buildHarness();
+		harness.crypto.exportRoomKeys.mockResolvedValue(
+			Array.from({ length: 5_001 }, (_, index) => ({
+				room_id: ROOM_ID,
+				session_id: `session-${index}`
+			}))
+		);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'oversized-export',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+		await vi.waitFor(() =>
+			expect(harness.crypto.exportRoomKeys).toHaveBeenCalledOnce()
+		);
+
+		expect(harness.client.encryptAndSendToDevice).not.toHaveBeenCalled();
+	});
+
+	it('emits a minimal diagnostic when an incoming request handler fails', async () => {
+		const harness = buildHarness();
+		harness.crypto.exportRoomKeys.mockRejectedValue(
+			new Error('sensitive crypto detail')
+		);
+		const diagnostic = vi.fn();
+		window.addEventListener(
+			MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT,
+			diagnostic
+		);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'failed-export',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+		await vi.waitFor(() =>
+			expect(diagnostic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					detail: { stage: 'request-handler-failed' }
+				})
+			)
+		);
+		expect(JSON.stringify(diagnostic.mock.calls)).not.toContain(
+			'sensitive crypto detail'
+		);
+		window.removeEventListener(
+			MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT,
+			diagnostic
+		);
+	});
+
 	it('loads lazy room members before authorising a requester', async () => {
 		const harness = buildHarness();
 		let membersLoaded = false;
@@ -259,6 +385,62 @@ describe('MatrixRoomHistoryKeyTransfer', () => {
 			{ room_id: ROOM_ID, session_id: 'wanted' }
 		]);
 		expect(imported).toHaveBeenCalledOnce();
+	});
+
+	it('rejects oversized key bundles before import', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_bundle', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'oversized',
+				keys: Array.from({ length: 5_001 }, (_, index) => ({
+					room_id: ROOM_ID,
+					session_id: `session-${index}`
+				}))
+			})
+		);
+		await Promise.resolve();
+
+		expect(harness.crypto.importRoomKeys).not.toHaveBeenCalled();
+	});
+
+	it('does not import from a sender who is no longer a room member', async () => {
+		const harness = buildHarness();
+		harness.memberships.set(PEER, member(PEER, 'ban'));
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_bundle', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'blocked-sender',
+				keys: [{ room_id: ROOM_ID, session_id: 'blocked' }]
+			})
+		);
+		await Promise.resolve();
+
+		expect(harness.crypto.importRoomKeys).not.toHaveBeenCalled();
+	});
+
+	it('does not broadcast diagnostics for unrelated to-device events', async () => {
+		const harness = buildHarness();
+		const diagnostic = vi.fn();
+		window.addEventListener(
+			MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT,
+			diagnostic
+		);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		harness.emitToDevice(event('m.dummy', PEER, {}));
+		await Promise.resolve();
+
+		expect(diagnostic).not.toHaveBeenCalled();
+		window.removeEventListener(
+			MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT,
+			diagnostic
+		);
 	});
 
 	it('does not export keys to a sender who is not joined', async () => {

--- a/src/services/matrixRoomHistoryKeyTransfer.test.ts
+++ b/src/services/matrixRoomHistoryKeyTransfer.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClientEvent } from 'matrix-js-sdk';
+import {
+	MATRIX_HISTORY_KEYS_IMPORTED_EVENT,
+	MatrixRoomHistoryKeyTransfer,
+	isUndecryptedRoomEvent
+} from './matrixRoomHistoryKeyTransfer';
+
+const ROOM_ID = '!case:matrix';
+const ME = '@new:matrix';
+const PEER = '@asker:matrix';
+
+const member = (userId: string, membership = 'join') => ({
+	userId,
+	membership
+});
+
+const buildHarness = () => {
+	let toDeviceHandler: ((event: any) => void) | undefined;
+	const memberships = new Map([
+		[ME, member(ME)],
+		[PEER, member(PEER)]
+	]);
+	const room = {
+		loadMembersIfNeeded: vi.fn(async () => true),
+		getMember: vi.fn((userId: string) => memberships.get(userId)),
+		getJoinedMembers: vi.fn(() =>
+			Array.from(memberships.values()).filter(
+				(item) => item.membership === 'join'
+			)
+		)
+	};
+	const crypto = {
+		getUserDeviceInfo: vi
+			.fn()
+			.mockResolvedValue(
+				new Map([[PEER, new Map([['ASKER1', { deviceId: 'ASKER1' }]])]])
+			),
+		exportRoomKeys: vi.fn().mockResolvedValue([
+			{ room_id: ROOM_ID, session_id: 'wanted' },
+			{ room_id: '!other:matrix', session_id: 'blocked' }
+		]),
+		importRoomKeys: vi.fn().mockResolvedValue(undefined)
+	};
+	const client = {
+		getCrypto: vi.fn(() => crypto),
+		getUserId: vi.fn(() => ME),
+		getDeviceId: vi.fn(() => 'NEW1'),
+		getRoom: vi.fn((roomId: string) => (roomId === ROOM_ID ? room : null)),
+		on: vi.fn((event: string, handler: (matrixEvent: any) => void) => {
+			if (event === ClientEvent.ReceivedToDeviceMessage)
+				toDeviceHandler = handler;
+		}),
+		off: vi.fn(),
+		encryptAndSendToDevice: vi.fn().mockResolvedValue(undefined)
+	};
+	return {
+		client,
+		crypto,
+		room,
+		memberships,
+		emitToDevice: (event: any) =>
+			toDeviceHandler?.({
+				message: {
+					type: event.getType(),
+					sender: event.getSender(),
+					content: event.getContent()
+				}
+			})
+	};
+};
+
+const event = (type: string, sender: string, content: object) => ({
+	getType: () => type,
+	getSender: () => sender,
+	getContent: () => content
+});
+
+describe('MatrixRoomHistoryKeyTransfer', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('requests history keys only from other joined users devices', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		expect(await service.requestKeys(ROOM_ID)).toBe(true);
+		expect(harness.client.encryptAndSendToDevice).toHaveBeenCalledWith(
+			'org.oriso.room_history_key_request',
+			[{ userId: PEER, deviceId: 'ASKER1' }],
+			expect.objectContaining({
+				room_id: ROOM_ID,
+				requester_user_id: ME,
+				requester_device_id: 'NEW1'
+			})
+		);
+	});
+
+	it('still requests from valid devices when another device has no Olm session', async () => {
+		const harness = buildHarness();
+		harness.crypto.getUserDeviceInfo.mockResolvedValue(
+			new Map([
+				[
+					PEER,
+					new Map([
+						['BROKEN', { deviceId: 'BROKEN' }],
+						['ASKER1', { deviceId: 'ASKER1' }]
+					])
+				]
+			])
+		);
+		harness.client.encryptAndSendToDevice.mockImplementation(
+			(_type: string, targets: Array<{ deviceId: string }>) =>
+				targets[0]?.deviceId === 'BROKEN'
+					? Promise.reject(new Error('missing Olm session'))
+					: Promise.resolve()
+		);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		await expect(service.requestKeys(ROOM_ID)).resolves.toBe(true);
+		expect(harness.client.encryptAndSendToDevice).toHaveBeenCalledWith(
+			'org.oriso.room_history_key_request',
+			[{ userId: PEER, deviceId: 'ASKER1' }],
+			expect.any(Object)
+		);
+	});
+
+	it('recognises both raw and SDK-normalised decryption failures', () => {
+		expect(
+			isUndecryptedRoomEvent({ isDecryptionFailure: () => true })
+		).toBe(true);
+		expect(
+			isUndecryptedRoomEvent({
+				isDecryptionFailure: () => false,
+				getContent: () => ({ msgtype: 'm.bad.encrypted' })
+			})
+		).toBe(true);
+		expect(
+			isUndecryptedRoomEvent({
+				isDecryptionFailure: () => false,
+				getType: () => 'm.room.message',
+				getClearContent: () => ({
+					msgtype: 'm.text',
+					body: '** Unable to decrypt: DecryptionError: missing room key **'
+				})
+			})
+		).toBe(true);
+		expect(
+			isUndecryptedRoomEvent({
+				isDecryptionFailure: () => false,
+				getType: () => 'm.room.message',
+				getContent: () => ({
+					msgtype: 'm.text',
+					body: '** Unable to decrypt: DecryptionError: missing room key **'
+				})
+			})
+		).toBe(true);
+		expect(
+			isUndecryptedRoomEvent({
+				isDecryptionFailure: () => false,
+				getContent: () => ({ msgtype: 'm.text' }),
+				getType: () => 'm.room.message'
+			})
+		).toBe(false);
+	});
+
+	it('retries a request queued before the Matrix client is prepared', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+
+		expect(await service.requestKeys(ROOM_ID)).toBe(false);
+		service.initialize(harness.client as any);
+
+		await vi.waitFor(() =>
+			expect(harness.client.encryptAndSendToDevice).toHaveBeenCalled()
+		);
+	});
+
+	it('answers an authorised joined requester with only that rooms keys', async () => {
+		const harness = buildHarness();
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'request-1',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+		await vi.waitFor(() =>
+			expect(harness.client.encryptAndSendToDevice).toHaveBeenCalled()
+		);
+
+		expect(harness.client.encryptAndSendToDevice).toHaveBeenCalledWith(
+			'org.oriso.room_history_key_bundle',
+			[{ userId: PEER, deviceId: 'ASKER1' }],
+			{
+				room_id: ROOM_ID,
+				request_id: 'request-1',
+				keys: [{ room_id: ROOM_ID, session_id: 'wanted' }]
+			}
+		);
+	});
+
+	it('loads lazy room members before authorising a requester', async () => {
+		const harness = buildHarness();
+		let membersLoaded = false;
+		harness.room.loadMembersIfNeeded = vi.fn(async () => {
+			membersLoaded = true;
+			return true;
+		});
+		harness.room.getMember.mockImplementation((userId: string) =>
+			membersLoaded ? harness.memberships.get(userId) : undefined
+		);
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'lazy-request',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+
+		await vi.waitFor(() =>
+			expect(harness.crypto.exportRoomKeys).toHaveBeenCalled()
+		);
+		expect(harness.room.loadMembersIfNeeded).toHaveBeenCalledOnce();
+	});
+
+	it('imports only matching room keys from a current or former member', async () => {
+		const harness = buildHarness();
+		const imported = vi.fn();
+		window.addEventListener(MATRIX_HISTORY_KEYS_IMPORTED_EVENT, imported, {
+			once: true
+		});
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_bundle', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'request-1',
+				keys: [
+					{ room_id: ROOM_ID, session_id: 'wanted' },
+					{ room_id: '!other:matrix', session_id: 'blocked' }
+				]
+			})
+		);
+		await vi.waitFor(() =>
+			expect(harness.crypto.importRoomKeys).toHaveBeenCalled()
+		);
+
+		expect(harness.crypto.importRoomKeys).toHaveBeenCalledWith([
+			{ room_id: ROOM_ID, session_id: 'wanted' }
+		]);
+		expect(imported).toHaveBeenCalledOnce();
+	});
+
+	it('does not export keys to a sender who is not joined', async () => {
+		const harness = buildHarness();
+		harness.memberships.set(PEER, member(PEER, 'leave'));
+		const service = new MatrixRoomHistoryKeyTransfer();
+		service.initialize(harness.client as any);
+		harness.emitToDevice(
+			event('org.oriso.room_history_key_request', PEER, {
+				room_id: ROOM_ID,
+				request_id: 'request-1',
+				requester_user_id: PEER,
+				requester_device_id: 'ASKER1'
+			})
+		);
+		await Promise.resolve();
+
+		expect(harness.crypto.exportRoomKeys).not.toHaveBeenCalled();
+	});
+});

--- a/src/services/matrixRoomHistoryKeyTransfer.ts
+++ b/src/services/matrixRoomHistoryKeyTransfer.ts
@@ -1,5 +1,6 @@
 import { ClientEvent, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import type { IMegolmSessionData } from 'matrix-js-sdk/lib/@types/crypto';
+import { isInvisibleCryptoEnabledForClient } from './matrixDeviceIsolation';
 
 const KEY_REQUEST_EVENT = 'org.oriso.room_history_key_request';
 const KEY_BUNDLE_EVENT = 'org.oriso.room_history_key_bundle';
@@ -60,6 +61,7 @@ export const isUndecryptedRoomEvent = (event: any): boolean => {
 export class MatrixRoomHistoryKeyTransfer {
 	private client: MatrixClient | null = null;
 	private readonly lastRequestAt = new Map<string, number>();
+	private readonly lastHandledRequestAt = new Map<string, number>();
 	private readonly pendingRooms = new Set<string>();
 
 	public initialize(client: MatrixClient): void {
@@ -90,16 +92,19 @@ export class MatrixRoomHistoryKeyTransfer {
 		const deviceId = client?.getDeviceId();
 		const room = client?.getRoom(roomId);
 		if (!client || !crypto || !userId || !deviceId || !room) {
+			emitDiagnostic('request-prerequisite-missing');
 			this.pendingRooms.add(roomId);
 			return false;
 		}
 		if (room.getMember(userId)?.membership !== 'join') {
+			emitDiagnostic('request-membership-rejected');
 			this.pendingRooms.add(roomId);
 			return false;
 		}
 
 		const now = Date.now();
 		if (now - (this.lastRequestAt.get(roomId) || 0) < REQUEST_THROTTLE_MS) {
+			emitDiagnostic('request-throttled');
 			return false;
 		}
 
@@ -107,7 +112,10 @@ export class MatrixRoomHistoryKeyTransfer {
 			.getJoinedMembers()
 			.map((member) => member.userId)
 			.filter((memberUserId) => memberUserId !== userId);
-		if (otherUsers.length === 0) return false;
+		if (otherUsers.length === 0) {
+			emitDiagnostic('request-no-peer');
+			return false;
+		}
 
 		const deviceMap = await crypto.getUserDeviceInfo(otherUsers, true);
 		const targets = otherUsers.flatMap((memberUserId) =>
@@ -118,7 +126,10 @@ export class MatrixRoomHistoryKeyTransfer {
 				})
 			)
 		);
-		if (targets.length === 0) return false;
+		if (targets.length === 0) {
+			emitDiagnostic('request-no-target-device');
+			return false;
+		}
 
 		const requestId =
 			typeof globalThis.crypto?.randomUUID === 'function'
@@ -143,7 +154,10 @@ export class MatrixRoomHistoryKeyTransfer {
 		const deliveredTargetCount = deliveryResults.filter(
 			(result) => result.status === 'fulfilled'
 		).length;
-		if (deliveredTargetCount === 0) return false;
+		if (deliveredTargetCount === 0) {
+			emitDiagnostic('request-delivery-failed');
+			return false;
+		}
 		window.dispatchEvent(
 			new CustomEvent(MATRIX_HISTORY_KEYS_REQUESTED_EVENT, {
 				detail: {
@@ -160,16 +174,21 @@ export class MatrixRoomHistoryKeyTransfer {
 	private onReceivedToDeviceMessage = (payload: any): void => {
 		const message = payload?.message;
 		if (!message) return;
-		emitDiagnostic('received', { eventType: message.type });
 		const event = {
 			getType: () => message.type,
 			getSender: () => message.sender,
 			getContent: () => message.content
 		} as MatrixEvent;
 		if (event.getType() === KEY_REQUEST_EVENT) {
-			void this.handleKeyRequest(event).catch(() => undefined);
+			emitDiagnostic('received', { eventType: KEY_REQUEST_EVENT });
+			void this.handleKeyRequest(event).catch(() =>
+				emitDiagnostic('request-handler-failed')
+			);
 		} else if (event.getType() === KEY_BUNDLE_EVENT) {
-			void this.handleKeyBundle(event).catch(() => undefined);
+			emitDiagnostic('received', { eventType: KEY_BUNDLE_EVENT });
+			void this.handleKeyBundle(event).catch(() =>
+				emitDiagnostic('bundle-handler-failed')
+			);
 		}
 	};
 
@@ -207,16 +226,6 @@ export class MatrixRoomHistoryKeyTransfer {
 			return;
 		}
 
-		const keys = (await crypto.exportRoomKeys()).filter(
-			(key) => key.room_id === content.room_id
-		);
-		if (keys.length === 0 || keys.length > MAX_KEY_BUNDLE_COUNT) {
-			emitDiagnostic('request-key-count-rejected', {
-				keyCount: keys.length
-			});
-			return;
-		}
-
 		// The requester may have logged in only seconds ago. Refresh its device
 		// list before Olm encryption; otherwise Rust Crypto can silently build an
 		// empty to-device batch for the not-yet-cached device.
@@ -230,6 +239,37 @@ export class MatrixRoomHistoryKeyTransfer {
 				?.has(content.requester_device_id)
 		) {
 			emitDiagnostic('requester-device-missing');
+			return;
+		}
+		if (isInvisibleCryptoEnabledForClient(client)) {
+			const verification = await crypto.getDeviceVerificationStatus(
+				content.requester_user_id,
+				content.requester_device_id
+			);
+			if (!verification?.isVerified()) {
+				emitDiagnostic('requester-device-unverified');
+				return;
+			}
+		}
+
+		const handledRequestKey = `${content.room_id}:${content.requester_user_id}:${content.requester_device_id}`;
+		const now = Date.now();
+		if (
+			now - (this.lastHandledRequestAt.get(handledRequestKey) || 0) <
+			REQUEST_THROTTLE_MS
+		) {
+			emitDiagnostic('request-handler-throttled');
+			return;
+		}
+		this.lastHandledRequestAt.set(handledRequestKey, now);
+
+		const keys = (await crypto.exportRoomKeys()).filter(
+			(key) => key.room_id === content.room_id
+		);
+		if (keys.length === 0 || keys.length > MAX_KEY_BUNDLE_COUNT) {
+			emitDiagnostic('request-key-count-rejected', {
+				keyCount: keys.length
+			});
 			return;
 		}
 
@@ -269,6 +309,7 @@ export class MatrixRoomHistoryKeyTransfer {
 			content.keys.length === 0 ||
 			content.keys.length > MAX_KEY_BUNDLE_COUNT
 		) {
+			emitDiagnostic('bundle-invalid');
 			return;
 		}
 
@@ -281,13 +322,17 @@ export class MatrixRoomHistoryKeyTransfer {
 				room.getMember(sender)?.membership || ''
 			)
 		) {
+			emitDiagnostic('bundle-membership-rejected');
 			return;
 		}
 
 		const roomKeys = content.keys.filter(
 			(key) => key && key.room_id === content.room_id
 		);
-		if (roomKeys.length === 0) return;
+		if (roomKeys.length === 0) {
+			emitDiagnostic('bundle-room-mismatch');
+			return;
+		}
 		await crypto.importRoomKeys(roomKeys);
 		window.dispatchEvent(
 			new CustomEvent(MATRIX_HISTORY_KEYS_IMPORTED_EVENT, {

--- a/src/services/matrixRoomHistoryKeyTransfer.ts
+++ b/src/services/matrixRoomHistoryKeyTransfer.ts
@@ -1,0 +1,300 @@
+import { ClientEvent, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import type { IMegolmSessionData } from 'matrix-js-sdk/lib/@types/crypto';
+
+const KEY_REQUEST_EVENT = 'org.oriso.room_history_key_request';
+const KEY_BUNDLE_EVENT = 'org.oriso.room_history_key_bundle';
+const REQUEST_THROTTLE_MS = 30_000;
+const MAX_KEY_BUNDLE_COUNT = 5_000;
+
+export const MATRIX_HISTORY_KEYS_IMPORTED_EVENT =
+	'oriso:matrix-history-keys-imported';
+export const MATRIX_HISTORY_KEYS_REQUESTED_EVENT =
+	'oriso:matrix-history-keys-requested';
+export const MATRIX_HISTORY_KEYS_SENT_EVENT = 'oriso:matrix-history-keys-sent';
+export const MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT =
+	'oriso:matrix-history-keys-diagnostic';
+
+const emitDiagnostic = (stage: string, detail: Record<string, unknown> = {}) =>
+	window.dispatchEvent(
+		new CustomEvent(MATRIX_HISTORY_KEYS_DIAGNOSTIC_EVENT, {
+			detail: { stage, ...detail }
+		})
+	);
+
+type KeyRequest = {
+	room_id: string;
+	request_id: string;
+	requester_user_id: string;
+	requester_device_id: string;
+};
+
+type KeyBundle = {
+	room_id: string;
+	request_id: string;
+	keys: IMegolmSessionData[];
+};
+
+const isNonEmptyString = (value: unknown): value is string =>
+	typeof value === 'string' && value.length > 0;
+
+export const isUndecryptedRoomEvent = (event: any): boolean => {
+	const clearContent = event?.getClearContent?.();
+	const sdkFailureBody = (clearContent || event?.getContent?.())?.body;
+	return (
+		event?.isDecryptionFailure?.() === true ||
+		event?.getContent?.()?.msgtype === 'm.bad.encrypted' ||
+		(event?.getType?.() === 'm.room.encrypted' && !clearContent?.msgtype) ||
+		(typeof sdkFailureBody === 'string' &&
+			sdkFailureBody.includes('Unable to decrypt: DecryptionError'))
+	);
+};
+
+/**
+ * Transfers only the Megolm sessions for one room, device-to-device over Olm.
+ *
+ * A late-joining counsellor cannot decrypt messages sent before they joined:
+ * that is an intentional Megolm property. For an authorised case handover the
+ * new device asks the other joined room members for the already-held sessions.
+ * The keys never pass through ORISO services or plaintext Matrix events.
+ */
+export class MatrixRoomHistoryKeyTransfer {
+	private client: MatrixClient | null = null;
+	private readonly lastRequestAt = new Map<string, number>();
+	private readonly pendingRooms = new Set<string>();
+
+	public initialize(client: MatrixClient): void {
+		if (this.client === client) return;
+		this.detach();
+		this.client = client;
+		client.on(
+			ClientEvent.ReceivedToDeviceMessage,
+			this.onReceivedToDeviceMessage
+		);
+		for (const roomId of this.pendingRooms) {
+			void this.requestKeys(roomId).catch(() => undefined);
+		}
+	}
+
+	public detach(): void {
+		this.client?.off(
+			ClientEvent.ReceivedToDeviceMessage,
+			this.onReceivedToDeviceMessage
+		);
+		this.client = null;
+	}
+
+	public async requestKeys(roomId: string): Promise<boolean> {
+		const client = this.client;
+		const crypto = client?.getCrypto();
+		const userId = client?.getUserId();
+		const deviceId = client?.getDeviceId();
+		const room = client?.getRoom(roomId);
+		if (!client || !crypto || !userId || !deviceId || !room) {
+			this.pendingRooms.add(roomId);
+			return false;
+		}
+		if (room.getMember(userId)?.membership !== 'join') {
+			this.pendingRooms.add(roomId);
+			return false;
+		}
+
+		const now = Date.now();
+		if (now - (this.lastRequestAt.get(roomId) || 0) < REQUEST_THROTTLE_MS) {
+			return false;
+		}
+
+		const otherUsers = room
+			.getJoinedMembers()
+			.map((member) => member.userId)
+			.filter((memberUserId) => memberUserId !== userId);
+		if (otherUsers.length === 0) return false;
+
+		const deviceMap = await crypto.getUserDeviceInfo(otherUsers, true);
+		const targets = otherUsers.flatMap((memberUserId) =>
+			Array.from(deviceMap.get(memberUserId)?.values() || []).map(
+				(device) => ({
+					userId: memberUserId,
+					deviceId: device.deviceId
+				})
+			)
+		);
+		if (targets.length === 0) return false;
+
+		const requestId =
+			typeof globalThis.crypto?.randomUUID === 'function'
+				? globalThis.crypto.randomUUID()
+				: `${deviceId}-${now}`;
+		this.lastRequestAt.set(roomId, now);
+		const requestContent = {
+			room_id: roomId,
+			request_id: requestId,
+			requester_user_id: userId,
+			requester_device_id: deviceId
+		};
+		const deliveryResults = await Promise.allSettled(
+			targets.map((target) =>
+				client.encryptAndSendToDevice(
+					KEY_REQUEST_EVENT,
+					[target],
+					requestContent
+				)
+			)
+		);
+		const deliveredTargetCount = deliveryResults.filter(
+			(result) => result.status === 'fulfilled'
+		).length;
+		if (deliveredTargetCount === 0) return false;
+		window.dispatchEvent(
+			new CustomEvent(MATRIX_HISTORY_KEYS_REQUESTED_EVENT, {
+				detail: {
+					roomId,
+					targetCount: deliveredTargetCount,
+					attemptedTargetCount: targets.length
+				}
+			})
+		);
+		this.pendingRooms.delete(roomId);
+		return true;
+	}
+
+	private onReceivedToDeviceMessage = (payload: any): void => {
+		const message = payload?.message;
+		if (!message) return;
+		emitDiagnostic('received', { eventType: message.type });
+		const event = {
+			getType: () => message.type,
+			getSender: () => message.sender,
+			getContent: () => message.content
+		} as MatrixEvent;
+		if (event.getType() === KEY_REQUEST_EVENT) {
+			void this.handleKeyRequest(event).catch(() => undefined);
+		} else if (event.getType() === KEY_BUNDLE_EVENT) {
+			void this.handleKeyBundle(event).catch(() => undefined);
+		}
+	};
+
+	private async handleKeyRequest(event: MatrixEvent): Promise<void> {
+		const client = this.client;
+		const crypto = client?.getCrypto();
+		const sender = event.getSender();
+		const content = event.getContent() as Partial<KeyRequest>;
+		if (
+			!client ||
+			!crypto ||
+			!sender ||
+			!isNonEmptyString(content.room_id) ||
+			!isNonEmptyString(content.request_id) ||
+			!isNonEmptyString(content.requester_user_id) ||
+			!isNonEmptyString(content.requester_device_id) ||
+			sender !== content.requester_user_id
+		) {
+			emitDiagnostic('request-invalid');
+			return;
+		}
+
+		const room = client.getRoom(content.room_id);
+		await (room as any)?.loadMembersIfNeeded?.();
+		if (
+			!room ||
+			room.getMember(sender)?.membership !== 'join' ||
+			!['join', 'leave'].includes(
+				room.getMember(client.getUserId() || '')?.membership || ''
+			)
+		) {
+			emitDiagnostic('request-membership-rejected', {
+				roomFound: Boolean(room)
+			});
+			return;
+		}
+
+		const keys = (await crypto.exportRoomKeys()).filter(
+			(key) => key.room_id === content.room_id
+		);
+		if (keys.length === 0 || keys.length > MAX_KEY_BUNDLE_COUNT) {
+			emitDiagnostic('request-key-count-rejected', {
+				keyCount: keys.length
+			});
+			return;
+		}
+
+		// The requester may have logged in only seconds ago. Refresh its device
+		// list before Olm encryption; otherwise Rust Crypto can silently build an
+		// empty to-device batch for the not-yet-cached device.
+		const requesterDevices = await crypto.getUserDeviceInfo(
+			[content.requester_user_id],
+			true
+		);
+		if (
+			!requesterDevices
+				.get(content.requester_user_id)
+				?.has(content.requester_device_id)
+		) {
+			emitDiagnostic('requester-device-missing');
+			return;
+		}
+
+		await client.encryptAndSendToDevice(
+			KEY_BUNDLE_EVENT,
+			[
+				{
+					userId: content.requester_user_id,
+					deviceId: content.requester_device_id
+				}
+			],
+			{
+				room_id: content.room_id,
+				request_id: content.request_id,
+				keys
+			}
+		);
+		window.dispatchEvent(
+			new CustomEvent(MATRIX_HISTORY_KEYS_SENT_EVENT, {
+				detail: { roomId: content.room_id, keyCount: keys.length }
+			})
+		);
+	}
+
+	private async handleKeyBundle(event: MatrixEvent): Promise<void> {
+		const client = this.client;
+		const crypto = client?.getCrypto();
+		const sender = event.getSender();
+		const content = event.getContent() as Partial<KeyBundle>;
+		if (
+			!client ||
+			!crypto ||
+			!sender ||
+			!isNonEmptyString(content.room_id) ||
+			!isNonEmptyString(content.request_id) ||
+			!Array.isArray(content.keys) ||
+			content.keys.length === 0 ||
+			content.keys.length > MAX_KEY_BUNDLE_COUNT
+		) {
+			return;
+		}
+
+		const room = client.getRoom(content.room_id);
+		await (room as any)?.loadMembersIfNeeded?.();
+		if (
+			!room ||
+			room.getMember(client.getUserId() || '')?.membership !== 'join' ||
+			!['join', 'leave'].includes(
+				room.getMember(sender)?.membership || ''
+			)
+		) {
+			return;
+		}
+
+		const roomKeys = content.keys.filter(
+			(key) => key && key.room_id === content.room_id
+		);
+		if (roomKeys.length === 0) return;
+		await crypto.importRoomKeys(roomKeys);
+		window.dispatchEvent(
+			new CustomEvent(MATRIX_HISTORY_KEYS_IMPORTED_EVENT, {
+				detail: { roomId: content.room_id, imported: roomKeys.length }
+			})
+		);
+	}
+}
+
+export const matrixRoomHistoryKeyTransfer = new MatrixRoomHistoryKeyTransfer();


### PR DESCRIPTION
## Summary

- render the immutable token-bound DPA contract before confirmation
- transfer affected Matrix room history keys to the authorised new case owner
- refresh the timeline after key import
- exclude the current Circle owner from co-moderator selection

## Verification

- 1,191 unit tests passed across 183 test files
- ESLint passed
- TypeScript passed
- production build passed
- Hot PreDev browser proof covers the visible DPA contract and confirmation flow
- Stylelint is not claimed: the repository baseline contains one inherited error at `src/components/messageSubmitInterface/messageSubmitInterface.styles.scss:1670`, outside this PR diff

Closes OpenResilienceInitiative/ORISO-Frontend#561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

