### PR TITLE
fix(call): expose room bootstrap state to the confined widget

### DIFF
--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -507,7 +507,7 @@ export const GroupCallWidget: React.FC = () => {
 							src={elementCallUrl}
 							referrerPolicy="no-referrer"
 							className="element-call-iframe"
-							allow="camera; microphone; display-capture; autoplay; fullscreen; clipboard-write"
+							allow="camera; microphone; display-capture; autoplay; fullscreen; clipboard-write; screen-wake-lock"
 							allowFullScreen
 							title="Group video call"
 						/>

--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -108,7 +108,14 @@ export class OrisoWidgetDriver extends WidgetDriver {
 		const deviceId = this.client.getDeviceId();
 		if (!userId || !deviceId) return granted;
 		requested.forEach((capability) => {
-			if (isAllowedWidgetCapability(capability, userId, deviceId)) {
+			if (
+				isAllowedWidgetCapability(
+					capability,
+					userId,
+					deviceId,
+					this.roomId
+				)
+			) {
 				granted.add(capability);
 			} else {
 				// eslint-disable-next-line no-console

--- a/src/components/call/widget/orisoWidgetCapabilities.test.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.test.ts
@@ -49,14 +49,16 @@ describe('isAllowedWidgetCapability', () => {
 		);
 	});
 
-	it('lets the widget read encryption state, but no member or room metadata', () => {
-		expect(
-			allowed('org.matrix.msc2762.receive.state_event:m.room.encryption')
-		).toBe(true);
-		for (const type of ['m.room.member', 'm.room.name', 'm.room.create']) {
+	it('lets the room-confined widget read the state required to boot', () => {
+		for (const type of [
+			'm.room.create',
+			'm.room.name',
+			'm.room.member',
+			'm.room.encryption'
+		]) {
 			expect(
 				allowed(`org.matrix.msc2762.receive.state_event:${type}`)
-			).toBe(false);
+			).toBe(true);
 		}
 	});
 
@@ -103,8 +105,7 @@ describe('isAllowedWidgetCapability', () => {
 		for (const capability of [
 			'org.matrix.msc2762.send.event:m.room.redaction',
 			'org.matrix.msc3819.send.to_device:m.call.invite',
-			'org.matrix.msc3819.send.to_device:m.call.hangup',
-			'org.matrix.msc2762.receive.state_event:m.room.member'
+			'org.matrix.msc3819.send.to_device:m.call.hangup'
 		]) {
 			expect(allowed(capability)).toBe(false);
 		}

--- a/src/components/call/widget/orisoWidgetCapabilities.test.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { isAllowedWidgetCapability } from './orisoWidgetCapabilities';
 
 const allowed = (capability: string) =>
-	isAllowedWidgetCapability(capability, '@a:hs', 'ORISO_WEB_test');
+	isAllowedWidgetCapability(
+		capability,
+		'@a:hs',
+		'ORISO_WEB_test',
+		'!call:hs'
+	);
 
 describe('isAllowedWidgetCapability', () => {
 	it('grants the call membership state events Element Call needs to join', () => {
@@ -60,6 +65,12 @@ describe('isAllowedWidgetCapability', () => {
 				allowed(`org.matrix.msc2762.receive.state_event:${type}`)
 			).toBe(true);
 		}
+	});
+
+	it('grants timeline access only to the active call room', () => {
+		expect(allowed('org.matrix.msc2762.timeline:!call:hs')).toBe(true);
+		expect(allowed('org.matrix.msc2762.timeline:!other:hs')).toBe(false);
+		expect(allowed('org.matrix.msc2762.timeline:*')).toBe(false);
 	});
 
 	it('does not let the widget write another device membership', () => {

--- a/src/components/call/widget/orisoWidgetCapabilities.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.ts
@@ -36,9 +36,9 @@ const ALLOWED_PLAIN_CAPABILITIES: ReadonlySet<string> = new Set([
 
 const ROOM_EVENT_PREFIXES = [
 	'org.matrix.msc2762.send.event:',
-	'org.matrix.msc2762.receive.event:',
-	'org.matrix.msc2762.timeline:'
+	'org.matrix.msc2762.receive.event:'
 ];
+const ROOM_TIMELINE_PREFIX = 'org.matrix.msc2762.timeline:';
 const SEND_STATE_EVENT_PREFIX = 'org.matrix.msc2762.send.state_event:';
 const RECEIVE_STATE_EVENT_PREFIX = 'org.matrix.msc2762.receive.state_event:';
 const TO_DEVICE_PREFIXES = [
@@ -84,9 +84,13 @@ const matchPrefix = (
 export const isAllowedWidgetCapability = (
 	capability: string,
 	userId: string,
-	deviceId: string
+	deviceId: string,
+	roomId: string
 ): boolean => {
 	if (ALLOWED_PLAIN_CAPABILITIES.has(capability)) return true;
+	if (capability.startsWith(ROOM_TIMELINE_PREFIX)) {
+		return capability === `${ROOM_TIMELINE_PREFIX}${roomId}`;
+	}
 
 	const roomPrefix = matchPrefix(capability, ROOM_EVENT_PREFIXES);
 	if (roomPrefix) {

--- a/src/components/call/widget/orisoWidgetCapabilities.ts
+++ b/src/components/call/widget/orisoWidgetCapabilities.ts
@@ -15,8 +15,13 @@ export const ALLOWED_SEND_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
 	'org.matrix.msc3401.call.member'
 ]);
 
+// create/name/member are read-only boot metadata for createRoomWidgetClient.
+// OrisoWidgetDriver still confines every state read to its single call room.
 export const ALLOWED_RECEIVE_STATE_EVENT_TYPES: ReadonlySet<string> = new Set([
 	...ALLOWED_SEND_STATE_EVENT_TYPES,
+	'm.room.create',
+	'm.room.name',
+	'm.room.member',
 	'm.room.encryption'
 ]);
 

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -340,6 +340,26 @@ describe('useElementCallWidget', () => {
 		});
 		expect(onAlwaysOnScreenChange).toHaveBeenCalledWith(true);
 
+		for (const action of [
+			'io.element.join',
+			'io.element.tile_layout',
+			'io.element.spotlight_layout'
+		]) {
+			const request = {
+				action,
+				requestId: `${action}-1`,
+				widgetId: 'widget',
+				data: {}
+			};
+			const event = new CustomEvent(action, {
+				cancelable: true,
+				detail: request
+			});
+			act(() => api.emit(`action:${action}`, event));
+			expect(event.defaultPrevented).toBe(true);
+			expect(api.transport.reply).toHaveBeenCalledWith(request, {});
+		}
+
 		await act(() => result.current.hangup());
 		expect(api.transport.send).toHaveBeenCalledWith('im.vector.hangup', {});
 	});

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -405,10 +405,40 @@ describe('useElementCallWidget', () => {
 			}),
 			getType: () => 'm.room.message'
 		};
+		let encryptedType = 'm.room.encrypted';
+		const decryptionListeners = new Set<
+			(event: unknown, error?: Error) => void
+		>();
+		const decryptedRawEvent = {
+			type: 'io.element.call.reaction',
+			content: { emoji: '👍' }
+		};
+		const encryptedEvent = {
+			...roomEvent,
+			getType: () => encryptedType,
+			getEffectiveEvent: () => decryptedRawEvent,
+			on: (
+				eventName: string,
+				listener: (event: unknown, error?: Error) => void
+			) => {
+				if (eventName === 'Event.decrypted') {
+					decryptionListeners.add(listener);
+				}
+			},
+			off: (
+				eventName: string,
+				listener: (event: unknown, error?: Error) => void
+			) => {
+				if (eventName === 'Event.decrypted') {
+					decryptionListeners.delete(listener);
+				}
+			}
+		};
 
 		act(() => {
 			client.emitTest('Room.localEchoUpdated', roomEvent);
 			client.emitTest('Room.localEchoUpdated', forbiddenEvent);
+			client.emitTest('Room.timeline', encryptedEvent, {}, false);
 			client.emitTest('RoomState.events', stateEvent, {
 				roomId: CALL_ROOM
 			});
@@ -421,6 +451,18 @@ describe('useElementCallWidget', () => {
 
 		expect(api.feedEvent).toHaveBeenCalledWith(rawEvent, CALL_ROOM);
 		expect(api.feedEvent).toHaveBeenCalledTimes(1);
+		expect(decryptionListeners).toHaveLength(1);
+
+		act(() => {
+			encryptedType = 'io.element.call.reaction';
+			decryptionListeners.forEach((listener) => listener(encryptedEvent));
+		});
+		expect(api.feedEvent).toHaveBeenCalledWith(
+			decryptedRawEvent,
+			CALL_ROOM
+		);
+		expect(api.feedEvent).toHaveBeenCalledTimes(2);
+		expect(decryptionListeners).toHaveLength(0);
 		expect(api.feedStateUpdate).toHaveBeenCalledWith(
 			stateEvent.getEffectiveEvent()
 		);

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -265,6 +265,19 @@ export const useElementCallWidget = (
 					api.transport.reply(event.detail, { success: true });
 				}
 			);
+			const acknowledgeLifecycleAction = (
+				event: CustomEvent<IWidgetApiRequest>
+			): void => {
+				event.preventDefault();
+				api.transport.reply(event.detail, {});
+			};
+			for (const action of [
+				'io.element.join',
+				'io.element.tile_layout',
+				'io.element.spotlight_layout'
+			]) {
+				api.on(`action:${action}`, acknowledgeLifecycleAction);
+			}
 		},
 		[client, onAlwaysOnScreenChange, onClose, roomId, url]
 	);

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -292,12 +292,21 @@ export const useElementCallWidget = (
 	useEffect(() => {
 		if (!client || !roomId) return undefined;
 
-		const onTimeline = (
-			event: MatrixEvent,
-			_room: unknown,
-			toStartOfTimeline: boolean | undefined
-		) => {
-			if (toStartOfTimeline) return; // backfill, not live
+		const pendingDecryptions = new Map<
+			MatrixEvent,
+			{
+				listener: (event: MatrixEvent, error?: Error) => void;
+				timeout: ReturnType<typeof setTimeout>;
+			}
+		>();
+		const clearPendingDecryption = (event: MatrixEvent) => {
+			const pending = pendingDecryptions.get(event);
+			if (!pending) return;
+			clearTimeout(pending.timeout);
+			event.off('Event.decrypted' as any, pending.listener as any);
+			pendingDecryptions.delete(event);
+		};
+		const feedAllowedRoomEvent = (event: MatrixEvent) => {
 			if (event.getRoomId() !== roomId) return;
 			if (!ALLOWED_ROOM_EVENT_TYPES.has(event.getType())) return;
 			apiRef.current
@@ -306,15 +315,47 @@ export const useElementCallWidget = (
 					/* the widget may have gone away mid-call */
 				});
 		};
+		const waitForSuccessfulDecryption = (event: MatrixEvent) => {
+			if (pendingDecryptions.has(event)) return;
+
+			const listener = (decryptedEvent: MatrixEvent, error?: Error) => {
+				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
+					return;
+				}
+				clearPendingDecryption(event);
+				feedAllowedRoomEvent(decryptedEvent);
+			};
+			const timeout = setTimeout(
+				() => clearPendingDecryption(event),
+				5 * 60 * 1000
+			);
+			pendingDecryptions.set(event, { listener, timeout });
+			event.on('Event.decrypted' as any, listener as any);
+
+			// Close the race where Rust Crypto finishes between the initial type
+			// check and listener registration.
+			if (event.getType() !== 'm.room.encrypted') listener(event);
+		};
+		const feedOrWaitForDecryption = (event: MatrixEvent) => {
+			if (event.getRoomId() !== roomId) return;
+			if (event.getType() === 'm.room.encrypted') {
+				waitForSuccessfulDecryption(event);
+				return;
+			}
+			feedAllowedRoomEvent(event);
+		};
+
+		const onTimeline = (
+			event: MatrixEvent,
+			_room: unknown,
+			toStartOfTimeline: boolean | undefined
+		) => {
+			if (toStartOfTimeline) return; // backfill, not live
+			feedOrWaitForDecryption(event);
+		};
 
 		const onLocalEchoUpdated = (event: MatrixEvent) => {
-			if (event.getRoomId() !== roomId) return;
-			if (!ALLOWED_ROOM_EVENT_TYPES.has(event.getType())) return;
-			apiRef.current
-				?.feedEvent(event.getEffectiveEvent() as never, roomId)
-				.catch(() => {
-					/* the widget may have gone away mid-call */
-				});
+			feedOrWaitForDecryption(event);
 		};
 
 		const onStateEvent = (
@@ -355,6 +396,9 @@ export const useElementCallWidget = (
 			client.off(RoomEvent.LocalEchoUpdated, onLocalEchoUpdated);
 			client.off(RoomStateEvent.Events, onStateEvent);
 			client.off(ClientEvent.ToDeviceEvent, onToDevice);
+			Array.from(pendingDecryptions.keys()).forEach(
+				clearPendingDecryption
+			);
 		};
 	}, [client, roomId]);
 


### PR DESCRIPTION
Follow-up to #790 and the cross-repository rollout tracked in OpenResilienceInitiative/ORISO-Helm#167.

The PreDev two-browser gate reached the Element Call iframe but failed with `Room not found. The widget-api did not pass over the relevant room events/information.` The capability hardening had removed the read-only state that `createRoomWidgetClient` needs to hydrate its configured room.

This change grants receive-only access to `m.room.create`, `m.room.name`, and `m.room.member`. `OrisoWidgetDriver` remains bound to one exact call room and rejects cross-room reads; room/member writes, redactions, general messages, and legacy call signalling remain denied.

Verification:
- `orisoWidgetCapabilities.test.ts`
- `OrisoWidgetDriver.test.ts`
- 40 focused tests passed

The PR remains draft until the rebuilt immutable images pass the complete PreDev two-browser E2EE call gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved call widget support for screen wake lock, helping keep the display active during calls.
  * Added support for additional call layout and participant actions.
  * Expanded access to essential call room information while restricting timeline access to the active room.

* **Bug Fixes**
  * Improved handling and forwarding of encrypted events after decryption.
  * Added cleanup and timeout handling to prevent stale event listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->