### PR TITLE
fix(security): set SameSite=Strict and secure on session cookies (FE-H01)

### DIFF
--- a/src/components/sessionCookie/accessSessionCookie.test.ts
+++ b/src/components/sessionCookie/accessSessionCookie.test.ts
@@ -78,4 +78,68 @@ describe('accessSessionCookie', () => {
 		expect(window.localStorage.getItem('auth.keycloak')).toBeNull();
 		expect(window.localStorage.getItem('auth.refreshToken')).toBeNull();
 	});
+
+	describe('cookie attributes (FE-H01)', () => {
+		const captureCookieWrite = (value: string) => {
+			const writes: string[] = [];
+			const original = Object.getOwnPropertyDescriptor(
+				Document.prototype,
+				'cookie'
+			);
+			Object.defineProperty(document, 'cookie', {
+				configurable: true,
+				get: () => '',
+				set: (written: string) => writes.push(written)
+			});
+			try {
+				setValueInCookie('keycloak', value);
+			} finally {
+				if (original) {
+					Object.defineProperty(document, 'cookie', original);
+				}
+			}
+			return writes[0] ?? '';
+		};
+
+		const withProtocol = (protocol: string, run: () => string) => {
+			const original = window.location;
+			Object.defineProperty(window, 'location', {
+				configurable: true,
+				value: { ...original, protocol }
+			});
+			try {
+				return run();
+			} finally {
+				Object.defineProperty(window, 'location', {
+					configurable: true,
+					value: original
+				});
+			}
+		};
+
+		it('restricts session cookies to same-site requests', () => {
+			const written = withProtocol('https:', () =>
+				captureCookieWrite('access-token')
+			);
+
+			expect(written).toContain('SameSite=Strict');
+		});
+
+		it('marks session cookies secure when served over https', () => {
+			const written = withProtocol('https:', () =>
+				captureCookieWrite('access-token')
+			);
+
+			expect(written).toContain('; secure');
+		});
+
+		it('omits the secure flag on plain http so local development keeps working', () => {
+			const written = withProtocol('http:', () =>
+				captureCookieWrite('access-token')
+			);
+
+			expect(written).not.toContain('secure');
+			expect(written).toContain('SameSite=Strict');
+		});
+	});
 });

--- a/src/components/sessionCookie/accessSessionCookie.ts
+++ b/src/components/sessionCookie/accessSessionCookie.ts
@@ -38,12 +38,23 @@ const removeAuthStorageValue = (name: string) => {
 	}
 };
 
+/**
+ * Session cookies are written by the frontend, so they cannot be HttpOnly (FE-H01).
+ * SameSite=Strict and, on https, the secure flag are the part we can enforce here:
+ * they keep the cookie out of cross-site requests and off plaintext connections.
+ * The secure flag is omitted on http so local development keeps working.
+ */
+const getCookieSecurityAttributes = () => {
+	const secure = window.location.protocol === 'https:' ? '; secure' : '';
+	return `SameSite=Strict${secure}`;
+};
+
 export const setValueInCookie = (
 	name: string,
 	value: string,
 	path: string = '/'
 ) => {
-	document.cookie = `${name}=${value};path=${path};`;
+	document.cookie = `${name}=${value};path=${path};${getCookieSecurityAttributes()}`;
 	setAuthStorageValue(name, value);
 };
 


### PR DESCRIPTION
## Why

Part of the security-audit closure pass (OpenResilienceInitiative/ORISO-Docs#72). While re-verifying FE-H01 (#196) against current `pre-dev`, most of the finding turned out to be already fixed — but point 6 was not:

`setValueInCookie` wrote `name=value;path=/;` with **no attributes**. That covers the Keycloak access token, the refresh token and the CSRF token: sent on cross-site requests, and on http transmitted in the clear.

## What changed

- `setValueInCookie` now appends `SameSite=Strict`, plus `; secure` when the page is served over https
- `secure` is deliberately omitted on http so local development keeps working
- Three regression tests capture the actual cookie string that gets written (jsdom hides attributes on read, so the test spies on the `document.cookie` setter)

## Status of the rest of FE-H01, verified against `pre-dev`

| Ticket point | State |
| --- | --- |
| 1. `element-sso-bridge.html` leaks the token into browser history | **Already gone** — the file no longer exists |
| 4. `matrix_sso_access_token` cookie with `domain=` | **Already fixed** — `UIVersionToggle.tsx:70` writes it without `domain`; only the harmless UI-version cookie still uses one |
| 5. `window.matrixClientService` global | **Already gone** — nothing assigns it anymore; only two dead files (`FloatingCallWidget.OLD.tsx`, `.PROFESSIONAL.tsx`) still read it |
| 6. `Secure`/`SameSite` on session cookies | **This PR** |
| 3. token in `localStorage` → React context | Open — needs a decision, see below |
| 7. backend-set `HttpOnly` cookies | Open — backend work |

Points 3 and 7 are the real remaining work and they are a design decision, not a cleanup: the Matrix JS SDK needs the token client-side, and the E2EE device keys depend on it surviving a reload. That belongs in #196 with an explicit decision, not in this PR.

## Verification

```
npx vitest run src/components/sessionCookie                       22 passed  (3 red before the change)
npx vitest run src/components/auth src/components/login src/utils src/globalState   447 passed
```

**QA note:** `SameSite=Strict` means these cookies are not sent on the first request after a cross-site top-level navigation — the Keycloak login redirect is exactly that shape. The app reads them via `document.cookie` in JS rather than relying on the request header, so this should be a no-op, but please smoke-test a full login on Pre-Dev before promoting.

Refs OpenResilienceInitiative/ORISO-Frontend#196

🤖 Generated with [Claude Code](https://claude.com/claude-code)