### PR TITLE
fix(call): make per-participant media E2EE an explicit toggle

### DIFF
--- a/src/components/call/widget/OrisoWidgetDriver.ts
+++ b/src/components/call/widget/OrisoWidgetDriver.ts
@@ -268,10 +268,23 @@ export class OrisoWidgetDriver extends WidgetDriver {
 		encrypted: boolean,
 		contentMap: { [userId: string]: { [deviceId: string]: object } }
 	): Promise<void> {
+		// These refusals are correct, but they abort media key distribution, and
+		// the widget surfaces nothing for it — the call connects and stays
+		// silent (ElementCall#35). Say so in the host log before throwing.
 		if (!ALLOWED_TO_DEVICE_EVENT_TYPES.has(eventType)) {
+			console.warn(
+				'[call] refusing to-device send of disallowed type:',
+				eventType
+			);
 			throw new Error(`Call widget may not send ${eventType} to devices`);
 		}
 		if (!encrypted) {
+			console.error(
+				'[call] refusing to send',
+				eventType,
+				'unencrypted — media keys are not distributed, so the call will',
+				'connect without audio or video'
+			);
 			throw new Error(
 				`Refusing to send ${eventType} unencrypted: call keys must never ` +
 					'travel in plaintext.'
@@ -280,6 +293,11 @@ export class OrisoWidgetDriver extends WidgetDriver {
 
 		const crypto = this.client.getCrypto();
 		if (!crypto) {
+			console.error(
+				'[call] refusing to send',
+				eventType,
+				'— host client has no crypto, so media keys cannot be distributed'
+			);
 			throw new Error(
 				'Refusing to send call keys: host client has no crypto. ' +
 					'Encrypted calls require an initialised crypto stack (ADR-004).'

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -470,4 +470,83 @@ describe('useElementCallWidget', () => {
 		expect(api.feedToDevice).toHaveBeenCalledWith(rawEvent, true);
 		expect(api.feedToDevice).toHaveBeenCalledTimes(1);
 	});
+
+	it('reports, and does not silently swallow, a call event that never decrypts', async () => {
+		vi.useFakeTimers();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const client = createClient();
+			const { result } = renderHook(() =>
+				useElementCallWidget(client, {
+					roomId: CALL_ROOM,
+					isVideo: true
+				})
+			);
+			await vi.waitFor(() => expect(result.current.url).not.toBeNull());
+			const iframe = document.createElement('iframe');
+			iframe.src = result.current.url!;
+			act(() => result.current.attachIframe(iframe));
+			const api =
+				widgetApiMocks.apiInstances[
+					widgetApiMocks.apiInstances.length - 1
+				];
+
+			const decryptionListeners = new Set<
+				(event: unknown, error?: Error) => void
+			>();
+			const stuckEvent = {
+				getRoomId: () => CALL_ROOM,
+				getId: () => '$stuck-key-event',
+				getType: () => 'm.room.encrypted',
+				getWireType: () => 'm.room.encrypted',
+				getEffectiveEvent: () => ({ type: 'm.room.encrypted' }),
+				on: (name: string, l: (e: unknown, err?: Error) => void) => {
+					if (name === 'Event.decrypted') decryptionListeners.add(l);
+				},
+				off: (name: string, l: (e: unknown, err?: Error) => void) => {
+					if (name === 'Event.decrypted')
+						decryptionListeners.delete(l);
+				}
+			};
+
+			act(() => {
+				client.emitTest('Room.timeline', stuckEvent, {}, false);
+			});
+			expect(decryptionListeners.size).toBe(1);
+
+			// A failed decryption must NOT drop the listener: Megolm keys often
+			// arrive later and the SDK retries. It must be reported, though.
+			act(() => {
+				decryptionListeners.forEach((l) =>
+					l(stuckEvent, new Error('The sender key is unknown'))
+				);
+			});
+			expect(decryptionListeners.size).toBe(1);
+			expect(api.feedEvent).not.toHaveBeenCalled();
+			expect(warn).toHaveBeenCalledWith(
+				'[call] call event still undecrypted, waiting for the key:',
+				'$stuck-key-event',
+				'The sender key is unknown'
+			);
+
+			// Only after the timeout is the event truly lost — and that loss is
+			// what makes a connected call silent, so it must be loud.
+			act(() => {
+				vi.advanceTimersByTime(5 * 60 * 1000);
+			});
+			expect(decryptionListeners.size).toBe(0);
+			expect(error).toHaveBeenCalledWith(
+				'[call] dropping call event that never decrypted:',
+				'$stuck-key-event',
+				'in',
+				CALL_ROOM,
+				'— media keys carried by this event are lost'
+			);
+		} finally {
+			warn.mockRestore();
+			error.mockRestore();
+			vi.useRealTimers();
+		}
+	});
 });

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -6,6 +6,7 @@ import { webcrypto } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useElementCallWidget } from './useElementCallWidget';
+import { setAppConfig } from '../../../utils/appConfig';
 
 const widgetApiMocks = vi.hoisted(() => ({
 	widgetDefinitions: [] as Array<Record<string, unknown>>,
@@ -124,6 +125,7 @@ describe('useElementCallWidget', () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		setAppConfig(null as never);
 	});
 
 	it('waits for room join and never puts credentials or premature E2EE flags in the URL', async () => {
@@ -166,6 +168,28 @@ describe('useElementCallWidget', () => {
 		// to-device transport, so a gap in the host's Olm path would connect the
 		// call with no audio and no error (ORISO-ElementCall#35).
 		expect(fragment.get('perParticipantE2EE')).toBeNull();
+	});
+
+	it('asks Element Call for media E2EE once the environment enables it', async () => {
+		// The off path alone would still pass if the parameter were dropped
+		// unconditionally, which would silently make the toggle unusable.
+		setAppConfig({
+			releaseToggles: { enableCallMediaE2EE: true }
+		} as never);
+		const client = createClient();
+
+		const { result } = renderHook(() =>
+			useElementCallWidget(client, {
+				roomId: CALL_ROOM,
+				isVideo: true
+			})
+		);
+		await waitFor(() => expect(result.current.url).not.toBeNull());
+
+		const fragment = new URLSearchParams(
+			new URL(result.current.url!).hash.slice(2)
+		);
+		expect(fragment.get('perParticipantE2EE')).toBe('true');
 	});
 
 	it('fails closed when the host cannot join the call room', async () => {

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -162,7 +162,10 @@ describe('useElementCallWidget', () => {
 		expect(fragment.has('accessToken')).toBe(false);
 		expect(fragment.has('password')).toBe(false);
 		expect(fragment.has('enableE2EE')).toBe(false);
-		expect(fragment.get('perParticipantE2EE')).toBe('true');
+		// Media E2EE is opt-in per environment: the media keys ride the MatrixRTC
+		// to-device transport, so a gap in the host's Olm path would connect the
+		// call with no audio and no error (ORISO-ElementCall#35).
+		expect(fragment.get('perParticipantE2EE')).toBeNull();
 	});
 
 	it('fails closed when the host cannot join the call room', async () => {

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -29,6 +29,7 @@ import {
 	ALLOWED_TO_DEVICE_EVENT_TYPES
 } from './orisoWidgetCapabilities';
 import { getElementCallBaseUrl } from '../../../resources/scripts/runtimeConfig';
+import { appConfig } from '../../../utils/appConfig';
 
 export interface ElementCallWidgetOptions {
 	/** The Matrix room the call takes place in. */
@@ -143,7 +144,12 @@ export const useElementCallWidget = (
 					confineToRoom: 'true',
 					header: 'none',
 					skipLobby: String(skipLobby),
-					perParticipantE2EE: 'true',
+					// See releaseToggles.enableCallMediaE2EE: Element Call only
+					// encrypts media when the host asks for it, because the host
+					// owns the crypto stack that distributes the media keys.
+					...(appConfig?.releaseToggles?.enableCallMediaE2EE === true
+						? { perParticipantE2EE: 'true' }
+						: {}),
 					intent: 'start_call',
 					callIntent: isVideo ? 'video' : 'audio'
 				}).toString()}`;

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -320,13 +320,34 @@ export const useElementCallWidget = (
 
 			const listener = (decryptedEvent: MatrixEvent, error?: Error) => {
 				if (error || decryptedEvent.getType() === 'm.room.encrypted') {
+					// Keep waiting: Megolm keys frequently arrive after the event,
+					// and the SDK re-runs decryption when they do. Only report it,
+					// so a call that stays silent is not silent in the log too.
+					console.warn(
+						'[call] call event still undecrypted, waiting for the key:',
+						event.getId(),
+						error?.message ?? 'no decryption error reported'
+					);
 					return;
 				}
 				clearPendingDecryption(event);
 				feedAllowedRoomEvent(decryptedEvent);
 			};
 			const timeout = setTimeout(
-				() => clearPendingDecryption(event),
+				() => {
+					// The widget never received this event. For
+					// `io.element.call.encryption_keys` that means media stays
+					// undecodable — the participant is connected but silent, with
+					// nothing else in the UI to explain it (see ElementCall#35).
+					console.error(
+						'[call] dropping call event that never decrypted:',
+						event.getId(),
+						'in',
+						event.getRoomId(),
+						'— media keys carried by this event are lost'
+					);
+					clearPendingDecryption(event);
+				},
 				5 * 60 * 1000
 			);
 			pendingDecryptions.set(event, { listener, timeout });

--- a/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
@@ -78,6 +78,16 @@ interface ReleaseToggles {
 	 */
 	enableInvisibleCrypto?: boolean;
 	/**
+	 * Per-participant media E2EE for calls: when on, the LiveKit SFU only ever
+	 * sees ciphertext. Off by default because media keys ride the MatrixRTC
+	 * to-device transport, so any gap in the host's Olm path makes a call
+	 * connect with no audio in either direction and no error anywhere
+	 * (ORISO-ElementCall#35). Turn it on per environment once a two-browser
+	 * call has proven key distribution end to end; call signalling and room
+	 * events are encrypted by the host regardless of this toggle.
+	 */
+	enableCallMediaE2EE?: boolean;
+	/**
 	 * #439 MSC3814 "dehydrated devices": when on, park a sleeping device
 	 * server-side so Megolm keys sent during a login gap are delivered and the
 	 * gap becomes readable on next login. Hard-depends on the key-backup /


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-ElementCall#35 — **needs ORISO-ElementCall#36 to take effect**

## Why

The widget URL asked Element Call for per-participant media E2EE unconditionally:

```ts
perParticipantE2EE: 'true',
```

so it turned on for every encrypted call room the moment the widget path shipped. Before the cutover, media was deliberately unencrypted and calls had audio.

Media keys ride the MatrixRTC **to-device** transport (`useExperimentalToDeviceTransport: true` in Element Call), so they depend entirely on this host's Olm path. Any gap there — a refused send, an undelivered key, an event that never decrypts — makes both participants publish media the other cannot decode. The call connects, neither side hears anything, and nothing reports an error. That is the shape of ElementCall#35, reported on both dev and Pre-Dev.

## Change

Drive the flag from `releaseToggles.enableCallMediaE2EE`, **default off**. An environment turns it on once a two-browser call has proven key distribution end to end — the order the cutover plan already prescribes ("media E2EE last, after the runtime gate").

What is **not** affected: call signalling, MatrixRTC membership and reactions stay encrypted, because those are encrypted by this client via the widget driver, not by Element Call. This toggle only controls whether the LiveKit SFU sees ciphertext or plaintext media — i.e. it restores exactly the pre-cutover posture, not a new weakening.

## Tests

`useElementCallWidget.test.tsx` now pins that the URL carries **no** `perParticipantE2EE` unless the toggle is on.

```
Test Files  3 passed (3)
     Tests  49 passed (49)
```

`tsc --noEmit` clean for the changed files; prettier clean.

## Honest scope

This does not prove where the key chain breaks — I could not run a two-browser call (brokered consultant/client sessions come back unauthenticated, and the local Docker backend would not pull on this network). It removes the unconditional switch that most plausibly caused the regression and makes the setting reversible without a redeploy. ORISO-Frontend#831 adds the logging that will name the failing link on the next call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting for per-participant end-to-end encryption in calls.
  * Improved handling of encrypted call events while waiting for decryption keys.
* **Bug Fixes**
  * Undecryptable events now retain retry handling temporarily and are safely discarded after five minutes.
  * Added clearer diagnostics for rejected or unsupported encrypted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->