### PR TITLE
fix(call): release camera and microphone when a call ends

### DIFF
--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -576,4 +576,30 @@ describe('useElementCallWidget', () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it('releases camera and microphone when the call ends, however it ended', async () => {
+		const client = createClient();
+		const { result, unmount } = renderHook(() =>
+			useElementCallWidget(client, { roomId: CALL_ROOM, isVideo: true })
+		);
+		await waitFor(() => expect(result.current.url).not.toBeNull());
+
+		const iframe = document.createElement('iframe');
+		iframe.src = result.current.url!;
+		act(() => result.current.attachIframe(iframe));
+		expect(iframe.src).toBe(result.current.url);
+
+		// Element Call hanging up on its own side unmounts the iframe, which
+		// calls the ref callback with null. Stopping the widget channel alone
+		// would leave the iframe document — and its capture — alive.
+		act(() => result.current.attachIframe(null));
+		expect(iframe.src).toBe('about:blank');
+
+		// And the same must hold when the surface simply unmounts.
+		const second = document.createElement('iframe');
+		second.src = result.current.url!;
+		act(() => result.current.attachIframe(second));
+		unmount();
+		expect(second.src).toBe('about:blank');
+	});
 });

--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -602,4 +602,29 @@ describe('useElementCallWidget', () => {
 		unmount();
 		expect(second.src).toBe('about:blank');
 	});
