### PR TITLE
fix(livechat): accept live chats via the anonymous assignment endpoint (#774)

### DIFF
--- a/src/api/apiAcceptAnonymousEnquiry.test.ts
+++ b/src/api/apiAcceptAnonymousEnquiry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchData } from './fetchData';
+import { apiAcceptAnonymousEnquiry } from './apiAcceptAnonymousEnquiry';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		acceptAnonymousEnquiry: (sessionId: number | string) =>
+			`/service/conversations/askers/anonymous/${sessionId}/accept`
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_METHODS: { PUT: 'PUT' },
+	FETCH_ERRORS: { CONFLICT: 'CONFLICT' },
+	fetchData: vi.fn(() => Promise.resolve())
+}));
+
+describe('apiAcceptAnonymousEnquiry', () => {
+	it('PUTs to the dedicated anonymous accept endpoint, not the registered one', async () => {
+		await apiAcceptAnonymousEnquiry(103507);
+
+		expect(fetchData).toHaveBeenCalledWith({
+			url: '/service/conversations/askers/anonymous/103507/accept',
+			method: 'PUT',
+			rcValidation: true,
+			responseHandling: ['CONFLICT']
+		});
+	});
+});

--- a/src/api/apiAcceptAnonymousEnquiry.ts
+++ b/src/api/apiAcceptAnonymousEnquiry.ts
@@ -1,0 +1,24 @@
+import { endpoints } from '../resources/scripts/endpoints';
+import { fetchData, FETCH_ERRORS, FETCH_METHODS } from './fetchData';
+
+/**
+ * Accepts an anonymous Live Chat enquiry for the authenticated consultant.
+ *
+ * Live chats use a dedicated cross-tenant assignment path
+ * (`assignAnonymousEnquiry`) that differs from the registered-enquiry accept
+ * (`apiEnquiryAcceptance` → `assignRegisteredEnquiry`). Routing a live chat
+ * through the registered endpoint mis-assigns it, so the consultant open/accept
+ * flow must call this endpoint for anonymous conversations (#774).
+ */
+export const apiAcceptAnonymousEnquiry = async (
+	sessionId: number
+): Promise<any> => {
+	const url = endpoints.acceptAnonymousEnquiry(sessionId);
+
+	return fetchData({
+		url,
+		method: FETCH_METHODS.PUT,
+		rcValidation: true,
+		responseHandling: [FETCH_ERRORS.CONFLICT]
+	});
+};

--- a/src/components/session/AcceptAssign.tsx
+++ b/src/components/session/AcceptAssign.tsx
@@ -15,9 +15,11 @@ import { useSearchParam } from '../../hooks/useSearchParams';
 import { SESSION_LIST_TAB } from './sessionHelpers';
 import { useE2EE } from '../../hooks/useE2EE';
 import { apiEnquiryAcceptance, FETCH_ERRORS } from '../../api';
+import { apiAcceptAnonymousEnquiry } from '../../api/apiAcceptAnonymousEnquiry';
 import { Button, BUTTON_TYPES, ButtonItem } from '../button/Button';
 import { useWatcher } from '../../hooks/useWatcher';
 import { apiGetSessionRoomBySessionId } from '../../api/apiGetSessionRooms';
+import { getModality, Modality } from './getModality';
 import { ReactComponent as XIcon } from '../../resources/img/illustrations/x.svg';
 import { useTranslation } from 'react-i18next';
 import { useE2EEViewElements } from '../../hooks/useE2EEViewElements';
@@ -171,7 +173,14 @@ export const AcceptAssign = ({ assigned, btnLabel }: AcceptAssignProps) => {
 		}
 		setIsRequestInProgress(true);
 
-		apiEnquiryAcceptance(sessionId)
+		// Live chats assign through the dedicated cross-tenant anonymous path;
+		// registered enquiries keep the existing accept endpoint (#774).
+		const acceptRequest =
+			getModality(activeSession) === Modality.LIVE_CHAT
+				? apiAcceptAnonymousEnquiry(sessionId)
+				: apiEnquiryAcceptance(sessionId);
+
+		acceptRequest
 			.then(() => fetchSessionRoutingAfterAccept(sessionId))
 			.then((routing) =>
 				encryptRoom(setE2EEState, routing.roomRouteId).then(

--- a/src/resources/scripts/endpoints.ts
+++ b/src/resources/scripts/endpoints.ts
@@ -55,6 +55,9 @@ export const endpoints = {
 	chatRoom: userServiceOrigin + '/service/users/chat/room',
 	anonymousEnquiryDetails: (sessionId: number | string) =>
 		userServiceOrigin + `/service/conversations/anonymous/${sessionId}`,
+	acceptAnonymousEnquiry: (sessionId: number | string) =>
+		userServiceOrigin +
+		`/service/conversations/askers/anonymous/${sessionId}/accept`,
 	finishAnonymousConversation: (sessionId: number | string) =>
 		userServiceOrigin +
 		`/service/conversations/anonymous/${sessionId}/finish`,


### PR DESCRIPTION
Part 2 of 2 for #774 (backend counterpart: OpenResilienceInitiative/ORISO-UserService#741, the open-path 204 fix).

## Problem
Even once a live chat request opens, accepting it uses the wrong backend path.

## Cause
`AcceptAssign` accepted every enquiry through `apiEnquiryAcceptance` (`PUT /users/sessions/new/{id}` → `assignRegisteredEnquiry`). Anonymous live chats use a separate cross-tenant assignment path (`PUT /conversations/askers/anonymous/{id}/accept` → `assignAnonymousEnquiry`), so accepting a live chat through the registered endpoint mis-handles it.

## Change
- Add `apiAcceptAnonymousEnquiry` hitting the anonymous accept endpoint.
- Branch `AcceptAssign` by modality: `getModality === LIVE_CHAT` → anonymous accept; registered enquiries unchanged.

## Tests
Red-green API test asserts the anonymous accept endpoint + PUT. `build` and `tsc` clean; full `test:unit`: **+1 passing, 0 new failures** vs the `pre-dev` baseline (35 pre-existing, unrelated).

## Note
Depends on ORISO-UserService#741 to open the request in the first place. Root cause of the whole flow confirmed live in-browser; end-to-end confirmation needs both deployed to dev. Supersedes #777 (that routing change did not fix #774).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accepting anonymous live chat enquiries through the appropriate service flow.
  * Live chat assignments now use a dedicated acceptance process, while other enquiry types continue using their existing flow.

* **Tests**
  * Added coverage confirming anonymous enquiries use the correct request and validation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->