### PR TITLE
Fix send button stylelint spacing

### DIFF
--- a/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
+++ b/src/components/messageSubmitInterface/inputField/sendButton.styles.scss
@@ -17,6 +17,7 @@
 	appearance: none;
 	cursor: pointer;
 	overflow: hidden;
+
 	// #597: resting / not-selected composer — #FFB4AA
 	background-color: var(--m3-primary-fixed-dim, #ffb4aa);
 	transition: background-color 250ms cubic-bezier(0.2, 0, 0, 1);


### PR DESCRIPTION
## Summary
- add the expected blank line before the send button SCSS comment
- fixes the stylelint rule violation in sendButton.styles.scss

## Validation
- npx stylelint src/components/messageSubmitInterface/inputField/sendButton.styles.scss
- npm run lint:scripts
- git diff --check