### PR TITLE
fix(tour): render the carousel summary as text, not raw markup

### DIFF
--- a/src/components/productTour/TourOverviewCarousel.component.test.tsx
+++ b/src/components/productTour/TourOverviewCarousel.component.test.tsx
@@ -13,7 +13,9 @@ import type { TourDefinition } from './types';
 
 const translations: Record<string, string> = {
 	'walkthrough.title': 'Rundgang',
-	'walkthrough.subtitle': 'Kurzer Rundgang durch die Anwendung.',
+	// The legacy walkthrough copy carries inline HTML — the card must not print it.
+	'walkthrough.subtitle':
+		'Kurzer Rundgang durch die Anwendung. <br /> Jederzeit erneut startbar.',
 	'walkthrough.overview.title': 'Meine Rundgänge',
 	'walkthrough.overview.subtitle': 'Tutorials starten und fortsetzen.',
 	'walkthrough.overview.empty': 'Keine Rundgänge verfügbar.',
@@ -61,6 +63,29 @@ afterEach(() => {
 });
 
 describe('TourOverviewCarousel', () => {
+	it('renders the summary as readable text, never as raw markup', async () => {
+		// Found on Pre-Dev during gate run e2e-20260720-1507: the card printed a
+		// literal "<br />" because the shared legacy copy contains inline HTML.
+		render(
+			<TourOverviewCarousel
+				tours={[consultantTour]}
+				audience="consultant"
+				loadProgress={() => Promise.resolve([])}
+				onStartTour={() => {}}
+			/>
+		);
+
+		await waitFor(() => expect(screen.getByText('Rundgang')).toBeTruthy());
+		const summary = document.querySelector(
+			'.tourOverview__cardSummary'
+		) as HTMLElement;
+		expect(summary.textContent).not.toContain('<br');
+		expect(summary.textContent).toContain(
+			'Kurzer Rundgang durch die Anwendung.'
+		);
+		expect(summary.textContent).toContain('Jederzeit erneut startbar.');
+	});
+
 	it('lists only tours matching the audience with their progress status', async () => {
 		render(
 			<TourOverviewCarousel

--- a/src/components/productTour/TourOverviewCarousel.tsx
+++ b/src/components/productTour/TourOverviewCarousel.tsx
@@ -23,6 +23,19 @@ export interface TourOverviewCarouselProps {
 	onStartTour: (tour: TourDefinition, mode: TourStartMode) => void;
 }
 
+/**
+ * Tour copy is shared with the tooltip, where it is rendered as sanitized HTML.
+ * The compact card renders plain text, so inline markup from the legacy
+ * walkthrough keys (e.g. `<br />`) would otherwise be printed literally — seen
+ * on Pre-Dev during gate run e2e-20260720-1507. Tags are dropped rather than
+ * rendered so the card never becomes an HTML sink.
+ */
+const toPlainText = (value: string): string =>
+	value
+		.replace(/<[^>]*>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+
 const actionForStatus = (status: TourStatus): TourStartMode => {
 	if (status === 'in_progress') {
 		return 'continue';
@@ -128,7 +141,7 @@ export const TourOverviewCarousel = ({
 									{translate(tour.titleKey)}
 								</h3>
 								<p className="tourOverview__cardSummary">
-									{translate(tour.summaryKey)}
+									{toPlainText(translate(tour.summaryKey))}
 								</p>
 								<Button
 									item={{


### PR DESCRIPTION
Part of epic OpenResilienceInitiative/ORISO-Frontend#521. Found on Pre-Dev during E2E gate run `e2e-20260720-1507` (screenshot evidence in that run's artifacts).

**Problem:** the "Meine Rundgänge" card printed a literal `<br />`. The tour copy is shared with the tooltip, which renders it as sanitized HTML; the compact card renders plain text, so inline markup from the legacy `walkthrough.*` keys showed up verbatim.

**What changed:** the card summary passes the translated string through a small `toPlainText` helper that drops tags and collapses whitespace. Tags are stripped rather than rendered, so the card does not become a second HTML sink — the tooltip stays the only place that renders tour HTML, and it keeps its sanitizer.

**Verification:** red-first component test asserting the rendered summary contains the sentences but never `<br`; full productTour module green (56 tests), `lint:scripts` and `test:unit` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product tour summaries by removing embedded HTML markup and normalizing spacing.
  * Ensured legacy translated content displays as readable text across tour overview cards.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->