### PR TITLE
Show platform version without legal links

### DIFF
--- a/src/components/stageLayout/StageLayout.tsx
+++ b/src/components/stageLayout/StageLayout.tsx
@@ -291,38 +291,40 @@ export const StageLayout = ({
 					{children}
 				</Box>
 
-				{showLegalLinks && (
+				{(showLegalLinks || platformVersion) && (
 					<div className="stageLayout__footer">
-						<div className={`stageLayout__legalLinks`}>
-							<LegalLinks
-								delimiter={
-									<Text
-										type="infoSmall"
-										className="stageLayout__legalLinksSeparator"
-										text=" | "
-									/>
-								}
-								params={{ aid: specificAgency?.id }}
-								legalLinks={legalLinks}
-							>
-								{(label, url) => (
-									<button
-										type="button"
-										className="button-as-link"
-										data-cy-link={url}
-										onClick={() =>
-											window.open(url, '_blank')
-										}
-									>
+						{showLegalLinks && (
+							<div className={`stageLayout__legalLinks`}>
+								<LegalLinks
+									delimiter={
 										<Text
-											className="stageLayout__legalLinksItem"
 											type="infoSmall"
-											text={label}
+											className="stageLayout__legalLinksSeparator"
+											text=" | "
 										/>
-									</button>
-								)}
-							</LegalLinks>
-						</div>
+									}
+									params={{ aid: specificAgency?.id }}
+									legalLinks={legalLinks}
+								>
+									{(label, url) => (
+										<button
+											type="button"
+											className="button-as-link"
+											data-cy-link={url}
+											onClick={() =>
+												window.open(url, '_blank')
+											}
+										>
+											<Text
+												className="stageLayout__legalLinksItem"
+												type="infoSmall"
+												text={label}
+											/>
+										</button>
+									)}
+								</LegalLinks>
+							</div>
+						)}
 						{platformVersion && (
 							<Text
 								className="stageLayout__platformVersion"


### PR DESCRIPTION
## Summary
- Render the Frontend stage footer when either legal links or the platform version is available.
- Keeps `PLATFORM_VERSION` visible even on stage-layout routes that hide legal links.

## Root cause
The stage footer was gated only by `showLegalLinks`, so the Helm-provided platform version could be configured but not mounted on routes without legal links.

## Validation
- `npm ci --legacy-peer-deps`
- `npm run lint:scripts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated footer visibility so it appears when legal links or platform version information is available.
  * Platform version text can now be displayed independently of legal links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->