### PR TITLE
Align mandatory 2FA and the voice player with M3

### DIFF
--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -1306,8 +1306,8 @@ $message-avatar-overlap: -19px;
 		max-width: 360px;
 		padding: 8px 10px;
 		border-radius: 999px;
-		background: #32b86c;
-		color: #fff;
+		background: var(--m3-primary-container, #cc1e1c);
+		color: var(--m3-on-primary-container, #ffe2de);
 
 		audio {
 			display: none;
@@ -1316,8 +1316,8 @@ $message-avatar-overlap: -19px;
 
 	&__voiceNote__play {
 		border: none;
-		background: rgba(0, 0, 0, 0.18);
-		color: #fff;
+		background: var(--m3-primary, #a5000a);
+		color: var(--m3-on-primary, #ffffff);
 		width: 32px;
 		height: 32px;
 		border-radius: 50%;
@@ -1328,6 +1328,15 @@ $message-avatar-overlap: -19px;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
+
+		&:hover {
+			background: var(--m3-primary-hover, #820006);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--m3-on-primary-container, #ffe2de);
+			outline-offset: 2px;
+		}
 	}
 
 	&__voiceNote__wave {
@@ -1337,7 +1346,7 @@ $message-avatar-overlap: -19px;
 		border-radius: 10px;
 		background-image: repeating-linear-gradient(
 			90deg,
-			rgba(255, 255, 255, 0.28) 0 3px,
+			var(--m3-primary-fixed-dim, #ffb4aa) 0 3px,
 			transparent 3px 7px
 		);
 		opacity: 1;
@@ -1353,7 +1362,7 @@ $message-avatar-overlap: -19px;
 		border-radius: 10px;
 		background-image: repeating-linear-gradient(
 			90deg,
-			rgba(255, 255, 255, 0.95) 0 3px,
+			var(--m3-on-primary-container, #ffe2de) 0 3px,
 			transparent 3px 7px
 		);
 		transition: width 120ms linear;

--- a/src/components/message/messageVoiceNote.styles.test.ts
+++ b/src/components/message/messageVoiceNote.styles.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const messageStyles = () =>
+	fs.readFileSync(
+		path.join(process.cwd(), 'src/components/message/message.styles.scss'),
+		'utf8'
+	);
+
+describe('voice-note M3 color roles', () => {
+	it('uses the primary token family instead of hard-coded success green', () => {
+		const scss = messageStyles();
+		const voiceNoteStyles = scss.slice(
+			scss.indexOf('&__voiceNote'),
+			scss.indexOf('&__action', scss.indexOf('&__voiceNote'))
+		);
+
+		expect(voiceNoteStyles).toContain(
+			'background: var(--m3-primary-container, #cc1e1c);'
+		);
+		expect(voiceNoteStyles).toContain(
+			'color: var(--m3-on-primary-container, #ffe2de);'
+		);
+		expect(voiceNoteStyles).toContain(
+			'background: var(--m3-primary, #a5000a);'
+		);
+		expect(voiceNoteStyles).toContain(
+			'color: var(--m3-on-primary, #ffffff);'
+		);
+		expect(voiceNoteStyles).not.toContain('#32b86c');
+		expect(voiceNoteStyles).not.toContain('rgba(0, 0, 0, 0.18)');
+	});
+});

--- a/src/components/twoFactorAuth/TwoFactorNag.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorNag.test.tsx
@@ -9,6 +9,7 @@ import { TwoFactorNag } from './TwoFactorNag';
 
 const overlayMock = vi.fn();
 const stableMocks = vi.hoisted(() => ({
+	openTwoFactorSettings: vi.fn(),
 	appConfig: {
 		twofactor: {
 			startObligatoryHint: new Date(0),
@@ -40,7 +41,7 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../../hooks/useOpenTwoFactorSettings', () => ({
-	useOpenTwoFactorSettings: () => vi.fn()
+	useOpenTwoFactorSettings: () => stableMocks.openTwoFactorSettings
 }));
 
 vi.mock('../../hooks/useAppConfig', () => ({
@@ -75,9 +76,33 @@ vi.mock('./twoFactorNag.styles', () => ({}));
 describe('TwoFactorNag', () => {
 	beforeEach(() => {
 		overlayMock.mockClear();
+		stableMocks.openTwoFactorSettings.mockClear();
+		stableMocks.appConfig.twofactor.dateTwoFactorObligatory = new Date(0);
 	});
 
-	it('allows the mandatory login reminder to be dismissed', async () => {
+	it('opens mandatory two-factor setup directly without showing the reminder', async () => {
+		const contextValue = {
+			userData: {
+				twoFactorAuth: { isActive: false, isEnabled: true }
+			}
+		} as React.ContextType<typeof UserDataContext>;
+
+		render(
+			<UserDataContext.Provider value={contextValue}>
+				<TwoFactorNag />
+			</UserDataContext.Provider>
+		);
+
+		await waitFor(() =>
+			expect(stableMocks.openTwoFactorSettings).toHaveBeenCalledOnce()
+		);
+		expect(overlayMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps the dismissible reminder before two-factor setup becomes mandatory', async () => {
+		stableMocks.appConfig.twofactor.dateTwoFactorObligatory = new Date(
+			Date.now() + 86_400_000
+		);
 		const contextValue = {
 			userData: {
 				twoFactorAuth: { isActive: false, isEnabled: true }
@@ -91,6 +116,7 @@ describe('TwoFactorNag', () => {
 		);
 
 		await waitFor(() => expect(overlayMock).toHaveBeenCalled());
+		expect(stableMocks.openTwoFactorSettings).not.toHaveBeenCalled();
 
 		const props = overlayMock.mock.lastCall?.[0] as {
 			handleOverlayClose: unknown;

--- a/src/components/twoFactorAuth/TwoFactorNag.tsx
+++ b/src/components/twoFactorAuth/TwoFactorNag.tsx
@@ -39,11 +39,15 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 			todaysDate >= settings.twofactor.startObligatoryHint &&
 			getDevToolbarOption(STORAGE_KEY_2FA) === '1'
 		) {
+			if (todaysDate >= settings.twofactor.dateTwoFactorObligatory) {
+				setForceHideTwoFactorNag(true);
+				setIsShownTwoFactorNag(false);
+				openTwoFactorSettings();
+				return;
+			}
+
 			setIsShownTwoFactorNag(true);
-			const configuredMessage =
-				todaysDate >= settings.twofactor.dateTwoFactorObligatory
-					? settings.twofactor.messages[1]
-					: settings.twofactor.messages[0];
+			const configuredMessage = settings.twofactor.messages[0];
 			setMessage({ ...configuredMessage, showClose: true });
 		} else {
 			setIsShownTwoFactorNag(false);
@@ -55,7 +59,8 @@ export const TwoFactorNag: React.FC<TwoFactorNagProps> = () => {
 		settings.twofactor.dateTwoFactorObligatory,
 		settings.twofactor.messages,
 		getDevToolbarOption,
-		location
+		location,
+		openTwoFactorSettings
 	]);
 
 	const handleTwoFactorNag = useCallback((val) => {

--- a/src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss
+++ b/src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss
@@ -351,7 +351,9 @@
 
 	@media (width <= 520px) {
 		&__paper {
-			width: min(368px, calc(100vw - 22px));
+			width: min(368px, calc(100vw - 22px)) !important;
+			max-width: calc(100vw - 22px) !important;
+			margin: 11px !important;
 			padding: 32px 28px;
 		}
 
@@ -366,9 +368,22 @@
 		}
 
 		&__stepper {
-			grid-auto-columns: minmax(58px, 1fr);
+			grid-auto-columns: 56px;
+			column-gap: 8px;
 			overflow-x: auto;
 			padding-bottom: 4px;
+		}
+
+		&__stepUnit::after {
+			left: calc(50% + 18px);
+			right: calc(-50% + 10px);
+		}
+
+		&__stepLabel {
+			font-size: 9px !important;
+			line-height: 12px !important;
+			white-space: normal;
+			overflow-wrap: anywhere;
 		}
 
 		&__downloadGrid,

--- a/src/components/twoFactorAuth/twoFactorSetupDialog.styles.test.ts
+++ b/src/components/twoFactorAuth/twoFactorSetupDialog.styles.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const dialogStyles = () =>
+	fs.readFileSync(
+		path.join(
+			process.cwd(),
+			'src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss'
+		),
+		'utf8'
+	);
+
+describe('two-factor setup dialog responsive layout', () => {
+	it('scopes compact columns, connectors, and wrapping to the mobile stepper', () => {
+		const scss = dialogStyles();
+		const mobileStyles = scss.slice(
+			scss.indexOf('@media (width <= 520px)')
+		);
+
+		expect(mobileStyles).toMatch(
+			/&__paper\s*\{[^}]*width:\s*min\(368px, calc\(100vw - 22px\)\)\s*!important;[^}]*max-width:\s*calc\(100vw - 22px\)\s*!important;[^}]*margin:\s*11px\s*!important;/
+		);
+		expect(mobileStyles).toMatch(
+			/&__stepper\s*\{[^}]*grid-auto-columns:\s*56px;[^}]*column-gap:\s*8px;/
+		);
+		expect(mobileStyles).toMatch(
+			/&__stepUnit::after\s*\{[^}]*left:\s*calc\(50% \+ 18px\);[^}]*right:\s*calc\(-50% \+ 10px\);/
+		);
+		expect(mobileStyles).toMatch(
+			/&__stepLabel\s*\{[^}]*font-size:\s*9px\s*!important;[^}]*line-height:\s*12px\s*!important;[^}]*white-space:\s*normal;[^}]*overflow-wrap:\s*anywhere;/
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- open mandatory 2FA setup directly without the redundant intermediate nag
- keep the complete five-step setup indicator readable on mobile
- theme the voice-message player with M3 primary token roles
- add focused behavior and style regression tests

Closes OpenResilienceInitiative/ORISO-Frontend#568

## Verification

- focused 2FA and voice-player suite — 3 files, 4 tests passed
- `npm run test:unit` — 183 files, 1170 tests passed
- `npm run lint:scripts`
- `npx stylelint src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss src/components/message/message.styles.scss`
- `npm run build`
- Real-browser desktop, mobile, and failed-attempt evidence is recorded in E2E run `e2e-20260719-1711` and the [Slack evidence canvas](https://sunflowercare.slack.com/docs/T03BZU8ADLM/F0BJQBA0GP6).

## Known repository gate

The global `npm run lint:style` currently fails on the unchanged `src/components/messageSubmitInterface/messageSubmitInterface.styles.scss:1670` because `origin/pre-dev` is missing a blank line before a comment. Both changed stylesheets pass Stylelint.

## Scope

The three changes share the Frontend's reusable security/message UI layer and token contract. They remain separate from approved PR #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
