### PR TITLE
fix(livechat): let consultants decrypt anonymous messages under invisible crypto (#774)

### DIFF
--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -128,7 +128,7 @@ export const AuthenticatedApp = ({
 							}
 							return userProfileData;
 						})
-						.then(async () => {
+						.then(async (userProfileData) => {
 							const matrixBootstrapActive = { current: true };
 							try {
 								await withTimeout(
@@ -152,7 +152,12 @@ export const AuthenticatedApp = ({
 														matrixLoginData.accessToken,
 													deviceId:
 														matrixLoginData.deviceId,
-													homeserverUrl
+													homeserverUrl,
+													isAnonymous:
+														hasUserAuthority(
+															AUTHORITIES.ANONYMOUS_DEFAULT,
+															userProfileData
+														)
 												}
 											);
 											if (

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -11,6 +11,11 @@ export interface MatrixLoginData {
 	deviceId: string;
 	homeserverUrl: string;
 	expiresInMs?: number;
+	// Anonymous live-chat users can never cross-sign a consultant's device, so
+	// their client must share Megolm keys to all devices; invisible crypto
+	// (verified-only) would silently make their messages undecryptable for the
+	// consultant. See matrixClientService.initializeClient.
+	isAnonymous?: boolean;
 }
 
 const MATRIX_DEVICE_ID_STORAGE_KEY = 'matrix_device_id';

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -140,6 +140,42 @@ describe('MatrixClientService', () => {
 		setAppConfig(null as any);
 	});
 
+	it('preserves the anonymous flag across a token refresh so decryption keeps working (#774)', async () => {
+		const { setAppConfig } = await import('../utils/appConfig');
+		setAppConfig({
+			releaseToggles: { enableInvisibleCrypto: true }
+		} as any);
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@anon_abc:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_ANON',
+			homeserverUrl: 'http://matrix.localhost:18008',
+			isAnonymous: true
+		});
+		expect(mockedCrypto.setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+
+		// A token refresh returns only transport fields (no isAnonymous).
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@anon_abc:matrix.localhost',
+			accessToken: 'refreshed-token',
+			deviceId: 'DEVICE_ANON',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		await service.refreshMatrixToken();
+
+		// The refreshed client must still share to all devices, not fall back to
+		// verified-only isolation and re-break decryption.
+		const lastCall = mockedCrypto.setDeviceIsolationMode.mock.calls.at(-1);
+		expect(lastCall?.[0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+		setAppConfig(null as any);
+	});
+
 	it('surfaces Rust crypto failures without leaving a client running', async () => {
 		mockedMatrixClient.initRustCrypto.mockRejectedValueOnce(
 			new Error('crypto store unavailable')

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeviceIsolationModeKind } from 'matrix-js-sdk/lib/crypto-api';
 import { getMatrixAccessToken } from '../components/sessionCookie/getMatrixAccessToken';
 import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import {
@@ -6,11 +7,16 @@ import {
 	isMatrixExpiredTokenError
 } from './matrixClientService';
 
+const mockedCrypto = vi.hoisted(() => ({
+	setDeviceIsolationMode: vi.fn()
+}));
+
 const mockedMatrixClient = vi.hoisted(() => ({
 	initRustCrypto: vi.fn(),
 	on: vi.fn(),
 	removeAllListeners: vi.fn(),
 	getRoom: vi.fn(),
+	getCrypto: vi.fn(),
 	joinRoom: vi.fn(),
 	sendMessage: vi.fn(),
 	startClient: vi.fn(),
@@ -55,6 +61,7 @@ describe('MatrixClientService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockedMatrixClient.initRustCrypto.mockResolvedValue(undefined);
+		mockedMatrixClient.getCrypto.mockReturnValue(mockedCrypto);
 		vi.stubGlobal('localStorage', {
 			getItem: vi.fn(() => null)
 		});
@@ -88,6 +95,49 @@ describe('MatrixClientService', () => {
 				'DEVICE_ONE'
 			)
 		});
+	});
+
+	it('keeps invisible crypto (verified-only) for a non-anonymous user when the toggle is on', async () => {
+		const { setAppConfig } = await import('../utils/appConfig');
+		setAppConfig({
+			releaseToggles: { enableInvisibleCrypto: true }
+		} as any);
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@consultant:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+
+		expect(mockedCrypto.setDeviceIsolationMode).toHaveBeenCalledTimes(1);
+		expect(mockedCrypto.setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.OnlySignedDevicesIsolationMode
+		);
+		setAppConfig(null as any);
+	});
+
+	it('shares to all devices for an anonymous live-chat user even when invisible crypto is on (#774)', async () => {
+		const { setAppConfig } = await import('../utils/appConfig');
+		setAppConfig({
+			releaseToggles: { enableInvisibleCrypto: true }
+		} as any);
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@anon_abc:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_ANON',
+			homeserverUrl: 'http://matrix.localhost:18008',
+			isAnonymous: true
+		});
+
+		expect(mockedCrypto.setDeviceIsolationMode).toHaveBeenCalledTimes(1);
+		expect(mockedCrypto.setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+		setAppConfig(null as any);
 	});
 
 	it('surfaces Rust crypto failures without leaving a client running', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -232,8 +232,18 @@ export class MatrixClientService {
 
 		this.refreshingToken = getMatrixAccessToken()
 			.then(async (loginData) => {
-				persistMatrixLoginData(loginData);
-				await this.initializeClient(loginData);
+				// getMatrixAccessToken only returns transport fields. A session's
+				// anonymity is stable across refreshes, so carry the existing flag
+				// forward — otherwise invisible crypto would re-apply verified-only
+				// isolation on the refreshed client and make an anonymous asker's
+				// messages undecryptable for the consultant again (#774).
+				const refreshedLoginData: MatrixLoginData = {
+					...loginData,
+					isAnonymous:
+						loginData.isAnonymous ?? this.loginData?.isAnonymous
+				};
+				persistMatrixLoginData(refreshedLoginData);
+				await this.initializeClient(refreshedLoginData);
 			})
 			.finally(() => {
 				this.refreshingToken = null;

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -153,10 +153,15 @@ export class MatrixClientService {
 
 		// #438 MSC4153 invisible crypto: once the rust crypto stack is up, share
 		// Megolm keys only with cross-signed devices when the toggle is on.
+		// Anonymous live-chat users are exempt: they can never cross-sign the
+		// consultant's device, so verified-only isolation would leave the
+		// consultant seeing only undecryptable noise. They always share to all
+		// devices so the accepted consultant can read the conversation (#774).
 		// Best-effort — never breaks client startup.
 		applyDeviceIsolationMode(
 			client,
-			appConfig?.releaseToggles?.enableInvisibleCrypto === true
+			appConfig?.releaseToggles?.enableInvisibleCrypto === true &&
+				loginData.isAnonymous !== true
 		);
 
 		(client as any).on(


### PR DESCRIPTION
The consultant sees an anonymous live-chat asker's messages as **encrypted/undecryptable**.

## Cause
When the `enableInvisibleCrypto` release toggle is on, the Matrix client uses `OnlySignedDevicesIsolationMode` ([matrixClientService.ts](https://github.com/OpenResilienceInitiative/ORISO-Frontend/blob/pre-dev/src/services/matrixClientService.ts)) — Megolm room keys are shared **only with cross-signed (verified) devices**. An anonymous asker and a consultant can **never cross-sign** each other (anonymous users are ephemeral — no verification, no key backup), so:
- the asker's client withholds the room key from the consultant → the consultant sees undecryptable noise, and
- the history-key responder also refuses the consultant as an unverified requester.

No existing open PR addresses this (checked both repos; the closest, #783, is about *call* rooms).

## Fix
Exempt anonymous users from invisible crypto: their client always uses `AllDevicesIsolationMode`, so the accepting consultant can read the conversation. Anonymous users are ephemeral and have nothing to protect via device isolation, so this loosens nothing meaningful. An `isAnonymous` flag (from the freshly-loaded user roles) is threaded into `initializeClient`; non-anonymous users keep verified-only isolation.

## Tests
- non-anonymous user → `OnlySignedDevicesIsolationMode` (unchanged)
- anonymous user → `AllDevicesIsolationMode` even with the toggle on
- `tsc`/`eslint`/`build` clean; full `test:unit`: 0 new failures vs the `pre-dev` baseline.

## Scope / honest caveats
- Device isolation mode is **client-global** in matrix-js-sdk, so this fixes the reported direction (consultant reading the asker's messages, and the asker sharing to the consultant). The **reverse** direction — the consultant's replies decrypting for the asker — still depends on the *consultant's* client, which under invisible crypto won't share to the unverified anonymous device. For fully bidirectional anonymous live chat while the toggle is on, that side needs the same treatment or the toggle off.
- **Fastest live remediation:** since invisible crypto is fundamentally incompatible with anonymous (un-cross-signable) live chat, disabling the `enableInvisibleCrypto` release toggle in ConsultingTypeService application settings fixes both directions immediately with no deploy. This PR is the safety net so anonymous chat can't silently break if the toggle is on.
- Not reproduced end-to-end (no consultant login); traced from the crypto isolation code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption device handling for anonymous live-chat sessions.
  * Anonymous users can now use the appropriate device-isolation behavior without invisible-crypto restrictions.
  * Standard authenticated sessions retain enhanced device isolation when enabled.

* **Tests**
  * Added coverage validating encryption behavior for both anonymous and authenticated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->