### PR TITLE
fix(call): make lost media keys visible instead of silent

### DIFF
--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -268,10 +268,23 @@ export class OrisoWidgetDriver extends WidgetDriver {
 		encrypted: boolean,
 		contentMap: { [userId: string]: { [deviceId: string]: object } }
 	): Promise<void> {
+		// These refusals are correct, but they abort media key distribution, and
+		// the widget surfaces nothing for it — the call connects and stays
+		// silent (ElementCall#35). Say so in the host log before throwing.
 		if (!ALLOWED_TO_DEVICE_EVENT_TYPES.has(eventType)) {
+			console.warn(
+				'[call] refusing to-device send of disallowed type:',
+				eventType
+			);
 			throw new Error(`Call widget may not send ${eventType} to devices`);
 		}
 		if (!encrypted) {
+			console.error(
+				'[call] refusing to send',
+				eventType,
+				'unencrypted — media keys are not distributed, so the call will',
+				'connect without audio or video'
+			);
 			throw new Error(
 				`Refusing to send ${eventType} unencrypted: call keys must never ` +
 					'travel in plaintext.'
@@ -280,6 +293,11 @@ export class OrisoWidgetDriver extends WidgetDriver {
 
 		const crypto = this.client.getCrypto();
 		if (!crypto) {
+			console.error(
+				'[call] refusing to send',
+				eventType,
+				'— host client has no crypto, so media keys cannot be distributed'
+			);
 			throw new Error(
 				'Refusing to send call keys: host client has no crypto. ' +
 					'Encrypted calls require an initialised crypto stack (ADR-004).'

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -470,4 +470,83 @@ describe('useElementCallWidget', () => {
 		expect(api.feedToDevice).toHaveBeenCalledWith(rawEvent, true);
 		expect(api.feedToDevice).toHaveBeenCalledTimes(1);
 	});
+
+	it('reports, and does not silently swallow, a call event that never decrypts', async () => {
+		vi.useFakeTimers();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const client = createClient();
+			const { result } = renderHook(() =>
+				useElementCallWidget(client, {
+					roomId: CALL_ROOM,
+					isVideo: true
+				})
+			);
+			await vi.waitFor(() => expect(result.current.url).not.toBeNull());
+			const iframe = document.createElement('iframe');
+			iframe.src = result.current.url!;
+			act(() => result.current.attachIframe(iframe));
+			const api =
+				widgetApiMocks.apiInstances[
+					widgetApiMocks.apiInstances.length - 1
+				];
+
+			const decryptionListeners = new Set<
+				(event: unknown, error?: Error) => void
+			>();
+			const stuckEvent = {
+				getRoomId: () => CALL_ROOM,
+				getId: () => '$stuck-key-event',
+				getType: () => 'm.room.encrypted',
+				getWireType: () => 'm.room.encrypted',
+				getEffectiveEvent: () => ({ type: 'm.room.encrypted' }),
+				on: (name: string, l: (e: unknown, err?: Error) => void) => {
+					if (name === 'Event.decrypted') decryptionListeners.add(l);
+				},
+				off: (name: string, l: (e: unknown, err?: Error) => void) => {
+					if (name === 'Event.decrypted')
+						decryptionListeners.delete(l);
+				}
+			};
+
+			act(() => {
+				client.emitTest('Room.timeline', stuckEvent, {}, false);
+			});
+			expect(decryptionListeners.size).toBe(1);
+
+			// A failed decryption must NOT drop the listener: Megolm keys often
+			// arrive later and the SDK retries. It must be reported, though.
+			act(() => {
+				decryptionListeners.forEach((l) =>
+					l(stuckEvent, new Error('The sender key is unknown'))
+				);
+			});
+			expect(decryptionListeners.size).toBe(1);
+			expect(api.feedEvent).not.toHaveBeenCalled();
+			expect(warn).toHaveBeenCalledWith(
+				'[call] call event still undecrypted, waiting for the key:',
+				'$stuck-key-event',
+				'The sender key is unknown'
+			);
+
+			// Only after the timeout is the event truly lost — and that loss is
+			// what makes a connected call silent, so it must be loud.
+			act(() => {
+				vi.advanceTimersByTime(5 * 60 * 1000);
+			});
+			expect(decryptionListeners.size).toBe(0);
+			expect(error).toHaveBeenCalledWith(
+				'[call] dropping call event that never decrypted:',
+				'$stuck-key-event',
+				'in',
+				CALL_ROOM,
+				'— media keys carried by this event are lost'
+			);
+		} finally {
+			warn.mockRestore();
+			error.mockRestore();
+			vi.useRealTimers();
+		}
+	});
 });

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -320,13 +320,34 @@ export const useElementCallWidget = (
 
 			const listener = (decryptedEvent: MatrixEvent, error?: Error) => {
 				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
+					// Keep waiting: Megolm keys frequently arrive after the event,
+					// and the SDK re-runs decryption when they do. Only report it,
+					// so a call that stays silent is not silent in the log too.
+					console.warn(
+						'[call] call event still undecrypted, waiting for the key:',
+						event.getId(),
+						error?.message ?? 'no decryption error reported'
+					);
 					return;
 				}
 				clearPendingDecryption(event);
 				feedAllowedRoomEvent(decryptedEvent);
 			};
 			const timeout = setTimeout(
-				() => clearPendingDecryption(event),
+				() => {
+					// The widget never received this event. For
+					// `io.element.call.encryption_keys` that means media stays
+					// undecodable — the participant is connected but silent, with
+					// nothing else in the UI to explain it (see ElementCall#35).
+					console.error(
+						'[call] dropping call event that never decrypted:',
+						event.getId(),
+						'in',
+						event.getRoomId(),
+						'— media keys carried by this event are lost'
+					);
+					clearPendingDecryption(event);
+				},
 				5 * 60 * 1000
 			);
 			pendingDecryptions.set(event, { listener, timeout });


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-ElementCall#35

## Why

A call that connects but plays no audio or video has no UI symptom — and, until now, no log line either. That is why ElementCall#35 reads *"No error surfaced in the UI once the call is established"*. The host swallows the cause in two places, both of which sit directly on the media-key path.

**1. `useElementCallWidget` drops undecryptable call events after five minutes.** An `m.room.encrypted` event is held back until Megolm decryption succeeds; if it never does, the pending entry is cleared and the event is gone:

```ts
const timeout = setTimeout(() => clearPendingDecryption(event), 5 * 60 * 1000);
```

When that event carries `io.element.call.encryption_keys`, the widget never receives a media key. Media then flows encrypted and decodes to nothing — exactly "connected but silent", in both directions, with nothing to explain it.

**2. `OrisoWidgetDriver.sendToDevice` refuses to distribute keys in three cases** — disallowed type, unencrypted send, and no crypto stack. All three refusals are correct and deliberate, and all three abort key distribution without a trace in the host log.

## What this changes

Logging only — no behaviour change.

- A failed decryption is now reported (`console.warn`) but **still keeps waiting**. This is deliberate: Megolm keys frequently arrive after the event and the SDK re-runs decryption, so tearing the listener down on the first error would break the common late-key case.
- The five-minute drop is logged as an **error**, because that is the moment the key is genuinely lost.
- All three `sendToDevice` refusals log why, and the unencrypted/no-crypto cases spell out the consequence ("the call will connect without audio or video").

## Tests

New regression test in `useElementCallWidget.test.tsx` pins the whole sequence: a decryption failure must **not** remove the listener and must be reported; only the timeout removes it and must log the loss. Verified to fail without the source change.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

`tsc --noEmit` clean for the changed files, prettier clean.

## What this does not do

It does not fix the no-audio itself. The root cause in ElementCall#35 is still open — this makes the next call on dev say out loud whether the keys were never sent, never decrypted, or dropped, which currently costs a debugging session each time to guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted call events that cannot be decrypted immediately.
  * The app now continues waiting for required encryption keys and warns when decryption fails.
  * Events that remain undecrypted for five minutes are safely dropped with an error logged.
  * Added clearer warnings and errors when media-key delivery is blocked or encryption support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->