### PR TITLE
fix(deps): clear fixable HIGH/CRITICAL image CVEs (Trivy publish gate)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,21 @@ FROM node:$NODE_VERSION
 
 ARG PORT=80
 
+# The node base image bundles an npm whose vendored dependencies (tar,
+# sigstore, picomatch, brace-expansion) carry fixable HIGH/CRITICAL CVEs
+# flagged by the Trivy publish gate. Upgrade npm to a release that ships
+# fixed versions and patch its vendored brace-expansion to 5.0.8
+# (CVE-2026-14257 fix), which no npm release bundles yet.
+RUN npm install -g npm@11.18.0 \
+	&& cd /tmp \
+	&& npm pack brace-expansion@5.0.8 \
+	&& mkdir -p /tmp/brace-expansion-patch \
+	&& tar -xzf brace-expansion-5.0.8.tgz -C /tmp/brace-expansion-patch \
+	&& rm -rf /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+	&& mv /tmp/brace-expansion-patch/package /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+	&& rm -rf /tmp/brace-expansion-patch /tmp/brace-expansion-5.0.8.tgz \
+	&& npm cache clean --force
+
 USER node
 WORKDIR /app
 EXPOSE $PORT


### PR DESCRIPTION
## Why

The post-merge **Frontend Build and Publish** workflow on `pre-dev` fails at the step *Reject fixable high or critical image vulnerabilities* — failing run: https://github.com/OpenResilienceInitiative/ORISO-Frontend/actions/runs/30267586126

All 6 findings (5 HIGH, 1 CRITICAL) live in the base image's bundled npm at `/usr/local/lib/node_modules/npm/node_modules` — none in `app/node_modules` (the proxy's runtime dependencies are clean; picomatch there is already pinned to 2.3.2 via overrides):

| Package | Installed | Fixed | CVEs |
|---|---|---|---|
| tar | 7.5.11 | 7.5.19 | CVE-2026-59873 (CRITICAL), CVE-2026-59874 (HIGH) |
| sigstore | 3.1.0 | 4.1.1 | CVE-2026-48815 (HIGH) |
| picomatch | 4.0.3 | 4.0.4 | CVE-2026-33671 (HIGH) |
| brace-expansion | 2.0.2 | 5.0.8 | CVE-2026-13149, CVE-2026-14257 (HIGH) |

The pinned `node:22-alpine` digest is already the newest published tag (ships npm 10.9.8), so a base-image bump cannot fix this.

## What

Dockerfile final stage only:
- Upgrade the bundled npm to **11.18.0**, which vendors fixed tar 7.5.19, sigstore 4.1.1 and picomatch 4.0.4.
- Patch npm's vendored brace-expansion to **5.0.8** (CVE-2026-14257 fix; drop-in for the 5.0.7 npm 11.18.0 ships — same dependency surface, no npm release bundles 5.0.8 yet).

No app or proxy dependency changes, no lockfile changes, Trivy gate untouched.

## Verification (local)

- `npm ci`, `npm run lint:scripts`, `CI=false npm run build` — green
- Docker image built with BuildKit from this Dockerfile; container starts and serves the app (`node ./server`)
- `trivy image --severity HIGH,CRITICAL --ignore-unfixed` (same flags as the gate) → **exit 0, no findings**; npm in image = 11.18.0 with brace-expansion 5.0.8 / tar 7.5.19 / sigstore 4.1.1

## Context

Task 2b of the Element Call Matryoshka recovery plan (2026-07-27) — unblocks the pre-dev image digest freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)