### PR TITLE
fix: make live chat availability backend-authoritative

### DIFF
--- a/src/api/apiSetLiveChatAvailability.response.test.ts
+++ b/src/api/apiSetLiveChatAvailability.response.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiHeartbeatLiveChatAvailability } from './apiSetLiveChatAvailability';
+
+describe('live-chat heartbeat response parsing', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('parses the authoritative availability from a real POST response', async () => {
+		vi.stubGlobal(
+			'Request',
+			class {
+				constructor(
+					public url: string,
+					public init?: RequestInit
+				) {}
+			}
+		);
+		const response = {
+			status: 200,
+			json: vi.fn().mockResolvedValue({ available: true })
+		} as unknown as Response;
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+		await expect(apiHeartbeatLiveChatAvailability()).resolves.toBe(true);
+		expect(response.json).toHaveBeenCalledOnce();
+	});
+});

--- a/src/api/apiSetLiveChatAvailability.response.test.ts
+++ b/src/api/apiSetLiveChatAvailability.response.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { apiHeartbeatLiveChatAvailability } from './apiSetLiveChatAvailability';
+import {
+	apiHeartbeatLiveChatAvailability,
+	apiSetLiveChatAvailability
+} from './apiSetLiveChatAvailability';
+import { FETCH_ERRORS } from './fetchData';
 
 describe('live-chat heartbeat response parsing', () => {
 	afterEach(() => {
@@ -25,5 +29,25 @@ describe('live-chat heartbeat response parsing', () => {
 
 		await expect(apiHeartbeatLiveChatAvailability()).resolves.toBe(true);
 		expect(response.json).toHaveBeenCalledOnce();
+	});
+
+	it('rejects an availability write failure for inline recovery', async () => {
+		vi.stubGlobal(
+			'Request',
+			class {
+				constructor(
+					public url: string,
+					public init?: RequestInit
+				) {}
+			}
+		);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({ status: 500 } as Response)
+		);
+
+		await expect(apiSetLiveChatAvailability(true)).rejects.toThrow(
+			FETCH_ERRORS.CATCH_ALL
+		);
 	});
 });

--- a/src/api/apiSetLiveChatAvailability.test.ts
+++ b/src/api/apiSetLiveChatAvailability.test.ts
@@ -5,7 +5,7 @@ import {
 	apiHeartbeatLiveChatAvailability,
 	apiSetLiveChatAvailability
 } from './apiSetLiveChatAvailability';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
 import { endpoints } from '../resources/scripts/endpoints';
 
 vi.mock('./fetchData', async () => {
@@ -44,7 +44,8 @@ describe('live-chat availability API', () => {
 		await expect(apiHeartbeatLiveChatAvailability()).resolves.toBe(false);
 		expect(fetchData).toHaveBeenCalledWith({
 			url: endpoints.consultantLiveChatAvailabilityHeartbeat,
-			method: FETCH_METHODS.POST
+			method: FETCH_METHODS.POST,
+			responseHandling: [FETCH_SUCCESS.CONTENT]
 		});
 	});
 });

--- a/src/api/apiSetLiveChatAvailability.test.ts
+++ b/src/api/apiSetLiveChatAvailability.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	apiGetLiveChatAvailability,
+	apiHeartbeatLiveChatAvailability,
+	apiSetLiveChatAvailability
+} from './apiSetLiveChatAvailability';
+import { fetchData, FETCH_METHODS } from './fetchData';
+import { endpoints } from '../resources/scripts/endpoints';
+
+vi.mock('./fetchData', async () => {
+	const actual: any = await vi.importActual('./fetchData');
+	return { ...actual, fetchData: vi.fn() };
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('live-chat availability API', () => {
+	it('reads the backend-authoritative state', async () => {
+		vi.mocked(fetchData).mockResolvedValueOnce({ available: true });
+
+		await expect(apiGetLiveChatAvailability()).resolves.toBe(true);
+		expect(fetchData).toHaveBeenCalledWith({
+			url: endpoints.consultantLiveChatAvailability,
+			method: FETCH_METHODS.GET
+		});
+	});
+
+	it('propagates rejected availability writes', async () => {
+		vi.mocked(fetchData).mockRejectedValueOnce(
+			new Error('redis unavailable')
+		);
+
+		await expect(apiSetLiveChatAvailability(true)).rejects.toThrow(
+			'redis unavailable'
+		);
+	});
+
+	it('uses the refresh-only heartbeat endpoint', async () => {
+		vi.mocked(fetchData).mockResolvedValueOnce(undefined);
+
+		await apiHeartbeatLiveChatAvailability();
+		expect(fetchData).toHaveBeenCalledWith({
+			url: endpoints.consultantLiveChatAvailabilityHeartbeat,
+			method: FETCH_METHODS.POST
+		});
+	});
+});

--- a/src/api/apiSetLiveChatAvailability.test.ts
+++ b/src/api/apiSetLiveChatAvailability.test.ts
@@ -39,9 +39,9 @@ describe('live-chat availability API', () => {
 	});
 
 	it('uses the refresh-only heartbeat endpoint', async () => {
-		vi.mocked(fetchData).mockResolvedValueOnce(undefined);
+		vi.mocked(fetchData).mockResolvedValueOnce({ available: false });
 
-		await apiHeartbeatLiveChatAvailability();
+		await expect(apiHeartbeatLiveChatAvailability()).resolves.toBe(false);
 		expect(fetchData).toHaveBeenCalledWith({
 			url: endpoints.consultantLiveChatAvailabilityHeartbeat,
 			method: FETCH_METHODS.POST

--- a/src/api/apiSetLiveChatAvailability.ts
+++ b/src/api/apiSetLiveChatAvailability.ts
@@ -1,5 +1,5 @@
 import { endpoints } from '../resources/scripts/endpoints';
-import { fetchData, FETCH_METHODS } from './fetchData';
+import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
 
 /**
  * Tells the backend whether the current consultant is available for live chat.
@@ -26,7 +26,8 @@ export const apiGetLiveChatAvailability = (): Promise<boolean> =>
 export const apiHeartbeatLiveChatAvailability = (): Promise<boolean> =>
 	fetchData({
 		url: endpoints.consultantLiveChatAvailabilityHeartbeat,
-		method: FETCH_METHODS.POST
+		method: FETCH_METHODS.POST,
+		responseHandling: [FETCH_SUCCESS.CONTENT]
 	}).then((response: { available?: boolean }) =>
 		Boolean(response?.available)
 	);

--- a/src/api/apiSetLiveChatAvailability.ts
+++ b/src/api/apiSetLiveChatAvailability.ts
@@ -1,5 +1,10 @@
 import { endpoints } from '../resources/scripts/endpoints';
-import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+import {
+	fetchData,
+	FETCH_ERRORS,
+	FETCH_METHODS,
+	FETCH_SUCCESS
+} from './fetchData';
 
 /**
  * Tells the backend whether the current consultant is available for live chat.
@@ -11,7 +16,8 @@ export const apiSetLiveChatAvailability = (available: boolean): Promise<void> =>
 	fetchData({
 		url: endpoints.consultantLiveChatAvailability,
 		method: FETCH_METHODS.PUT,
-		bodyData: JSON.stringify({ available })
+		bodyData: JSON.stringify({ available }),
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
 	}).then(() => undefined);
 
 export const apiGetLiveChatAvailability = (): Promise<boolean> =>

--- a/src/api/apiSetLiveChatAvailability.ts
+++ b/src/api/apiSetLiveChatAvailability.ts
@@ -1,19 +1,30 @@
 import { endpoints } from '../resources/scripts/endpoints';
-import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
+import { fetchData, FETCH_METHODS } from './fetchData';
 
 /**
  * Tells the backend whether the current consultant is available for live chat.
  *
- * Driven by the Live Chat toggle and by logout so the anonymous availability count
- * updates immediately. Best-effort: failures are swallowed (the backend heartbeat
- * window will reconcile state) so this never blocks the toggle or logout flow.
+ * The promise rejects when Redis-backed availability was not acknowledged. Callers
+ * must not present or persist the requested state before this resolves.
  */
 export const apiSetLiveChatAvailability = (available: boolean): Promise<void> =>
 	fetchData({
 		url: endpoints.consultantLiveChatAvailability,
 		method: FETCH_METHODS.PUT,
-		bodyData: JSON.stringify({ available }),
-		responseHandling: [FETCH_ERRORS.CATCH_ALL]
-	})
-		.then(() => undefined)
-		.catch(() => undefined);
+		bodyData: JSON.stringify({ available })
+	}).then(() => undefined);
+
+export const apiGetLiveChatAvailability = (): Promise<boolean> =>
+	fetchData({
+		url: endpoints.consultantLiveChatAvailability,
+		method: FETCH_METHODS.GET
+	}).then((response: { available?: boolean }) =>
+		Boolean(response?.available)
+	);
+
+/** Refreshes an existing backend lease and can never enable availability. */
+export const apiHeartbeatLiveChatAvailability = (): Promise<void> =>
+	fetchData({
+		url: endpoints.consultantLiveChatAvailabilityHeartbeat,
+		method: FETCH_METHODS.POST
+	}).then(() => undefined);

--- a/src/api/apiSetLiveChatAvailability.ts
+++ b/src/api/apiSetLiveChatAvailability.ts
@@ -23,8 +23,10 @@ export const apiGetLiveChatAvailability = (): Promise<boolean> =>
 	);
 
 /** Refreshes an existing backend lease and can never enable availability. */
-export const apiHeartbeatLiveChatAvailability = (): Promise<void> =>
+export const apiHeartbeatLiveChatAvailability = (): Promise<boolean> =>
 	fetchData({
 		url: endpoints.consultantLiveChatAvailabilityHeartbeat,
 		method: FETCH_METHODS.POST
-	}).then(() => undefined);
+	}).then((response: { available?: boolean }) =>
+		Boolean(response?.available)
+	);

--- a/src/components/app/NavigationBar.tsx
+++ b/src/components/app/NavigationBar.tsx
@@ -42,9 +42,9 @@ import {
 } from '../select/SelectDropdown';
 import {
 	useLiveChatAvailable,
+	useLiveChatAvailabilityHeartbeat,
 	useLiveChatViaSidebar
 } from '../../utils/liveChatToggle';
-import { apiSetLiveChatAvailability } from '../../api/apiSetLiveChatAvailability';
 import {
 	LiveChatToggleActiveIcon,
 	LiveChatToggleInactiveIcon
@@ -102,20 +102,17 @@ export const NavigationBar = ({
 		AUTHORITIES.CONSULTANT_DEFAULT,
 		userData
 	);
-	const [liveChatAvailable, setLiveChatAvailable] = useLiveChatAvailable();
-	const [liveChatViaSidebar] = useLiveChatViaSidebar();
-
-	/*
-	 * Resync persisted Live Chat availability to the backend after login/reload.
-	 * The flag lives in localStorage, so on a fresh session (or after a backend
-	 * restart) the server doesn't yet know this consultant is available. Re-assert
-	 * it so the anonymous availability count is correct without a manual re-toggle.
-	 */
-	useEffect(() => {
-		if (isConsultant && liveChatAvailable) {
-			void apiSetLiveChatAvailability(true);
+	const [
+		liveChatAvailable,
+		setLiveChatAvailable,
+		{
+			loading: liveChatLoading,
+			pending: liveChatPending,
+			error: liveChatError
 		}
-	}, [isConsultant, liveChatAvailable]);
+	] = useLiveChatAvailable();
+	const [liveChatViaSidebar] = useLiveChatViaSidebar();
+	useLiveChatAvailabilityHeartbeat(isConsultant, liveChatAvailable);
 	const { tenant } = useContext(TenantContext);
 
 	const ref_menu = useRef<any[]>([]);
@@ -137,11 +134,15 @@ export const NavigationBar = ({
 	 * matching the original 1.0 behaviour. The rail icon stays visible in both
 	 * states — only its active/inactive styling changes.
 	 */
-	const handleLiveChatToggle = useCallback(() => {
+	const handleLiveChatToggle = useCallback(async () => {
 		const nextActive = !liveChatAvailable;
-		setLiveChatAvailable(nextActive);
-		if (nextActive) {
-			navigate('/sessions/consultant/sessionPreview?chip=liveChat');
+		try {
+			await setLiveChatAvailable(nextActive);
+			if (nextActive) {
+				navigate('/sessions/consultant/sessionPreview?chip=liveChat');
+			}
+		} catch {
+			// The hook retains the acknowledged state and exposes a localized error.
 		}
 	}, [liveChatAvailable, navigate, setLiveChatAvailable]);
 
@@ -518,6 +519,15 @@ export const NavigationBar = ({
 									? 'navigation.liveChatToggleActive'
 									: 'navigation.liveChatToggleInactive'
 							)}
+							aria-busy={liveChatPending}
+							disabled={liveChatLoading || liveChatPending}
+							title={
+								liveChatError
+									? translate(
+											'error.statusCodes.500.description'
+										)
+									: undefined
+							}
 							onClick={handleLiveChatToggle}
 						>
 							<div

--- a/src/components/logout/logout.ts
+++ b/src/components/logout/logout.ts
@@ -1,5 +1,6 @@
 import { apiKeycloakLogout } from '../../api/apiLogoutKeycloak';
 import { apiSetLiveChatAvailability } from '../../api/apiSetLiveChatAvailability';
+import { clearLiveChatAvailabilityPreference } from '../../utils/liveChatAvailabilityStorage';
 import { getTenantSettings } from '../../utils/tenantSettingsHelper';
 import { budibaseLogout } from '../budibase/budibaseLogout';
 import { removeAllCookies } from '../sessionCookie/accessSessionCookie';
@@ -39,7 +40,14 @@ export const logout = async (
 
 	/* Drop live-chat availability while the access token is still valid, so the
 	 * anonymous availability count decreases immediately on logout. */
-	await apiSetLiveChatAvailability(false);
+	try {
+		await apiSetLiveChatAvailability(false);
+	} catch {
+		// Logout must continue even when the availability store is unavailable.
+	} finally {
+		// Prevent this or another tab from continuing to present/refresh stale state.
+		clearLiveChatAvailabilityPreference();
+	}
 
 	Promise.all([
 		apiKeycloakLogout(),

--- a/src/components/profile/LiveChatAvailability.tsx
+++ b/src/components/profile/LiveChatAvailability.tsx
@@ -14,14 +14,24 @@ import {
 export const LiveChatAvailability = () => {
 	const { t: translate } = useTranslation();
 	const navigate = useNavigate();
-	const [liveChatAvailable, setLiveChatAvailable] = useLiveChatAvailable();
+	const [
+		liveChatAvailable,
+		setLiveChatAvailable,
+		{ loading, pending, error }
+	] = useLiveChatAvailable();
 	const [liveChatViaSidebar, setLiveChatViaSidebar] = useLiveChatViaSidebar();
 
 	const handleToggle = useCallback(
-		(checked: boolean) => {
-			setLiveChatAvailable(checked);
-			if (checked) {
-				navigate('/sessions/consultant/sessionPreview?chip=liveChat');
+		async (checked: boolean) => {
+			try {
+				await setLiveChatAvailable(checked);
+				if (checked) {
+					navigate(
+						'/sessions/consultant/sessionPreview?chip=liveChat'
+					);
+				}
+			} catch {
+				// Keep the backend-acknowledged state; the message below is localized.
 			}
 		},
 		[navigate, setLiveChatAvailable]
@@ -49,7 +59,7 @@ export const LiveChatAvailability = () => {
 						className="mr--1"
 						onChange={handleToggle}
 						checked={liveChatAvailable}
-						disabled={liveChatViaSidebar}
+						disabled={liveChatViaSidebar || loading || pending}
 						aria-label={translate(
 							'profile.functions.liveChat.toggleLabel'
 						)}
@@ -60,6 +70,14 @@ export const LiveChatAvailability = () => {
 						)}
 						type="standard"
 					/>
+					{error && (
+						<Text
+							text={translate(
+								'error.statusCodes.500.description'
+							)}
+							type="standard"
+						/>
+					)}
 				</div>
 				{/* New preference: move the availability control into the nav
 				    rail. See the description text for the exact behaviour. */}

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -64,6 +64,9 @@ export const endpoints = {
 		userServiceOrigin + '/service/conversations/consultants/enquiries/',
 	consultantLiveChatAvailability:
 		userServiceOrigin + '/service/conversations/consultants/availability',
+	consultantLiveChatAvailabilityHeartbeat:
+		userServiceOrigin +
+		'/service/conversations/consultants/availability/heartbeat',
 	consultantSessions:
 		userServiceOrigin + '/service/users/sessions/consultants?status=2&',
 	consultantStatistics:

--- a/src/utils/liveChatAvailabilityStorage.ts
+++ b/src/utils/liveChatAvailabilityStorage.ts
@@ -1,0 +1,36 @@
+export const LIVE_CHAT_AVAILABILITY_STORAGE_KEY =
+	'caritas_liveChatAvailability';
+export const LIVE_CHAT_AVAILABILITY_CHANGE_EVENT =
+	'caritas:liveChatAvailabilityChange';
+
+/** This is a desired preference only; visible active state comes from the API. */
+export const readLiveChatAvailabilityPreference = (): boolean => {
+	try {
+		return localStorage.getItem(LIVE_CHAT_AVAILABILITY_STORAGE_KEY) === '1';
+	} catch {
+		return false;
+	}
+};
+
+export const persistLiveChatAvailabilityPreference = (
+	active: boolean
+): void => {
+	try {
+		if (active) {
+			localStorage.setItem(LIVE_CHAT_AVAILABILITY_STORAGE_KEY, '1');
+		} else {
+			localStorage.removeItem(LIVE_CHAT_AVAILABILITY_STORAGE_KEY);
+		}
+	} catch {
+		/* Storage errors do not change the backend-acknowledged state. */
+	}
+	window.dispatchEvent(
+		new CustomEvent(LIVE_CHAT_AVAILABILITY_CHANGE_EVENT, {
+			detail: { active }
+		})
+	);
+};
+
+export const clearLiveChatAvailabilityPreference = (): void => {
+	persistLiveChatAvailabilityPreference(false);
+};

--- a/src/utils/liveChatToggle.test.tsx
+++ b/src/utils/liveChatToggle.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	useLiveChatAvailable,
+	useLiveChatAvailabilityHeartbeat
+} from './liveChatToggle';
+import {
+	apiGetLiveChatAvailability,
+	apiHeartbeatLiveChatAvailability,
+	apiSetLiveChatAvailability
+} from '../api/apiSetLiveChatAvailability';
+
+vi.mock('../api/apiSetLiveChatAvailability', () => ({
+	apiGetLiveChatAvailability: vi.fn(),
+	apiHeartbeatLiveChatAvailability: vi.fn(),
+	apiSetLiveChatAvailability: vi.fn()
+}));
+
+describe('live-chat availability state', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.mocked(apiGetLiveChatAvailability).mockResolvedValue(false);
+		vi.mocked(apiSetLiveChatAvailability).mockResolvedValue(undefined);
+		vi.mocked(apiHeartbeatLiveChatAvailability).mockResolvedValue(
+			undefined
+		);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('does not display stale local availability when the backend says false', async () => {
+		localStorage.setItem('caritas_liveChatAvailability', '1');
+
+		const { result } = renderHook(() => useLiveChatAvailable());
+
+		await waitFor(() =>
+			expect(apiGetLiveChatAvailability).toHaveBeenCalled()
+		);
+		expect(result.current[0]).toBe(false);
+	});
+
+	it('commits availability only after the backend acknowledges it', async () => {
+		const { result } = renderHook(() => useLiveChatAvailable());
+		await waitFor(() =>
+			expect(apiGetLiveChatAvailability).toHaveBeenCalled()
+		);
+
+		await act(async () => result.current[1](true));
+
+		expect(result.current[0]).toBe(true);
+		expect(localStorage.getItem('caritas_liveChatAvailability')).toBe('1');
+	});
+
+	it('keeps the previous state and preference when enabling is rejected', async () => {
+		vi.mocked(apiSetLiveChatAvailability).mockRejectedValueOnce(
+			new Error('redis unavailable')
+		);
+		const { result } = renderHook(() => useLiveChatAvailable());
+		await waitFor(() =>
+			expect(apiGetLiveChatAvailability).toHaveBeenCalled()
+		);
+
+		await expect(act(async () => result.current[1](true))).rejects.toThrow(
+			'redis unavailable'
+		);
+
+		expect(result.current[0]).toBe(false);
+		expect(localStorage.getItem('caritas_liveChatAvailability')).toBeNull();
+	});
+
+	it('reconciles only relevant cross-tab preference changes with the backend', async () => {
+		const { result } = renderHook(() => useLiveChatAvailable());
+		await waitFor(() => expect(result.current[2].loading).toBe(false));
+		vi.mocked(apiGetLiveChatAvailability).mockClear();
+
+		window.dispatchEvent(new StorageEvent('storage', { key: 'unrelated' }));
+		expect(apiGetLiveChatAvailability).not.toHaveBeenCalled();
+
+		vi.mocked(apiGetLiveChatAvailability).mockResolvedValue(true);
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: 'caritas_liveChatAvailability',
+					newValue: '1'
+				})
+			);
+		});
+		await waitFor(() => expect(result.current[0]).toBe(true));
+	});
+
+	it('heartbeats while active and stops after unmount', async () => {
+		vi.useFakeTimers();
+		const { unmount } = renderHook(() =>
+			useLiveChatAvailabilityHeartbeat(true, true)
+		);
+
+		await act(async () => vi.advanceTimersByTimeAsync(45_000));
+		expect(apiHeartbeatLiveChatAvailability).toHaveBeenCalledTimes(1);
+
+		unmount();
+		await act(async () => vi.advanceTimersByTimeAsync(90_000));
+		expect(apiHeartbeatLiveChatAvailability).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not heartbeat when the acknowledged state is inactive', async () => {
+		vi.useFakeTimers();
+		renderHook(() => useLiveChatAvailabilityHeartbeat(true, false));
+
+		await act(async () => vi.advanceTimersByTimeAsync(90_000));
+		expect(apiHeartbeatLiveChatAvailability).not.toHaveBeenCalled();
+	});
+
+	it('stops heartbeating immediately when acknowledged state becomes inactive', async () => {
+		vi.useFakeTimers();
+		const { rerender } = renderHook(
+			({ active }) => useLiveChatAvailabilityHeartbeat(true, active),
+			{ initialProps: { active: true } }
+		);
+		await act(async () => vi.advanceTimersByTimeAsync(45_000));
+		expect(apiHeartbeatLiveChatAvailability).toHaveBeenCalledTimes(1);
+
+		rerender({ active: false });
+		await act(async () => vi.advanceTimersByTimeAsync(90_000));
+		expect(apiHeartbeatLiveChatAvailability).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/liveChatToggle.test.tsx
+++ b/src/utils/liveChatToggle.test.tsx
@@ -22,9 +22,7 @@ describe('live-chat availability state', () => {
 		localStorage.clear();
 		vi.mocked(apiGetLiveChatAvailability).mockResolvedValue(false);
 		vi.mocked(apiSetLiveChatAvailability).mockResolvedValue(undefined);
-		vi.mocked(apiHeartbeatLiveChatAvailability).mockResolvedValue(
-			undefined
-		);
+		vi.mocked(apiHeartbeatLiveChatAvailability).mockResolvedValue(true);
 	});
 
 	afterEach(() => {
@@ -92,6 +90,22 @@ describe('live-chat availability state', () => {
 		await waitFor(() => expect(result.current[0]).toBe(true));
 	});
 
+	it('does not let a stale GET overwrite an acknowledged toggle', async () => {
+		let resolveGet: (available: boolean) => void = () => undefined;
+		vi.mocked(apiGetLiveChatAvailability).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveGet = resolve;
+			})
+		);
+		const { result } = renderHook(() => useLiveChatAvailable());
+
+		await act(async () => result.current[1](true));
+		await act(async () => resolveGet(false));
+
+		expect(result.current[0]).toBe(true);
+		expect(localStorage.getItem('caritas_liveChatAvailability')).toBe('1');
+	});
+
 	it('heartbeats while active and stops after unmount', async () => {
 		vi.useFakeTimers();
 		const { unmount } = renderHook(() =>
@@ -126,5 +140,23 @@ describe('live-chat availability state', () => {
 		rerender({ active: false });
 		await act(async () => vi.advanceTimersByTimeAsync(90_000));
 		expect(apiHeartbeatLiveChatAvailability).toHaveBeenCalledTimes(1);
+	});
+
+	it('deactivates all consumers when the backend reports an expired heartbeat lease', async () => {
+		vi.useFakeTimers();
+		vi.mocked(apiGetLiveChatAvailability).mockResolvedValue(true);
+		vi.mocked(apiHeartbeatLiveChatAvailability).mockResolvedValue(false);
+		const { result } = renderHook(() => {
+			const availability = useLiveChatAvailable();
+			useLiveChatAvailabilityHeartbeat(true, availability[0]);
+			return availability;
+		});
+		await act(async () => Promise.resolve());
+		expect(result.current[0]).toBe(true);
+
+		await act(async () => vi.advanceTimersByTimeAsync(45_000));
+
+		expect(result.current[0]).toBe(false);
+		expect(localStorage.getItem('caritas_liveChatAvailability')).toBeNull();
 	});
 });

--- a/src/utils/liveChatToggle.test.tsx
+++ b/src/utils/liveChatToggle.test.tsx
@@ -159,4 +159,28 @@ describe('live-chat availability state', () => {
 		expect(result.current[0]).toBe(false);
 		expect(localStorage.getItem('caritas_liveChatAvailability')).toBeNull();
 	});
+
+	it('ignores a stale heartbeat result after a newly acknowledged enable', async () => {
+		vi.useFakeTimers();
+		vi.mocked(apiGetLiveChatAvailability).mockResolvedValue(true);
+		let resolveHeartbeat: (available: boolean) => void = () => undefined;
+		vi.mocked(apiHeartbeatLiveChatAvailability).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveHeartbeat = resolve;
+			})
+		);
+		const { result } = renderHook(() => {
+			const availability = useLiveChatAvailable();
+			useLiveChatAvailabilityHeartbeat(true, availability[0]);
+			return availability;
+		});
+		await act(async () => Promise.resolve());
+		await act(async () => vi.advanceTimersByTimeAsync(45_000));
+
+		await act(async () => result.current[1](true));
+		await act(async () => resolveHeartbeat(false));
+
+		expect(result.current[0]).toBe(true);
+		expect(localStorage.getItem('caritas_liveChatAvailability')).toBe('1');
+	});
 });

--- a/src/utils/liveChatToggle.ts
+++ b/src/utils/liveChatToggle.ts
@@ -128,14 +128,17 @@ export const useLiveChatAvailabilityHeartbeat = (
 	useEffect(() => {
 		if (!enabled || !active) return;
 		const heartbeat = window.setInterval(() => {
+			const requestedAtRevision = availabilityRevision;
 			void apiHeartbeatLiveChatAvailability()
 				.then((leaseActive) => {
+					if (requestedAtRevision !== availabilityRevision) return;
 					if (!leaseActive) {
 						availabilityRevision += 1;
 						persistLiveChatAvailabilityPreference(false);
 					}
 				})
 				.catch(() => {
+					if (requestedAtRevision !== availabilityRevision) return;
 					availabilityRevision += 1;
 					window.dispatchEvent(
 						new CustomEvent(LIVE_CHAT_AVAILABILITY_CHANGE_EVENT, {

--- a/src/utils/liveChatToggle.ts
+++ b/src/utils/liveChatToggle.ts
@@ -29,6 +29,7 @@ import {
  */
 const SIDEBAR_STORAGE_KEY = 'caritas_liveChatViaSidebar';
 const SIDEBAR_CHANGE_EVENT = 'caritas:liveChatViaSidebarChange';
+let availabilityRevision = 0;
 
 export const isLiveChatAvailable = (): boolean => {
 	return readLiveChatAvailabilityPreference();
@@ -36,6 +37,7 @@ export const isLiveChatAvailable = (): boolean => {
 
 export const setLiveChatAvailable = async (active: boolean): Promise<void> => {
 	await apiSetLiveChatAvailability(active);
+	availabilityRevision += 1;
 	persistLiveChatAvailabilityPreference(active);
 };
 
@@ -59,14 +61,15 @@ export const useLiveChatAvailable = (): [
 	useEffect(() => {
 		let mounted = true;
 		const reconcile = async () => {
+			const requestedAtRevision = availabilityRevision;
 			try {
 				const backendActive = await apiGetLiveChatAvailability();
-				if (mounted) {
+				if (mounted && requestedAtRevision === availabilityRevision) {
 					setActive(backendActive);
 					setError(false);
 				}
 			} catch {
-				if (mounted) {
+				if (mounted && requestedAtRevision === availabilityRevision) {
 					setActive(false);
 					setError(true);
 				}
@@ -75,8 +78,13 @@ export const useLiveChatAvailable = (): [
 			}
 		};
 		const onChange = (event: Event) => {
-			const detail = (event as CustomEvent<{ active: boolean }>).detail;
-			if (detail) setActive(detail.active);
+			const detail = (
+				event as CustomEvent<{ active: boolean; error?: boolean }>
+			).detail;
+			if (detail) {
+				setActive(detail.active);
+				setError(Boolean(detail.error));
+			}
 		};
 		const onStorage = (event: StorageEvent) => {
 			if (event.key === LIVE_CHAT_AVAILABILITY_STORAGE_KEY)
@@ -120,7 +128,21 @@ export const useLiveChatAvailabilityHeartbeat = (
 	useEffect(() => {
 		if (!enabled || !active) return;
 		const heartbeat = window.setInterval(() => {
-			void apiHeartbeatLiveChatAvailability().catch(() => undefined);
+			void apiHeartbeatLiveChatAvailability()
+				.then((leaseActive) => {
+					if (!leaseActive) {
+						availabilityRevision += 1;
+						persistLiveChatAvailabilityPreference(false);
+					}
+				})
+				.catch(() => {
+					availabilityRevision += 1;
+					window.dispatchEvent(
+						new CustomEvent(LIVE_CHAT_AVAILABILITY_CHANGE_EVENT, {
+							detail: { active: false, error: true }
+						})
+					);
+				});
 		}, 45_000);
 		return () => window.clearInterval(heartbeat);
 	}, [active, enabled]);

--- a/src/utils/liveChatToggle.ts
+++ b/src/utils/liveChatToggle.ts
@@ -1,18 +1,25 @@
-import { useEffect, useState } from 'react';
-import { apiSetLiveChatAvailability } from '../api/apiSetLiveChatAvailability';
+import { useCallback, useEffect, useState } from 'react';
+import {
+	apiGetLiveChatAvailability,
+	apiHeartbeatLiveChatAvailability,
+	apiSetLiveChatAvailability
+} from '../api/apiSetLiveChatAvailability';
+import {
+	LIVE_CHAT_AVAILABILITY_CHANGE_EVENT,
+	LIVE_CHAT_AVAILABILITY_STORAGE_KEY,
+	persistLiveChatAvailabilityPreference,
+	readLiveChatAvailabilityPreference
+} from './liveChatAvailabilityStorage';
 
 /**
- * LocalStorage-backed toggle for whether the consultant is "live-chat
- * available". When on, anonymous enquiries are fetched and merged into the
- * consultant's enquiry list; when off, only registered enquiries are shown.
+ * Backend-authoritative state for whether the consultant is "live-chat
+ * available". LocalStorage keeps only the consultant's desired preference;
+ * it must never make the visible or routing state active by itself.
  *
  * Exposed as a plain util + a tiny hook so both the NavigationBar (owner of
  * the button) and the SessionsList (consumer of the state) stay in sync
  * without threading another context through the app.
  */
-const STORAGE_KEY = 'caritas_liveChatAvailability';
-const CHANGE_EVENT = 'caritas:liveChatAvailabilityChange';
-
 /**
  * Separate, UI-only preference: whether the consultant drives their Live Chat
  * availability from the navigation rail ("Live Chat über Menü Leiste
@@ -24,45 +31,99 @@ const SIDEBAR_STORAGE_KEY = 'caritas_liveChatViaSidebar';
 const SIDEBAR_CHANGE_EVENT = 'caritas:liveChatViaSidebarChange';
 
 export const isLiveChatAvailable = (): boolean => {
-	try {
-		return localStorage.getItem(STORAGE_KEY) === '1';
-	} catch {
-		return false;
-	}
+	return readLiveChatAvailabilityPreference();
 };
 
-export const setLiveChatAvailable = (active: boolean): void => {
-	try {
-		if (active) {
-			localStorage.setItem(STORAGE_KEY, '1');
-		} else {
-			localStorage.removeItem(STORAGE_KEY);
-		}
-	} catch {
-		/* storage errors are non-fatal — the toggle just won't persist */
-	}
-	/* Tell the backend immediately so the anonymous availability count reflects
-	 * this consultant going available/unavailable without waiting for a poll. */
-	void apiSetLiveChatAvailability(active);
-	window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { active } }));
+export const setLiveChatAvailable = async (active: boolean): Promise<void> => {
+	await apiSetLiveChatAvailability(active);
+	persistLiveChatAvailabilityPreference(active);
 };
 
-/** Hook: keeps UI in sync with the storage-backed flag. */
-export const useLiveChatAvailable = (): [boolean, (v: boolean) => void] => {
-	const [active, setActive] = useState<boolean>(() => isLiveChatAvailable());
+export interface LiveChatAvailabilityState {
+	loading: boolean;
+	pending: boolean;
+	error: boolean;
+}
+
+/** Hook: visible state always starts from and reconciles with the backend. */
+export const useLiveChatAvailable = (): [
+	boolean,
+	(v: boolean) => Promise<void>,
+	LiveChatAvailabilityState
+] => {
+	const [active, setActive] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState(false);
 
 	useEffect(() => {
-		const onChange = () => setActive(isLiveChatAvailable());
-		window.addEventListener(CHANGE_EVENT, onChange);
-		/* Also listen to cross-tab updates via the native storage event. */
-		window.addEventListener('storage', onChange);
+		let mounted = true;
+		const reconcile = async () => {
+			try {
+				const backendActive = await apiGetLiveChatAvailability();
+				if (mounted) {
+					setActive(backendActive);
+					setError(false);
+				}
+			} catch {
+				if (mounted) {
+					setActive(false);
+					setError(true);
+				}
+			} finally {
+				if (mounted) setLoading(false);
+			}
+		};
+		const onChange = (event: Event) => {
+			const detail = (event as CustomEvent<{ active: boolean }>).detail;
+			if (detail) setActive(detail.active);
+		};
+		const onStorage = (event: StorageEvent) => {
+			if (event.key === LIVE_CHAT_AVAILABILITY_STORAGE_KEY)
+				void reconcile();
+		};
+		void reconcile();
+		window.addEventListener(LIVE_CHAT_AVAILABILITY_CHANGE_EVENT, onChange);
+		window.addEventListener('storage', onStorage);
 		return () => {
-			window.removeEventListener(CHANGE_EVENT, onChange);
-			window.removeEventListener('storage', onChange);
+			mounted = false;
+			window.removeEventListener(
+				LIVE_CHAT_AVAILABILITY_CHANGE_EVENT,
+				onChange
+			);
+			window.removeEventListener('storage', onStorage);
 		};
 	}, []);
 
-	return [active, setLiveChatAvailable];
+	const update = useCallback(async (nextActive: boolean) => {
+		setPending(true);
+		setError(false);
+		try {
+			await setLiveChatAvailable(nextActive);
+			setActive(nextActive);
+		} catch (updateError) {
+			setError(true);
+			throw updateError;
+		} finally {
+			setPending(false);
+		}
+	}, []);
+
+	return [active, update, { loading, pending, error }];
+};
+
+/** Mounted exactly once by the consultant navigation shell. */
+export const useLiveChatAvailabilityHeartbeat = (
+	enabled: boolean,
+	active: boolean
+): void => {
+	useEffect(() => {
+		if (!enabled || !active) return;
+		const heartbeat = window.setInterval(() => {
+			void apiHeartbeatLiveChatAvailability().catch(() => undefined);
+		}, 45_000);
+		return () => window.clearInterval(heartbeat);
+	}, [active, enabled]);
 };
 
 export const isLiveChatViaSidebar = (): boolean => {


### PR DESCRIPTION
## Summary

- initialize visible Live Chat availability from the authoritative backend GET instead of localStorage
- persist and broadcast the desired preference only after the backend acknowledges the toggle
- add a single 45-second refresh-only heartbeat owner in the consultant navigation shell
- stop heartbeats on disable/unmount, reconcile relevant cross-tab changes, and clear stale preference during logout
- keep the previous state on rejected writes and expose localized busy/error UI

## TDD evidence

The initial regression suite failed because the GET and heartbeat clients did not exist, writes swallowed failures, stale localStorage immediately appeared active, and no heartbeat lifecycle existed. It is now green.

## Verification

- `npm run test:unit`: 183 files / 1,177 tests passed
- `npm run lint:scripts`: passed
- `npm run build`: passed with existing warnings
- `npm run lint:style`: blocked by the unchanged pre-dev violation at `src/components/messageSubmitInterface/messageSubmitInterface.styles.scss:1670`
- focused availability/API/endpoint suite: 13 tests passed

Depends on: OpenResilienceInitiative/ORISO-UserService#528
Related earlier UI work: #562
Closes #563
Parent: OpenResilienceInitiative/ORISO-UserService#520

🤖 Generated with [Claude Code](https://claude.com/claude-code)