### PR TITLE
fix(call): release the devices before the iframe is detached

### DIFF
--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -31,6 +31,15 @@ export const GroupCallWidget: React.FC = () => {
 	const [isDismissed, setIsDismissed] = useState(false);
 
 	const closeCallSurface = useCallback(() => {
+		// Release camera and microphone while the iframe is still in the
+		// document. Clearing the state below unmounts it, and navigating an
+		// iframe that the browser has already detached does not load anything —
+		// the capture would stay alive until a reload. This is the path Element
+		// Call's own hangup button takes, so it has to release here rather than
+		// rely on the teardown in useElementCallWidget.
+		if (iframeRef.current) {
+			iframeRef.current.src = 'about:blank';
+		}
 		setElementCallUrl('');
 		setCallData(null);
 		setCallState(null);


### PR DESCRIPTION
Follow-up to #836 — the capture indicator still stayed lit on Pre-Dev after ending a call with **Element Call's own hangup button**.

## Why #836 was not enough

#836 releases the devices in the hook's teardown, which React invokes around unmount. By then the browser may already have **detached** the iframe — and navigating a detached iframe loads nothing, so `src = 'about:blank'` silently does not release the capture.

That is exactly the path users take. Element Call's red button reaches the host as `im.vector.hangup` → `onClose` → `closeCallSurface`, which clears React state and unmounts the surface. The host's *own* end-call button never had this problem, because it blanks the iframe first, while it is still in the document:

```ts
// handleEndCall — worked all along
iframeRef.current.src = 'about:blank';
closeCallSurface();
```

## Fix

Do the same in `closeCallSurface`, before the state clears and the surface unmounts. The teardown in `useElementCallWidget` stays as the backstop for the replacement and unmount paths, including the re-attachment guard from #836.

## Verification

`src/components/call` suite: **52 passed**. `tsc --noEmit` and `eslint --max-warnings 0` clean.

This one needs a human check on Pre-Dev, because the failure is a browser-level capture indicator that no unit test can observe: start a call, end it with **Element Call's red button**, and confirm the camera indicator goes out **without** reloading.

## Note on the earlier report

The previous round of testing did not disprove #836 — it never ran it. The deploy landed on `oriso-dev-master1` while `predev.oriso.org` serves `46.224.170.69`, so Pre-Dev was still running a 19-hour-old bundle. #836 is now genuinely deployed there, and this PR fixes the remaining path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call shutdown to reliably release camera and microphone access when closing a call.
  * Ensured the call interface is cleared cleanly before being removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->