### PR TITLE
ci: scope the GHA build cache per image (frontend + storybook)

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -69,5 +69,9 @@ runs:
       sbom: true
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
+      # Scope the GHA cache per image so images built from this shared action
+      # (here oriso-frontend and oriso-storybook) can't collide on one cache
+      # namespace and restore each other's layers — root cause of
+      # OpenResilienceInitiative/ORISO-Admin#424.
+      cache-from: type=gha,scope=${{ inputs.image_name }}
+      cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}


### PR DESCRIPTION
Same class as OpenResilienceInitiative/ORISO-Admin#424 (fixed in ORISO-Admin#556).

**Problem:** `oriso-frontend` (`Dockerfile`) and `oriso-storybook` (`Dockerfile.storybook`) both build from the shared `docker-build-push` action on every push, and the action used `cache-from/to: type=gha` with **no `scope`**. Both images share one GHA cache namespace and race, which lets one build restore the other's (or an older) `COPY build` layer — shipping a stale bundle under a fresh tag while CI stays green.

**What changed:** scope the GHA cache per image — `type=gha,scope=${{ inputs.image_name }}` on `cache-from` and `cache-to`. `image_name` is distinct per image, so the two families are isolated while push+PR builds of the same image still share cache.

**Verification:** YAML parses (`yaml.safe_load`). First proof is the next build — the per-image scopes are visible in the buildx logs. (Note: the Admin-style "assert the published image contains the freshly built bundle" step is a recommended frontend-specific follow-up; the frontend serves via a node image, not the same nginx static path, so it needs its own check.)

One-time cost: the first build after this merges gets a cache miss on the new scope key, then normal.
