### PR TITLE
fix(livechat): open answered live chats via the Matrix room-id route (#774)

### DIFF
--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -548,6 +548,8 @@ export const SessionListItemComponent = ({
 					isGroup: activeSession.isGroup,
 					isAsker,
 					isEmptyEnquiry: activeSession.isEmptyEnquiry,
+					isLiveChat:
+						getModality(activeSession) === Modality.LIVE_CHAT,
 					tabSuffix: getSessionListTab()
 				})
 			);

--- a/src/components/sessionsListItem/sessionNavigationPath.test.ts
+++ b/src/components/sessionsListItem/sessionNavigationPath.test.ts
@@ -45,6 +45,61 @@ describe('getSessionNavigationPath', () => {
 		).toBe('/sessions/user/view/session/4');
 	});
 
+	it('opens a consultant live chat through the Matrix room-id route (#774)', () => {
+		// A consultant opening an answered live chat must use the same room-id
+		// route the accept flow uses; the /session/:id route resolves through a
+		// different backend lookup that returns nothing for answered live chats.
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/consultant/sessionView',
+				sessionId: 42,
+				groupId: '!livechat:matrix.localhost',
+				isGroup: false,
+				isAsker: false,
+				isEmptyEnquiry: false,
+				isLiveChat: true,
+				tabSuffix: ''
+			})
+		).toBe(
+			'/sessions/consultant/sessionView/!livechat%3Amatrix.localhost/42'
+		);
+	});
+
+	it('falls back to the resolved room id for a consultant live chat', () => {
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/consultant/sessionView',
+				sessionId: 43,
+				groupId: undefined,
+				rid: '!livechat-rid:matrix.localhost',
+				isGroup: false,
+				isAsker: false,
+				isEmptyEnquiry: false,
+				isLiveChat: true,
+				tabSuffix: '?sessionListTab=all'
+			})
+		).toBe(
+			'/sessions/consultant/sessionView/!livechat-rid%3Amatrix.localhost/43?sessionListTab=all'
+		);
+	});
+
+	it('keeps an asker live chat on the session-id route', () => {
+		// Only the consultant open path is affected by #774; the asker keeps its
+		// existing routing.
+		expect(
+			getSessionNavigationPath({
+				listPath: '/sessions/user/view',
+				sessionId: 44,
+				groupId: '!livechat:matrix.localhost',
+				isGroup: false,
+				isAsker: true,
+				isEmptyEnquiry: false,
+				isLiveChat: true,
+				tabSuffix: ''
+			})
+		).toBe('/sessions/user/view/session/44');
+	});
+
 	it('keeps an empty enquiry on its current list route and tab', () => {
 		expect(
 			getSessionNavigationPath({

--- a/src/components/sessionsListItem/sessionsListItemHelpers.ts
+++ b/src/components/sessionsListItem/sessionsListItemHelpers.ts
@@ -32,6 +32,7 @@ interface SessionNavigationPathOptions {
 	isGroup: boolean;
 	isAsker: boolean;
 	isEmptyEnquiry: boolean;
+	isLiveChat?: boolean;
 	tabSuffix: string;
 }
 
@@ -43,6 +44,7 @@ export const getSessionNavigationPath = ({
 	isGroup,
 	isAsker,
 	isEmptyEnquiry,
+	isLiveChat = false,
 	tabSuffix
 }: SessionNavigationPathOptions) => {
 	const roomId = groupId ?? rid;
@@ -55,6 +57,21 @@ export const getSessionNavigationPath = ({
 		// Resolve the Series through the supported session-id route instead of
 		// falling into asker-enquiry routing.
 		return `${listPath}/session/${sessionId}${tabSuffix}`;
+	}
+
+	// #774: a consultant opening an answered live chat must use the Matrix
+	// room-id route — the same lookup the accept flow uses successfully
+	// (AcceptAssign.redirectToAcceptedSession). The default /session/:id route
+	// resolves through a different backend lookup that returns nothing for an
+	// answered live chat, leaving the conversation blank. Scoped to the
+	// consultant open path; the asker keeps its existing routing.
+	if (isLiveChat && !isAsker) {
+		const matrixRoomId = [groupId, rid].find((id) =>
+			isMatrixRoomIdHeuristic(id)
+		);
+		if (matrixRoomId) {
+			return `${listPath}/${encodeURIComponent(matrixRoomId)}/${sessionId}${tabSuffix}`;
+		}
 	}
 
 	if (groupId && !isMatrixRoomIdHeuristic(groupId)) {


### PR DESCRIPTION
Fixes #774.

## Problem
A consultant who answered a live chat can see it in the list, but opening it from the list leaves the conversation blank.

## Cause
Two entry points open the same conversation via different routes and backend lookups:
- **Accept flow** (`AcceptAssign.redirectToAcceptedSession`) → `/:roomId/:sessionId`, loads by Matrix room id → works.
- **List click** (`getSessionNavigationPath`) routed a Matrix-backed single session to `/session/:sessionId`, a different lookup that returns nothing for an answered live chat → `useSession` gets a null session and `SessionView` redirects to the empty list.

## Change
- Route a consultant-opened live chat to the same room-id route the accept flow already uses.
- Scoped to `getModality === LIVE_CHAT` **and** `!isAsker`; asker and non-live routing unchanged.
- Red-green unit tests for both consultant cases and the unchanged asker case.

## Verification
- `test:unit`: 35 failures, identical to the `pre-dev` baseline (unrelated localStorage/circle-defaults); +3 new passing, 0 new failures.
- `tsc` 0 errors; `eslint` on changed files clean; `build` exit 0.
- `lint:style`: 1 pre-existing error in `sendButton.styles.scss` (untouched file).

## Note
Traced statically across ORISO-Frontend and ORISO-UserService; not reproduced against a live backend (needs a consultant login + two-party live chat). The fix aligns the failing list path to the proven-working accept path, so it cannot regress working cases. The reason the by-session-id lookup returns empty for answered live chats likely also involves a UserService detail (`checkConsultantAssignment`) worth confirming on the running env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation for consultants opening answered live-chat sessions.
  * Live chats now route using the correct Matrix room identifier when available.
  * Added fallback routing when a room identifier is unavailable, while preserving tab selections.
  * Existing asker live-chat navigation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->