### PR TITLE
fix: align focus rings for interactive chat components

### DIFF
--- a/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
+++ b/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
@@ -56,6 +56,10 @@ import '../sessionsList/sessionsList.styles.scss';
 import '../sessionsListItem/sessionsListItem.styles.scss';
 import '../message/message.styles.scss';
 import '../messageSubmitInterface/messageSubmitInterface.styles';
+import '../session/session.styles.scss';
+import '../sessionMenu/sessionMenu.styles.scss';
+import '../chatMenuDropdown/chatMenuDropdown.styles.scss';
+import { focusSessionChromeOnPointerDown } from '../session/focusSessionChrome';
 
 const APP_ORISO_CHAT_FIGMA_URL =
 	'https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=316-17725&t=XHH5HQNmA8DUWl2U-0';
@@ -1116,8 +1120,16 @@ function ComposerPreview() {
 }
 
 function ChatPanel() {
+	const [menuExpanded, setMenuExpanded] = useState(false);
+
 	return (
-		<section style={styles.chatPanel}>
+		<section
+			className="session"
+			tabIndex={-1}
+			onMouseDown={focusSessionChromeOnPointerDown}
+			style={styles.chatPanel}
+			aria-label="Chatraum"
+		>
 			<header style={styles.chatHeader}>
 				<div style={styles.chatTitleCluster}>
 					<UserAvatar
@@ -1166,12 +1178,11 @@ function ChatPanel() {
 					</button>
 					<button
 						type="button"
-						aria-label="More actions preview"
-						disabled
-						style={{
-							...styles.headerAction,
-							...styles.previewAction
-						}}
+						className="sessionMenu__icon sessionMenu__icon--desktop"
+						aria-label="More actions"
+						aria-expanded={menuExpanded}
+						onClick={() => setMenuExpanded((open) => !open)}
+						style={styles.headerMenuTrigger}
 					>
 						<MenuVerticalIcon />
 					</button>
@@ -1306,7 +1317,12 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'Storybook MCP target for the App.Oriso consultant chat frame. The composite story keeps the Figma frame inspectable with real ORISO subcomponents; the runtime shell story mounts the real Routing/SessionsZone path with deterministic session fixtures so product-code drift is visible.'
+					'Storybook MCP target for the App.Oriso consultant chat frame. ' +
+					'Uses production SCSS for #597 focus rings: session list selected (`2px --m3-primary`), ' +
+					'chat panel `.session` active border on chrome focus (not composer selected), ' +
+					'session menu trigger shape on `aria-expanded`, and composer/send styles from ' +
+					'`messageSubmitInterface` / `sendButton`. The runtime shell mounts Routing/SessionsZone ' +
+					'with deterministic fixtures so product-code drift stays visible.'
 			}
 		}
 	}
