### PR TITLE
fix(chat): prevent duplicate after failed-message retry

### DIFF
--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -280,6 +280,36 @@ describe('MatrixClientService', () => {
 		});
 	});
 
+	it('removes the rejected Matrix local echo before the UI offers a fresh retry', async () => {
+		const failedLocalEcho = {
+			getTxnId: () => 'txn-failed-send'
+		};
+		const sendError = new Error('network unavailable');
+		const sendMessage = vi.fn(() => Promise.reject(sendError));
+		const cancelPendingEvent = vi.fn();
+		const service = new MatrixClientService();
+		setClient(service, {
+			makeTxnId: () => 'txn-failed-send',
+			sendMessage,
+			cancelPendingEvent,
+			getRoom: () => ({
+				timeline: [failedLocalEcho]
+			})
+		});
+
+		await expect(
+			service.sendMessage('!room:example.org', 'Retry me once')
+		).rejects.toBe(sendError);
+
+		expect(sendMessage).toHaveBeenCalledWith(
+			'!room:example.org',
+			{ msgtype: 'm.text', body: 'Retry me once' },
+			'txn-failed-send'
+		);
+		expect(cancelPendingEvent).toHaveBeenCalledOnce();
+		expect(cancelPendingEvent).toHaveBeenCalledWith(failedLocalEcho);
+	});
+
 	it('edits a message via m.replace, targeting the original event', async () => {
 		const sendMessage = vi.fn(() =>
 			Promise.resolve({ event_id: '$edit:example.org' })

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -269,7 +269,37 @@ export class MatrixClientService {
 			if (!client.getRoom(roomId)) {
 				await client.joinRoom(roomId);
 			}
-			return client.sendMessage(roomId, content);
+			// Every real matrix-js-sdk client provides makeTxnId(). The guard also
+			// keeps deliberately minimal test doubles and adapters compatible.
+			const txnId = client.makeTxnId?.();
+			try {
+				return await (txnId
+					? client.sendMessage(roomId, content, txnId)
+					: client.sendMessage(roomId, content));
+			} catch (error) {
+				// matrix-js-sdk keeps a rejected send as a NOT_SENT local echo.
+				// The ORISO timeline owns failed-message presentation and retry,
+				// so retaining the SDK echo as well would reveal two copies after
+				// the user successfully retries with a fresh transaction.
+				const room = client.getRoom(roomId);
+				const errorEvent = (error as { event?: MatrixEvent })?.event;
+				const failedLocalEcho = txnId
+					? errorEvent?.getTxnId?.() === txnId
+						? errorEvent
+						: room?.timeline?.find(
+								(event) => event.getTxnId?.() === txnId
+							)
+					: undefined;
+				if (failedLocalEcho) {
+					try {
+						client.cancelPendingEvent(failedLocalEcho);
+					} catch {
+						// Preserve the original transport error. A status race must not
+						// turn failed-send recovery into a second exception.
+					}
+				}
+				throw error;
+			}
 		};
 
 		try {


### PR DESCRIPTION
## Summary

- assign every outgoing Matrix message an explicit transaction id
- cancel the matching rejected matrix-js-sdk local echo before ORISO exposes its retry UI
- keep the original transport error and the existing bounded, user-triggered retry behavior

## Why

The regular PreDev rerun of #575 proved the failed state itself, but one successful retry rendered the stale SDK `NOT_SENT` local echo beside the newly delivered event. Network evidence showed one successful Matrix request while the UI displayed two identical messages.

## Verification

- regression test: rejected local echo is cancelled by transaction id
- 1,259/1,259 unit tests across 194 files
- ESLint and TypeScript
- production build
- browser runner strengthened to require exactly one matching message after retry

Refs #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)