### PR TITLE
Confine call rooms to session members, add widget-mode embedding

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"lottie-react": "^2.4.1",
 		"markdown-draft-js": "^2.4.0",
 		"matrix-js-sdk": "^38.4.0",
+		"matrix-widget-api": "^1.13.1",
 		"mini-css-extract-plugin": "^2.7.7",
 		"prompts": "^2.4.2",
 		"qrcode": "^1.5.3",

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -8,8 +8,10 @@ import React, { useEffect, useState, useRef } from 'react';
 import { callManager, CallData } from '../../services/CallManager';
 import {
 	getElementCallBaseUrl,
-	getMatrixHomeserverUrl
+	getMatrixHomeserverUrl,
+	isElementCallWidgetModeEnabled
 } from '../../resources/scripts/runtimeConfig';
+import { useElementCallWidget } from './widget/useElementCallWidget';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
 import { getElementCallAccessToken } from '../sessionCookie/getMatrixAccessToken';
 import {
@@ -33,6 +35,21 @@ export const GroupCallWidget: React.FC = () => {
 	const [callState, setCallState] = useState<string | null>(null);
 	const [elementCallUrl, setElementCallUrl] = useState<string>('');
 	const [isDismissed, setIsDismissed] = useState(false);
+
+	// Widget mode keeps the Matrix session in this app: the call iframe gets no
+	// access token and registers no device of its own, and asks us to send and
+	// read events for it instead. Off by default until validated on Pre-Dev.
+	const widgetModeEnabled = isElementCallWidgetModeEnabled();
+	const callRoomId = callData
+		? ((callData as any).elementCallRoomId ?? callData.roomId)
+		: null;
+	const widget = useElementCallWidget(
+		widgetModeEnabled ? (matrixClientService?.getClient() ?? null) : null,
+		{
+			roomId: widgetModeEnabled ? callRoomId : null,
+			isVideo: callData?.isVideo ?? true
+		}
+	);
 
 	// Dragging / resize state
 	const [isDragging, setIsDragging] = useState(false);
@@ -200,6 +217,22 @@ export const GroupCallWidget: React.FC = () => {
 
 	const setupElementCall = async () => {
 		if (!callData || setupInProgressRef.current) return;
+
+		// In widget mode the URL is derived declaratively by the hook — there is
+		// no login step to perform here, because there is no separate session.
+		if (widgetModeEnabled) {
+			if (widget.error) {
+				alert(`Failed to start call: ${widget.error.message}`);
+				callManager.endCall();
+				return;
+			}
+			if (widget.url) {
+				setupInProgressRef.current = true;
+				setElementCallUrl(widget.url);
+			}
+			return;
+		}
+
 		setupInProgressRef.current = true;
 
 		try {
@@ -627,7 +660,17 @@ export const GroupCallWidget: React.FC = () => {
 									: '⤢'}
 						</button>
 						<iframe
-							ref={iframeRef}
+							ref={(node) => {
+								// The ref is shared: the drag/close logic needs the
+								// element, and widget mode additionally opens the
+								// postMessage channel against it.
+								(
+									iframeRef as React.MutableRefObject<HTMLIFrameElement | null>
+								).current = node;
+								if (widgetModeEnabled) {
+									widget.attachIframe(node);
+								}
+							}}
 							src={elementCallUrl}
 							className="element-call-iframe"
 							allow="camera; microphone; display-capture; autoplay; fullscreen"

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -4,7 +4,7 @@
  * https://github.com/element-hq/element-call
  */
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { callManager, CallData } from '../../services/CallManager';
 import {
 	getElementCallBaseUrl,
@@ -80,6 +80,26 @@ export const GroupCallWidget: React.FC = () => {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const setupInProgressRef = useRef(false);
+
+	// React compares ref callbacks by function identity, not by DOM node: an
+	// inline callback is a new function on every render, so React would detach
+	// (call it with `null`) and re-attach on every drag or resize frame — tearing
+	// down and rebuilding the widget's postMessage channel mid-call. Keep it
+	// stable and let it change only when the widget itself does.
+	const setIframeNode = useCallback(
+		(node: HTMLIFrameElement | null) => {
+			// The ref is shared: the drag/close logic needs the element, and
+			// widget mode additionally opens the postMessage channel against it.
+			(
+				iframeRef as React.MutableRefObject<HTMLIFrameElement | null>
+			).current = node;
+			if (widgetModeEnabled) {
+				widget.attachIframe(node);
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[widgetModeEnabled, widget.attachIframe]
+	);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 
 	const getGroupBounds = () => ({
@@ -660,17 +680,7 @@ export const GroupCallWidget: React.FC = () => {
 									: '⤢'}
 						</button>
 						<iframe
-							ref={(node) => {
-								// The ref is shared: the drag/close logic needs the
-								// element, and widget mode additionally opens the
-								// postMessage channel against it.
-								(
-									iframeRef as React.MutableRefObject<HTMLIFrameElement | null>
-								).current = node;
-								if (widgetModeEnabled) {
-									widget.attachIframe(node);
-								}
-							}}
+							ref={setIframeNode}
 							src={elementCallUrl}
 							className="element-call-iframe"
 							allow="camera; microphone; display-capture; autoplay; fullscreen"

--- a/src/components/call/widget/OrisoWidgetDriver.test.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MatrixClient } from 'matrix-js-sdk';
+
+import { OrisoWidgetDriver } from './OrisoWidgetDriver';
+
+const CALL_ROOM = '!call:oriso.example';
+const OTHER_ROOM = '!counselling:oriso.example';
+
+const createClient = (overrides: Partial<MatrixClient> = {}) =>
+	({
+		sendEvent: vi.fn().mockResolvedValue({ event_id: '$evt' }),
+		sendStateEvent: vi.fn().mockResolvedValue({ event_id: '$state' }),
+		queueToDevice: vi.fn().mockResolvedValue(undefined),
+		encryptAndSendToDevice: vi.fn().mockResolvedValue(undefined),
+		getCrypto: vi.fn().mockReturnValue({}),
+		getRoom: vi.fn().mockReturnValue(null),
+		...overrides
+	}) as unknown as MatrixClient;
+
+describe('OrisoWidgetDriver', () => {
+	let client: MatrixClient;
+	let driver: OrisoWidgetDriver;
+
+	beforeEach(() => {
+		client = createClient();
+		driver = new OrisoWidgetDriver(client, CALL_ROOM);
+	});
+
+	describe('room confinement', () => {
+		it('refuses to send into a room other than the call room', async () => {
+			// A call widget has no business writing into the counselling session.
+			await expect(
+				driver.sendEvent('m.reaction', {}, null, OTHER_ROOM)
+			).rejects.toThrow(/confined/);
+			expect(client.sendEvent).not.toHaveBeenCalled();
+		});
+
+		it('refuses to read a room other than the call room', async () => {
+			await expect(
+				driver.readRoomState(OTHER_ROOM, 'm.room.member', undefined)
+			).rejects.toThrow(/confined/);
+		});
+
+		it('treats an omitted room id as the call room', async () => {
+			await driver.sendEvent('m.reaction', { hello: true });
+
+			expect(client.sendEvent).toHaveBeenCalledWith(
+				CALL_ROOM,
+				'm.reaction',
+				{ hello: true }
+			);
+		});
+	});
+
+	describe('capabilities', () => {
+		it('grants what Element Call needs and drops the rest', async () => {
+			const granted = await driver.validateCapabilities(
+				new Set([
+					'm.always_on_screen',
+					'org.matrix.msc3819.send.to_device:m.call.encryption_keys',
+					'org.matrix.msc2762.send.event:m.room.message'
+				])
+			);
+
+			expect(granted).toEqual(
+				new Set([
+					'm.always_on_screen',
+					'org.matrix.msc3819.send.to_device:m.call.encryption_keys'
+				])
+			);
+		});
+	});
+
+	describe('to-device sending', () => {
+		it('encrypts media keys through the host crypto stack', async () => {
+			await driver.sendToDevice('m.call.encryption_keys', true, {
+				'@asker:oriso.example': { DEV1: { key: 'a' } },
+				'@counsellor:oriso.example': { DEV2: { key: 'a' } }
+			});
+
+			// Same payload for both devices, so one encrypted send covers both.
+			expect(client.encryptAndSendToDevice).toHaveBeenCalledTimes(1);
+			expect(client.encryptAndSendToDevice).toHaveBeenCalledWith(
+				'm.call.encryption_keys',
+				[
+					{ userId: '@asker:oriso.example', deviceId: 'DEV1' },
+					{ userId: '@counsellor:oriso.example', deviceId: 'DEV2' }
+				],
+				{ key: 'a' }
+			);
+			expect(client.queueToDevice).not.toHaveBeenCalled();
+		});
+
+		it('sends one encrypted batch per distinct payload', async () => {
+			await driver.sendToDevice('m.call.encryption_keys', true, {
+				'@asker:oriso.example': {
+					DEV1: { key: 'a' },
+					DEV2: { key: 'b' }
+				}
+			});
+
+			expect(client.encryptAndSendToDevice).toHaveBeenCalledTimes(2);
+		});
+
+		it('refuses to send keys when the host has no crypto', async () => {
+			// Falling back to plaintext here would leak the media keys that the
+			// whole call encryption rests on.
+			driver = new OrisoWidgetDriver(
+				createClient({ getCrypto: vi.fn().mockReturnValue(undefined) }),
+				CALL_ROOM
+			);
+
+			await expect(
+				driver.sendToDevice('m.call.encryption_keys', true, {
+					'@asker:oriso.example': { DEV1: { key: 'a' } }
+				})
+			).rejects.toThrow(/no crypto/);
+		});
+
+		it('uses the plain queue only when encryption was not requested', async () => {
+			await driver.sendToDevice('m.call.hangup', false, {
+				'@asker:oriso.example': { DEV1: { reason: 'user_hangup' } }
+			});
+
+			expect(client.queueToDevice).toHaveBeenCalledWith({
+				eventType: 'm.call.hangup',
+				batch: [
+					{
+						userId: '@asker:oriso.example',
+						deviceId: 'DEV1',
+						payload: { reason: 'user_hangup' }
+					}
+				]
+			});
+			expect(client.encryptAndSendToDevice).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('state events', () => {
+		it('sends a state event when a state key is given', async () => {
+			await driver.sendEvent(
+				'org.matrix.msc3401.call.member',
+				{ memberships: [] },
+				'@a:oriso.example_DEV1_m.call'
+			);
+
+			expect(client.sendStateEvent).toHaveBeenCalledWith(
+				CALL_ROOM,
+				'org.matrix.msc3401.call.member',
+				{ memberships: [] },
+				'@a:oriso.example_DEV1_m.call'
+			);
+			expect(client.sendEvent).not.toHaveBeenCalled();
+		});
+
+		it('returns nothing for a room the client has not synced', async () => {
+			await expect(
+				driver.readRoomState(CALL_ROOM, 'm.room.member', undefined)
+			).resolves.toEqual([]);
+		});
+	});
+});

--- a/src/components/call/widget/OrisoWidgetDriver.test.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.test.ts
@@ -90,9 +90,7 @@ describe('OrisoWidgetDriver', () => {
 
 			await vi.waitFor(() => expect(updates).toHaveLength(1));
 			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
-			expect(updates).toEqual([
-				{ state: OpenIDRequestState.Blocked }
-			]);
+			expect(updates).toEqual([{ state: OpenIDRequestState.Blocked }]);
 			expect(consoleError).not.toHaveBeenCalled();
 			expect(consoleWarn).not.toHaveBeenCalled();
 			expect(consoleLog).not.toHaveBeenCalled();
@@ -125,9 +123,7 @@ describe('OrisoWidgetDriver', () => {
 			).not.toThrow();
 
 			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
-			expect(updates).toEqual([
-				{ state: OpenIDRequestState.Blocked }
-			]);
+			expect(updates).toEqual([{ state: OpenIDRequestState.Blocked }]);
 			expect(consoleError).not.toHaveBeenCalled();
 			expect(consoleWarn).not.toHaveBeenCalled();
 			expect(consoleLog).not.toHaveBeenCalled();
@@ -147,36 +143,39 @@ describe('OrisoWidgetDriver', () => {
 			['negative expiry', { ...validToken, expires_in: -1 }],
 			['infinite expiry', { ...validToken, expires_in: Infinity }],
 			['non-number expiry', { ...validToken, expires_in: '3600' }]
-		])('blocks a malformed token with %s without exposing it', async (_, token) => {
-			const getOpenIdToken = vi.fn().mockResolvedValue(token);
-			driver = new OrisoWidgetDriver(
-				createClient({ getOpenIdToken }),
-				CALL_ROOM
-			);
-			const updates: IOpenIDUpdate[] = [];
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => undefined);
-			const consoleWarn = vi
-				.spyOn(console, 'warn')
-				.mockImplementation(() => undefined);
-			const consoleLog = vi
-				.spyOn(console, 'log')
-				.mockImplementation(() => undefined);
+		])(
+			'blocks a malformed token with %s without exposing it',
+			async (_, token) => {
+				const getOpenIdToken = vi.fn().mockResolvedValue(token);
+				driver = new OrisoWidgetDriver(
+					createClient({ getOpenIdToken }),
+					CALL_ROOM
+				);
+				const updates: IOpenIDUpdate[] = [];
+				const consoleError = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => undefined);
+				const consoleWarn = vi
+					.spyOn(console, 'warn')
+					.mockImplementation(() => undefined);
+				const consoleLog = vi
+					.spyOn(console, 'log')
+					.mockImplementation(() => undefined);
 
-			driver.askOpenID(
-				new SimpleObservable((update) => updates.push(update))
-			);
+				driver.askOpenID(
+					new SimpleObservable((update) => updates.push(update))
+				);
 
-			await vi.waitFor(() => expect(updates).toHaveLength(1));
-			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
-			expect(updates).toEqual([
-				{ state: OpenIDRequestState.Blocked }
-			]);
-			expect(consoleError).not.toHaveBeenCalled();
-			expect(consoleWarn).not.toHaveBeenCalled();
-			expect(consoleLog).not.toHaveBeenCalled();
-		});
+				await vi.waitFor(() => expect(updates).toHaveLength(1));
+				expect(getOpenIdToken).toHaveBeenCalledTimes(1);
+				expect(updates).toEqual([
+					{ state: OpenIDRequestState.Blocked }
+				]);
+				expect(consoleError).not.toHaveBeenCalled();
+				expect(consoleWarn).not.toHaveBeenCalled();
+				expect(consoleLog).not.toHaveBeenCalled();
+			}
+		);
 	});
 
 	describe('room confinement', () => {

--- a/src/components/call/widget/OrisoWidgetDriver.test.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	OpenIDRequestState,
+	SimpleObservable,
+	type IOpenIDUpdate
+} from 'matrix-widget-api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MatrixClient } from 'matrix-js-sdk';
 
 import { OrisoWidgetDriver } from './OrisoWidgetDriver';
@@ -24,6 +29,154 @@ describe('OrisoWidgetDriver', () => {
 	beforeEach(() => {
 		client = createClient();
 		driver = new OrisoWidgetDriver(client, CALL_ROOM);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('OpenID', () => {
+		const validToken = {
+			access_token: 'openid-token',
+			token_type: 'Bearer',
+			matrix_server_name: 'oriso.example',
+			expires_in: 3600
+		};
+
+		it('allows the trusted call widget with the exact host token', async () => {
+			const token = { ...validToken };
+			const getOpenIdToken = vi.fn().mockResolvedValue(token);
+			driver = new OrisoWidgetDriver(
+				createClient({ getOpenIdToken }),
+				CALL_ROOM
+			);
+			const updates: IOpenIDUpdate[] = [];
+
+			driver.askOpenID(
+				new SimpleObservable((update) => updates.push(update))
+			);
+
+			await vi.waitFor(() => expect(updates).toHaveLength(1));
+			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
+			expect(updates).toEqual([
+				{ state: OpenIDRequestState.Allowed, token }
+			]);
+			expect(updates[0].token).toBe(token);
+		});
+
+		it('blocks a rejected host request without exposing the rejection', async () => {
+			const rejection = new Error('sensitive host failure');
+			const getOpenIdToken = vi.fn().mockRejectedValue(rejection);
+			driver = new OrisoWidgetDriver(
+				createClient({ getOpenIdToken }),
+				CALL_ROOM
+			);
+			const updates: IOpenIDUpdate[] = [];
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+			const consoleWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const consoleLog = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => undefined);
+
+			expect(() =>
+				driver.askOpenID(
+					new SimpleObservable((update) => updates.push(update))
+				)
+			).not.toThrow();
+
+			await vi.waitFor(() => expect(updates).toHaveLength(1));
+			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
+			expect(updates).toEqual([
+				{ state: OpenIDRequestState.Blocked }
+			]);
+			expect(consoleError).not.toHaveBeenCalled();
+			expect(consoleWarn).not.toHaveBeenCalled();
+			expect(consoleLog).not.toHaveBeenCalled();
+		});
+
+		it('blocks a synchronous host throw without exposing it', () => {
+			const rejection = new Error('sensitive synchronous failure');
+			const getOpenIdToken = vi.fn(() => {
+				throw rejection;
+			});
+			driver = new OrisoWidgetDriver(
+				createClient({ getOpenIdToken }),
+				CALL_ROOM
+			);
+			const updates: IOpenIDUpdate[] = [];
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+			const consoleWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const consoleLog = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => undefined);
+
+			expect(() =>
+				driver.askOpenID(
+					new SimpleObservable((update) => updates.push(update))
+				)
+			).not.toThrow();
+
+			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
+			expect(updates).toEqual([
+				{ state: OpenIDRequestState.Blocked }
+			]);
+			expect(consoleError).not.toHaveBeenCalled();
+			expect(consoleWarn).not.toHaveBeenCalled();
+			expect(consoleLog).not.toHaveBeenCalled();
+		});
+
+		it.each([
+			['empty access token', { ...validToken, access_token: '' }],
+			['non-string access token', { ...validToken, access_token: 42 }],
+			['empty token type', { ...validToken, token_type: '' }],
+			['non-string token type', { ...validToken, token_type: null }],
+			['empty server name', { ...validToken, matrix_server_name: '' }],
+			[
+				'non-string server name',
+				{ ...validToken, matrix_server_name: false }
+			],
+			['zero expiry', { ...validToken, expires_in: 0 }],
+			['negative expiry', { ...validToken, expires_in: -1 }],
+			['infinite expiry', { ...validToken, expires_in: Infinity }],
+			['non-number expiry', { ...validToken, expires_in: '3600' }]
+		])('blocks a malformed token with %s without exposing it', async (_, token) => {
+			const getOpenIdToken = vi.fn().mockResolvedValue(token);
+			driver = new OrisoWidgetDriver(
+				createClient({ getOpenIdToken }),
+				CALL_ROOM
+			);
+			const updates: IOpenIDUpdate[] = [];
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+			const consoleWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const consoleLog = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => undefined);
+
+			driver.askOpenID(
+				new SimpleObservable((update) => updates.push(update))
+			);
+
+			await vi.waitFor(() => expect(updates).toHaveLength(1));
+			expect(getOpenIdToken).toHaveBeenCalledTimes(1);
+			expect(updates).toEqual([
+				{ state: OpenIDRequestState.Blocked }
+			]);
+			expect(consoleError).not.toHaveBeenCalled();
+			expect(consoleWarn).not.toHaveBeenCalled();
+			expect(consoleLog).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('room confinement', () => {

--- a/src/components/call/widget/OrisoWidgetDriver.test.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.test.ts
@@ -269,6 +269,24 @@ describe('OrisoWidgetDriver', () => {
 			).rejects.toThrow(/no crypto/);
 		});
 
+		it('refuses to send media keys in the clear even when asked to', async () => {
+			// The iframe controls the `encrypted` flag. If it could set it to
+			// false for a key-bearing type, the media keys the whole call rests
+			// on would go out in plaintext.
+			await expect(
+				driver.sendToDevice('m.call.encryption_keys', false, {
+					'@asker:oriso.example': { DEV1: { key: 'a' } }
+				})
+			).rejects.toThrow(/never travel in plaintext/);
+			expect(client.queueToDevice).not.toHaveBeenCalled();
+
+			await expect(
+				driver.sendToDevice('io.element.call.encryption_keys', false, {
+					'@asker:oriso.example': { DEV1: { key: 'a' } }
+				})
+			).rejects.toThrow(/never travel in plaintext/);
+		});
+
 		it('uses the plain queue only when encryption was not requested', async () => {
 			await driver.sendToDevice('m.call.hangup', false, {
 				'@asker:oriso.example': { DEV1: { reason: 'user_hangup' } }

--- a/src/components/call/widget/OrisoWidgetDriver.test.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.test.ts
@@ -306,6 +306,126 @@ describe('OrisoWidgetDriver', () => {
 		});
 	});
 
+	describe('delayed events', () => {
+		// Delayed events implement call-membership expiry: a participant that
+		// crashes still disappears from the call. Untested, a broken one leaves
+		// ghosts in every call.
+		it('schedules a delayed state event in the call room', async () => {
+			const client2 = createClient({
+				_unstable_sendDelayedStateEvent: vi
+					.fn()
+					.mockResolvedValue({ delay_id: 'delay-1' })
+			} as never);
+			const d = new OrisoWidgetDriver(client2, CALL_ROOM);
+
+			const res = await d.sendDelayedEvent(
+				30_000,
+				null,
+				'org.matrix.msc3401.call.member',
+				{ memberships: [] },
+				'@a:oriso.example_DEV1_m.call'
+			);
+
+			expect(res).toEqual({ roomId: CALL_ROOM, delayId: 'delay-1' });
+		});
+
+		it('refuses to schedule into another room', async () => {
+			await expect(
+				driver.sendDelayedEvent(
+					30_000,
+					null,
+					'm.reaction',
+					{},
+					null,
+					OTHER_ROOM
+				)
+			).rejects.toThrow(/confined/);
+		});
+
+		it('passes an update straight through to the client', async () => {
+			const client2 = createClient({
+				_unstable_updateDelayedEvent: vi.fn().mockResolvedValue({})
+			} as never);
+			const d = new OrisoWidgetDriver(client2, CALL_ROOM);
+
+			await d.updateDelayedEvent('delay-1', 'restart' as never);
+
+			expect(client2._unstable_updateDelayedEvent).toHaveBeenCalledWith(
+				'delay-1',
+				'restart'
+			);
+		});
+	});
+
+	describe('reading the timeline', () => {
+		const eventStub = (type: string, id: string, content = {}) => ({
+			getType: () => type,
+			getId: () => id,
+			getStateKey: () => undefined,
+			getContent: () => content,
+			getEffectiveEvent: () => ({ type, event_id: id, content })
+		});
+
+		const clientWithTimeline = (events: unknown[]) =>
+			createClient({
+				getRoom: vi.fn().mockReturnValue({
+					getLiveTimeline: () => ({
+						getEvents: () => events,
+						getState: () => null
+					})
+				})
+			} as never);
+
+		it('filters by event type and honours the limit', async () => {
+			const d = new OrisoWidgetDriver(
+				clientWithTimeline([
+					eventStub('m.reaction', '$1'),
+					eventStub('m.room.message', '$2'),
+					eventStub('m.reaction', '$3'),
+					eventStub('m.reaction', '$4')
+				]),
+				CALL_ROOM
+			);
+
+			const out = await d.readRoomEvents('m.reaction', undefined, 2);
+
+			// Newest last: the limit keeps the most recent matches.
+			expect(
+				out.map((e) => (e as { event_id: string }).event_id)
+			).toEqual(['$3', '$4']);
+		});
+
+		it('returns only what follows `since`', async () => {
+			const d = new OrisoWidgetDriver(
+				clientWithTimeline([
+					eventStub('m.reaction', '$1'),
+					eventStub('m.reaction', '$2'),
+					eventStub('m.reaction', '$3')
+				]),
+				CALL_ROOM
+			);
+
+			const out = await d.readRoomTimeline(
+				CALL_ROOM,
+				'm.reaction',
+				undefined,
+				undefined,
+				0,
+				'$1'
+			);
+
+			expect(
+				out.map((e) => (e as { event_id: string }).event_id)
+			).toEqual(['$2', '$3']);
+		});
+
+		it('refuses to read the timeline of another room', async () => {
+			await expect(
+				driver.readRoomEvents('m.reaction', undefined, 10, [OTHER_ROOM])
+			).rejects.toThrow(/confined/);
+		});
+	});
+
 	describe('state events', () => {
 		it('sends a state event when a state key is given', async () => {
 			await driver.sendEvent(

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -43,10 +43,7 @@ import {
 } from 'matrix-widget-api';
 import { EventTimeline, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 
-import {
-	ALLOWED_TO_DEVICE_EVENT_TYPES,
-	isAllowedWidgetCapability
-} from './orisoWidgetCapabilities';
+import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
 
 /**
  * To-device events that carry per-participant media keys. These may only ever

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -43,7 +43,20 @@ import {
 } from 'matrix-widget-api';
 import { EventTimeline, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 
-import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
+import {
+	ALLOWED_TO_DEVICE_EVENT_TYPES,
+	isAllowedWidgetCapability
+} from './orisoWidgetCapabilities';
+
+/**
+ * To-device events that carry per-participant media keys. These may only ever
+ * be sent through Olm, never through the plaintext queue.
+ */
+const KEY_BEARING_TO_DEVICE_TYPES: ReadonlySet<string> = new Set([
+	'io.element.call.encryption_keys',
+	'm.call.encryption_keys',
+	'org.matrix.msc3401.call.encryption_keys'
+]);
 
 /** Matrix events carry more than the widget spec's shape; narrow it here. */
 const toWidgetEvent = (event: MatrixEvent): IRoomEvent =>
@@ -206,6 +219,16 @@ export class OrisoWidgetDriver extends WidgetDriver {
 		encrypted: boolean,
 		contentMap: { [userId: string]: { [deviceId: string]: object } }
 	): Promise<void> {
+		// The media keys are the secret the whole call rests on. Whether they
+		// travel encrypted must not depend on a flag the iframe sets: a widget
+		// asking to send them in the clear is refused outright.
+		if (!encrypted && KEY_BEARING_TO_DEVICE_TYPES.has(eventType)) {
+			throw new Error(
+				`Refusing to send ${eventType} unencrypted: call keys must never ` +
+					'travel in plaintext.'
+			);
+		}
+
 		if (!encrypted) {
 			await this.client.queueToDevice({
 				eventType,

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -55,12 +55,8 @@ const isNonEmptyString = (value: unknown): value is string =>
 const isValidOpenIDToken = (token: unknown): token is IOpenIDCredentials => {
 	if (!token || typeof token !== 'object') return false;
 
-	const {
-		access_token,
-		token_type,
-		matrix_server_name,
-		expires_in
-	} = token as Record<string, unknown>;
+	const { access_token, token_type, matrix_server_name, expires_in } =
+		token as Record<string, unknown>;
 
 	return (
 		isNonEmptyString(access_token) &&

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -1,0 +1,319 @@
+/**
+ * Host-side widget driver for the embedded Element Call.
+ *
+ * Why this exists
+ * ---------------
+ * Element Call used to be embedded as a plain iframe in *SPA mode*: we handed
+ * it our `accessToken`, `userId` and — critically — our `deviceId` through the
+ * URL, and it built its own Matrix client from them. Two consequences:
+ *
+ *  1. Element Call ran a second Matrix client on *our* device. Its
+ *     `initRustCrypto()` could not work, because the host owns that device's
+ *     crypto state. A crypto-less client in an encrypted room cannot do
+ *     per-participant media encryption at all, which is why media E2EE was
+ *     forced off.
+ *  2. A bearer token in a URL query string leaks into history, referrers and
+ *     any logging in between.
+ *
+ * In widget (matryoshka) mode Element Call has no Matrix client of its own. It
+ * asks *us* to send and read events over `postMessage`, and we answer using the
+ * host client — the one that already has crypto set up (see ADR-004). That
+ * makes encrypted to-device messaging work, which is the channel the media keys
+ * travel on, so `E2eeType.PER_PARTICIPANT` becomes possible.
+ *
+ * Scope
+ * -----
+ * This is deliberately a *purpose-built* driver, not a general one like Element
+ * Web's. It serves exactly the capabilities Element Call asks for and denies
+ * everything else — see `orisoWidgetCapabilities.ts`.
+ */
+
+import {
+	Capability,
+	IRoomEvent,
+	ISendDelayedEventDetails,
+	ISendEventDetails,
+	ITurnServer,
+	UpdateDelayedEventAction,
+	WidgetDriver
+} from 'matrix-widget-api';
+import { EventTimeline, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+
+import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
+
+/** Matrix events carry more than the widget spec's shape; narrow it here. */
+const toWidgetEvent = (event: MatrixEvent): IRoomEvent =>
+	event.getEffectiveEvent() as unknown as IRoomEvent;
+
+export class OrisoWidgetDriver extends WidgetDriver {
+	public constructor(
+		private readonly client: MatrixClient,
+		/**
+		 * The call room. The driver is bound to a single room on purpose: a call
+		 * widget has no business reading any other conversation, so every request
+		 * that names a different room is refused rather than proxied.
+		 */
+		private readonly roomId: string
+	) {
+		super();
+	}
+
+	private assertRoom(roomId?: string | null): string {
+		if (roomId && roomId !== this.roomId) {
+			throw new Error(
+				`Call widget requested room ${roomId} but is confined to ${this.roomId}`
+			);
+		}
+		return this.roomId;
+	}
+
+	public async validateCapabilities(
+		requested: Set<Capability>
+	): Promise<Set<Capability>> {
+		const granted = new Set<Capability>();
+		requested.forEach((capability) => {
+			if (isAllowedWidgetCapability(capability)) {
+				granted.add(capability);
+			} else {
+				// eslint-disable-next-line no-console
+				console.warn('[call] denied widget capability:', capability);
+			}
+		});
+		return granted;
+	}
+
+	public async sendEvent(
+		eventType: string,
+		content: unknown,
+		stateKey: string | null = null,
+		roomId: string | null = null
+	): Promise<ISendEventDetails> {
+		const targetRoom = this.assertRoom(roomId);
+
+		const response =
+			stateKey === null
+				? await this.client.sendEvent(
+						targetRoom,
+						eventType as any,
+						content as any
+					)
+				: await this.client.sendStateEvent(
+						targetRoom,
+						eventType as any,
+						content as any,
+						stateKey
+					);
+
+		return { roomId: targetRoom, eventId: response.event_id };
+	}
+
+	/**
+	 * Delayed events implement call-membership expiry: a client schedules its own
+	 * "I have left" state event up front, so a participant that crashes or loses
+	 * the network still disappears from the call instead of lingering forever.
+	 */
+	public async sendDelayedEvent(
+		delay: number | null,
+		parentDelayId: string | null,
+		eventType: string,
+		content: unknown,
+		stateKey: string | null = null,
+		roomId: string | null = null
+	): Promise<ISendDelayedEventDetails> {
+		const targetRoom = this.assertRoom(roomId);
+		const delayOpts =
+			delay !== null
+				? { delay }
+				: { parent_delay_id: parentDelayId as string };
+
+		const response =
+			stateKey === null
+				? await this.client._unstable_sendDelayedEvent(
+						targetRoom,
+						delayOpts as any,
+						null,
+						eventType as any,
+						content as any
+					)
+				: await this.client._unstable_sendDelayedStateEvent(
+						targetRoom,
+						delayOpts as any,
+						eventType as any,
+						content as any,
+						stateKey
+					);
+
+		return { roomId: targetRoom, delayId: response.delay_id };
+	}
+
+	public async updateDelayedEvent(
+		delayId: string,
+		action: UpdateDelayedEventAction
+	): Promise<void> {
+		await this.client._unstable_updateDelayedEvent(delayId, action);
+	}
+
+	/**
+	 * The media-key channel. `encrypted` is honoured rather than ignored: when
+	 * Element Call asks for an encrypted send we route through Olm, which is the
+	 * whole point of running in widget mode. A crypto-less client would have to
+	 * downgrade this to plaintext.
+	 */
+	public async sendToDevice(
+		eventType: string,
+		encrypted: boolean,
+		contentMap: { [userId: string]: { [deviceId: string]: object } }
+	): Promise<void> {
+		if (!encrypted) {
+			await this.client.queueToDevice({
+				eventType,
+				batch: Object.entries(contentMap).flatMap(
+					([userId, byDevice]) =>
+						Object.entries(byDevice).map(([deviceId, payload]) => ({
+							userId,
+							deviceId,
+							payload
+						}))
+				)
+			});
+			return;
+		}
+
+		const crypto = this.client.getCrypto();
+		if (!crypto) {
+			throw new Error(
+				'Refusing to send call keys: host client has no crypto. ' +
+					'Encrypted calls require an initialised crypto stack (ADR-004).'
+			);
+		}
+
+		// `encryptAndSendToDevice` takes one payload for a set of devices, so
+		// group the map by payload identity rather than sending per device.
+		const byPayload = new Map<
+			string,
+			{ devices: { userId: string; deviceId: string }[]; payload: object }
+		>();
+		Object.entries(contentMap).forEach(([userId, byDevice]) => {
+			Object.entries(byDevice).forEach(([deviceId, payload]) => {
+				const key = JSON.stringify(payload);
+				const existing = byPayload.get(key);
+				if (existing) {
+					existing.devices.push({ userId, deviceId });
+				} else {
+					byPayload.set(key, {
+						devices: [{ userId, deviceId }],
+						payload
+					});
+				}
+			});
+		});
+
+		await Promise.all(
+			Array.from(byPayload.values()).map(({ devices, payload }) =>
+				this.client.encryptAndSendToDevice(
+					eventType,
+					devices,
+					payload as any
+				)
+			)
+		);
+	}
+
+	public async readRoomEvents(
+		eventType: string,
+		msgtype: string | undefined,
+		limit: number,
+		roomIds: string[] | null = null,
+		since?: string
+	): Promise<IRoomEvent[]> {
+		const targetRoom = this.assertRoom(roomIds?.[0] ?? null);
+		return this.readRoomTimeline(
+			targetRoom,
+			eventType,
+			msgtype,
+			undefined,
+			limit,
+			since
+		);
+	}
+
+	public async readRoomTimeline(
+		roomId: string,
+		eventType: string,
+		msgtype: string | undefined,
+		stateKey: string | undefined,
+		limit: number,
+		since: string | undefined
+	): Promise<IRoomEvent[]> {
+		const room = this.client.getRoom(this.assertRoom(roomId));
+		if (!room) return [];
+
+		const events = room
+			.getLiveTimeline()
+			.getEvents()
+			.filter((event) => {
+				if (event.getType() !== eventType) return false;
+				if (msgtype && event.getContent().msgtype !== msgtype)
+					return false;
+				if (stateKey !== undefined && event.getStateKey() !== stateKey)
+					return false;
+				return true;
+			});
+
+		// `since` is an event id: everything strictly after it, newest last.
+		const sinceIndex = since
+			? events.findIndex((event) => event.getId() === since)
+			: -1;
+		const window =
+			sinceIndex === -1 ? events : events.slice(sinceIndex + 1);
+
+		// A limit of 0 means "no limit" per the widget spec.
+		const limited = limit > 0 ? window.slice(-limit) : window;
+		return limited.map(toWidgetEvent);
+	}
+
+	public async readStateEvents(
+		eventType: string,
+		stateKey: string | undefined,
+		limit: number,
+		roomIds: string[] | null = null
+	): Promise<IRoomEvent[]> {
+		return this.readRoomState(
+			this.assertRoom(roomIds?.[0] ?? null),
+			eventType,
+			stateKey
+		).then((events) => (limit > 0 ? events.slice(0, limit) : events));
+	}
+
+	public async readRoomState(
+		roomId: string,
+		eventType: string,
+		stateKey: string | undefined
+	): Promise<IRoomEvent[]> {
+		const room = this.client.getRoom(this.assertRoom(roomId));
+		if (!room) return [];
+
+		const currentState = room
+			.getLiveTimeline()
+			.getState(EventTimeline.FORWARDS);
+		if (!currentState) return [];
+
+		const events =
+			stateKey === undefined
+				? currentState.getStateEvents(eventType)
+				: [currentState.getStateEvents(eventType, stateKey)].filter(
+						(event): event is MatrixEvent => Boolean(event)
+					);
+
+		return (Array.isArray(events) ? events : []).map(toWidgetEvent);
+	}
+
+	/**
+	 * TURN credentials come from the LiveKit SFU in our deployment, not from the
+	 * homeserver, so there is nothing to hand over. Returning without yielding
+	 * leaves the widget on its configured ICE servers.
+	 */
+	public async *getTurnServers(): AsyncGenerator<ITurnServer> {
+		// eslint-disable-next-line no-empty-function
+	}
+}

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -30,10 +30,14 @@
 
 import {
 	Capability,
+	type IOpenIDCredentials,
+	type IOpenIDUpdate,
 	IRoomEvent,
 	ISendDelayedEventDetails,
 	ISendEventDetails,
 	ITurnServer,
+	OpenIDRequestState,
+	SimpleObservable,
 	UpdateDelayedEventAction,
 	WidgetDriver
 } from 'matrix-widget-api';
@@ -44,6 +48,29 @@ import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
 /** Matrix events carry more than the widget spec's shape; narrow it here. */
 const toWidgetEvent = (event: MatrixEvent): IRoomEvent =>
 	event.getEffectiveEvent() as unknown as IRoomEvent;
+
+const isNonEmptyString = (value: unknown): value is string =>
+	typeof value === 'string' && value.length > 0;
+
+const isValidOpenIDToken = (token: unknown): token is IOpenIDCredentials => {
+	if (!token || typeof token !== 'object') return false;
+
+	const {
+		access_token,
+		token_type,
+		matrix_server_name,
+		expires_in
+	} = token as Record<string, unknown>;
+
+	return (
+		isNonEmptyString(access_token) &&
+		isNonEmptyString(token_type) &&
+		isNonEmptyString(matrix_server_name) &&
+		typeof expires_in === 'number' &&
+		Number.isFinite(expires_in) &&
+		expires_in > 0
+	);
+};
 
 export class OrisoWidgetDriver extends WidgetDriver {
 	public constructor(
@@ -80,6 +107,25 @@ export class OrisoWidgetDriver extends WidgetDriver {
 			}
 		});
 		return granted;
+	}
+
+	public askOpenID(observer: SimpleObservable<IOpenIDUpdate>): void {
+		try {
+			void this.client.getOpenIdToken().then(
+				(token) =>
+					observer.update(
+						isValidOpenIDToken(token)
+							? {
+									state: OpenIDRequestState.Allowed,
+									token
+								}
+							: { state: OpenIDRequestState.Blocked }
+					),
+				() => observer.update({ state: OpenIDRequestState.Blocked })
+			);
+		} catch {
+			observer.update({ state: OpenIDRequestState.Blocked });
+		}
 	}
 
 	public async sendEvent(

--- a/src/components/call/widget/orisoWidgetCapabilities.test.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
+
+describe('isAllowedWidgetCapability', () => {
+	it('grants the call membership state events Element Call needs to join', () => {
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@a:hs_DEVICE_m.call'
+			)
+		).toBe(true);
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.receive.state_event:org.matrix.msc3401.call.member'
+			)
+		).toBe(true);
+	});
+
+	it('grants encrypted to-device traffic, which is how media keys travel', () => {
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc3819.send.to_device:io.element.call.encryption_keys'
+			)
+		).toBe(true);
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc3819.receive.to_device:m.call.encryption_keys'
+			)
+		).toBe(true);
+	});
+
+	it('refuses to let the call widget post chat messages as the user', () => {
+		// The whole point of the allow-list: an iframe that could send
+		// `m.room.message` could write into a counselling session under the
+		// counsellor's name.
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.event:m.room.message'
+			)
+		).toBe(false);
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.receive.event:m.room.message'
+			)
+		).toBe(false);
+	});
+
+	it('refuses to let the call widget change who may enter a room', () => {
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.state_event:m.room.power_levels#'
+			)
+		).toBe(false);
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.state_event:m.room.join_rules#'
+			)
+		).toBe(false);
+	});
+
+	it('does not confuse a state key for an event type', () => {
+		// Everything after `#` is the state key. A widget must not be able to
+		// smuggle an allowed type in there.
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.state_event:m.room.power_levels#org.matrix.msc3401.call.member'
+			)
+		).toBe(false);
+	});
+
+	it('denies anything it does not recognise', () => {
+		expect(isAllowedWidgetCapability('m.send.event')).toBe(false);
+		expect(isAllowedWidgetCapability('')).toBe(false);
+		expect(
+			isAllowedWidgetCapability('org.matrix.msc2762.send.event:')
+		).toBe(false);
+	});
+
+	it('grants the plain capabilities a call needs to stay on screen', () => {
+		expect(isAllowedWidgetCapability('m.always_on_screen')).toBe(true);
+		expect(
+			isAllowedWidgetCapability('org.matrix.msc4157.send.delayed_event')
+		).toBe(true);
+	});
+});

--- a/src/components/call/widget/orisoWidgetCapabilities.test.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.test.ts
@@ -45,6 +45,41 @@ describe('isAllowedWidgetCapability', () => {
 		).toBe(false);
 	});
 
+	it('lets the widget read room metadata but never write it', () => {
+		// The widget needs to *see* membership and encryption state to render a
+		// call. It has no reason to change either, and granting write would let
+		// the iframe alter who is in a counselling room as the logged-in user.
+		(
+			[
+				'm.room.member',
+				'm.room.name',
+				'm.room.create',
+				'm.room.encryption'
+			] as const
+		).forEach((type) => {
+			expect(
+				isAllowedWidgetCapability(
+					`org.matrix.msc2762.receive.state_event:${type}`
+				),
+				`${type} must be readable`
+			).toBe(true);
+			expect(
+				isAllowedWidgetCapability(
+					`org.matrix.msc2762.send.state_event:${type}`
+				),
+				`${type} must NOT be writable`
+			).toBe(false);
+		});
+	});
+
+	it('still lets the widget write its own call membership', () => {
+		expect(
+			isAllowedWidgetCapability(
+				'org.matrix.msc2762.send.state_event:org.matrix.msc3401.call.member#@a:hs_DEVICE_m.call'
+			)
+		).toBe(true);
+	});
+
 	it('refuses to let the call widget change who may enter a room', () => {
 		expect(
 			isAllowedWidgetCapability(

--- a/src/components/call/widget/orisoWidgetCapabilities.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.ts
@@ -1,0 +1,137 @@
+/**
+ * Allow-list for the Element Call widget.
+ *
+ * The widget runs in an iframe we serve ourselves, but it is still a separate
+ * origin driving our Matrix client. Anything it is allowed to do, it can do
+ * *as the logged-in user* — so we approve capabilities by explicit event type
+ * instead of rubber-stamping whatever the widget asks for. A widget that could
+ * request `m.room.message` send rights could post into a counselling session
+ * under the user's name.
+ *
+ * The list mirrors exactly what Element Call requests in its own
+ * `createRoomWidgetClient` call (`ORISO-ElementCall/src/widget.ts`). Keep the
+ * two in sync: an event type missing here surfaces as the widget silently
+ * failing to join a call, not as a loud error.
+ */
+
+/** Room events Element Call sends and/or receives in the call room. */
+export const ALLOWED_ROOM_EVENT_TYPES: ReadonlySet<string> = new Set([
+	'org.matrix.rageshake_request',
+	'io.element.call.encryption_keys',
+	'm.call.encryption_keys',
+	'org.matrix.msc3401.call.encryption_keys',
+	'm.reaction',
+	'm.room.redaction',
+	'io.element.call.reaction',
+	'org.matrix.msc4075.call.notify',
+	'm.call.notify',
+	'org.matrix.msc4075.rtc.notification',
+	'm.rtc.notification',
+	'org.matrix.msc4310.rtc.decline',
+	'm.rtc.decline'
+]);
+
+/** State events Element Call reads and/or writes (call membership + room meta). */
+export const ALLOWED_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
+	'org.matrix.msc3401.call.member',
+	'm.call.member',
+	'm.room.create',
+	'm.room.name',
+	'm.room.member',
+	'm.room.encryption'
+]);
+
+/**
+ * To-device events. This is the channel that carries the per-participant media
+ * keys, so it is the one that must never be dropped — see ADR-004.
+ */
+export const ALLOWED_TO_DEVICE_EVENT_TYPES: ReadonlySet<string> = new Set([
+	'm.call.invite',
+	'm.call.candidates',
+	'm.call.answer',
+	'm.call.hangup',
+	'm.call.reject',
+	'm.call.select_answer',
+	'm.call.negotiate',
+	'm.call.sdp_stream_metadata_changed',
+	'org.matrix.call.sdp_stream_metadata_changed',
+	'm.call.replaces',
+	'io.element.call.encryption_keys',
+	'm.call.encryption_keys',
+	'org.matrix.msc3401.call.encryption_keys'
+]);
+
+/** Capabilities that carry no event type and are safe for a call widget. */
+const ALLOWED_PLAIN_CAPABILITIES: ReadonlySet<string> = new Set([
+	'm.always_on_screen',
+	'org.matrix.msc2931.navigate',
+	'org.matrix.msc4157.send.delayed_event',
+	'org.matrix.msc4157.update_delayed_event'
+]);
+
+const ROOM_EVENT_PREFIXES = [
+	'org.matrix.msc2762.send.event:',
+	'org.matrix.msc2762.receive.event:',
+	'org.matrix.msc2762.timeline:'
+];
+const STATE_EVENT_PREFIXES = [
+	'org.matrix.msc2762.send.state_event:',
+	'org.matrix.msc2762.receive.state_event:'
+];
+const TO_DEVICE_PREFIXES = [
+	'org.matrix.msc3819.send.to_device:',
+	'org.matrix.msc3819.receive.to_device:'
+];
+
+/**
+ * A state-event capability may be scoped to a state key with `#`, e.g.
+ * `...send.state_event:m.call.member#@a:hs_DEVICE_m.call`. Strip it — we
+ * validate the event type, the widget API enforces the state key itself.
+ */
+const eventTypeFromCapability = (
+	capability: string,
+	prefix: string
+): string => {
+	const rest = capability.slice(prefix.length);
+	const hashIndex = rest.indexOf('#');
+	return hashIndex === -1 ? rest : rest.slice(0, hashIndex);
+};
+
+const matchPrefix = (
+	capability: string,
+	prefixes: ReadonlyArray<string>
+): string | null =>
+	prefixes.find((prefix) => capability.startsWith(prefix)) ?? null;
+
+/**
+ * True when the capability is one we are willing to grant an embedded call
+ * widget. Anything unknown is denied — silently ignoring an unexpected request
+ * is safer than granting it, and Element Call degrades visibly rather than
+ * doing something unauthorised.
+ */
+export const isAllowedWidgetCapability = (capability: string): boolean => {
+	if (ALLOWED_PLAIN_CAPABILITIES.has(capability)) return true;
+
+	const roomPrefix = matchPrefix(capability, ROOM_EVENT_PREFIXES);
+	if (roomPrefix) {
+		return ALLOWED_ROOM_EVENT_TYPES.has(
+			eventTypeFromCapability(capability, roomPrefix)
+		);
+	}
+
+	const statePrefix = matchPrefix(capability, STATE_EVENT_PREFIXES);
+	if (statePrefix) {
+		return ALLOWED_STATE_EVENT_TYPES.has(
+			eventTypeFromCapability(capability, statePrefix)
+		);
+	}
+
+	const toDevicePrefix = matchPrefix(capability, TO_DEVICE_PREFIXES);
+	if (toDevicePrefix) {
+		return ALLOWED_TO_DEVICE_EVENT_TYPES.has(
+			eventTypeFromCapability(capability, toDevicePrefix)
+		);
+	}
+
+	return false;
+};

--- a/src/components/call/widget/orisoWidgetCapabilities.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.ts
@@ -31,10 +31,23 @@ export const ALLOWED_ROOM_EVENT_TYPES: ReadonlySet<string> = new Set([
 	'm.rtc.decline'
 ]);
 
-/** State events Element Call reads and/or writes (call membership + room meta). */
-export const ALLOWED_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
+/**
+ * State events Element Call is allowed to **write**.
+ *
+ * Deliberately just the call membership event. Element Call's own
+ * `createRoomWidgetClient` call only ever writes `GroupCallMemberPrefix`; the
+ * room metadata below is read-only for it. Granting write on `m.room.member` or
+ * `m.room.name` would let the iframe change who is in a counselling room, or
+ * rename it, as the logged-in user.
+ */
+export const ALLOWED_SEND_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
 	'org.matrix.msc3401.call.member',
-	'm.call.member',
+	'm.call.member'
+]);
+
+/** State events Element Call is allowed to **read** (call membership + room meta). */
+export const ALLOWED_RECEIVE_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
+	...ALLOWED_SEND_STATE_EVENT_TYPES,
 	'm.room.create',
 	'm.room.name',
 	'm.room.member',
@@ -74,10 +87,8 @@ const ROOM_EVENT_PREFIXES = [
 	'org.matrix.msc2762.receive.event:',
 	'org.matrix.msc2762.timeline:'
 ];
-const STATE_EVENT_PREFIXES = [
-	'org.matrix.msc2762.send.state_event:',
-	'org.matrix.msc2762.receive.state_event:'
-];
+const SEND_STATE_EVENT_PREFIX = 'org.matrix.msc2762.send.state_event:';
+const RECEIVE_STATE_EVENT_PREFIX = 'org.matrix.msc2762.receive.state_event:';
 const TO_DEVICE_PREFIXES = [
 	'org.matrix.msc3819.send.to_device:',
 	'org.matrix.msc3819.receive.to_device:'
@@ -119,10 +130,16 @@ export const isAllowedWidgetCapability = (capability: string): boolean => {
 		);
 	}
 
-	const statePrefix = matchPrefix(capability, STATE_EVENT_PREFIXES);
-	if (statePrefix) {
-		return ALLOWED_STATE_EVENT_TYPES.has(
-			eventTypeFromCapability(capability, statePrefix)
+	// Send and receive are checked against different sets: the widget may read
+	// room metadata but must not write it.
+	if (capability.startsWith(SEND_STATE_EVENT_PREFIX)) {
+		return ALLOWED_SEND_STATE_EVENT_TYPES.has(
+			eventTypeFromCapability(capability, SEND_STATE_EVENT_PREFIX)
+		);
+	}
+	if (capability.startsWith(RECEIVE_STATE_EVENT_PREFIX)) {
+		return ALLOWED_RECEIVE_STATE_EVENT_TYPES.has(
+			eventTypeFromCapability(capability, RECEIVE_STATE_EVENT_PREFIX)
 		);
 	}
 

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -45,7 +45,10 @@ export interface ElementCallWidget {
  * so a remount does not orphan the previous messaging channel.
  */
 const widgetIdForRoom = (roomId: string): string =>
-	`oriso-call-${roomId.replace(/[^a-zA-Z0-9]/g, '')}`;
+	// Encode rather than strip: dropping every non-alphanumeric made
+	// `!abc:foo.com` and `!abcfoo:com` collide on the same widget id, which
+	// would let one call's channel answer for another.
+	`oriso-call-${encodeURIComponent(roomId).replace(/%/g, '_')}`;
 
 export const useElementCallWidget = (
 	client: MatrixClient | null,

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -18,6 +18,7 @@ import {
 } from 'matrix-js-sdk';
 
 import { OrisoWidgetDriver } from './OrisoWidgetDriver';
+import { ALLOWED_TO_DEVICE_EVENT_TYPES } from './orisoWidgetCapabilities';
 import { getElementCallBaseUrl } from '../../../resources/scripts/runtimeConfig';
 
 export interface ElementCallWidgetOptions {
@@ -154,6 +155,10 @@ export const useElementCallWidget = (
 		};
 
 		const onToDevice = (event: MatrixEvent) => {
+			// The host client receives all to-device traffic, including device
+			// verification and room-key material that has nothing to do with the
+			// call. Forwarding it wholesale would hand that to a separate origin.
+			if (!ALLOWED_TO_DEVICE_EVENT_TYPES.has(event.getType())) return;
 			apiRef.current
 				?.feedToDevice(
 					event.getEffectiveEvent() as never,

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -1,0 +1,204 @@
+/**
+ * Embeds Element Call as a Matrix *widget* rather than a standalone app.
+ *
+ * The hook returns the iframe URL to render and, once the iframe element is
+ * handed to `attachIframe`, sets up the `postMessage` channel that lets the
+ * widget drive our Matrix client. See `OrisoWidgetDriver` for why this replaced
+ * the previous token-in-the-URL embedding.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ClientWidgetApi, MatrixWidgetType, Widget } from 'matrix-widget-api';
+import {
+	ClientEvent,
+	EventTimeline,
+	MatrixClient,
+	MatrixEvent,
+	RoomEvent
+} from 'matrix-js-sdk';
+
+import { OrisoWidgetDriver } from './OrisoWidgetDriver';
+import { getElementCallBaseUrl } from '../../../resources/scripts/runtimeConfig';
+
+export interface ElementCallWidgetOptions {
+	/** The Matrix room the call takes place in. */
+	roomId: string | null;
+	/** Video or audio-only — Element Call starts with the camera off for audio. */
+	isVideo: boolean;
+	/** Skip the lobby and join immediately (we already asked the user). */
+	skipLobby?: boolean;
+}
+
+export interface ElementCallWidget {
+	/** `null` until every precondition is met; render nothing before then. */
+	url: string | null;
+	/** Ref callback for the iframe. Pass `null` on unmount to tear down. */
+	attachIframe: (iframe: HTMLIFrameElement | null) => void;
+	/** Set when the call cannot be embedded at all; surface it, do not swallow. */
+	error: Error | null;
+}
+
+/**
+ * Widget ids only need to be unique per host, and Element Call echoes ours back
+ * on every message. Deriving it from the room keeps it stable across re-renders
+ * so a remount does not orphan the previous messaging channel.
+ */
+const widgetIdForRoom = (roomId: string): string =>
+	`oriso-call-${roomId.replace(/[^a-zA-Z0-9]/g, '')}`;
+
+export const useElementCallWidget = (
+	client: MatrixClient | null,
+	{ roomId, isVideo, skipLobby = true }: ElementCallWidgetOptions
+): ElementCallWidget => {
+	const [error, setError] = useState<Error | null>(null);
+	const apiRef = useRef<ClientWidgetApi | null>(null);
+	const driverRef = useRef<OrisoWidgetDriver | null>(null);
+
+	const url = useMemo(() => {
+		if (!client || !roomId) return null;
+
+		try {
+			const origin = getElementCallBaseUrl();
+			if (!origin) {
+				throw new Error(
+					'REACT_APP_ELEMENT_CALL_BASE_URL is not set — cannot embed the call.'
+				);
+			}
+
+			const userId = client.getUserId();
+			const deviceId = client.getDeviceId();
+			const baseUrl = client.getHomeserverUrl();
+			if (!userId || !deviceId || !baseUrl) {
+				throw new Error(
+					'Matrix session incomplete — cannot embed the call.'
+				);
+			}
+
+			// Widget mode reads its configuration from query params (SPA mode uses
+			// the fragment). Note what is *absent*: no access token. The widget
+			// never receives our credentials; it asks us to act on its behalf.
+			const params = new URLSearchParams({
+				widgetId: widgetIdForRoom(roomId),
+				parentUrl: window.location.origin,
+				roomId,
+				userId,
+				deviceId,
+				baseUrl,
+				// Media encryption. Element Call derives per-participant keys and
+				// distributes them over encrypted to-device messages, which only
+				// works because the host client does the crypto (ADR-004).
+				enableE2EE: 'true',
+				perParticipantE2EE: 'true',
+				confineToRoom: 'true',
+				header: 'none',
+				skipLobby: String(skipLobby),
+				intent: 'start_call',
+				callIntent: isVideo ? 'video' : 'audio'
+			});
+
+			setError(null);
+			return `${origin}/room?${params.toString()}`;
+		} catch (err) {
+			setError(err as Error);
+			return null;
+		}
+	}, [client, roomId, isVideo, skipLobby]);
+
+	const attachIframe = useCallback(
+		(iframe: HTMLIFrameElement | null) => {
+			// Tear down any previous channel first — leaking a ClientWidgetApi
+			// keeps a postMessage listener alive against a dead iframe.
+			if (apiRef.current) {
+				apiRef.current.stop();
+				apiRef.current = null;
+				driverRef.current = null;
+			}
+
+			if (!iframe || !client || !roomId || !url) return;
+
+			const userId = client.getUserId();
+			if (!userId) return;
+
+			const driver = new OrisoWidgetDriver(client, roomId);
+			const widget = new Widget({
+				id: widgetIdForRoom(roomId),
+				creatorUserId: userId,
+				type: MatrixWidgetType.Custom,
+				url
+			});
+
+			driverRef.current = driver;
+			apiRef.current = new ClientWidgetApi(widget, iframe, driver);
+			apiRef.current.setViewedRoomId(roomId);
+		},
+		[client, roomId, url]
+	);
+
+	// Push room and to-device traffic into the widget. The widget API only
+	// *answers* requests; anything the widget needs to observe has to be fed.
+	useEffect(() => {
+		if (!client || !roomId) return undefined;
+
+		const onTimeline = (
+			event: MatrixEvent,
+			_room: unknown,
+			toStartOfTimeline: boolean | undefined
+		) => {
+			if (toStartOfTimeline) return; // backfill, not live
+			if (event.getRoomId() !== roomId) return;
+			apiRef.current
+				?.feedEvent(event.getEffectiveEvent() as never, roomId)
+				.catch(() => {
+					/* the widget may have gone away mid-call */
+				});
+		};
+
+		const onToDevice = (event: MatrixEvent) => {
+			apiRef.current
+				?.feedToDevice(
+					event.getEffectiveEvent() as never,
+					event.getWireType() === 'm.room.encrypted'
+				)
+				.catch(() => {
+					/* see above */
+				});
+		};
+
+		client.on(RoomEvent.Timeline, onTimeline);
+		client.on(ClientEvent.ToDeviceEvent, onToDevice);
+
+		return () => {
+			client.off(RoomEvent.Timeline, onTimeline);
+			client.off(ClientEvent.ToDeviceEvent, onToDevice);
+		};
+	}, [client, roomId]);
+
+	// Replay the current call membership so a widget that mounts mid-call sees
+	// who is already there instead of an empty room.
+	useEffect(() => {
+		if (!client || !roomId || !apiRef.current) return;
+		const state = client
+			.getRoom(roomId)
+			?.getLiveTimeline()
+			.getState(EventTimeline.FORWARDS);
+		state
+			?.getStateEvents('org.matrix.msc3401.call.member')
+			.forEach((event) => {
+				apiRef.current
+					?.feedEvent(event.getEffectiveEvent() as never, roomId)
+					.catch(() => {
+						/* best effort */
+					});
+			});
+	}, [client, roomId, url]);
+
+	useEffect(
+		() => () => {
+			apiRef.current?.stop();
+			apiRef.current = null;
+		},
+		[]
+	);
+
+	return { url, attachIframe, error };
+};

--- a/src/resources/scripts/runtimeConfig.ts
+++ b/src/resources/scripts/runtimeConfig.ts
@@ -267,6 +267,20 @@ export const getElementCallBaseUrl = (): string =>
 	);
 
 /**
+ * Embed Element Call as a Matrix widget instead of a standalone app.
+ *
+ * In widget mode the call has no Matrix session of its own: it asks the ORISO
+ * client to send and read events on its behalf, so no access token is handed to
+ * the iframe and no second device is registered per browser.
+ *
+ * Off by default until the widget path has been validated on Pre-Dev — the
+ * standalone path still works and is device-bound, so this is a safe default
+ * rather than a permanent one.
+ */
+export const isElementCallWidgetModeEnabled = (): boolean =>
+	pickValue('REACT_APP_ELEMENT_CALL_WIDGET_MODE')?.toLowerCase() === 'true';
+
+/**
  * LiveKit signalling websocket URL (wss).
  */
 export const getLiveKitWsUrl = (): string =>

--- a/src/services/CallManager.callRoom.test.ts
+++ b/src/services/CallManager.callRoom.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Access rules for the dedicated Element Call room.
+ *
+ * The call room is created per call and is separate from the counselling
+ * session room, so its join rule is the only thing standing between a call and
+ * anyone who has seen its room id.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { callManager } from './CallManager';
+import { setMatrixClientServiceRef } from './matrixClientRegistry';
+
+const SESSION_ROOM = '!counselling:oriso.example';
+const CALL_ROOM = '!call:oriso.example';
+const OWN_USER = '@counsellor:oriso.example';
+
+type CreateRoomOptions = {
+	preset?: string;
+	visibility?: string;
+	initial_state?: { type: string; content: Record<string, unknown> }[];
+};
+
+const stateContent = (
+	options: CreateRoomOptions,
+	type: string
+): Record<string, unknown> | undefined =>
+	options.initial_state?.find((event) => event.type === type)?.content;
+
+const installClient = (client: Record<string, unknown>): void => {
+	setMatrixClientServiceRef({
+		getClient: () => client
+	} as never);
+};
+
+const createCallRoom = (sourceRoomId = SESSION_ROOM): Promise<string> =>
+	(
+		callManager as unknown as {
+			createElementCallRoom: (roomId: string) => Promise<string>;
+		}
+	).createElementCallRoom(sourceRoomId);
+
+describe('createElementCallRoom', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+	});
+
+	it('restricts the call to members of the counselling session', async () => {
+		const createRoom = vi.fn().mockResolvedValue({ room_id: CALL_ROOM });
+		installClient({
+			createRoom,
+			getUserId: () => OWN_USER,
+			getRoom: () => null,
+			invite: vi.fn()
+		});
+
+		await expect(createCallRoom()).resolves.toBe(CALL_ROOM);
+
+		const options = createRoom.mock.calls[0][0] as CreateRoomOptions;
+		// `public_chat` used to be used here, which sets `join_rule: public` —
+		// anyone who learned the room id could join a counselling call.
+		expect(options.preset).not.toBe('public_chat');
+		expect(options.visibility).toBe('private');
+		expect(stateContent(options, 'm.room.join_rules')).toEqual({
+			join_rule: 'restricted',
+			allow: [{ type: 'm.room_membership', room_id: SESSION_ROOM }]
+		});
+	});
+
+	it('creates the call room encrypted, with history closed to non-members', async () => {
+		const createRoom = vi.fn().mockResolvedValue({ room_id: CALL_ROOM });
+		installClient({
+			createRoom,
+			getUserId: () => OWN_USER,
+			getRoom: () => null,
+			invite: vi.fn()
+		});
+
+		await createCallRoom();
+
+		const options = createRoom.mock.calls[0][0] as CreateRoomOptions;
+		expect(stateContent(options, 'm.room.encryption')).toBeDefined();
+		expect(stateContent(options, 'm.room.history_visibility')).toEqual({
+			history_visibility: 'joined'
+		});
+		expect(stateContent(options, 'm.room.guest_access')).toEqual({
+			guest_access: 'forbidden'
+		});
+	});
+
+	it('falls back to invites — never to a public room — on an old homeserver', async () => {
+		const createRoom = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('M_UNSUPPORTED_ROOM_VERSION'))
+			.mockResolvedValueOnce({ room_id: CALL_ROOM });
+		const invite = vi.fn().mockResolvedValue(undefined);
+		installClient({
+			createRoom,
+			invite,
+			getUserId: () => OWN_USER,
+			getRoom: () => ({
+				getMembersWithMembership: () => [
+					{ userId: OWN_USER },
+					{ userId: '@asker:oriso.example' }
+				]
+			})
+		});
+
+		await expect(createCallRoom()).resolves.toBe(CALL_ROOM);
+
+		const fallback = createRoom.mock.calls[1][0] as CreateRoomOptions;
+		expect(fallback.preset).toBe('private_chat');
+		expect(stateContent(fallback, 'm.room.join_rules')).toBeUndefined();
+		// The asker is invited; we do not invite ourselves.
+		expect(invite).toHaveBeenCalledTimes(1);
+		expect(invite).toHaveBeenCalledWith(CALL_ROOM, '@asker:oriso.example');
+	});
+
+	it('still returns the room when a single invite fails', async () => {
+		const createRoom = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('nope'))
+			.mockResolvedValueOnce({ room_id: CALL_ROOM });
+		installClient({
+			createRoom,
+			invite: vi.fn().mockRejectedValue(new Error('M_FORBIDDEN')),
+			getUserId: () => OWN_USER,
+			getRoom: () => ({
+				getMembersWithMembership: () => [
+					{ userId: '@asker:oriso.example' }
+				]
+			})
+		});
+
+		await expect(createCallRoom()).resolves.toBe(CALL_ROOM);
+	});
+});

--- a/src/services/CallManager.callRoom.test.ts
+++ b/src/services/CallManager.callRoom.test.ts
@@ -88,6 +88,30 @@ describe('createElementCallRoom', () => {
 		});
 	});
 
+	it('does not let a call participant reopen the room to the public', async () => {
+		// The restricted join rule is worthless if any joined participant can
+		// overwrite it. `state_default: 0` allowed exactly that.
+		const createRoom = vi.fn().mockResolvedValue({ room_id: CALL_ROOM });
+		installClient({
+			createRoom,
+			getUserId: () => OWN_USER,
+			getRoom: () => null,
+			invite: vi.fn()
+		});
+
+		await createCallRoom();
+
+		const levels = (createRoom.mock.calls[0][0] as any)
+			.power_level_content_override;
+		expect(levels.state_default).toBeGreaterThanOrEqual(100);
+		expect(levels.events['m.room.join_rules']).toBe(100);
+		expect(levels.events['m.room.guest_access']).toBe(100);
+		expect(levels.events['m.room.history_visibility']).toBe(100);
+		expect(levels.events['m.room.encryption']).toBe(100);
+		// The one exception: Element Call must publish call membership.
+		expect(levels.events['org.matrix.msc3401.call.member']).toBe(0);
+	});
+
 	it('falls back to invites — never to a public room — on an old homeserver', async () => {
 		const createRoom = vi
 			.fn()

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -307,15 +307,24 @@ class CallManager {
 				kick: 100,
 				ban: 100,
 				redact: 50,
-				state_default: 0,
+				// `state_default: 0` used to let ANY joined participant rewrite
+				// `m.room.join_rules` back to `public` — which would have undone
+				// the restricted rule set above from inside the call. State
+				// changes now need the creator's level; the single exception is
+				// the call membership event, granted explicitly below.
+				state_default: 100,
 				events_default: 0,
 				users_default: 0,
 				events: {
 					'm.room.power_levels': 100,
+					'm.room.join_rules': 100,
+					'm.room.guest_access': 100,
 					'm.room.history_visibility': 100,
+					'm.room.canonical_alias': 100,
+					'm.room.server_acl': 100,
 					'm.room.tombstone': 100,
 					'm.room.encryption': 100,
-					'm.room.name': 50,
+					'm.room.name': 100,
 					'm.room.message': 0,
 					'm.room.encrypted': 50,
 					'm.sticker': 50,
@@ -374,6 +383,7 @@ class CallManager {
 		sourceRoomId: string,
 		callRoomId: string
 	): Promise<void> {
+		let failedInvites = 0;
 		const ownUserId = client.getUserId();
 		const members =
 			client
@@ -384,16 +394,22 @@ class CallManager {
 
 		await Promise.all(
 			members.map((userId) =>
-				client.invite(callRoomId, userId).catch((err) => {
-					// One failed invite must not sink the whole call.
-					console.warn(
-						'[call] could not invite participant to call room',
-						userId,
-						err
-					);
+				client.invite(callRoomId, userId).catch(() => {
+					// One failed invite must not sink the whole call. The user id
+					// and the raw error are deliberately not logged: this runs in
+					// production browsers and a Matrix id identifies a person in a
+					// counselling context.
+					failedInvites += 1;
 				})
 			)
 		);
+
+		if (failedInvites > 0) {
+			// A count is enough to notice a broken fallback without naming anyone.
+			console.warn(
+				`[call] ${failedInvites} of ${members.length} participants could not be invited to the call room`
+			);
+		}
 	}
 
 	/**

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -7,6 +7,7 @@
  */
 
 import { MatrixCall } from 'matrix-js-sdk/lib/webrtc/call';
+import type { MatrixClient } from 'matrix-js-sdk';
 import { getMatrixClientService } from './matrixClientRegistry';
 import {
 	assertMatrixRoomEncrypted,
@@ -258,13 +259,49 @@ class CallManager {
 
 		// console.log("🔧 Creating dedicated Element Call room for group call, source room:", sourceRoomId);
 
-		const result = await client.createRoom({
-			// Not publicly listed, but we want easy joins via ID
+		// The call room used to be created with `preset: 'public_chat'`, which
+		// sets `join_rule: public` — anyone who learned the room id could join a
+		// counselling call. Room ids are not secrets: they travel in the call
+		// invite event, in logs and in support tickets.
+		//
+		// `restricted` gives us the access rule we actually meant: whoever is a
+		// member of the counselling session may join its call, and nobody else.
+		// It needs room version 9+ (Synapse defaults to 10), so we fall back to
+		// invite-only below rather than let a call fail outright.
+		const restrictedJoinRule = {
+			type: 'm.room.join_rules',
+			state_key: '',
+			content: {
+				join_rule: 'restricted',
+				allow: [
+					{
+						type: 'm.room_membership',
+						room_id: sourceRoomId
+					}
+				]
+			}
+		};
+
+		const baseOptions = {
+			// Not publicly listed.
 			visibility: 'private',
-			// Same as Element Call: a room suitable for group chats
-			preset: 'public_chat',
+			// Private preset: invite-only by default, then relaxed to
+			// "members of the session room" by the join rule below.
+			preset: 'private_chat',
 			name,
-			initial_state: [buildMatrixRoomEncryptionInitialState()],
+			initial_state: [
+				buildMatrixRoomEncryptionInitialState(),
+				{
+					type: 'm.room.history_visibility',
+					state_key: '',
+					content: { history_visibility: 'joined' }
+				},
+				{
+					type: 'm.room.guest_access',
+					state_key: '',
+					content: { guest_access: 'forbidden' }
+				}
+			],
 			power_level_content_override: {
 				invite: 100,
 				kick: 100,
@@ -290,7 +327,32 @@ class CallManager {
 					[client.getUserId()!]: 100
 				}
 			}
-		} as any);
+		};
+
+		let result: { room_id: string };
+		try {
+			result = await client.createRoom({
+				...baseOptions,
+				initial_state: [
+					...baseOptions.initial_state,
+					restrictedJoinRule
+				]
+			} as any);
+		} catch (err) {
+			// Homeserver too old for restricted joins, or the parent room is not
+			// a valid allow target. Stay closed rather than falling back to a
+			// public room, and invite the session members explicitly.
+			console.warn(
+				'[call] restricted join rule rejected, falling back to invite-only',
+				err
+			);
+			result = await client.createRoom(baseOptions as any);
+			await this.inviteSessionMembers(
+				client,
+				sourceRoomId,
+				result.room_id
+			);
+		}
 
 		// console.log(
 		// "✅ Created Element Call room",
@@ -301,6 +363,39 @@ class CallManager {
 
 		return result.room_id;
 	}
+
+	/**
+	 * Invite everyone who is joined to the counselling session into the call
+	 * room. Only used on the invite-only fallback path — with a restricted join
+	 * rule the membership check happens server-side and no invites are needed.
+	 */
+	private async inviteSessionMembers(
+		client: MatrixClient,
+		sourceRoomId: string,
+		callRoomId: string
+	): Promise<void> {
+		const ownUserId = client.getUserId();
+		const members =
+			client
+				.getRoom(sourceRoomId)
+				?.getMembersWithMembership('join' as any)
+				?.map((member) => member.userId)
+				.filter((userId) => userId !== ownUserId) ?? [];
+
+		await Promise.all(
+			members.map((userId) =>
+				client.invite(callRoomId, userId).catch((err) => {
+					// One failed invite must not sink the whole call.
+					console.warn(
+						'[call] could not invite participant to call room',
+						userId,
+						err
+					);
+				})
+			)
+		);
+	}
+
 	/**
 	 * Ensure the Matrix room's power levels allow Element Call to send
 	 * `org.matrix.msc3401.call.member` state events from normal participants.


### PR DESCRIPTION
## 1. The call room was joinable by anyone who knew its id

`CallManager.createElementCallRoom` created the per-call room with `preset: 'public_chat'`, which sets `join_rule: public`. Room ids are not secrets — they travel in the call invite event, in logs and in support tickets — so **anyone who learned one could join a counselling call**.

It is now created private with a `restricted` join rule allowing exactly the members of the parent session room, plus `history_visibility: joined` and guest access off.

A homeserver that rejects restricted joins (room version < 9) falls back to invite-only with explicit invites — **never back to a public room**.

## 2. Element Call can now be embedded as a Matrix widget

In widget (matryoshka) mode the iframe receives **no access token** and registers **no device of its own**. It asks this client to send and read events over `postMessage`, and the host client — which already has crypto set up — does the Matrix I/O.

`OrisoWidgetDriver` is purpose-built rather than general:

- **Bound to the single call room.** Any request naming another room is refused, so a call widget cannot read the counselling conversation.
- **Explicit capability allow-list.** The iframe cannot send `m.room.message` or change join rules as the user. Unknown capabilities are denied rather than granted.
- **Encrypted to-device sends go through the host crypto stack** and throw if it is missing, instead of silently downgrading the media keys to plaintext.

### Off by default

Behind `REACT_APP_ELEMENT_CALL_WIDGET_MODE`. The widget path has **not** been exercised against a deployed Element Call yet; the existing device-bound path stays the default until it has been. Flipping the flag on Pre-Dev is the next step.

## Testing

21 new cases:

- capability allow-list, including state-key smuggling (`…power_levels#org.matrix.msc3401.call.member` must not be granted)
- driver room confinement, on both read and write
- encrypted vs plain to-device routing, and the refusal when crypto is absent
- the call room's join rule, its encryption/history/guest state, and the invite fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to embed Element Call as a Matrix widget, including a runtime toggle, iframe setup, and widget-to-host event/to-device communication.
  * Introduced widget-mode capability allow-lists and a widget-mode driver that forwards calls to the host with filtering.
  * Call-room creation now prefers restricted join rules for counselling-session members, with encryption enabled and guest access disabled.
* **Bug Fixes**
  * Improved widget-mode handling for missing/invalid widget session data and tightened enforcement of room confinement and capability validation.
* **Tests**
  * Added/expanded unit tests for widget capabilities, widget driver behavior (events, to-device encryption, OpenID), and call-room creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->