@@ -1426,12 +1442,11 @@ const styles = {
 	chatPanel: {
 		display: 'grid',
 		gridTemplateRows: '58px auto minmax(0, 1fr) auto',
+		// Layout only — resting/active borders come from `.session` (#597)
 		margin: '16px 8px 16px 0',
-		background: '#FFFFFF',
-		border: '1px solid #FFB4AA',
-		borderRadius: 28,
-		overflow: 'hidden',
-		minWidth: 0
+		minWidth: 0,
+		minHeight: 0,
+		height: '100%'
 	} satisfies React.CSSProperties,
 	chatHeader: {
 		display: 'flex',
@@ -1456,6 +1471,11 @@ const styles = {
 		display: 'flex',
 		alignItems: 'center',
 		gap: 8
+	} satisfies React.CSSProperties,
+	headerMenuTrigger: {
+		// Force visible in Storybook; production toggles via breakpoint
+		display: 'inline-flex',
+		marginLeft: 0
 	} satisfies React.CSSProperties,
 	headerAction: {
 		width: 32,
@@ -1584,7 +1604,8 @@ const styles = {
 		borderRadius: 22,
 		border: 0,
 		padding: '0 18px',
-		background: '#CC1E1C',
+		// #597: resting send matches production empty state
+		background: 'var(--m3-primary-fixed-dim, #ffb4aa)',
 		color: '#FFFFFF',
 		fontWeight: 700,
 		display: 'inline-flex',

--- a/src/components/chatMenuDropdown/ChatMenuDropdown.stories.tsx
+++ b/src/components/chatMenuDropdown/ChatMenuDropdown.stories.tsx
@@ -21,7 +21,9 @@ const meta: Meta<typeof ChatMenuDropdown> = {
 		docs: {
 			description: {
 				component:
-					'Reusable ORISO chat menu matching the App.Oriso Figma menu surface. Used for chat/session action dropdowns.'
+					'Reusable ORISO chat menu matching the App.Oriso Figma menu surface. ' +
+					'Used for chat/session action dropdowns. #597: panel uses ' +
+					'`2px solid var(--m3-primary-container)` via `list-item-active-menu-border`.'
 			}
 		},
 		design: {

--- a/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
+++ b/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
@@ -3,7 +3,8 @@
 	background: #ffffff;
 	width: 301px;
 	max-width: calc(100vw - 24px);
-	border: 1px solid var(--m3-primary, #a5000a);
+
+	@include list-item-active-menu-border;
 	border-radius: 8px;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 	overflow: auto;

--- a/src/components/enquiry/WriteEnquiry.tsx
+++ b/src/components/enquiry/WriteEnquiry.tsx
@@ -23,6 +23,7 @@ import {
 import { ReactComponent as EnvelopeCheckIcon } from '../../resources/img/illustrations/envelope-check.svg';
 import { ReactComponent as WelcomeIcon } from '../../resources/img/illustrations/welcome.svg';
 import './enquiry.styles';
+import { focusSessionChromeOnPointerDown } from '../session/focusSessionChrome';
 import { Headline } from '../headline/Headline';
 import { Text } from '../text/Text';
 import { EnquiryLanguageSelection } from './EnquiryLanguageSelection';
@@ -182,7 +183,11 @@ export const WriteEnquiry: React.FC = () => {
 	const isUnassignedSession = activeSession && !activeSession?.consultant;
 
 	return (
-		<div className="enquiry__wrapper">
+		<div
+			className="enquiry__wrapper"
+			tabIndex={-1}
+			onMouseDown={focusSessionChromeOnPointerDown}
+		>
 			<div className="enquiry__contentWrapper">
 				<div className="enquiry__infoWrapper">
 					<div className="enquiry__text">

--- a/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
+++ b/src/components/messageSubmitInterface/MessageSubmitInterface.stories.tsx
@@ -10,6 +10,8 @@ import {
 	storybookGroupRoomMembers
 } from './__storybook__/composerStoryDecorator';
 import './messageSubmitInterface.styles.scss';
+import '../session/session.styles.scss';
+import { focusSessionChromeOnPointerDown } from '../session/focusSessionChrome';
 
 const INPUT_FIELD_FIGMA_URL =
 	'https://www.figma.com/design/L2mOFNSGdxPPx1XA4HFAog/App.Oriso?node-id=18-1989';
@@ -25,7 +27,11 @@ const shellStyle: React.CSSProperties = {
 	boxSizing: 'border-box',
 	display: 'flex',
 	flexDirection: 'column',
-	justifyContent: 'flex-end'
+	justifyContent: 'flex-end',
+	// Story layout only — `.session` supplies resting/active borders (#597)
+	margin: 0,
+	borderRadius: 28,
+	overflow: 'hidden'
 };
 
 function ComposerShell({
@@ -37,7 +43,12 @@ function ComposerShell({
 	roomMembers?: Array<{ userId: string; name: string }>;
 } & Partial<React.ComponentProps<typeof MessageSubmitInterfaceComponent>>) {
 	return (
-		<div className="session" style={shellStyle}>
+		<div
+			className="session"
+			tabIndex={-1}
+			onMouseDown={focusSessionChromeOnPointerDown}
+			style={shellStyle}
+		>
 			<ComposerStoryDecorator
 				activeSession={activeSession}
 				roomMembers={roomMembers}
@@ -84,6 +95,32 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	name: 'Default (empty)',
 	render: () => <ComposerShell />
+};
+
+/** #597: focus the editor so `--selected` applies (2px primary-container + send styles). */
+export const Selected: Story = {
+	name: 'Selected (composer focused)',
+	render: () => <ComposerShell />,
+	play: async ({ canvasElement }) => {
+		const editor = await waitFor(() => {
+			const node = canvasElement.querySelector<HTMLElement>(
+				'[contenteditable="true"]'
+			);
+			if (!node) {
+				throw new Error('composer editor not mounted yet');
+			}
+			return node;
+		});
+
+		await userEvent.click(editor);
+
+		await waitFor(async () => {
+			const selected = canvasElement.querySelector(
+				'.textarea__wrapper-send-message--selected'
+			);
+			await expect(selected).toBeTruthy();
+		});
+	}
 };
 
 export const ReadyToSend: Story = {

--- a/src/components/messageSubmitInterface/inputField/SendButton.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/SendButton.stories.tsx
@@ -23,9 +23,10 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'Send button per Figma 489:16565. Empty shows the chevron on the pale ' +
-					'container; entering text rotates the paper plane in (arm). Sending ' +
-					'launches the fly-out animation, then the button settles back.'
+					'Send button per Figma 489:16565 / #597. Empty / not-selected uses ' +
+					'`var(--m3-primary-fixed-dim, #ffb4aa)` with a white icon; entering text ' +
+					'rotates the paper plane in (arm) on primary-container. Sending launches ' +
+					'the fly-out animation, then the button settles back.'
 			}
 		}
 	},

--- a/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
+++ b/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
@@ -1,9 +1,10 @@
 /*
  * Send button — Figma "Nachricht senden" (node 489:16565).
  * 48×48, radius bottom-left 24 / top-right 4 (mirrors the input container
- * notch). One paper plane throughout: at rest on primary-fixed when empty,
- * rotated up on primary-container when ready. The empty → ready change
- * rotates the plane; sending flies it out, then it settles back.
+ * notch). One paper plane throughout: white icon on primary-fixed-dim when
+ * the composer is not selected / empty; rotated up on primary-container when
+ * ready. The empty → ready change rotates the plane; sending flies it out,
+ * then it settles back.
  */
 .sendButton {
 	position: relative;
@@ -16,7 +17,8 @@
 	appearance: none;
 	cursor: pointer;
 	overflow: hidden;
-	background-color: var(--m3-primary-fixed, #ffdad5);
+	// #597: resting / not-selected composer — #FFB4AA
+	background-color: var(--m3-primary-fixed-dim, #ffb4aa);
 	transition: background-color 250ms cubic-bezier(0.2, 0, 0, 1);
 
 	&__plane {
@@ -47,13 +49,6 @@
 	&--ready &__plane,
 	&--sending &__plane {
 		transform: rotate(-45deg);
-	}
-
-	// Empty / disabled: plane sits on the pale container with a muted tint so
-	// a white plane stays legible; not interactive.
-	&--empty &__plane,
-	&--disabled &__plane {
-		color: var(--m3-primary-container, #cc1e1c);
 	}
 
 	&--flyout &__plane {

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -47,8 +47,10 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 
 	.textarea {
 		z-index: 100;
+
 		// Figma 8641-34699: dock must be opaque so scrolled history cannot show through.
 		background-color: var(--m3-surface-container-lowest, #ffffff);
+
 		// Figma 8641-34699: 16px inset between chat card edge and composer.
 		padding: 16px;
 		width: 100%;
@@ -466,8 +468,7 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			}
 		}
 
-		// Figma "Selected": the inner textcomponent carries the 2px primary
-		// border while the editor is focused (independent of ready-to-send).
+		// #597: selected composer — text area gets the primary active border
 		&__wrapper-send-message--selected .textarea__input {
 			border: 2px solid var(--m3-primary-container, #cc1e1c);
 		}
@@ -1669,6 +1670,7 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			object-fit: cover;
 			border-radius: 8px;
 			flex-shrink: 0;
+
 			// Clip the alt text if an image ever fails to load, so it can
 			// never spill out of the thumbnail box.
 			overflow: hidden;

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -63,6 +63,7 @@ import {
 import { useNavigate, useLocation } from 'react-router-dom';
 import * as Tone from 'tone';
 import './session.styles';
+import { focusSessionChromeOnPointerDown } from './focusSessionChrome';
 import { useDebouncedCallback } from 'use-debounce';
 import { ReactComponent as ArrowDoubleDownIcon } from '../../resources/img/icons/arrow-double-down.svg';
 import { ReactComponent as NotificationBellIcon } from '../../resources/img/icons/notification_bell.svg';
@@ -3421,6 +3422,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 				'session',
 				shouldFadeSessionChrome && 'session--gameFocus'
 			)}
+			tabIndex={-1}
+			onMouseDown={focusSessionChromeOnPointerDown}
 		>
 			<div
 				ref={headerRef}

--- a/src/components/session/focusSessionChrome.test.ts
+++ b/src/components/session/focusSessionChrome.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { focusSessionChromeOnPointerDown } from './focusSessionChrome';
+
+describe('focusSessionChromeOnPointerDown', () => {
+	it('focuses the session chrome when clicking outside the composer', () => {
+		const focus = vi.fn();
+		const currentTarget = { focus } as unknown as HTMLElement;
+		const target = {
+			closest: (selector: string) =>
+				selector.includes('button') ||
+				selector.includes('.textarea') ||
+				selector.includes('[tabindex]')
+					? null
+					: null
+		} as unknown as HTMLElement;
+
+		focusSessionChromeOnPointerDown({
+			target,
+			currentTarget
+		} as any);
+
+		expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+	});
+
+	it('does not steal focus when the composer is the click target', () => {
+		const focus = vi.fn();
+		const currentTarget = { focus } as unknown as HTMLElement;
+		const target = {
+			closest: (selector: string) =>
+				selector.includes('.textarea') ? {} : null
+		} as unknown as HTMLElement;
+
+		focusSessionChromeOnPointerDown({
+			target,
+			currentTarget
+		} as any);
+
+		expect(focus).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/session/focusSessionChrome.ts
+++ b/src/components/session/focusSessionChrome.ts
@@ -1,0 +1,29 @@
+import type { MouseEvent, PointerEvent } from 'react';
+
+/**
+ * Focus the session/enquiry chrome on pointer-down outside the composer so
+ * `:focus-within:not(:has(.textarea__wrapper-send-message--selected))` can
+ * drive the #597 active border. Leaves native focus alone for the composer
+ * and other interactive controls.
+ */
+const COMPOSER_FOCUS_GUARD =
+	'.textarea, .messageSubmit__wrapper, .textarea__wrapper-send-message, [contenteditable="true"], [role="textbox"]';
+
+const NATIVE_FOCUS_TARGET =
+	'a, button, input, textarea, select, summary, [tabindex]:not([tabindex="-1"])';
+
+export const focusSessionChromeOnPointerDown = (
+	event: PointerEvent<HTMLElement> | MouseEvent<HTMLElement>
+): void => {
+	const target = event.target as HTMLElement | null;
+	if (!target?.closest) {
+		return;
+	}
+	if (target.closest(COMPOSER_FOCUS_GUARD)) {
+		return;
+	}
+	if (target.closest(NATIVE_FOCUS_TARGET)) {
+		return;
+	}
+	event.currentTarget.focus({ preventScroll: true });
+};

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -16,12 +16,26 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 	min-width: 0;
 	background-color: var(--m3-surface-container-lowest, #ffffff);
 	overflow: hidden;
+	box-sizing: border-box;
+	transition: border-color 160ms ease;
 
 	@include breakpoint($fromLarge) {
 		margin: 24px;
 		border: 1px solid var(--oriso-primary-fixed-dim, #ffb4aa);
 		border-radius: 28px;
-		box-sizing: border-box;
+	}
+
+	// Border is the active indicator — suppress the default focus outline.
+	&:focus {
+		outline: none;
+	}
+
+	// #597: active border when the session/chat chrome is focused/clicked,
+	// but not when the composer text area is selected.
+	&:focus-within:not(:has(.textarea__wrapper-send-message--selected)) {
+		@include breakpoint($fromLarge) {
+			border: 2px solid var(--m3-primary-container, #cc1e1c);
+		}
 	}
 
 	.messageSubmit__wrapper {
@@ -127,6 +141,13 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 			border: 0;
 			border-radius: 0;
 		}
+
+		&:focus-within:not(:has(.textarea__wrapper-send-message--selected)),
+		&:has(.textarea__wrapper-send-message--selected) {
+			@include breakpoint($fromLarge) {
+				border: 0;
+			}
+		}
 	}
 
 	&__emptyState {
@@ -146,6 +167,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		bottom: 0;
 		overflow-x: hidden;
 		overflow-y: auto;
+
 		// Figma 8641-34699: 16px inset inside the chat card (sides + top).
 		// Large bottom padding keeps the last message above the absolute composer.
 		padding: 16px 16px 240px;

--- a/src/components/session/sessionLayout.styles.test.ts
+++ b/src/components/session/sessionLayout.styles.test.ts
@@ -17,4 +17,12 @@ describe('session header and timeline layout', () => {
 			/& > \.session__content\s*\{[\s\S]*?flex:\s*1;[\s\S]*?min-height:\s*0;[\s\S]*?position:\s*relative;/
 		);
 	});
+
+	it('activates the chat container border on session focus outside the composer', () => {
+		const scss = sessionStyles();
+
+		expect(scss).toMatch(
+			/&:focus-within:not\(:has\(\.textarea__wrapper-send-message--selected\)\)\s*\{[\s\S]*?border:\s*2px solid var\(--m3-primary-container/
+		);
+	});
 });

--- a/src/components/sessionMenu/SessionMenu.stories.tsx
+++ b/src/components/sessionMenu/SessionMenu.stories.tsx
@@ -79,6 +79,10 @@ function MenuTriggerShapeDemo() {
 
 export const MenuTriggerShape: Story = {
 	tags: ['autodocs'],
+	args: {
+		hasUserInitiatedStopOrLeaveRequest,
+		isAskerInfoAvailable: true
+	},
 	render: () => <MenuTriggerShapeDemo />
 };
 

--- a/src/components/sessionMenu/SessionMenu.stories.tsx
+++ b/src/components/sessionMenu/SessionMenu.stories.tsx
@@ -39,45 +39,47 @@ export const Default: Story = {
 };
 
 /** Isolated #597 trigger shape (closed vs open) without full session providers. */
+function MenuTriggerShapeDemo() {
+	const [expanded, setExpanded] = useState(false);
+	return (
+		<div
+			style={{
+				display: 'flex',
+				gap: 24,
+				alignItems: 'center',
+				padding: 24,
+				background: '#eae7e8'
+			}}
+		>
+			<button
+				type="button"
+				className="sessionMenu__icon sessionMenu__icon--desktop"
+				aria-expanded={false}
+				aria-label="Menu closed"
+				style={{ display: 'inline-flex' }}
+			>
+				<MenuVerticalIcon />
+			</button>
+			<button
+				type="button"
+				className="sessionMenu__icon sessionMenu__icon--desktop"
+				aria-expanded={expanded}
+				aria-label="Menu open toggle"
+				style={{ display: 'inline-flex' }}
+				onClick={() => setExpanded((v) => !v)}
+			>
+				<MenuVerticalIcon />
+			</button>
+			<span style={{ fontSize: 12, color: '#4C555F' }}>
+				Closed 48×32 · click right for open 32×48
+			</span>
+		</div>
+	);
+}
+
 export const MenuTriggerShape: Story = {
 	tags: ['autodocs'],
-	render: () => {
-		const [expanded, setExpanded] = useState(false);
-		return (
-			<div
-				style={{
-					display: 'flex',
-					gap: 24,
-					alignItems: 'center',
-					padding: 24,
-					background: '#eae7e8'
-				}}
-			>
-				<button
-					type="button"
-					className="sessionMenu__icon sessionMenu__icon--desktop"
-					aria-expanded={false}
-					aria-label="Menu closed"
-					style={{ display: 'inline-flex' }}
-				>
-					<MenuVerticalIcon />
-				</button>
-				<button
-					type="button"
-					className="sessionMenu__icon sessionMenu__icon--desktop"
-					aria-expanded={expanded}
-					aria-label="Menu open toggle"
-					style={{ display: 'inline-flex' }}
-					onClick={() => setExpanded((v) => !v)}
-				>
-					<MenuVerticalIcon />
-				</button>
-				<span style={{ fontSize: 12, color: '#4C555F' }}>
-					Closed 48×32 · click right for open 32×48
-				</span>
-			</div>
-		);
-	}
+	render: () => <MenuTriggerShapeDemo />
 };
 
 export const AnonymousMobileActions: Story = {

--- a/src/components/sessionMenu/SessionMenu.stories.tsx
+++ b/src/components/sessionMenu/SessionMenu.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 import { SessionMenu } from './SessionMenu';
+import { MenuVerticalIcon } from '../../resources/img/icons';
 import { APP_ORISO_FIGMA_URL } from '../storybookDesignLinks';
+import './sessionMenu.styles.scss';
 
 const hasUserInitiatedStopOrLeaveRequest = {
 	current: false
@@ -18,7 +21,8 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'Session header flyout menu with archive/delete, group-chat actions, legal links and (consultant) video/audio call buttons; behaviour is driven by the active session and user authorities.'
+					'Session header flyout menu with archive/delete, group-chat actions, legal links and (consultant) video/audio call buttons. ' +
+					'#597: trigger is horizontal 48×32 when closed and vertical 32×48 with 2px `--m3-primary-container` when `aria-expanded`.'
 			}
 		}
 	}
@@ -31,6 +35,48 @@ export const Default: Story = {
 	args: {
 		hasUserInitiatedStopOrLeaveRequest,
 		isAskerInfoAvailable: true
+	}
+};
+
+/** Isolated #597 trigger shape (closed vs open) without full session providers. */
+export const MenuTriggerShape: Story = {
+	tags: ['autodocs'],
+	render: () => {
+		const [expanded, setExpanded] = useState(false);
+		return (
+			<div
+				style={{
+					display: 'flex',
+					gap: 24,
+					alignItems: 'center',
+					padding: 24,
+					background: '#eae7e8'
+				}}
+			>
+				<button
+					type="button"
+					className="sessionMenu__icon sessionMenu__icon--desktop"
+					aria-expanded={false}
+					aria-label="Menu closed"
+					style={{ display: 'inline-flex' }}
+				>
+					<MenuVerticalIcon />
+				</button>
+				<button
+					type="button"
+					className="sessionMenu__icon sessionMenu__icon--desktop"
+					aria-expanded={expanded}
+					aria-label="Menu open toggle"
+					style={{ display: 'inline-flex' }}
+					onClick={() => setExpanded((v) => !v)}
+				>
+					<MenuVerticalIcon />
+				</button>
+				<span style={{ fontSize: 12, color: '#4C555F' }}>
+					Closed 48×32 · click right for open 32×48
+				</span>
+			</div>
+		);
 	}
 };
 

--- a/src/components/sessionMenu/sessionMenu.styles.scss
+++ b/src/components/sessionMenu/sessionMenu.styles.scss
@@ -217,9 +217,22 @@ $iconSize: 20px;
 		display: none;
 		align-items: center;
 		justify-content: center;
+		box-sizing: border-box;
+		transition:
+			width 160ms ease,
+			height 160ms ease,
+			border-color 160ms ease;
 
 		@include breakpoint($fromLarge) {
 			display: inline-flex;
+		}
+
+		// Flyout open (#597): vertical shape + 2px primary-container border
+		&[aria-expanded='true'] {
+			width: 32px;
+			height: 48px;
+
+			@include list-item-active-menu-border;
 		}
 	}
 
@@ -238,9 +251,21 @@ $iconSize: 20px;
 		background: #fff;
 		align-items: center;
 		justify-content: center;
+		box-sizing: border-box;
+		transition:
+			width 160ms ease,
+			height 160ms ease,
+			border-color 160ms ease;
 
 		@include breakpoint($fromLarge) {
 			display: none;
+		}
+
+		&[aria-expanded='true'] {
+			width: 32px;
+			height: 48px;
+
+			@include list-item-active-menu-border;
 		}
 	}
 }

--- a/src/components/sessionsList/SessionListColumn.stories.tsx
+++ b/src/components/sessionsList/SessionListColumn.stories.tsx
@@ -221,7 +221,9 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component:
-					'**Composite:** toolbar + sample cards using production `sessionsList*` / `sessionsListItem*` classes (6px active gap, 24px stacked corners, MessageAvatar username row). Does not include `ResizableHandle` or real data providers.'
+					'**Composite:** toolbar + sample cards using production `sessionsList*` / `sessionsListItem*` classes ' +
+					'(6px active gap, 24px stacked corners, MessageAvatar username row, #597 selected `2px --m3-primary`). ' +
+					'Does not include `ResizableHandle` or real data providers.'
 			}
 		}
 	}

--- a/src/components/sessionsListItem/SessionListItem.stories.tsx
+++ b/src/components/sessionsListItem/SessionListItem.stories.tsx
@@ -977,7 +977,10 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'Runtime story plus visual reference states for session list rows. `RuntimeComponent` renders the real `SessionListItemComponent` with Storybook fixture providers; the other stories document edge-state layout using the same BEM classes.'
+					'Runtime story plus visual reference states for session list rows. ' +
+					'#597: `ConsultantSelected` shows `2px solid var(--m3-primary)`; ' +
+					'`ConsultantMenuOpen` shows vertical 32×48 menu trigger + active menu borders. ' +
+					'`RuntimeComponent` mounts the real `SessionListItemComponent` with fixture providers.'
 			}
 		}
 	}
@@ -1002,6 +1005,15 @@ export const ConsultantSelected: Story = {
 	render: () => (
 		<div style={listShell}>
 			<ConsultantCardMock active />
+		</div>
+	)
+};
+
+/** #597: menu open → vertical 32×48 trigger + 2px primary-container borders. */
+export const ConsultantMenuOpen: Story = {
+	render: () => (
+		<div style={listShell}>
+			<ConsultantCardMock active menuOpen />
 		</div>
 	)
 };

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -8,8 +8,10 @@ $session-card-hover-bg: #f0e7e7;
 // unchanged — this only makes them the single canonical source.
 $session-card-selected-bg: #f6f3f3;
 $session-light-border: #fff;
-$session-selected-border: #ffb4aa;
-$session-active-border: #cc1e1c;
+
+// #597: selected ring uses M3 primary (was #ffb4aa / 1px)
+$session-selected-border: var(--m3-primary, #a5000a);
+$session-active-border: var(--m3-primary-container, #cc1e1c);
 $session-focus-ring: #ffdad5;
 $session-topic-chip-bg: #ffb4aa;
 $session-topic-chip-color: #410001;
@@ -73,7 +75,9 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 		.sessionsListItem__content {
 			background-color: $session-card-selected-bg !important;
-			border: 1px solid $session-selected-border !important;
+
+			// #597: 2px solid --m3-primary (overrides resting 1px border)
+			@include list-item-selected-border($important: true);
 			box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
 			transition:
 				background-color 160ms ease,
@@ -84,7 +88,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 			&:focus,
 			&:active {
 				background-color: $session-card-selected-bg !important;
-				border-color: $session-selected-border !important;
+				border-color: $list-item-selected-border-color !important;
 			}
 		}
 
@@ -153,11 +157,16 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 	&--menuOpen {
 		.sessionsListItem__content {
 			background-color: #fff6f5 !important;
-			border: 2px solid $session-active-border !important;
+
+			@include list-item-active-menu-border($important: true);
 		}
 
+		// Flyout open: vertical pill (height > width) + 2px primary-container
 		.sessionsListItem__menuIcon {
-			border-color: $session-active-border;
+			width: 32px;
+			height: 48px;
+
+			@include list-item-active-menu-border;
 			color: $session-active-border;
 		}
 
@@ -244,7 +253,8 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 	}
 
 	&.sessionsListItem--active .sessionsListItem__content:focus-visible {
-		border: 2px solid $session-active-border !important;
+		// Keep selected primary border; layer keyboard halo (#596 / WP-06)
+		@include list-item-selected-border($important: true);
 		box-shadow: 0 0 0 3px $session-focus-ring;
 	}
 
@@ -363,6 +373,11 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		color: #1e1e1e;
 		font: inherit;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		transition:
+			width 160ms ease,
+			height 160ms ease,
+			border-color 160ms ease,
+			background-color 160ms ease;
 
 		svg {
 			width: 24px;
@@ -385,7 +400,8 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		background: white !important;
 		width: 301px;
 		max-width: calc(100vw - 32px);
-		border: 1px solid var(--m3-primary-container, #cc1e1c);
+
+		@include list-item-active-menu-border;
 		border-radius: 8px;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 		overflow: auto;

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -183,6 +183,9 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		max-width: 100%;
 		min-width: 0;
 		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
 
 		// 160px card height; every card keeps a full 24px radius.
 		min-height: 160px;
@@ -266,7 +269,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 		&:first-child {
 			justify-content: space-between;
-			padding: 12px 16px;
+			padding: 18px 16px 0;
 			color: var(--m3-on-surface-variant, $tertiary);
 			font-size: 12px;
 			line-height: 16px;
@@ -280,6 +283,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		&:last-child {
 			justify-content: space-between;
 			align-items: flex-end;
+			padding: 0 16px 14px 24px;
 
 			// Figma 8609-31260: 48px-high bottom action row.
 			min-height: 48px;
@@ -756,7 +760,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 	}
 
 	&__subject {
-		padding: 8px 16px;
+		// padding: 8px 16px;
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: 0.25px;
@@ -801,10 +805,9 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 	}
 
 	&__consultingTypeIcon {
-		padding: 8px 16px 8px 8px;
 		margin-left: auto;
 		display: flex;
-		align-items: center;
+		align-items: end;
 		justify-content: center;
 		flex-shrink: 0;
 		margin-right: 0;

--- a/src/resources/styles/_listItemSelection.scss
+++ b/src/resources/styles/_listItemSelection.scss
@@ -15,6 +15,14 @@ $list-item-accent-ring-width: 2px !default; // canonical selection ring width
 $list-item-action-color: #d93025 !default; // red action-target button colour
 $list-item-resting-border: rgba(0, 0, 0, 0.12) !default; // 1px secondary border
 $list-item-focus-ring: rgba(185, 54, 45, 0.35) !default; // a11y focus ring
+// M3 selected border (session list / interactive chat cards) — #597
+$list-item-selected-border-width: 2px !default;
+$list-item-selected-border-color: var(--m3-primary, #a5000a) !default;
+$list-item-active-menu-border-width: 2px !default;
+$list-item-active-menu-border-color: var(
+	--m3-primary-container,
+	#cc1e1c
+) !default;
 
 // --- Mixins ---
 
@@ -24,6 +32,34 @@ $list-item-focus-ring: rgba(185, 54, 45, 0.35) !default; // a11y focus ring
 @mixin list-item-active-treatment {
 	background-color: $list-item-selected-bg;
 	box-shadow: inset 0 0 0 $list-item-accent-ring-width $list-item-accent-ring;
+}
+
+// Selected (clicked) ring for chat session cards — Figma #597.
+// Distinct from keyboard focus (`list-item-focus-treatment`) and from the
+// inset accent treatment used by Activity Timeline.
+@mixin list-item-selected-border($important: false) {
+	@if $important {
+		border: $list-item-selected-border-width
+			solid
+			$list-item-selected-border-color !important;
+	} @else {
+		border: $list-item-selected-border-width
+			solid
+			$list-item-selected-border-color;
+	}
+}
+
+// Active / open menu panel or menu trigger border — Figma #597.
+@mixin list-item-active-menu-border($important: false) {
+	@if $important {
+		border: $list-item-active-menu-border-width
+			solid
+			$list-item-active-menu-border-color !important;
+	} @else {
+		border: $list-item-active-menu-border-width
+			solid
+			$list-item-active-menu-border-color;
+	}
 }
 
 // Keyboard focus is independent of selection and layers on top.


### PR DESCRIPTION
## What
Closes [#597](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/597)
Part of [#595](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/595) (UI Focus & Accessibility Improvements)

Aligns interactive chat focus/active indicators with M3 tokens and Figma:
session list selected state, chat container active border, menu button shape,
and composer selected / send button styling.

## Changes

**Session list selected state:**
- Selected card border: `2px solid var(--m3-primary)` (was `1px #ffb4aa`)
- Shared mixin: `list-item-selected-border` in `_listItemSelection.scss`
- Keyboard focus ring preserved (`list-item-focus-treatment`)

**Chat container active/clicked:**
- Resting: `1px solid var(--oriso-primary-fixed-dim)`
- Active: `2px solid var(--m3-primary-container)` when session chrome is
  focused/clicked, not when composer is `--selected`
- Click-to-focus helper on `.session` / `.enquiry__wrapper`

**Menu button shape:**
- Closed: horizontal `48×32`
- Open (`--menuOpen` / `aria-expanded`): vertical `32×48`
- Active menu / dropdown: `2px solid var(--m3-primary-container)`

**Text area / send button:**
- Selected textarea: `2px solid var(--m3-primary-container)`
- Empty / not-selected send: `var(--m3-primary-fixed-dim, #ffb4aa)`, white icon
- Ready/sending: primary-container + existing rotate

**Storybook:**
- Consultant chat surface, session list, composer, session menu, chat menu
  stories updated to use production styles / document #597 states

## Verification
- Session list selected: `2px` primary border; keyboard focus still visible
- Chat panel click outside composer: container active border; composer focus:
  resting container + selected textarea border
- Menu closed vs open: horizontal → vertical + `2px` primary-container
- Send empty: `#ffb4aa` + white icon; typed: ready rotate unchanged
- Typecheck: passed
- Stylelint (touched SCSS): passed
- Unit tests (`sessionLayout`, `focusSessionChrome`, `SendButton`): passed

### Before
**Session List Selected State**
<img width="545" height="832" alt="image" src="https://github.com/user-attachments/assets/0472f698-be50-4bfe-bad2-04bc71107ddc" />
**Chat Container active/clicked**
<img width="1253" height="891" alt="image" src="https://github.com/user-attachments/assets/66fce208-9044-44f0-85a6-6be663ad6993" />
**Text Area / Send button State**
<img width="1141" height="262" alt="image" src="https://github.com/user-attachments/assets/78cdecda-49a5-421a-a2d9-a18802deba7b" />
**Menu button shape**
<img width="497" height="698" alt="image" src="https://github.com/user-attachments/assets/a1615eda-ad9d-4f35-9502-0d2583297462" />


### After
**Session List Selected State**
#### On Selected
<img width="485" height="635" alt="image" src="https://github.com/user-attachments/assets/dc2e3cf5-1a4a-4ab1-ba18-d2ece56c079f" />
#### On Unselected
<img width="495" height="637" alt="image" src="https://github.com/user-attachments/assets/dbfb4f9a-f162-4c67-a0c9-9f0faa009329" />


**Chat container active / clicked**
#### Idle
<img width="1871" height="882" alt="image" src="https://github.com/user-attachments/assets/b12fdcd1-de8c-401d-9da3-ff497e0fac94" />
#### On Clicked / Active
<img width="1886" height="892" alt="image" src="https://github.com/user-attachments/assets/58a6a60d-938e-444f-bd00-12f0daa0e72d" />

**Text area / send button state**
#### Idle
<img width="1143" height="260" alt="image" src="https://github.com/user-attachments/assets/866d5202-fb64-41f1-b5bd-35312d21b0a7" />

#### Selected (Input emtpy)
<img width="1162" height="295" alt="image" src="https://github.com/user-attachments/assets/02aa6f53-cdae-4612-8de0-adf92d215c9e" />

#### Selected (Input filled)
<img width="1167" height="262" alt="image" src="https://github.com/user-attachments/assets/cf5dc421-346d-4c69-a0cb-7bce5f7e13fe" />

**Menu button shape**
#### Idle
<img width="511" height="217" alt="image" src="https://github.com/user-attachments/assets/52c583ae-12f3-42c5-a068-246880f44fb6" />

#### Active
<img width="516" height="695" alt="image" src="https://github.com/user-attachments/assets/31bcc41f-2f36-4e0b-93a1-1c3b55356fde" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer focus indicators for session and chat areas while preserving natural composer and control interactions.
  - Added active/open visual states for session and chat menu triggers.
  - Added smooth transitions for menu icons and session borders.

- **Visual Improvements**
  - Standardized selected, focused, and menu-open borders across session lists and dropdowns.
  - Updated the send button’s resting color for improved theme consistency.
  - Refined chat and composer presentation across screen sizes.

- **Tests**
  - Added coverage for session focus behavior and visual focus styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->