+
+	it('keeps a live call running when the same iframe is re-attached', async () => {
+		const client = createClient();
+		const { result } = renderHook(() =>
+			useElementCallWidget(client, { roomId: CALL_ROOM, isVideo: true })
+		);
+		await waitFor(() => expect(result.current.url).not.toBeNull());
+
+		const iframe = document.createElement('iframe');
+		iframe.src = result.current.url!;
+		act(() => result.current.attachIframe(iframe));
+
+		// React hands the same element to a new ref callback whenever that
+		// callback's identity changes. Releasing the devices here would kill
+		// the media of a call that is still running.
+		act(() => result.current.attachIframe(iframe));
+		expect(iframe.src).toBe(result.current.url);
+
+		// Swapping in a different iframe must still release the old one.
+		const replacement = document.createElement('iframe');
+		replacement.src = result.current.url!;
+		act(() => result.current.attachIframe(replacement));
+		expect(iframe.src).toBe('about:blank');
+		expect(replacement.src).toBe(result.current.url);
+	});
 });

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -198,7 +198,15 @@ export const useElementCallWidget = (
 			// stays lit after hanging up until the user reloads the page.
 			// Navigating it away destroys that document and releases the
 			// devices, whoever ended the call.
-			releaseIframeDevices(attachedIframeRef.current);
+			//
+			// Only when this iframe is really going away, though. React calls
+			// the previous ref callback with null and the new one with the same
+			// element whenever the callback's identity changes, so blanking
+			// unconditionally would tear the media out of a live call.
+			const previous = attachedIframeRef.current;
+			if (previous && previous !== iframe) {
+				releaseIframeDevices(previous);
+			}
 			attachedIframeRef.current = null;
 			if (messageGuardRef.current) {
 				window.removeEventListener(

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -74,6 +74,23 @@ const fragmentParams = (url: string): URLSearchParams => {
 	return new URLSearchParams(queryStart === -1 ? '' : hash.slice(queryStart));
 };
 
+/**
+ * Navigate a call iframe to a blank document so the browser releases the camera
+ * and microphone it holds.
+ *
+ * Removing the element from the DOM is not reliable enough on its own: the
+ * capture indicator can stay lit after a call ends, which on a counselling
+ * platform reads to the person on the other side as still being watched.
+ */
+const releaseIframeDevices = (iframe: HTMLIFrameElement | null): void => {
+	if (!iframe) return;
+	try {
+		iframe.src = 'about:blank';
+	} catch {
+		/* the iframe may already be detached; the devices go with it */
+	}
+};
+
 export const useElementCallWidget = (
 	client: MatrixClient | null,
 	{
@@ -88,6 +105,7 @@ export const useElementCallWidget = (
 	const [url, setUrl] = useState<string | null>(null);
 	const apiRef = useRef<ClientWidgetApi | null>(null);
 	const driverRef = useRef<OrisoWidgetDriver | null>(null);
+	const attachedIframeRef = useRef<HTMLIFrameElement | null>(null);
 	const instanceNonceRef = useRef(globalThis.crypto.randomUUID());
 	const messageGuardRef = useRef<
 		((event: MessageEvent<unknown>) => void) | null
@@ -175,6 +193,13 @@ export const useElementCallWidget = (
 				apiRef.current = null;
 				driverRef.current = null;
 			}
+			// Stopping the channel does not stop the call: the iframe document
+			// keeps its camera and microphone tracks, so the capture indicator
+			// stays lit after hanging up until the user reloads the page.
+			// Navigating it away destroys that document and releases the
+			// devices, whoever ended the call.
+			releaseIframeDevices(attachedIframeRef.current);
+			attachedIframeRef.current = null;
 			if (messageGuardRef.current) {
 				window.removeEventListener(
 					'message',
@@ -235,6 +260,7 @@ export const useElementCallWidget = (
 			});
 
 			driverRef.current = driver;
+			attachedIframeRef.current = iframe;
 			const api = new ClientWidgetApi(widget, iframe, driver);
 			apiRef.current = api;
 			api.setViewedRoomId(roomId);
@@ -433,6 +459,8 @@ export const useElementCallWidget = (
 		() => () => {
 			apiRef.current?.stop();
 			apiRef.current = null;
+			releaseIframeDevices(attachedIframeRef.current);
+			attachedIframeRef.current = null;
 			if (messageGuardRef.current) {
 				window.removeEventListener(
 					'message',


### PR DESCRIPTION
Reported on Pre-Dev: after hanging up, the camera indicator stayed lit until the page was reloaded — *"felt like someone watching you"*. On a counselling platform that is a privacy defect, not a cosmetic one.

## Cause

The host tore down the widget channel on every path, but only **one** path actually stopped the capture:

```ts
// handleEndCall — the host's own red button
void widget.hangup();
iframeRef.current.src = 'about:blank';   // ← releases the devices
closeCallSurface();
```

Ending the call **inside Element Call** — its own hangup button, which is what users press — arrives as `im.vector.hangup` and goes through `onClose` → `closeCallSurface`, which only clears React state and relies on unmount.

That is not enough. `apiRef.current.stop()` stops the *postMessage channel*, not the call: the iframe document keeps its `MediaStreamTrack`s, and removing the element from the DOM does not reliably release camera and microphone either. So the devices stayed open until a reload tore the document down.

## Fix

Navigate the attached iframe to `about:blank` on **every** teardown path, inside the hook that owns it:

- when a new iframe replaces the current one,
- when the ref callback passes `null` (React unmounting the iframe — the Element-Call-initiated path),
- when the hook itself unmounts.

Destroying the document releases the devices deterministically, regardless of who ended the call. No behaviour change beyond that.

## Test

New regression test drives both routes — `attachIframe(null)` and hook `unmount()` — and asserts the iframe was navigated to `about:blank`. Verified it fails without the source change:

```
× releases camera and microphone when the call ends, however it ended
  Tests  1 failed | 9 passed
```

With the fix: **10 passed**. `tsc --noEmit` and `eslint --max-warnings 0` clean on the changed files.

## Context

Found while working through the Pre-Dev call outage (ORISO-ElementCall#35, ORISO-Livekit#20). Calls now connect after four infrastructure fixes; this was the first defect in the *application* layer rather than the infrastructure, and it only became visible once calls survived long enough to be hung up normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Camera and microphone access are now reliably released when the call iframe is replaced or closed.
  * Prevents devices from remaining active after leaving or reloading an embedded call.

* **Tests**
  * Added regression coverage to verify device capture is released during iframe detachment and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->