### PR TITLE
fix(theme): sweep brand-red literals onto the --m3-* token contract (#143)

### DIFF
--- a/scripts/theme-migration/mapping.json
+++ b/scripts/theme-migration/mapping.json
@@ -53,7 +53,12 @@
 		"#4c555f": "--m3-secondary",
 		"#4b515a": "--m3-secondary",
 		"#c6c5c4": "--m3-outline-variant",
-		"#5f6873": "--m3-secondary-container"
+		"#5f6873": "--m3-secondary-container",
+		"#a5000a": "--m3-primary",
+		"#820006": "--m3-primary-hover",
+		"#7e0008": "--m3-primary-hover",
+		"#930008": "--m3-primary-outline",
+		"#ffdad7": "--m3-primary-fixed"
 	},
 	"untouchedHex": [
 		"#fff",
@@ -111,10 +116,8 @@
 		"#7f1d1d",
 		"#8c878c",
 		"#8d97a5",
-		"#930008",
 		"#9e9e9e",
 		"#a31816",
-		"#a5000a",
 		"#b42334",
 		"#b91c1c",
 		"#bdbdbd",

--- a/src/components/Switch/switch.module.scss
+++ b/src/components/Switch/switch.module.scss
@@ -5,8 +5,8 @@
 .switch {
 	--switch-primary: var(--m3-primary, #a5000a);
 	--switch-primary-container: var(--m3-primary-container, #cc1e1c);
-	--switch-on-primary: #ffffff;
-	--switch-on-primary-container: #ffe2de;
+	--switch-on-primary: var(--m3-on-primary, #ffffff);
+	--switch-on-primary-container: var(--m3-on-primary-container, #ffe2de);
 	--switch-surface: #fcf9f9;
 	--switch-surface-container-highest: #e4e2e2;
 	--switch-on-surface: #1b1b1c;

--- a/src/components/Switch/switch.module.scss
+++ b/src/components/Switch/switch.module.scss
@@ -3,8 +3,8 @@
 }
 
 .switch {
-	--switch-primary: #a5000a;
-	--switch-primary-container: #cc1e1c;
+	--switch-primary: var(--m3-primary, #a5000a);
+	--switch-primary-container: var(--m3-primary-container, #cc1e1c);
 	--switch-on-primary: #ffffff;
 	--switch-on-primary-container: #ffe2de;
 	--switch-surface: #fcf9f9;
@@ -12,7 +12,7 @@
 	--switch-on-surface: #1b1b1c;
 	--switch-on-surface-variant: #444748;
 	--switch-outline: #747878;
-	--switch-focus: #4c555f;
+	--switch-focus: var(--m3-secondary, #4c555f);
 
 	align-items: center;
 	cursor: pointer;
@@ -156,6 +156,7 @@
 
 .switch:hover .input:not(:disabled):checked + .track .target {
 	background: rgba(165, 0, 10, 0.08);
+	background: color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent);
 }
 
 .switch:hover .input:not(:disabled):checked + .track .handle {
@@ -174,6 +175,7 @@
 
 .switch:active .input:not(:disabled):checked + .track .target {
 	background: rgba(165, 0, 10, 0.1);
+	background: color-mix(in srgb, var(--m3-primary, #a5000a) 10%, transparent);
 }
 
 .input:focus-visible + .track {

--- a/src/components/app/navigation.styles.scss
+++ b/src/components/app/navigation.styles.scss
@@ -392,7 +392,7 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 					.navigation__icon-slot--row
 					.navigation__icon__filled {
 					display: block;
-					color: #930008;
+					color: var(--m3-primary-outline, #930008);
 					fill: currentColor;
 				}
 
@@ -761,7 +761,7 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 	}
 
 	&__item__count {
-		color: #930008;
+		color: var(--m3-primary-outline, #930008);
 		background-color: #ffffff;
 	}
 

--- a/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
+++ b/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
@@ -26,7 +26,7 @@
 
 	&__subtitle {
 		font-size: 12px;
-		color: #646d78;
+		color: var(--m3-secondary-container, #646d78);
 		margin: 0;
 		line-height: 17px;
 	}
@@ -76,11 +76,16 @@
 		&:focus-visible:not(:disabled, &--disabled),
 		&--active:not(:disabled, &--disabled) {
 			background-color: rgba(165, 0, 10, 0.08);
+			background-color: color-mix(
+				in srgb,
+				var(--m3-primary, #a5000a) 8%,
+				transparent
+			);
 			outline: none;
 
 			.chatMenuDropdown__itemTitle,
 			.chatMenuDropdown__itemShortcut {
-				color: #a5000a;
+				color: var(--m3-primary, #a5000a);
 			}
 
 			.chatMenuDropdown__itemDescription {
@@ -88,7 +93,7 @@
 			}
 
 			.chatMenuDropdown__itemIcon {
-				color: #a5000a;
+				color: var(--m3-primary, #a5000a);
 			}
 		}
 

--- a/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
+++ b/src/components/chatMenuDropdown/chatMenuDropdown.styles.scss
@@ -89,7 +89,7 @@
 			}
 
 			.chatMenuDropdown__itemDescription {
-				color: #410001;
+				color: var(--m3-on-primary-fixed, #410001);
 			}
 
 			.chatMenuDropdown__itemIcon {

--- a/src/components/form/orisoInputDesign.ts
+++ b/src/components/form/orisoInputDesign.ts
@@ -1,22 +1,30 @@
+// #143: role colours read the runtime --m3-* tokens so tenant seeds reach the
+// form fields; the literal fallbacks keep today's rendering when no palette is
+// injected. `error` stays literal: the static --m3-error (#cc0000) would
+// override the intended magenta error role.
 export const orisoInputColors = {
-	onSurface: '#1b1b1c',
-	onSurfaceVariant: '#444748',
-	outline: '#747878',
-	outlineVariant: '#747878',
-	surface: '#fcf9f9',
-	surfaceContainerLowest: '#fcf9f9',
-	surfaceContainerLow: '#f7f4f4',
-	surfaceContainer: '#f1eeee',
-	surfaceContainerHigh: '#ebe8e8',
-	secondary: '#4c555f',
-	onSecondary: '#ffffff',
-	primary: '#a5000a',
-	onPrimary: '#ffffff',
-	primaryDark: '#7e0008',
+	onSurface: 'var(--m3-on-surface, #1b1b1c)',
+	onSurfaceVariant: 'var(--m3-on-surface-variant, #444748)',
+	outline: 'var(--m3-outline, #747878)',
+	// value-matched to --m3-outline on purpose: the fields use the darker
+	// outline tone for both states, --m3-outline-variant is far lighter.
+	outlineVariant: 'var(--m3-outline, #747878)',
+	surface: 'var(--m3-surface, #fcf9f9)',
+	surfaceContainerLowest: 'var(--m3-surface-container-lowest, #fcf9f9)',
+	surfaceContainerLow: 'var(--m3-surface-container-low, #f7f4f4)',
+	surfaceContainer: 'var(--m3-surface-container, #f1eeee)',
+	surfaceContainerHigh: 'var(--m3-surface-container-high, #ebe8e8)',
+	secondary: 'var(--m3-secondary, #4c555f)',
+	onSecondary: 'var(--m3-on-secondary, #ffffff)',
+	primary: 'var(--m3-primary, #a5000a)',
+	onPrimary: 'var(--m3-on-primary, #ffffff)',
+	primaryDark: 'var(--m3-primary-hover, #7e0008)',
 	error: '#b1005e',
-	focus: '#a5000a',
-	focusLayer: 'rgba(165, 0, 10, 0.08)',
-	selectedLayer: 'rgba(165, 0, 10, 0.08)',
+	focus: 'var(--m3-primary, #a5000a)',
+	focusLayer:
+		'color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)',
+	selectedLayer:
+		'color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)',
 	hoverLayer: 'rgba(27, 27, 28, 0.04)'
 } as const;
 

--- a/src/components/form/orisoInputDesign.ts
+++ b/src/components/form/orisoInputDesign.ts
@@ -21,10 +21,12 @@ export const orisoInputColors = {
 	primaryDark: 'var(--m3-primary-hover, #7e0008)',
 	error: '#b1005e',
 	focus: 'var(--m3-primary, #a5000a)',
-	focusLayer:
-		'color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)',
-	selectedLayer:
-		'color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)',
+	// State layers stay rgba literals: these are single CSS-in-JS values,
+	// so there is no second declaration to fall back to — an engine
+	// without color-mix() would drop the style entirely (CodeRabbit
+	// #848). The focus INDICATION itself is the themed border above.
+	focusLayer: 'rgba(165, 0, 10, 0.08)',
+	selectedLayer: 'rgba(165, 0, 10, 0.08)',
 	hoverLayer: 'rgba(27, 27, 28, 0.04)'
 } as const;
 

--- a/src/components/legalLinks/legalLinkModal.styles.scss
+++ b/src/components/legalLinks/legalLinkModal.styles.scss
@@ -31,7 +31,7 @@
 	}
 
 	a {
-		color: #a5000a;
+		color: var(--m3-primary, #a5000a);
 		text-decoration: underline;
 	}
 }

--- a/src/components/login/login.styles.scss
+++ b/src/components/login/login.styles.scss
@@ -281,7 +281,7 @@ $link-hover-text-decoration: $link-text-decoration !default;
 		background: var(--m3-primary, #a5000a);
 		border: none;
 		border-radius: 28px;
-		color: white;
+		color: var(--m3-on-primary, #ffffff);
 		font-size: 15px;
 		font-weight: 600;
 		letter-spacing: 0.3px;

--- a/src/components/login/login.styles.scss
+++ b/src/components/login/login.styles.scss
@@ -26,6 +26,8 @@ $link-hover-text-decoration: $link-text-decoration !default;
 	background: #ffffff;
 	position: relative;
 	border: 0px solid rgba(220, 38, 38, 0.3);
+	border: 0px solid
+		color-mix(in srgb, var(--m3-primary, #a5000a) 30%, transparent);
 	border-radius: 20px;
 	animation: fadeIn 0.5s ease-out;
 	transition: transform 0.3s ease;
@@ -105,6 +107,12 @@ $link-hover-text-decoration: $link-text-decoration !default;
 				background: white;
 				outline: none;
 				box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.05);
+				box-shadow: 0 0 0 3px
+					color-mix(
+						in srgb,
+						var(--m3-primary, #a5000a) 5%,
+						transparent
+					);
 			}
 
 			&::placeholder {
@@ -163,6 +171,8 @@ $link-hover-text-decoration: $link-text-decoration !default;
 			background: #ffffff;
 			color: #111827;
 			box-shadow: inset 0 -2px 0 rgba(216, 0, 3, 0.8);
+			box-shadow: inset 0 -2px 0
+				color-mix(in srgb, var(--m3-primary, #a5000a) 80%, transparent);
 		}
 	}
 
@@ -268,7 +278,7 @@ $link-hover-text-decoration: $link-text-decoration !default;
 		max-width: 100%;
 		margin-top: 25px;
 		padding: 15px 24px;
-		background: rgba(216, 0, 3);
+		background: var(--m3-primary, #a5000a);
 		border: none;
 		border-radius: 28px;
 		color: white;
@@ -276,12 +286,20 @@ $link-hover-text-decoration: $link-text-decoration !default;
 		font-weight: 600;
 		letter-spacing: 0.3px;
 		box-shadow: 0 4px 15px rgba(220, 38, 38, 0.3);
+		box-shadow: 0 4px 15px
+			color-mix(in srgb, var(--m3-primary, #a5000a) 30%, transparent);
 		transition: all 0.3s ease;
 		transform: $login-icon-transform;
 
 		&:hover:not(:disabled) {
-			background: linear-gradient(135deg, #b91c1c 0%, #7f1d1d 100%);
+			background: linear-gradient(
+				135deg,
+				var(--m3-primary, #b91c1c) 0%,
+				var(--m3-primary-hover, #7f1d1d) 100%
+			);
 			box-shadow: 0 6px 20px rgba(220, 38, 38, 0.4);
+			box-shadow: 0 6px 20px
+				color-mix(in srgb, var(--m3-primary, #a5000a) 40%, transparent);
 			transform: translateY(-2px);
 		}
 

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -793,7 +793,7 @@ $message-avatar-overlap: -19px;
 
 		&--systemNotification {
 			background: #fffafa;
-			border: 1px solid #ffdad5;
+			border: 1px solid var(--m3-primary-fixed, #ffdad5);
 			border-radius: 12px;
 		}
 
@@ -832,6 +832,11 @@ $message-avatar-overlap: -19px;
 			padding: 4px 0 4px 10px;
 			border-left: 3px solid var(--m3-primary-container, #cc1e1c); // incoming + default quote color
 			background: rgba(204, 30, 28, 0.06);
+			background: color-mix(
+				in srgb,
+				var(--m3-primary, #a5000a) 6%,
+				transparent
+			);
 			border-radius: 0 6px 6px 0;
 		}
 
@@ -1029,7 +1034,7 @@ $message-avatar-overlap: -19px;
 				}
 
 				.messageItem__message__attachment__meta {
-					color: #a5000a;
+					color: var(--m3-primary, #a5000a);
 				}
 			}
 
@@ -1109,6 +1114,11 @@ $message-avatar-overlap: -19px;
 			blockquote {
 				border-left-color: var(--m3-primary, $primary);
 				background: rgba(165, 0, 10, 0.08);
+				background: color-mix(
+					in srgb,
+					var(--m3-primary, #a5000a) 8%,
+					transparent
+				);
 			}
 		}
 	}

--- a/src/components/messageSubmitInterface/TipTapComposer.styles.scss
+++ b/src/components/messageSubmitInterface/TipTapComposer.styles.scss
@@ -101,6 +101,11 @@
 				border-left: 3px solid var(--m3-primary-container, #cc1e1c);
 				color: #4a5561;
 				background: rgba(204, 30, 28, 0.04);
+				background: color-mix(
+					in srgb,
+					var(--m3-primary, #a5000a) 4%,
+					transparent
+				);
 				border-radius: 0 6px 6px 0;
 			}
 		}

--- a/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
+++ b/src/components/messageSubmitInterface/messageSubmitInterface.styles.scss
@@ -490,7 +490,7 @@ $inputBoxShadow: inset 0 2px 0 0 #ffffff;
 			padding: 2px 7px;
 			border-radius: 10px;
 			background: rgba(255, 255, 255, 0.92);
-			color: #646d78;
+			color: var(--m3-secondary-container, #646d78);
 			font-size: 11px;
 			font-weight: 500;
 			line-height: 16px;

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -261,7 +261,7 @@
 			border: none;
 			border-radius: 50%;
 			background: var(--m3-primary, #a5000a);
-			color: #ffffff;
+			color: var(--m3-on-primary, #ffffff);
 
 			svg {
 				fill: #ffffff;
@@ -345,7 +345,7 @@
 		border: none;
 		border-radius: 23px;
 		background: var(--m3-primary, #a5000a);
-		color: #ffffff;
+		color: var(--m3-on-primary, #ffffff);
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -466,7 +466,7 @@
 		border: none;
 		border-radius: 999px;
 		background: var(--m3-primary, #a5000a);
-		color: #ffffff;
+		color: var(--m3-on-primary, #ffffff);
 		font-size: 16px;
 		font-weight: 600;
 		cursor: pointer;
@@ -541,7 +541,7 @@
 	&__consentButton--approve {
 		border-color: var(--m3-primary, #a5000a);
 		background: var(--m3-primary, #a5000a);
-		color: #ffffff;
+		color: var(--m3-on-primary, #ffffff);
 	}
 
 	&__embeddedSessionFrame {

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -145,7 +145,7 @@
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 
 		svg {
 			width: 20px;
@@ -224,7 +224,7 @@
 		width: 8px;
 		height: 8px;
 		border-radius: 50%;
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 	}
 
 	// The selected notification pops out of the stack with vertical spacing
@@ -245,7 +245,7 @@
 	// Selecting a card grows it in subtly (same easing as the toolbar chips).
 	&__card--active {
 		background: #ffffff;
-		border: 2px solid #a5000a;
+		border: 2px solid var(--m3-primary, #a5000a);
 		border-radius: 28px;
 		padding: 15px 19px;
 		animation: notificationsCenterCardActivate 240ms
@@ -254,13 +254,13 @@
 
 		&:hover {
 			background: #ffffff;
-			border-color: #a5000a;
+			border-color: var(--m3-primary, #a5000a);
 		}
 
 		.notificationsCenter__cardIcon {
 			border: none;
 			border-radius: 50%;
-			background: #a5000a;
+			background: var(--m3-primary, #a5000a);
 			color: #ffffff;
 
 			svg {
@@ -273,7 +273,7 @@
 		}
 
 		.notificationsCenter__cardConnector {
-			border-left-color: #a5000a;
+			border-left-color: var(--m3-primary, #a5000a);
 			min-height: 35px;
 		}
 
@@ -287,7 +287,7 @@
 		}
 
 		.notificationsCenter__cardTime--footer {
-			color: #a5000a;
+			color: var(--m3-primary, #a5000a);
 			font-weight: 600;
 		}
 
@@ -313,7 +313,7 @@
 		appearance: none;
 		width: 44px;
 		height: 28px;
-		border: 1px solid #ffdad5;
+		border: 1px solid var(--m3-primary-fixed, #ffdad5);
 		border-radius: 999px;
 		background: #ffffff;
 		color: #444748;
@@ -328,7 +328,7 @@
 		}
 
 		&:hover {
-			background: #ffdad7;
+			background: var(--m3-primary-fixed, #ffdad7);
 		}
 
 		&:focus-visible {
@@ -344,7 +344,7 @@
 		width: 46px;
 		border: none;
 		border-radius: 23px;
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 		color: #ffffff;
 		display: inline-flex;
 		align-items: center;
@@ -360,7 +360,7 @@
 		&:hover,
 		&--open,
 		&--open:hover {
-			background: #7e0008;
+			background: var(--m3-primary-hover, #7e0008);
 		}
 
 		&:focus-visible {
@@ -386,7 +386,7 @@
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		border: 1.5px solid #a5000a;
+		border: 1.5px solid var(--m3-primary, #a5000a);
 		border-radius: 32px;
 		background: #ffffff;
 		overflow: hidden;
@@ -465,7 +465,7 @@
 		padding: 0 32px;
 		border: none;
 		border-radius: 999px;
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 		color: #ffffff;
 		font-size: 16px;
 		font-weight: 600;
@@ -478,7 +478,7 @@
 		}
 
 		&:hover {
-			background: #7e0008;
+			background: var(--m3-primary-hover, #7e0008);
 		}
 
 		&:focus-visible {
@@ -492,7 +492,7 @@
 		border: 1px solid #c4c7c7;
 		border-radius: 999px;
 		background: #ffffff;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		font-size: 15px;
 		font-weight: 600;
 		cursor: pointer;
@@ -524,7 +524,7 @@
 		border: 1px solid #c4c7c7;
 		border-radius: 999px;
 		background: #ffffff;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		font-weight: 700;
 		cursor: pointer;
 
@@ -539,8 +539,8 @@
 	}
 
 	&__consentButton--approve {
-		border-color: #a5000a;
-		background: #a5000a;
+		border-color: var(--m3-primary, #a5000a);
+		background: var(--m3-primary, #a5000a);
 		color: #ffffff;
 	}
 

--- a/src/components/profile/NotificationSettings/notificationConfigDialog.styles.scss
+++ b/src/components/profile/NotificationSettings/notificationConfigDialog.styles.scss
@@ -85,7 +85,7 @@
 		height: 24px;
 		border: none;
 		background: transparent;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		padding: 0;
 		cursor: pointer;
 
@@ -204,7 +204,7 @@
 	&__signalText {
 		margin: 0 0 10px;
 		font-size: 13px;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 	}
 
 	&__signalThanks {

--- a/src/components/pseudonym/AnonymousConsentGate.styles.scss
+++ b/src/components/pseudonym/AnonymousConsentGate.styles.scss
@@ -184,6 +184,7 @@
 
 	&:hover:not(:disabled) {
 		background: var(--m3-primary, #a5000a);
+		color: var(--m3-on-primary, #ffffff);
 	}
 }
 

--- a/src/components/pseudonym/AnonymousConsentGate.styles.scss
+++ b/src/components/pseudonym/AnonymousConsentGate.styles.scss
@@ -90,7 +90,7 @@
 		text-decoration: underline;
 
 		&:hover {
-			color: #a5000a;
+			color: var(--m3-primary, #a5000a);
 		}
 	}
 }
@@ -100,7 +100,7 @@
 	font-size: 14px;
 	line-height: 1.4em;
 	font-weight: 500;
-	color: #a5000a;
+	color: var(--m3-primary, #a5000a);
 	background: #fde8e8;
 	border: 1px solid #f5bcbb;
 	border-radius: 10px;
@@ -183,7 +183,7 @@
 	color: var(--m3-on-primary-container, #ffe2de);
 
 	&:hover:not(:disabled) {
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 	}
 }
 

--- a/src/components/pseudonym/BreathingTutorialCard.styles.scss
+++ b/src/components/pseudonym/BreathingTutorialCard.styles.scss
@@ -199,6 +199,7 @@
 
 	&:hover:not(:disabled) {
 		background: var(--m3-primary, #a5000a);
+		color: var(--m3-on-primary, #ffffff);
 	}
 }
 

--- a/src/components/pseudonym/BreathingTutorialCard.styles.scss
+++ b/src/components/pseudonym/BreathingTutorialCard.styles.scss
@@ -198,7 +198,7 @@
 	color: var(--m3-on-primary-container, #ffe2de);
 
 	&:hover:not(:disabled) {
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 	}
 }
 

--- a/src/components/pseudonym/PseudonymActionBar.styles.scss
+++ b/src/components/pseudonym/PseudonymActionBar.styles.scss
@@ -64,7 +64,7 @@
 	flex: 1 1 auto;
 	border-radius: 999px;
 	background: var(--m3-primary, #a5000a);
-	color: #ffffff;
+	color: var(--m3-on-primary, #ffffff);
 
 	&:hover:not(:disabled) {
 		background: #8a0008;

--- a/src/components/pseudonym/PseudonymActionBar.styles.scss
+++ b/src/components/pseudonym/PseudonymActionBar.styles.scss
@@ -63,7 +63,7 @@
 .pseudonymActionBar__btnContinue {
 	flex: 1 1 auto;
 	border-radius: 999px;
-	background: #a5000a;
+	background: var(--m3-primary, #a5000a);
 	color: #ffffff;
 
 	&:hover:not(:disabled) {

--- a/src/components/pseudonym/WaitingQueueActionBar.styles.scss
+++ b/src/components/pseudonym/WaitingQueueActionBar.styles.scss
@@ -147,6 +147,10 @@
 		0 0 0 0 rgba(165, 0, 10, 0.28),
 		0 4px 8px 3px rgba(0, 0, 0, 0.15),
 		0 1px 3px 0 rgba(0, 0, 0, 0.3);
+	box-shadow:
+		0 0 0 0 color-mix(in srgb, var(--m3-primary, #a5000a) 28%, transparent),
+		0 4px 8px 3px rgba(0, 0, 0, 0.15),
+		0 1px 3px 0 rgba(0, 0, 0, 0.3);
 	overflow: hidden;
 	animation: waitingQueueActionBar-outlineGlow 4.8s ease-in-out infinite;
 }
@@ -476,12 +480,22 @@
 			0 0 0 0 rgba(165, 0, 10, 0.22),
 			0 4px 8px 3px rgba(0, 0, 0, 0.15),
 			0 1px 3px 0 rgba(0, 0, 0, 0.3);
+		box-shadow:
+			0 0 0 0
+				color-mix(in srgb, var(--m3-primary, #a5000a) 22%, transparent),
+			0 4px 8px 3px rgba(0, 0, 0, 0.15),
+			0 1px 3px 0 rgba(0, 0, 0, 0.3);
 	}
 
 	48% {
 		border-color: rgba(255, 255, 255, 0.9);
 		box-shadow:
 			0 0 0 9px rgba(165, 0, 10, 0.18),
+			0 4px 8px 3px rgba(0, 0, 0, 0.15),
+			0 1px 3px 0 rgba(0, 0, 0, 0.3);
+		box-shadow:
+			0 0 0 9px
+				color-mix(in srgb, var(--m3-primary, #a5000a) 18%, transparent),
 			0 4px 8px 3px rgba(0, 0, 0, 0.15),
 			0 1px 3px 0 rgba(0, 0, 0, 0.3);
 	}

--- a/src/components/registration/registrationDesign/registrationDesign.ts
+++ b/src/components/registration/registrationDesign/registrationDesign.ts
@@ -37,8 +37,10 @@ import u25Prevention05 from '../../../resources/img/registration-md3/icons/t-05-
 
 export const registrationMd3 = {
 	...orisoInputColors,
+	// #143: hero panel follows the tenant primary family; the literal stops
+	// keep the designed red gradient when no palette is injected.
 	heroGradient:
-		'linear-gradient(152deg, #DA2530 0%, #C0121F 46%, #7C0D15 100%)'
+		'linear-gradient(152deg, var(--m3-primary-container, #DA2530) 0%, var(--m3-primary, #C0121F) 46%, var(--m3-primary-hover, #7C0D15) 100%)'
 } as const;
 
 export const registrationMd3TextFieldSx = orisoTextFieldSx;

--- a/src/components/select/select.react.styles.scss
+++ b/src/components/select/select.react.styles.scss
@@ -74,6 +74,10 @@ $inputHeight: 50px;
 				--m3-selected-layer,
 				rgba(165, 0, 10, 0.08)
 			) !important;
+			background-color: var(
+				--m3-selected-layer,
+				color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)
+			) !important;
 
 			&:hover {
 				// The `!important` annotation is relevant to not be overridden by inline styles.
@@ -81,6 +85,14 @@ $inputHeight: 50px;
 				background-color: var(
 					--m3-selected-layer,
 					rgba(165, 0, 10, 0.12)
+				) !important;
+				background-color: var(
+					--m3-selected-layer,
+					color-mix(
+						in srgb,
+						var(--m3-primary, #a5000a) 12%,
+						transparent
+					)
 				) !important;
 
 				.select__input__multi-value__label,

--- a/src/components/select/select2.react.styles.scss
+++ b/src/components/select/select2.react.styles.scss
@@ -68,6 +68,10 @@ $inputHeight: 50px;
 				--m3-selected-layer,
 				rgba(165, 0, 10, 0.08)
 			) !important;
+			background-color: var(
+				--m3-selected-layer,
+				color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent)
+			) !important;
 
 			&:hover {
 				// The `!important` annotation is relevant to not be overridden by inline styles.
@@ -75,6 +79,14 @@ $inputHeight: 50px;
 				background-color: var(
 					--m3-selected-layer,
 					rgba(165, 0, 10, 0.12)
+				) !important;
+				background-color: var(
+					--m3-selected-layer,
+					color-mix(
+						in srgb,
+						var(--m3-primary, #a5000a) 12%,
+						transparent
+					)
 				) !important;
 
 				.select__input__multi-value__label,

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -557,6 +557,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 
 		&:hover:not(:disabled) {
 			background: var(--m3-primary, #a5000a);
+			color: var(--m3-on-primary, #ffffff);
 		}
 	}
 
@@ -599,6 +600,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 
 		&:hover:not(:disabled) {
 			background: var(--m3-primary, #a5000a);
+			color: var(--m3-on-primary, #ffffff);
 		}
 
 		&:active:not(:disabled) {

--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -556,7 +556,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 			0 1px 3px 0 rgba(0, 0, 0, 0.3);
 
 		&:hover:not(:disabled) {
-			background: #a5000a;
+			background: var(--m3-primary, #a5000a);
 		}
 	}
 
@@ -598,7 +598,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 			transform 160ms ease;
 
 		&:hover:not(:disabled) {
-			background: #a5000a;
+			background: var(--m3-primary, #a5000a);
 		}
 
 		&:active:not(:disabled) {
@@ -1027,7 +1027,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		text-align: center;
 		font-size: 15px;
 		line-height: 1.4;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		background-color: #f4f6f9;
 	}
 
@@ -1083,6 +1083,8 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 
 	&__waitingModulePreset {
 		border: 1px solid rgba(204, 30, 28, 0.25);
+		border: 1px solid
+			color-mix(in srgb, var(--m3-primary, #a5000a) 25%, transparent);
 		background: #fff;
 		color: #a91a1a;
 		border-radius: 999px;
@@ -1093,6 +1095,11 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 
 		&--active {
 			background: rgba(204, 30, 28, 0.12);
+			background: color-mix(
+				in srgb,
+				var(--m3-primary, #a5000a) 12%,
+				transparent
+			);
 			color: #8c1111;
 		}
 	}
@@ -1180,6 +1187,8 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 			rgba(205, 27, 27, 0.85)
 		);
 		box-shadow: 0 0 16px rgba(204, 30, 28, 0.36);
+		box-shadow: 0 0 16px
+			color-mix(in srgb, var(--m3-primary, #a5000a) 36%, transparent);
 		animation: breathing-pulse-orbit 7s linear infinite;
 	}
 
@@ -1503,6 +1512,11 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 			background: #fff;
 			color: #b01919;
 			border-color: rgba(204, 30, 28, 0.32);
+			border-color: color-mix(
+				in srgb,
+				var(--m3-primary, #a5000a) 32%,
+				transparent
+			);
 		}
 
 		&--secondary {
@@ -1561,7 +1575,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		}
 
 		&--red {
-			background: #a5000a;
+			background: var(--m3-primary, #a5000a);
 			clip-path: inset(0 6px);
 		}
 	}
@@ -1604,7 +1618,7 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 		width: 4px;
 		height: 44px;
 		border-radius: 4px;
-		background: #a5000a;
+		background: var(--m3-primary, #a5000a);
 		pointer-events: none;
 	}
 
@@ -2303,9 +2317,13 @@ $session-scroll-to-bottom-radius: $button-border-radius !default;
 	0%,
 	100% {
 		box-shadow: 0 0 0 rgba(204, 30, 28, 0.24);
+		box-shadow: 0 0 0
+			color-mix(in srgb, var(--m3-primary, #a5000a) 24%, transparent);
 	}
 	50% {
 		box-shadow: 0 0 18px rgba(204, 30, 28, 0.4);
+		box-shadow: 0 0 18px
+			color-mix(in srgb, var(--m3-primary, #a5000a) 40%, transparent);
 	}
 }
 

--- a/src/components/sessionsList/sessionsList.styles.scss
+++ b/src/components/sessionsList/sessionsList.styles.scss
@@ -443,6 +443,10 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 		box-shadow:
 			0 0 0 1px rgba(165, 0, 10, 0.22),
 			0 3px 10px rgba(0, 0, 0, 0.14);
+		box-shadow:
+			0 0 0 1px
+				color-mix(in srgb, var(--m3-primary, #a5000a) 22%, transparent),
+			0 3px 10px rgba(0, 0, 0, 0.14);
 		transform: translateY(-50%) scaleX(1.08);
 	}
 
@@ -1311,8 +1315,8 @@ $caseHandoverBodyText: var(--m3-on-surface, #30343a);
 	}
 
 	&__searchModalTab--active {
-		color: #a5000a;
-		border-bottom-color: #a5000a;
+		color: var(--m3-primary, #a5000a);
+		border-bottom-color: var(--m3-primary, #a5000a);
 	}
 
 	&__searchModalTabIcon {

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -451,6 +451,11 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		width: 100%;
 		height: 1px;
 		background-color: rgba(204, 30, 28, 0.15);
+		background-color: color-mix(
+			in srgb,
+			var(--m3-primary, #a5000a) 15%,
+			transparent
+		);
 		margin: 8px 0;
 	}
 
@@ -481,7 +486,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 			.sessionsListItem__dropdownOptionTitle,
 			.sessionsListItem__dropdownOptionShortcut {
-				color: #a5000a;
+				color: var(--m3-primary, #a5000a);
 			}
 
 			.sessionsListItem__dropdownOptionDescription {
@@ -491,12 +496,14 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 		&:focus-visible:not(:disabled) {
 			outline: 2px solid rgba(204, 30, 28, 0.42);
+			outline: 2px solid
+				color-mix(in srgb, var(--m3-primary, #a5000a) 42%, transparent);
 			outline-offset: -2px;
 			background-color: #e7effc;
 
 			.sessionsListItem__dropdownOptionTitle,
 			.sessionsListItem__dropdownOptionShortcut {
-				color: #a5000a;
+				color: var(--m3-primary, #a5000a);
 			}
 
 			.sessionsListItem__dropdownOptionDescription {
@@ -543,7 +550,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 	&__dropdownOptionTitle {
 		font-size: 16px;
 		font-weight: 500;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		line-height: 24px;
 		flex: 1;
 
@@ -558,7 +565,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 		justify-content: flex-end;
 		font-size: 12px;
 		font-weight: 400;
-		color: #4c555f;
+		color: var(--m3-secondary, #4c555f);
 		background: transparent;
 		border: none;
 		padding: 0;
@@ -568,7 +575,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 
 	&__dropdownOptionDescription {
 		font-size: 12px;
-		color: #646d78;
+		color: var(--m3-secondary-container, #646d78);
 		line-height: 20px;
 		margin: 0;
 

--- a/src/components/sessionsListItem/sessionsListItem.styles.scss
+++ b/src/components/sessionsListItem/sessionsListItem.styles.scss
@@ -490,7 +490,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 			}
 
 			.sessionsListItem__dropdownOptionDescription {
-				color: #410001;
+				color: var(--m3-on-primary-fixed, #410001);
 			}
 		}
 
@@ -507,7 +507,7 @@ $case-handover-denied-text: var(--m3-on-error-container, #a5000a);
 			}
 
 			.sessionsListItem__dropdownOptionDescription {
-				color: #410001;
+				color: var(--m3-on-primary-fixed, #410001);
 			}
 		}
 

--- a/src/components/stage/stage.styles.scss
+++ b/src/components/stage/stage.styles.scss
@@ -38,6 +38,26 @@ $gridSpacing: $grid-base-four;
 	transition-delay: $animation-duration - $animation-duration-width;
 	text-align: center;
 	background-color: var(--m3-primary, $primary);
+
+	// Full fallback first: engines without color-mix() reject the whole
+	// shorthand below and keep this legacy-glow variant (CodeRabbit #848).
+	background:
+		radial-gradient(
+			circle at var(--stage-mx, 32%) var(--stage-my, 24%),
+			rgba(255, 255, 255, var(--stage-glow-opacity, 0.32)),
+			rgba(255, 255, 255, 0) 40%
+		),
+		radial-gradient(
+			660px circle at var(--stage-mx, 32%) var(--stage-my, 24%),
+			rgba(255, 180, 168, var(--stage-glow-opacity, 0.32)),
+			rgba(255, 180, 168, 0) 62%
+		),
+		linear-gradient(
+			152deg,
+			var(--m3-primary-container, #da2530) 0%,
+			var(--m3-primary, #c0121f) 46%,
+			var(--m3-primary-hover, #7c0d15) 100%
+		);
 	background:
 		radial-gradient(
 			circle at var(--stage-mx, 32%) var(--stage-my, 24%),

--- a/src/components/stage/stage.styles.scss
+++ b/src/components/stage/stage.styles.scss
@@ -46,10 +46,25 @@ $gridSpacing: $grid-base-four;
 		),
 		radial-gradient(
 			660px circle at var(--stage-mx, 32%) var(--stage-my, 24%),
-			rgba(255, 180, 168, var(--stage-glow-opacity, 0.32)),
-			rgba(255, 180, 168, 0) 62%
+			color-mix(
+				in srgb,
+				var(--m3-primary-fixed-dim, #ffb4aa)
+					calc(var(--stage-glow-opacity, 0.32) * 100%),
+				transparent
+			),
+			color-mix(
+					in srgb,
+					var(--m3-primary-fixed-dim, #ffb4aa) 0%,
+					transparent
+				)
+				62%
 		),
-		linear-gradient(152deg, #da2530 0%, #c0121f 46%, #7c0d15 100%);
+		linear-gradient(
+			152deg,
+			var(--m3-primary-container, #da2530) 0%,
+			var(--m3-primary, #c0121f) 46%,
+			var(--m3-primary-hover, #7c0d15) 100%
+		);
 	color: var(--m3-on-primary, $text-invert);
 	flex-direction: column;
 	align-items: center;

--- a/src/utils/theme/applyTenantTheme.test.ts
+++ b/src/utils/theme/applyTenantTheme.test.ts
@@ -125,6 +125,26 @@ describe('fallbacks (Tests #20/#21, UAT-E)', () => {
 		window.removeEventListener(THEME_APPLIED_EVENT, listener);
 		expect(listener).not.toHaveBeenCalled();
 	});
+
+	it('rejects a near-achromatic seed (tooPale guard, #143) and logs', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const listener = vi.fn();
+		window.addEventListener(THEME_APPLIED_EVENT, listener);
+		const root = freshRoot();
+		const applied = applyTenantPalette({ primaryColor: '#000000' }, root);
+		window.removeEventListener(THEME_APPLIED_EVENT, listener);
+		expect(applied).toBe(false);
+		expect(root.style.length).toBe(0);
+		expect(listener).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('too pale'));
+	});
+
+	it('still applies a chromatic dark seed (guard is about chroma, not tone)', () => {
+		const root = freshRoot();
+		const applied = applyTenantPalette({ primaryColor: '#4B0082' }, root);
+		expect(applied).toBe(true);
+		expect(root.style.length).toBeGreaterThan(0);
+	});
 });
 
 describe('scheme-keyed variable map (Test #22, UAT-I)', () => {

--- a/src/utils/theme/applyTenantTheme.ts
+++ b/src/utils/theme/applyTenantTheme.ts
@@ -77,7 +77,18 @@ export const applyTenantPalette = (
 		return false;
 	}
 	try {
-		const { tokens } = computeOrisoPalette(seeds, 'light');
+		const { tokens, tooPale } = computeOrisoPalette(seeds, 'light');
+		if (tooPale) {
+			// #143: a near-achromatic seed (chroma < TOO_PALE_CHROMA, e.g.
+			// black or grey) cannot yield distinguishable role colours —
+			// hover/container/shadow tints all collapse into one family.
+			// Keep the compiled default palette instead of injecting it.
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Tenant theming: seed ${seeds.primary} is too pale (chroma < 12), keeping the default palette.`
+			);
+			return false;
+		}
 		Object.entries(tokens).forEach(([name, value]) => {
 			root.style.setProperty(name, value);
 		});
@@ -141,7 +152,16 @@ export const applyPreviewFromLocation = (
 		return false;
 	}
 	try {
-		const { tokens } = computeOrisoPalette(seeds, 'light');
+		const { tokens, tooPale } = computeOrisoPalette(seeds, 'light');
+		if (tooPale) {
+			// Preview (Theme Builder sandbox) deliberately still applies:
+			// an admin evaluating a pale seed must see the degenerate
+			// result the guard protects real tenants from.
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Theme preview: seed ${seeds.primary} is too pale (chroma < 12); a stored tenant seed like this would be ignored.`
+			);
+		}
 		Object.entries(tokens).forEach(([name, value]) => {
 			root.style.setProperty(name, value);
 		});


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-Frontend#143

## Why

On Pre-Dev the tenant seed is `#000000`, and the app split into two looks: every token-based surface followed the seed (black), while surfaces with raw brand hexes — the notifications center above all — stayed frozen on legacy red. Root cause: the brand reds (`#a5000a` family) were parked in `rawHexNotMigrated`, so the THB-07 sweep never tokenized them, and several login/stage colours lived in `rgba()`/gradient literals the sweep cannot touch.

## What changed

1. **mapping.json**: `#a5000a → --m3-primary`, `#820006`/`#7e0008 → --m3-primary-hover`, `#930008 → --m3-primary-outline`, `#ffdad7 → --m3-primary-fixed` — all value-matched to the static token definitions (ΔE ≤ JND, verified by the m3Sweep drift guard), removed from `rawHexNotMigrated`.
2. **`sweep.js --apply-hex`** rewrote 14 SCSS files to `var(--m3-<role>, #legacy)` — including `notificationsCenter.styles.scss` (12 raw reds → tokens).
3. **Brand-red `rgba()` state layers** (focus rings, glows, shadows in 11 files) now carry a `color-mix(in srgb, var(--m3-primary, #a5000a) N%, transparent)` declaration with the original `rgba()` line kept as fallback for engines without `color-mix` (already used in the codebase).
4. **Login + stage + registration hero**: the submit button (`rgba(216,0,3)`), the hover gradient (`#b91c1c/#7f1d1d`) and the hero gradients (`#da2530/#c0121f/#7c0d15`) now follow the primary family. These were off-brand reds; they deliberately converge on the token values (visible, intended change).
5. **`orisoInputDesign.ts`**: the form-field colour object reads the runtime tokens (fields, focus ring, selects). `error` stays the intended magenta literal — the static `--m3-error` would override it with `#cc0000`.

6. **`tooPale` guard wired** (decided with Frank 2026-08-01): `applyTenantPalette` now rejects near-achromatic seeds (chroma < 12, e.g. `#000000`) with a console warning and keeps the compiled default palette — derived hover/container/shadow tints and transparent layers need a chromatic seed. The Theme Builder preview still applies pale seeds on purpose so an admin can see the degenerate result before saving.

Out of scope (per the issue): neutral whites/blacks/greys, and an Admin-panel save-time hint for pale seeds (possible follow-up).

## Verification

- `node scripts/theme-migration/sweep.js --check`: 2 pre-existing unrelated violations, no new ones
- `vitest` full unit suite: **1428 tests green** (incl. the m3Sweep zero-drift guard and two new tooPale cases)
- `npm run lint:style` clean
- Local dev server against Pre-Dev (`predev.oriso.org`, real tenant seed `#000000`): with the guard, the pale seed is rejected (warning logged) and the whole app renders the default red family coherently
- Theme preview `?themePreviewPrimary=a5000a`: everything red again, one family
- Storybook `Organisms/NotificationsCenter`: timeline follows an injected palette (screenshots in comments)

Screenshots (before/after, black tenant + red preview) are attached in the PR comments.

### Reviewer test plan

Add a screenshot of each tested screen to the comments.

- [ ] Open Pre-Dev (tenant seed is currently `#000000`) → the seed is rejected (console warning "too pale"), the whole app renders the default red family, no black leftovers
- [ ] Set the tenant primary back to `#A5000A` in the Admin panel → whole app red again, including the Zeitstrahl cards/buttons (no black leftovers)
- [ ] Open the Zeitstrahl → active card ring, icon chips, expand pill and unread dots all match the primary colour
- [ ] Focus a login form field → focus ring tints in the primary colour
- [ ] Check at 412px (phone emulation) → same colour coherence on the mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded theme customization across navigation, forms, messaging, notifications, sessions, selections, and other interface elements.
  * Added configurable gradients, hover states, shadows, and color-mixed backgrounds for a more consistent themed experience.
* **Bug Fixes**
  * Invalid near-achromatic theme colors are now rejected while preserving the default appearance.
  * Added safeguards and coverage for valid and invalid theme palette application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->