### PR TITLE
fix(security): ignore dev-only DevToolbar switches outside development (FE-M10)

### DIFF
--- a/src/components/devToolbar/DevToolbar.tsx
+++ b/src/components/devToolbar/DevToolbar.tsx
@@ -247,12 +247,8 @@ const LOCAL_STORAGE_SWITCHES: (TLocalStorageSwitches | null)[] = [
 ];
 
 const getVisibleLocalStorageSwitches = () =>
-	LOCAL_STORAGE_SWITCHES.filter(Boolean).filter(
-		(localStorageSwitch) =>
-			!(
-				DEV_ONLY_SWITCH_KEYS.has(localStorageSwitch.key) &&
-				process.env.NODE_ENV !== 'development'
-			)
+	LOCAL_STORAGE_SWITCHES.filter(Boolean).filter((localStorageSwitch) =>
+		canUseStoredValue(localStorageSwitch.key)
 	);
 
 export const useDevToolbar = () => {

--- a/src/components/devToolbar/DevToolbar.tsx
+++ b/src/components/devToolbar/DevToolbar.tsx
@@ -13,6 +13,13 @@ import {
 	setValueInCookie
 } from '../sessionCookie/accessSessionCookie';
 import { STORAGE_KEY_E2EE_DISABLED } from '../../globalState/provider/E2EEProvider';
+import {
+	canUseStoredValue,
+	DEV_ONLY_SWITCH_KEYS,
+	STORAGE_KEY_2FA,
+	STORAGE_KEY_DISABLE_2FA_DUTY,
+	STORAGE_KEY_LOCALE
+} from './devToolbarKeys';
 import { AppConfigInterface } from '../../globalState/interfaces';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import {
@@ -22,22 +29,23 @@ import {
 	RequestLog
 } from '../../utils/requestCollector';
 
-export const STORAGE_KEY_LOCALE = 'locale';
 export const STORAGE_KEY_API = 'devProxy';
 export const STORAGE_KEY_DEV_TOOLBAR = 'showDevTools';
 export const STORAGE_KEY_POSITION = 'positionDevTools';
 export const STORAGE_KEY_HIDDEN = 'hiddenDevTools';
 
-export const STORAGE_KEY_2FA = '2fa';
-export const STORAGE_KEY_DISABLE_2FA_DUTY = 'disable 2fa_duty';
 export const STORAGE_KEY_RELEASE_NOTES = 'release_notes';
 export const STORAGE_KEY_ERROR_BOUNDARY = 'error_boundary';
 export { STORAGE_KEY_E2EE_DISABLED };
+export {
+	STORAGE_KEY_LOCALE,
+	STORAGE_KEY_2FA,
+	STORAGE_KEY_DISABLE_2FA_DUTY,
+	DEV_ONLY_SWITCH_KEYS
+};
 export const STORAGE_KEY_TRANSLATION_DISABLE_CACHE =
 	'translation_disable_cache';
 export const STORAGE_KEY_ENABLE_TRANSLATION_CHECK = 'enable_translation_check';
-
-const DEV_ONLY_SWITCH_KEYS = new Set([STORAGE_KEY_E2EE_DISABLED]);
 
 const DEVTOOLBAR_EVENT = 'devToolbar';
 
@@ -265,8 +273,13 @@ export const useDevToolbar = () => {
 
 	const getDevToolbarOption = useCallback(
 		(key) => {
+			// A dev-only switch must fall back to its default outside development,
+			// even when someone set the localStorage key by hand (FE-M10).
+			const storedValue = canUseStoredValue(key)
+				? localStorage.getItem(key)
+				: null;
 			const value =
-				localStorage.getItem(key) ??
+				storedValue ??
 				LOCAL_STORAGE_SWITCHES.filter(Boolean).find(
 					(localStorageSwitch) => localStorageSwitch.key === key
 				)?.value;

--- a/src/components/devToolbar/devToolbarKeys.test.ts
+++ b/src/components/devToolbar/devToolbarKeys.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+	canUseStoredValue,
+	DEV_ONLY_SWITCH_KEYS,
+	STORAGE_KEY_2FA,
+	STORAGE_KEY_DISABLE_2FA_DUTY,
+	STORAGE_KEY_LOCALE
+} from './devToolbarKeys';
+import { STORAGE_KEY_E2EE_DISABLED } from '../../utils/e2eeSettings';
+
+describe('dev-only DevToolbar switches (FE-M10)', () => {
+	it('treats the security-relevant switches as dev-only', () => {
+		expect(DEV_ONLY_SWITCH_KEYS.has(STORAGE_KEY_E2EE_DISABLED)).toBe(true);
+		expect(DEV_ONLY_SWITCH_KEYS.has(STORAGE_KEY_2FA)).toBe(true);
+		expect(DEV_ONLY_SWITCH_KEYS.has(STORAGE_KEY_DISABLE_2FA_DUTY)).toBe(
+			true
+		);
+	});
+
+	it('ignores a stored value for dev-only switches outside development', () => {
+		expect(canUseStoredValue(STORAGE_KEY_2FA, 'production')).toBe(false);
+		expect(
+			canUseStoredValue(STORAGE_KEY_DISABLE_2FA_DUTY, 'production')
+		).toBe(false);
+		expect(canUseStoredValue(STORAGE_KEY_E2EE_DISABLED, 'production')).toBe(
+			false
+		);
+	});
+
+	it('honours a stored value for dev-only switches during development', () => {
+		expect(canUseStoredValue(STORAGE_KEY_2FA, 'development')).toBe(true);
+		expect(
+			canUseStoredValue(STORAGE_KEY_E2EE_DISABLED, 'development')
+		).toBe(true);
+	});
+
+	it('leaves harmless switches usable everywhere', () => {
+		expect(canUseStoredValue(STORAGE_KEY_LOCALE, 'production')).toBe(true);
+		expect(canUseStoredValue(STORAGE_KEY_LOCALE, 'development')).toBe(true);
+	});
+});

--- a/src/components/devToolbar/devToolbarKeys.ts
+++ b/src/components/devToolbar/devToolbarKeys.ts
@@ -1,0 +1,22 @@
+import { STORAGE_KEY_E2EE_DISABLED } from '../../utils/e2eeSettings';
+
+export const STORAGE_KEY_LOCALE = 'locale';
+export const STORAGE_KEY_2FA = '2fa';
+export const STORAGE_KEY_DISABLE_2FA_DUTY = 'disable 2fa_duty';
+
+/**
+ * Switches that weaken a security control and must therefore never be honoured
+ * outside a local development build (FE-M10). Hiding them from the toolbar UI is
+ * not enough - the stored value has to be ignored as well, otherwise anyone can
+ * set the localStorage key by hand in production.
+ */
+export const DEV_ONLY_SWITCH_KEYS = new Set([
+	STORAGE_KEY_E2EE_DISABLED,
+	STORAGE_KEY_2FA,
+	STORAGE_KEY_DISABLE_2FA_DUTY
+]);
+
+export const canUseStoredValue = (
+	key: string,
+	nodeEnv: string = process.env.NODE_ENV
+): boolean => !DEV_ONLY_SWITCH_KEYS.has(key) || nodeEnv === 'development';


### PR DESCRIPTION
## Why

FE-M10 (#232) reported that 2FA and E2EE are toggleable per localStorage flag in the production bundle. While verifying it for the security-audit closure pass (OpenResilienceInitiative/ORISO-Docs#72), it turned out the existing mitigation was thinner than it looked:

`DEV_ONLY_SWITCH_KEYS` only fed `getVisibleLocalStorageSwitches()`, which filters what the toolbar *renders*. `getDevToolbarOption` read `localStorage.getItem(key)` unconditionally. So in a production build:

- setting `2fa` to `"0"` suppressed the 2FA obligation dialog — `TwoFactorNag.tsx:40` gates the entire nag on that switch
- setting `e2ee_disabled` still took effect, even though that switch was already considered "gated"

Hiding the control was never the same as disabling it.

## What changed

- New `devToolbarKeys.ts` holds the affected keys plus `DEV_ONLY_SWITCH_KEYS` and the `canUseStoredValue()` guard; `DevToolbar.tsx` re-exports the keys so existing imports keep working
- `getDevToolbarOption` now falls back to the compiled-in default for dev-only switches whenever `NODE_ENV !== 'development'` — the stored value is ignored, not just hidden
- Both 2FA switches (`2fa`, `disable 2fa_duty`) join the E2EE switch in that set

## Verification

```
npx vitest run src/components/devToolbar/devToolbarKeys.test.ts        4 passed  (red before devToolbarKeys.ts existed)
npx vitest run src/components/twoFactorAuth src/components/devToolbar src/globalState   26 passed
npx tsc --noEmit                                                       no errors in the touched files
```

Not verified in the browser preview on purpose: the change is a no-op in a development build, which is the only mode the dev server runs — the behaviour under test is the production path.

Refs OpenResilienceInitiative/ORISO-Frontend#232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for development-only toolbar switches by preventing stored security settings from affecting production environments.
  * Preserved access to non-security preferences, such as locale settings, across environments.

* **Tests**
  * Added coverage verifying environment-based handling of development-only switches and security-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->