### PR TITLE
Keep the session header clickable with the optional toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
 		"dev:server": "nodemon",
 		"build": "node scripts/build.js",
 		"test": "cross-env NODE_ENV=development FAST_REFRESH=false BROWSER=none REACT_APP_API_URL=http://127.0.0.1:9001 HTTPS=0 PORT=9001 WDS_SOCKET_PORT=9001 concurrently --kill-others --success first \"npm run dev\" \"wait-on http://127.0.0.1:9001 && cypress run\"",
-		"test:unit": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vitest run --maxWorkers=2 --minWorkers=1",
+		"test:unit": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --maxWorkers=2 --minWorkers=1",
 		"test:smoke": "playwright test",
 		"test:matrix-megolm": "node scripts/matrixMegolmSmoke.mjs",
 		"test:matrix-browser-reload": "concurrently --kill-others --success first \"vite --config vite.matrix-smoke.config.ts --host 127.0.0.1 --port 9010\" \"wait-on http://127.0.0.1:9010/playwright/matrix-crypto-browser-harness.html && PLAYWRIGHT_BASE_URL=http://127.0.0.1:9010 playwright test playwright/matrix-crypto-reload.smoke.spec.ts --project=chromium --reporter=list\"",

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -53,7 +53,11 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		flex: 0 0 auto; /* Header stays fixed height */
 	}
 
-	& > div:nth-child(2) {
+	// Keep the timeline in normal flex flow regardless of optional siblings
+	// such as the thread-list toolbar. An nth-child selector made the timeline
+	// absolute whenever that toolbar preceded it, allowing message controls to
+	// cover and intercept clicks on the session header.
+	& > .session__content {
 		flex: 1; /* Content takes remaining space */
 		min-height: 0;
 		position: relative;

--- a/src/components/session/sessionLayout.styles.test.ts
+++ b/src/components/session/sessionLayout.styles.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sessionStyles = () =>
+	fs.readFileSync(
+		path.join(
+			process.cwd(),
+			'src/components/session/session.styles.scss'
+		),
+		'utf8'
+	);
+
+describe('session header and timeline layout', () => {
+	it('keeps the timeline in flow when an optional toolbar precedes it', () => {
+		const scss = sessionStyles();
+
+		expect(scss).not.toContain('& > div:nth-child(2)');
+		expect(scss).toMatch(
+			/& > \.session__content\s*\{[\s\S]*?flex:\s*1;[\s\S]*?min-height:\s*0;[\s\S]*?position:\s*relative;/
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- keep the session timeline below the optional thread toolbar
- select the timeline by its semantic class instead of its child position
- add a regression test for the toolbar-plus-timeline layout

Closes OpenResilienceInitiative/ORISO-Frontend#567

## Verification

- `npm run test:unit -- --run src/components/session/sessionLayout.styles.test.ts`
- `npm run test:unit` — 182 files, 1168 tests passed
- `npm run lint:scripts`
- `npx stylelint src/components/session/session.styles.scss`
- `npm run build`
- Real-browser desktop and mobile proof is recorded in E2E run `e2e-20260719-1711` and the [Slack evidence canvas](https://sunflowercare.slack.com/docs/T03BZU8ADLM/F0BJQBA0GP6).

## Known repository gate

The global `npm run lint:style` currently fails on the unchanged `src/components/messageSubmitInterface/messageSubmitInterface.styles.scss:1670` because `origin/pre-dev` is missing a blank line before a comment. The changed stylesheet passes Stylelint.

## Scope

This deliberately does not modify approved PR #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session layouts when optional toolbar elements are present.
  * Ensured session timeline content remains in normal flow, preventing interference with header interactions.

* **Tests**
  * Added coverage to verify session content retains the correct flexible layout and positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->