### PR TITLE
Storybook: cover the chat message and Carimat components, incl. mobile

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -804,6 +804,27 @@ const preview: Preview = {
 			theme: themes.light,
 			toc: true
 		},
+		/*
+		 * Storybook's built-in `mobile1` is 320x568 ("Small mobile"), which is
+		 * narrower than any phone this product targets. Stories that name a
+		 * width need a viewport that actually is that width, otherwise the
+		 * toolbar contradicts the story name and the component's media queries
+		 * fire at the wrong breakpoint. See ORISO-Frontend#849.
+		 */
+		viewport: {
+			options: {
+				phone375: {
+					name: 'Phone 375 (iPhone SE / 8)',
+					styles: { width: '375px', height: '812px' },
+					type: 'mobile'
+				},
+				phone390: {
+					name: 'Phone 390 (iPhone 12/13/14)',
+					styles: { width: '390px', height: '844px' },
+					type: 'mobile'
+				}
+			}
+		},
 		backgrounds: {
 			default: 'light',
 			values: [

--- a/scripts/shoot-stories.mjs
+++ b/scripts/shoot-stories.mjs
@@ -9,7 +9,9 @@ const STATIC = path.join(ROOT, 'storybook-static');
 const OUT = path.join(STATIC, 'shots');
 const BASE = 'http://localhost:6017';
 
-const index = JSON.parse(fs.readFileSync(path.join(STATIC, 'index.json'), 'utf8'));
+const index = JSON.parse(
+	fs.readFileSync(path.join(STATIC, 'index.json'), 'utf8')
+);
 const entries = Object.entries(index.entries)
 	.filter(
 		([id]) =>
@@ -18,12 +20,19 @@ const entries = Object.entries(index.entries)
 	)
 	.sort(([a], [b]) => a.localeCompare(b));
 
-const isMobile = (name) => /mobile|390|compact/i.test(name);
+// One resolver for the viewport width, so a story that names a width actually
+// renders at it. The 375px consent-card story reproduces an overflow that does
+// not occur at 390px, so rendering it at 390 would have quietly hidden the very
+// thing it exists to show.
+const viewportWidth = (id, name) =>
+	/375/.test(id + name) ? 375 : /mobile|390|compact/i.test(name) ? 390 : 760;
 // Animated stories need time to settle; the typewriter runs char-by-char.
 const settleMs = (id, name) =>
-	/botmessageanimation|staged|typewriter|reveal/i.test(id + name) ? 6000
-	: /cards--(choose-display-name|privacy-notice)$/.test(id) ? 5000
-	: 900;
+	/botmessageanimation|staged|typewriter|reveal/i.test(id + name)
+		? 6000
+		: /cards--(choose-display-name|privacy-notice)$/.test(id)
+			? 5000
+			: 900;
 
 fs.rmSync(OUT, { recursive: true, force: true });
 fs.mkdirSync(OUT, { recursive: true });
@@ -33,12 +42,19 @@ const results = [];
 let n = 0;
 
 for (const [id, entry] of entries) {
-	const mob = isMobile(entry.name);
+	const width = viewportWidth(id, entry.name);
+	const mob = width <= 390;
 	const page = await browser.newPage({
-		viewport: { width: mob ? 390 : 760, height: 900 },
+		viewport: { width, height: 900 },
 		deviceScaleFactor: 2
 	});
 	let status = 'ok';
+	// A story can navigate and render yet still throw at runtime. Without this
+	// the run reports "0 problems" while the screenshot shows a broken card.
+	let pageError = null;
+	page.on('pageerror', (err) => {
+		pageError = err?.message?.split('\n')[0]?.slice(0, 90) ?? 'unknown';
+	});
 	try {
 		await page.goto(`${BASE}/iframe.html?id=${id}&viewMode=story`, {
 			waitUntil: 'load',
@@ -57,19 +73,36 @@ for (const [id, entry] of entries) {
 				textLen: t.length
 			};
 		});
-		if (info.needsData) status = 'needs-data';
+		if (pageError) status = 'PAGEERROR: ' + pageError;
+		else if (info.needsData) status = 'needs-data';
 		else if (info.empty) status = 'EMPTY';
 
 		await page.setViewportSize({
-			width: mob ? 390 : 760,
+			width,
 			height: Math.min(Math.max(info.height + 32, 80), 1400)
 		});
 		await page.waitForTimeout(120);
 		await page.screenshot({ path: path.join(OUT, `${id}.png`) });
-		results.push({ id, title: entry.title, name: entry.name, mob, status, h: info.height, textLen: info.textLen });
+		results.push({
+			id,
+			title: entry.title,
+			name: entry.name,
+			mob,
+			status,
+			h: info.height,
+			textLen: info.textLen
+		});
 	} catch (e) {
 		status = 'ERROR: ' + e.message.split('\n')[0].slice(0, 90);
-		results.push({ id, title: entry.title, name: entry.name, mob, status, h: 0, textLen: 0 });
+		results.push({
+			id,
+			title: entry.title,
+			name: entry.name,
+			mob,
+			status,
+			h: 0,
+			textLen: 0
+		});
 	}
 	await page.close();
 	n++;
@@ -77,7 +110,10 @@ for (const [id, entry] of entries) {
 }
 
 await browser.close();
-fs.writeFileSync(path.join(OUT, 'results.json'), JSON.stringify(results, null, 1));
+fs.writeFileSync(
+	path.join(OUT, 'results.json'),
+	JSON.stringify(results, null, 1)
+);
 
 const bad = results.filter((r) => r.status !== 'ok');
 console.log(`rendered ${results.length} stories`);

--- a/scripts/shoot-stories.mjs
+++ b/scripts/shoot-stories.mjs
@@ -11,7 +11,11 @@ const BASE = 'http://localhost:6017';
 
 const index = JSON.parse(fs.readFileSync(path.join(STATIC, 'index.json'), 'utf8'));
 const entries = Object.entries(index.entries)
-	.filter(([id]) => id.startsWith('components-carimat-') || id.startsWith('components-chat-'))
+	.filter(
+		([id]) =>
+			id.startsWith('components-chat-') ||
+			id.startsWith('components-dialog-')
+	)
 	.sort(([a], [b]) => a.localeCompare(b));
 
 const isMobile = (name) => /mobile|390|compact/i.test(name);

--- a/scripts/shoot-stories.mjs
+++ b/scripts/shoot-stories.mjs
@@ -1,0 +1,81 @@
+// Render every Chat + Carimat story to a PNG so the review sheet is static
+// images instead of 121 live Storybook previews. Not part of the app build.
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const STATIC = path.join(ROOT, 'storybook-static');
+const OUT = path.join(STATIC, 'shots');
+const BASE = 'http://localhost:6017';
+
+const index = JSON.parse(fs.readFileSync(path.join(STATIC, 'index.json'), 'utf8'));
+const entries = Object.entries(index.entries)
+	.filter(([id]) => id.startsWith('components-carimat-') || id.startsWith('components-chat-'))
+	.sort(([a], [b]) => a.localeCompare(b));
+
+const isMobile = (name) => /mobile|390|compact/i.test(name);
+// Animated stories need time to settle; the typewriter runs char-by-char.
+const settleMs = (id, name) =>
+	/botmessageanimation|staged|typewriter|reveal/i.test(id + name) ? 6000
+	: /cards--(choose-display-name|privacy-notice)$/.test(id) ? 5000
+	: 900;
+
+fs.rmSync(OUT, { recursive: true, force: true });
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+const results = [];
+let n = 0;
+
+for (const [id, entry] of entries) {
+	const mob = isMobile(entry.name);
+	const page = await browser.newPage({
+		viewport: { width: mob ? 390 : 760, height: 900 },
+		deviceScaleFactor: 2
+	});
+	let status = 'ok';
+	try {
+		await page.goto(`${BASE}/iframe.html?id=${id}&viewMode=story`, {
+			waitUntil: 'load',
+			timeout: 30000
+		});
+		await page.waitForSelector('#storybook-root', { timeout: 15000 });
+		await page.waitForTimeout(settleMs(id, entry.name));
+
+		const info = await page.evaluate(() => {
+			const r = document.getElementById('storybook-root');
+			const t = (r?.innerText || '').trim();
+			return {
+				empty: !r || r.children.length === 0,
+				needsData: !!document.querySelector('[data-sb-needs-data]'),
+				height: Math.max(r?.scrollHeight || 0, 40),
+				textLen: t.length
+			};
+		});
+		if (info.needsData) status = 'needs-data';
+		else if (info.empty) status = 'EMPTY';
+
+		await page.setViewportSize({
+			width: mob ? 390 : 760,
+			height: Math.min(Math.max(info.height + 32, 80), 1400)
+		});
+		await page.waitForTimeout(120);
+		await page.screenshot({ path: path.join(OUT, `${id}.png`) });
+		results.push({ id, title: entry.title, name: entry.name, mob, status, h: info.height, textLen: info.textLen });
+	} catch (e) {
+		status = 'ERROR: ' + e.message.split('\n')[0].slice(0, 90);
+		results.push({ id, title: entry.title, name: entry.name, mob, status, h: 0, textLen: 0 });
+	}
+	await page.close();
+	n++;
+	if (n % 20 === 0) console.log(`  ${n}/${entries.length}`);
+}
+
+await browser.close();
+fs.writeFileSync(path.join(OUT, 'results.json'), JSON.stringify(results, null, 1));
+
+const bad = results.filter((r) => r.status !== 'ok');
+console.log(`rendered ${results.length} stories`);
+console.log(`problems: ${bad.length}`);
+for (const b of bad) console.log(`  [${b.status}] ${b.title} :: ${b.name}`);

--- a/src/components/message/Appointment.stories.tsx
+++ b/src/components/message/Appointment.stories.tsx
@@ -4,8 +4,9 @@ import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
 import { Appointment } from './Appointment';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -127,5 +128,6 @@ export const Mobile: Story = {
 		}),
 		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
 	},
-	parameters: mobileParameters
+	parameters: mobileParameters,
+	globals: phone390Globals
 };

--- a/src/components/message/Appointment.stories.tsx
+++ b/src/components/message/Appointment.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';

--- a/src/components/message/Appointment.stories.tsx
+++ b/src/components/message/Appointment.stories.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ALIAS_MESSAGE_TYPES } from '../../api/apiSendAliasMessage';
+import { Appointment } from './Appointment';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The appointment card. Four alias message types share one component and one
+ * payload shape; the type selects the wording (set / cancelled / rescheduled /
+ * initial appointment defined).
+ *
+ * Note the API: `data` is a **JSON string**, parsed unguarded with
+ * `JSON.parse` at render time, so malformed data throws inside render rather
+ * than degrading. There is deliberately no story for that case — it would only
+ * ever render Storybook's error boundary. It is noted here because a backend
+ * payload change would surface as a blank conversation, not as an error.
+ *
+ * Like the other alias-based messages, this path is currently not reachable —
+ * see `ReassignMessage.stories.tsx` for the routing detail.
+ */
+const meta = {
+	title: 'Components/Chat/Appointment',
+	component: Appointment,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Appointment card for the four appointment alias types. `data` is a JSON string; `messageType` picks the wording. Times are converted from UTC to local, so the rendered hour depends on the viewer’s timezone.'
+			}
+		}
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof Appointment>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const appointment = (overrides: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		title: 'Beratungstermin',
+		user: 'sanftes Alpaka Mika',
+		counselor: 'Karina P',
+		date: '2026-08-12T09:00:00.000Z',
+		duration: 50,
+		location: 'Video',
+		...overrides
+	});
+
+export const Set: Story = {
+	name: 'Appointment set',
+	args: {
+		data: appointment(),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
+	}
+};
+
+export const Cancelled: Story = {
+	name: 'Appointment cancelled',
+	args: {
+		data: appointment(),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_CANCELLED
+	}
+};
+
+export const Rescheduled: Story = {
+	name: 'Appointment rescheduled',
+	args: {
+		data: appointment({ date: '2026-08-19T13:30:00.000Z' }),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_RESCHEDULED
+	}
+};
+
+export const InitialAppointmentDefined: Story = {
+	name: 'Initial appointment defined',
+	args: {
+		data: appointment(),
+		messageType: ALIAS_MESSAGE_TYPES.INITIAL_APPOINTMENT_DEFINED
+	}
+};
+
+export const WithNote: Story = {
+	name: 'With a note (expandable)',
+	args: {
+		data: appointment({
+			note: 'Bitte bringen Sie, wenn möglich, Ihre Unterlagen mit. Falls Ihnen der Termin nicht passt, melden Sie sich gern vorher.'
+		}),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'The note is behind an expand toggle. Collapsed is the default state — click to expand.'
+			}
+		}
+	}
+};
+
+export const LongTitleAndNames: Story = {
+	name: 'Long title and generated name',
+	args: {
+		data: appointment({
+			title: 'Ausführliches Erstgespräch zur Klärung der weiteren Begleitung',
+			user: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+		}),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px) — with note',
+	args: {
+		data: appointment({
+			note: 'Bitte bringen Sie, wenn möglich, Ihre Unterlagen mit.',
+			user: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+		}),
+		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
+	},
+	parameters: mobileParameters
+};

--- a/src/components/message/Appointment.stories.tsx
+++ b/src/components/message/Appointment.stories.tsx
@@ -113,7 +113,7 @@ export const LongTitleAndNames: Story = {
 	args: {
 		data: appointment({
 			title: 'Ausführliches Erstgespräch zur Klärung der weiteren Begleitung',
-			user: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+			user: 'absichtslose Schildkröte Andrea'
 		}),
 		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
 	}
@@ -124,7 +124,7 @@ export const Mobile: Story = {
 	args: {
 		data: appointment({
 			note: 'Bitte bringen Sie, wenn möglich, Ihre Unterlagen mit.',
-			user: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+			user: 'absichtslose Schildkröte Andrea'
 		}),
 		messageType: ALIAS_MESSAGE_TYPES.APPOINTMENT_SET
 	},

--- a/src/components/message/E2EEActivatedMessage.stories.tsx
+++ b/src/components/message/E2EEActivatedMessage.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { E2EEActivatedMessage } from './E2EEActivatedMessage';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The encryption banner shown at the top of a conversation. It takes no props —
+ * the only things that vary are the locale and the available width, and both
+ * matter: the German string is noticeably longer than the English one.
+ */
+const meta = {
+	title: 'Components/Chat/E2EEActivatedMessage',
+	component: E2EEActivatedMessage,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Propless banner rendering the `e2ee.hint` translation next to a shield icon. Switch the locale in the toolbar to check the wrapping — this string is one of the longer ones in the chat surface.'
+			}
+		}
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof E2EEActivatedMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	name: 'Desktop (1000px)'
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px)',
+	parameters: {
+		...mobileParameters,
+		docs: {
+			description: {
+				story: 'At 390px the German hint wraps to several lines. The shield icon must stay aligned to the first line rather than centring against the whole block.'
+			}
+		}
+	}
+};
+
+export const InDarkSurface: Story = {
+	name: 'On dark background',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		docs: {
+			description: {
+				story: 'The banner is placed on the session background rather than on a bubble. This story surfaces any hard-coded light-only colour.'
+			}
+		}
+	}
+};

--- a/src/components/message/E2EEActivatedMessage.stories.tsx
+++ b/src/components/message/E2EEActivatedMessage.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { E2EEActivatedMessage } from './E2EEActivatedMessage';

--- a/src/components/message/E2EEActivatedMessage.stories.tsx
+++ b/src/components/message/E2EEActivatedMessage.stories.tsx
@@ -3,8 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { E2EEActivatedMessage } from './E2EEActivatedMessage';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -43,6 +44,7 @@ export const Default: Story = {
 
 export const Mobile: Story = {
 	name: 'Mobile (390px)',
+	globals: phone390Globals,
 	parameters: {
 		...mobileParameters,
 		docs: {

--- a/src/components/message/FurtherSteps.stories.tsx
+++ b/src/components/message/FurtherSteps.stories.tsx
@@ -6,8 +6,9 @@ import { FurtherSteps } from './FurtherSteps';
 import { mockUserData } from './MessageItemComponent.mocks';
 import {
 	mobileParameters,
-	withMessageContexts,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageContexts
 } from './messageStoryShell';
 import './furtherSteps.styles.scss';
 
@@ -184,6 +185,7 @@ export const NoEmailTrägerOptOut: Story = {
 
 export const Mobile: Story = {
 	name: 'Mobile (390px) — both CTAs',
+	globals: phone390Globals,
 	parameters: {
 		...mobileParameters,
 		userData: asker({

--- a/src/components/message/FurtherSteps.stories.tsx
+++ b/src/components/message/FurtherSteps.stories.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { AUTHORITIES } from '../../globalState';
+import { FurtherSteps } from './FurtherSteps';
+import { mockUserData } from './MessageItemComponent.mocks';
+import {
+	mobileParameters,
+	withMessageContexts,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './furtherSteps.styles.scss';
+
+/**
+ * The "So geht es weiter" card: three illustrated steps, plus up to two
+ * optional calls to action.
+ *
+ * ## Why this component has no props
+ *
+ * Everything it shows is derived from `UserDataContext`:
+ *
+ * - `showAddEmail = !userData.email`
+ * - `is2faEnabledAndNotActive = twoFactorAuth.isEnabled && !twoFactorAuth.isActive`
+ * - `isConsultant` swaps the CTAs for an explanatory hint
+ *
+ * So the stories vary the mocked user, not the args. That is also the pattern
+ * ADR-018 keeps for the Erstantwort Bausteine: an action block owns no state of
+ * its own, it reads state that already exists and hides its button once the
+ * thing is done.
+ *
+ * ## Status
+ *
+ * **This component does not currently reach anybody.** It renders only for
+ * `alias.messageType === 'FURTHER_STEPS'`, and no Matrix code path produces an
+ * `alias` object. It is kept here as the visual reference for the Erstantwort
+ * rebuild (ORISO-Frontend#772), not as documentation of live behaviour.
+ */
+const meta = {
+	title: 'Components/Chat/FurtherSteps',
+	component: FurtherSteps,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		userData: mockUserData({
+			grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT],
+			userId: 'asker-storybook',
+			displayName: 'sanftes Alpaka Mika'
+		}),
+		docs: {
+			description: {
+				component:
+					'Post-enquiry card with three steps and two optional CTAs (leave an e-mail, protect the account). Not currently reachable in the product — see the component docblock.'
+			}
+		}
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageContexts(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof FurtherSteps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const asker = (overrides = {}) =>
+	mockUserData({
+		grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT],
+		userId: 'asker-storybook',
+		displayName: 'sanftes Alpaka Mika',
+		...overrides
+	});
+
+export const BothCallsToAction: Story = {
+	name: 'Advice seeker — both CTAs',
+	parameters: {
+		userData: asker({
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: false,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		}),
+		docs: {
+			description: {
+				story: 'No e-mail on file and 2FA available but not switched on: both offers are shown. This is the state a freshly registered advice seeker is in.'
+			}
+		}
+	}
+};
+
+export const EmailAlreadyGiven: Story = {
+	name: 'E-mail already given — only 2FA CTA',
+	parameters: {
+		userData: asker({
+			email: 'someone@example.org',
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: false,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		} as any),
+		docs: {
+			description: {
+				story: 'The e-mail block disappears the moment an address exists — regardless of *how* it was added. That retroactive "already done" behaviour is intentional (ADR-018 §4).'
+			}
+		}
+	}
+};
+
+export const TwoFactorAlreadyActive: Story = {
+	name: '2FA already active — only e-mail CTA',
+	parameters: {
+		userData: asker({
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: true,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		})
+	}
+};
+
+export const NothingLeftToDo: Story = {
+	name: 'Nothing left to do — steps only',
+	parameters: {
+		userData: asker({
+			email: 'someone@example.org',
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: true,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		} as any),
+		docs: {
+			description: {
+				story: 'Both offers satisfied. Worth pinning: the card must still read as a complete message, not as an empty shell with a dangling headline.'
+			}
+		}
+	}
+};
+
+export const ConsultantView: Story = {
+	name: 'Counsellor view — hint instead of CTAs',
+	parameters: {
+		userData: mockUserData(),
+		docs: {
+			description: {
+				story: 'A counsellor sees the same three steps plus `furtherSteps.consultant.info`, and neither CTA — the offers belong to the advice seeker.'
+			}
+		}
+	}
+};
+
+export const NoEmailTrägerOptOut: Story = {
+	name: 'E-mail invitation switched off (U25 case)',
+	parameters: {
+		userData: asker({
+			email: 'suppressed@example.org',
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: false,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		} as any),
+		docs: {
+			description: {
+				story: 'Approximates what a Träger that forbids e-mail collection should see: no e-mail invitation, 2FA still offered. **Today this state is not reachable by configuration** — the e-mail block is gated only on "has none yet" (`FurtherSteps.tsx:159`). The switch that would produce it is ORISO-Admin#602.'
+			}
+		}
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px) — both CTAs',
+	parameters: {
+		...mobileParameters,
+		userData: asker({
+			twoFactorAuth: {
+				isEnabled: true,
+				isActive: false,
+				isShown: true,
+				secret: '',
+				qrCode: ''
+			}
+		}),
+		docs: {
+			description: {
+				story: 'At 390px the three-step row with its arrow illustrations is the tightest part of this card. Check that the arrows do not collapse the step text into a narrow column.'
+			}
+		}
+	}
+};

--- a/src/components/message/FurtherSteps.stories.tsx
+++ b/src/components/message/FurtherSteps.stories.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { AUTHORITIES } from '../../globalState';
+import type { UserDataInterface } from '../../globalState/interfaces';
 import { FurtherSteps } from './FurtherSteps';
 import { mockUserData } from './MessageItemComponent.mocks';
 import {
@@ -64,7 +64,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const asker = (overrides = {}) =>
+const asker = (overrides: Partial<UserDataInterface> = {}) =>
 	mockUserData({
 		grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT],
 		userId: 'asker-storybook',
@@ -104,7 +104,7 @@ export const EmailAlreadyGiven: Story = {
 				secret: '',
 				qrCode: ''
 			}
-		} as any),
+		}),
 		docs: {
 			description: {
 				story: 'The e-mail block disappears the moment an address exists — regardless of *how* it was added. That retroactive "already done" behaviour is intentional (ADR-018 §4).'
@@ -140,7 +140,7 @@ export const NothingLeftToDo: Story = {
 				secret: '',
 				qrCode: ''
 			}
-		} as any),
+		}),
 		docs: {
 			description: {
 				story: 'Both offers satisfied. Worth pinning: the card must still read as a complete message, not as an empty shell with a dangling headline.'
@@ -173,7 +173,7 @@ export const NoEmailTrägerOptOut: Story = {
 				secret: '',
 				qrCode: ''
 			}
-		} as any),
+		}),
 		docs: {
 			description: {
 				story: 'Approximates what a Träger that forbids e-mail collection should see: no e-mail invitation, 2FA still offered. **Today this state is not reachable by configuration** — the e-mail block is gated only on "has none yet" (`FurtherSteps.tsx:159`). The switch that would produce it is ORISO-Admin#602.'

--- a/src/components/message/MasterKeyLostMessage.stories.tsx
+++ b/src/components/message/MasterKeyLostMessage.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MasterKeyLostMessage } from './MasterKeyLostMessage';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * Shown when a message cannot be decrypted. The single boolean prop selects
+ * between two different translated explanations
+ * (`e2ee.subscriptionKeyLost.message.{true|false}`), and the notice carries a
+ * button that opens the recovery overlay.
+ *
+ * This is the one place in the chat where the platform tells someone their
+ * history is gone, so both wordings are worth having side by side.
+ */
+const meta = {
+	title: 'Components/Chat/MasterKeyLostMessage',
+	component: MasterKeyLostMessage,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Built on `SystemMessage` with the info icon. `subscriptionKeyLost` picks the wording; the button opens `subscriptionKeyLostOverlayItem`.'
+			}
+		}
+	},
+	args: { subscriptionKeyLost: true },
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof MasterKeyLostMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SubscriptionKeyLost: Story = {
+	name: 'Room key lost',
+	args: { subscriptionKeyLost: true }
+};
+
+export const MasterKeyLost: Story = {
+	name: 'Master key lost',
+	args: { subscriptionKeyLost: false }
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px)',
+	args: { subscriptionKeyLost: true },
+	parameters: {
+		...mobileParameters,
+		docs: {
+			description: {
+				story: 'The explanation is long and sits next to an icon; at 390px it must not push its button off the card.'
+			}
+		}
+	}
+};

--- a/src/components/message/MasterKeyLostMessage.stories.tsx
+++ b/src/components/message/MasterKeyLostMessage.stories.tsx
@@ -3,8 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { MasterKeyLostMessage } from './MasterKeyLostMessage';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -55,6 +56,7 @@ export const MasterKeyLost: Story = {
 export const Mobile: Story = {
 	name: 'Mobile (390px)',
 	args: { subscriptionKeyLost: true },
+	globals: phone390Globals,
 	parameters: {
 		...mobileParameters,
 		docs: {

--- a/src/components/message/MasterKeyLostMessage.stories.tsx
+++ b/src/components/message/MasterKeyLostMessage.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { MasterKeyLostMessage } from './MasterKeyLostMessage';

--- a/src/components/message/MessageDisplayName.stories.tsx
+++ b/src/components/message/MessageDisplayName.stories.tsx
@@ -112,7 +112,7 @@ export const LongName: Story = {
 	name: 'Long display name',
 	args: {
 		type: 'user',
-		displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+		displayName: 'absichtslose Schildkröte Andrea'
 	},
 	parameters: {
 		docs: {
@@ -127,7 +127,7 @@ export const Mobile: Story = {
 	name: 'Mobile (390px) — long name',
 	args: {
 		type: 'user',
-		displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+		displayName: 'absichtslose Schildkröte Andrea'
 	},
 	parameters: mobileParameters
 };

--- a/src/components/message/MessageDisplayName.stories.tsx
+++ b/src/components/message/MessageDisplayName.stories.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MessageDisplayName } from './MessageDisplayName';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The name line above a message bubble. Four visual types, and one behavioural
+ * rule that is easy to break: `type: 'system'` ignores every name prop and
+ * renders the translated system label instead.
+ */
+const meta = {
+	title: 'Components/Chat/MessageDisplayName',
+	component: MessageDisplayName,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Name line above a bubble. The `type` drives the `messageItem__username--{type}` modifier. Name resolution goes through `formatMessagePersonName(displayName, username, firstName, lastName)` — except for `system`, which always renders the `message.systemNotification` translation and ignores the name props entirely.'
+			}
+		}
+	},
+	args: {
+		isUser: true,
+		isMyMessage: false,
+		type: 'user',
+		userId: '@sanftes.alpaka:oriso.invalid',
+		username: 'sanftes_alpaka_4821'
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof MessageDisplayName>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AdviceSeekerWithDisplayName: Story = {
+	name: 'Advice seeker — generated display name',
+	args: {
+		type: 'user',
+		displayName: 'sanftes Alpaka Mika'
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'The normal anonymous case: the generated `adjective + animal + name` display name, not the login name.'
+			}
+		}
+	}
+};
+
+export const AdviceSeekerUsernameFallback: Story = {
+	name: 'Advice seeker — no display name (username fallback)',
+	args: { type: 'user', displayName: undefined },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Falls back to the login name. Worth keeping visible: this is the state in which the cryptic identifier leaks into the UI.'
+			}
+		}
+	}
+};
+
+export const Consultant: Story = {
+	name: 'Counsellor — first + last name',
+	args: {
+		type: 'consultant',
+		username: 'karina.p@oriso.invalid',
+		firstName: 'Karina',
+		lastName: 'P'
+	}
+};
+
+export const Self: Story = {
+	name: 'Own message',
+	args: {
+		type: 'self',
+		isMyMessage: true,
+		username: 'karina.p@oriso.invalid',
+		displayName: 'Karina P'
+	}
+};
+
+export const SystemNotification: Story = {
+	name: 'System — name props ignored',
+	args: {
+		type: 'system',
+		username: 'this-is-ignored',
+		displayName: 'so-is-this'
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Renders the `message.systemNotification` translation regardless of the name props. This is the line that sits above a Carimat bubble.'
+			}
+		}
+	}
+};
+
+export const LongName: Story = {
+	name: 'Long display name',
+	args: {
+		type: 'user',
+		displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'The generator can produce long German compounds; the name line must not push the bubble layout.'
+			}
+		}
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px) — long name',
+	args: {
+		type: 'user',
+		displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra'
+	},
+	parameters: mobileParameters
+};

--- a/src/components/message/MessageDisplayName.stories.tsx
+++ b/src/components/message/MessageDisplayName.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { MessageDisplayName } from './MessageDisplayName';

--- a/src/components/message/MessageDisplayName.stories.tsx
+++ b/src/components/message/MessageDisplayName.stories.tsx
@@ -3,8 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { MessageDisplayName } from './MessageDisplayName';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -128,5 +129,6 @@ export const Mobile: Story = {
 		type: 'user',
 		displayName: 'absichtslose Schildkröte Andrea'
 	},
-	parameters: mobileParameters
+	parameters: mobileParameters,
+	globals: phone390Globals
 };

--- a/src/components/message/MessageItemComponent.stories.tsx
+++ b/src/components/message/MessageItemComponent.stories.tsx
@@ -32,6 +32,7 @@ import {
 	mockUserData,
 	mockVisibilityMessage
 } from './MessageItemComponent.mocks';
+import { phone390Globals } from './messageStoryShell';
 import './message.styles.scss';
 
 type MessageItemStoryParameters = {
@@ -178,14 +179,12 @@ export const ClientIn1on1Outgoing: Story = {
  * Uses the real MessageItemComponent + production `message.styles.scss`.
  */
 export const AndroidCompactKebabTouchZone: Story = {
+	globals: phone390Globals,
 	name: 'Android Compact — kebab 32×32 touch zone',
 	parameters: {
 		activeSession: mockActiveSession1on1(),
 		userData: mockUserData(),
 		compactShell: true,
-		viewport: {
-			defaultViewport: 'mobile1'
-		},
 		docs: {
 			description: {
 				story: 'Incoming + outgoing rows on a compact viewport. Each `.messageItem__kebabButton` must measure **32×32px** (min-width/height + box-sizing from production SCSS).'

--- a/src/components/message/MessageMetaData.stories.tsx
+++ b/src/components/message/MessageMetaData.stories.tsx
@@ -9,8 +9,9 @@ import {
 } from './MessageItemComponent.mocks';
 import {
 	mobileParameters,
-	withMessageContexts,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageContexts
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -134,5 +135,6 @@ export const NoTimestamp: Story = {
 export const Mobile: Story = {
 	name: 'Mobile (390px)',
 	args: { isNotRead: false },
-	parameters: mobileParameters
+	parameters: mobileParameters,
+	globals: phone390Globals
 };

--- a/src/components/message/MessageMetaData.stories.tsx
+++ b/src/components/message/MessageMetaData.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { AUTHORITIES } from '../../globalState';

--- a/src/components/message/MessageMetaData.stories.tsx
+++ b/src/components/message/MessageMetaData.stories.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { AUTHORITIES } from '../../globalState';
+import { MessageMetaData } from './MessageMetaData';
+import {
+	mockActiveSession1on1,
+	mockActiveSessionGroup,
+	mockUserData
+} from './MessageItemComponent.mocks';
+import {
+	mobileParameters,
+	withMessageContexts,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * Time + delivery state in the bubble's footer row.
+ *
+ * The read status is deliberately suppressed in five separate situations, and
+ * every one of them is a privacy or product decision rather than a styling
+ * choice — hence one story each:
+ *
+ * - the viewer is an advice seeker (they never see whether staff read them)
+ * - `isReadStatusDisabled`
+ * - the session is a group
+ * - `type === 'user'`
+ * - `t === 'rm'` (removed/redacted message)
+ */
+const meta = {
+	title: 'Components/Chat/MessageMetaData',
+	component: MessageMetaData,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Bubble footer: `formatToHHMM(messageTime)` plus an optional checkmark. `isNotRead` switches the checkmark to the grey `--grey` modifier and the label from `message.read` to `message.sent`.'
+			}
+		}
+	},
+	args: {
+		isMyMessage: true,
+		isNotRead: true,
+		isReadStatusDisabled: false,
+		messageTime: '2026-07-30T09:41:00.000Z',
+		type: 'consultant',
+		t: null
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageContexts(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof MessageMetaData>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SentNotRead: Story = {
+	name: 'Sent, not yet read (grey check)',
+	args: { isNotRead: true }
+};
+
+export const Read: Story = {
+	name: 'Read (solid check)',
+	args: { isNotRead: false }
+};
+
+export const AskerViewNoReadStatus: Story = {
+	name: 'Advice-seeker view — no read status',
+	parameters: {
+		userData: mockUserData({
+			grantedAuthorities: [AUTHORITIES.ASKER_DEFAULT],
+			userId: 'asker-storybook'
+		}),
+		docs: {
+			description: {
+				story: 'An advice seeker never learns whether their message was read. Only the time remains.'
+			}
+		}
+	}
+};
+
+export const ReadStatusDisabled: Story = {
+	name: 'Read status disabled',
+	args: { isReadStatusDisabled: true }
+};
+
+export const GroupSessionNoReadStatus: Story = {
+	name: 'Group session — no read status',
+	parameters: {
+		activeSession: mockActiveSessionGroup(),
+		docs: {
+			description: {
+				story: '"Read" has no single meaning with several recipients, so the checkmark is suppressed for groups.'
+			}
+		}
+	}
+};
+
+export const TypeUserNoReadStatus: Story = {
+	name: "type='user' — no read status",
+	args: { type: 'user' }
+};
+
+export const RemovedMessage: Story = {
+	name: "t='rm' — no read status",
+	args: { t: 'rm' as const },
+	parameters: {
+		activeSession: mockActiveSession1on1(),
+		docs: {
+			description: {
+				story: 'A removed message keeps its timestamp but loses the delivery state.'
+			}
+		}
+	}
+};
+
+export const NoTimestamp: Story = {
+	name: 'Missing timestamp',
+	args: { messageTime: '' },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Renders an empty string rather than "Invalid Date". Worth pinning — the component returns `\'\'`, not `null`.'
+			}
+		}
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px)',
+	args: { isNotRead: false },
+	parameters: mobileParameters
+};

--- a/src/components/message/ReassignMessage.stories.tsx
+++ b/src/components/message/ReassignMessage.stories.tsx
@@ -9,8 +9,9 @@ import {
 } from './ReassignMessage';
 import {
 	mobileParameters,
-	withMessageContexts,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageContexts
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -90,6 +91,7 @@ export const RequestMobile: Story = {
 			onClick={() => {}}
 		/>
 	),
+	globals: phone390Globals,
 	parameters: {
 		...mobileParameters,
 		docs: {

--- a/src/components/message/ReassignMessage.stories.tsx
+++ b/src/components/message/ReassignMessage.stories.tsx
@@ -86,7 +86,7 @@ export const RequestMobile: Story = {
 	render: () => (
 		<ReassignRequestMessage
 			fromConsultantName="Karina P"
-			toConsultantName="außerordentlich nachdenkliches Schnabeltier Alexandra"
+			toConsultantName="absichtslose Schildkröte Andrea"
 			onClick={() => {}}
 		/>
 	),

--- a/src/components/message/ReassignMessage.stories.tsx
+++ b/src/components/message/ReassignMessage.stories.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+	ReassignRequestAcceptedMessage,
+	ReassignRequestDeclinedMessage,
+	ReassignRequestMessage,
+	ReassignRequestSentMessage
+} from './ReassignMessage';
+import {
+	mobileParameters,
+	withMessageContexts,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The four states of the legacy consultant-reassignment exchange.
+ *
+ * `ReassignRequestMessage` is the only in-chat system message in the codebase
+ * that carries **accept/decline buttons pressed by the advice seeker**, which
+ * makes it the closest existing precedent for an action Baustein (ADR-018).
+ *
+ * ## Status: dead path
+ *
+ * Neither end of this exchange runs today. `apiSendAliasMessage` (producer) and
+ * `apiPatchMessage` (the button handler) both target `/service/messages/...`,
+ * which no ingress rule routes to a backend, and UserService has no
+ * `PATCH /messages/{id}` handler. Both call sites swallow their errors
+ * silently, so the failure is invisible in the product — the message simply
+ * never appears.
+ *
+ * These stories therefore document a **design reference**, not live behaviour.
+ * Treat them as the visual answer to "what did an actionable system message
+ * look like", and do not infer that pressing the buttons does anything.
+ *
+ * The three `…Sent`, `…Accepted`, `…Declined` variants resolve consultant names
+ * out of `ConsultantListContext`, so they are wrapped in the shared context
+ * shell rather than driven purely by args.
+ */
+const meta = {
+	title: 'Components/Chat/ReassignMessage',
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Four states of consultant reassignment. **Dead path** — see the docblock; kept as the precedent for in-chat action buttons.'
+			}
+		}
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageContexts(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RequestWithButtons: Story = {
+	name: 'Request — accept / decline buttons',
+	render: () => (
+		<ReassignRequestMessage
+			fromConsultantName="Karina P"
+			toConsultantName="Jonas M"
+			onClick={() => {
+				/* no-op: the real handler targets an unrouted endpoint */
+			}}
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'The advice seeker is asked to approve a change of counsellor. Both buttons are inert here **and in production** — the handler PATCHes an endpoint that is not served.'
+			}
+		}
+	}
+};
+
+export const RequestMobile: Story = {
+	name: 'Request — mobile (390px)',
+	render: () => (
+		<ReassignRequestMessage
+			fromConsultantName="Karina P"
+			toConsultantName="außerordentlich nachdenkliches Schnabeltier Alexandra"
+			onClick={() => {}}
+		/>
+	),
+	parameters: {
+		...mobileParameters,
+		docs: {
+			description: {
+				story: 'Two buttons plus a long name at 390px — the case where an action Baustein is most likely to break. Buttons should stack rather than shrink below a comfortable touch target.'
+			}
+		}
+	}
+};
+
+export const Sent: Story = {
+	name: 'Sent (counsellor view)',
+	render: () => (
+		<ReassignRequestSentMessage
+			toAskerName="sanftes Alpaka Mika"
+			fromConsultantId="consultant-storybook"
+			toConsultantId="consultant-other"
+			isMySession={true}
+		/>
+	)
+};
+
+export const Accepted: Story = {
+	name: 'Accepted',
+	render: () => (
+		<ReassignRequestAcceptedMessage
+			toAskerName="sanftes Alpaka Mika"
+			toConsultantName="Jonas M"
+			toConsultantId="consultant-other"
+			isAsker={false}
+			fromConsultantId="consultant-storybook"
+			isMySession={true}
+		/>
+	)
+};
+
+export const AcceptedAskerView: Story = {
+	name: 'Accepted (advice-seeker view)',
+	render: () => (
+		<ReassignRequestAcceptedMessage
+			toAskerName="sanftes Alpaka Mika"
+			toConsultantName="Jonas M"
+			toConsultantId="consultant-other"
+			isAsker={true}
+			fromConsultantId="consultant-storybook"
+			isMySession={false}
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: "`isAsker` suppresses the consultant-name lookup, so the advice seeker never learns the previous counsellor's identity from this message."
+			}
+		}
+	}
+};
+
+export const Declined: Story = {
+	name: 'Declined',
+	render: () => (
+		<ReassignRequestDeclinedMessage
+			isAsker={false}
+			isMySession={true}
+			toAskerName="sanftes Alpaka Mika"
+			fromConsultantName="Karina P"
+			fromConsultantId="consultant-storybook"
+		/>
+	)
+};
+
+export const DeclinedAskerView: Story = {
+	name: 'Declined (advice-seeker view)',
+	render: () => (
+		<ReassignRequestDeclinedMessage
+			isAsker={true}
+			isMySession={false}
+			toAskerName="sanftes Alpaka Mika"
+			fromConsultantName="Karina P"
+			fromConsultantId="consultant-storybook"
+		/>
+	)
+};

--- a/src/components/message/SystemMessage.stories.tsx
+++ b/src/components/message/SystemMessage.stories.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ICON_CALL_OFF, ICON_INFO, SystemMessage } from './SystemMessage';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The in-chat system notice: an optional icon plus a subject line, with
+ * optional children below it. It is the shared skeleton behind the
+ * encryption-key notice, the video-call notices and the case-handover cards —
+ * so a change here is felt in all of them.
+ */
+const meta = {
+	title: 'Components/Chat/SystemMessage',
+	component: SystemMessage,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Shared skeleton for in-chat system notices. `subject` is a React element (not a string), so callers can embed links and emphasis. `icon` accepts `info` or `call_off`; both carry a translated `title`/`aria-label`, which is why the icon is never decorative-only.'
+			}
+		}
+	},
+	args: {
+		subject: <>Diese Unterhaltung ist Ende-zu-Ende-verschlüsselt.</>
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof SystemMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoIcon: Story = {
+	name: 'Subject only (no icon)',
+	parameters: {
+		docs: {
+			description: {
+				story: 'The minimal case. Used where the surrounding card already carries an icon.'
+			}
+		}
+	}
+};
+
+export const WithInfoIcon: Story = {
+	name: 'Info icon',
+	args: { icon: ICON_INFO }
+};
+
+export const WithCallOffIcon: Story = {
+	name: 'Call-off icon',
+	args: {
+		icon: ICON_CALL_OFF,
+		subject: <>Der Videoanruf wurde beendet.</>
+	}
+};
+
+export const WithChildren: Story = {
+	name: 'Subject + body',
+	args: {
+		icon: ICON_INFO,
+		subject: <>Ihre Nachricht konnte nicht entschlüsselt werden.</>,
+		children: (
+			<p className="systemMessage__infoText">
+				Das passiert, wenn Sie sich auf einem neuen Gerät angemeldet
+				haben. Ältere Nachrichten bleiben auf dem ursprünglichen Gerät
+				lesbar.
+			</p>
+		)
+	}
+};
+
+export const LongSubject: Story = {
+	name: 'Long subject (wrapping)',
+	args: {
+		icon: ICON_INFO,
+		subject: (
+			<>
+				Diese Beratungsstelle arbeitet im Team: Ihre Nachrichten können
+				von mehreren beratenden Personen gelesen werden, die alle der
+				Schweigepflicht unterliegen und sich vertraulich intern
+				austauschen.
+			</>
+		)
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Guards against the subject line being styled as single-line. Disclosure texts of this length are expected (ADR-018, the "who reads along" Baustein).'
+			}
+		}
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px)',
+	args: {
+		icon: ICON_INFO,
+		subject: (
+			<>
+				Diese Beratungsstelle arbeitet im Team: Ihre Nachrichten können
+				von mehreren beratenden Personen gelesen werden.
+			</>
+		)
+	},
+	parameters: {
+		...mobileParameters,
+		docs: {
+			description: {
+				story: 'Same notice at 390px. The icon column must not squeeze the text into a one-word-per-line ladder.'
+			}
+		}
+	}
+};

--- a/src/components/message/SystemMessage.stories.tsx
+++ b/src/components/message/SystemMessage.stories.tsx
@@ -4,8 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ICON_CALL_OFF, ICON_INFO, SystemMessage } from './SystemMessage';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -114,6 +115,7 @@ export const Mobile: Story = {
 			</>
 		)
 	},
+	globals: phone390Globals,
 	parameters: {
 		...mobileParameters,
 		docs: {

--- a/src/components/message/UserAvatar.stories.tsx
+++ b/src/components/message/UserAvatar.stories.tsx
@@ -95,27 +95,10 @@ export const UsernameOnly: Story = {
 export const MultipleAvatars: Story = {
 	render: () => (
 		<div style={{ display: 'flex', gap: '16px', padding: '20px' }}>
-			<UserAvatar
-				username="alice"
-				userId="alice"
-				size="32px"
-			/>
-			<UserAvatar
-				username="bob"
-				userId="bob"
-				size="32px"
-			/>
-			<UserAvatar
-				username="consultant"
-				userId="consultant"
-				size="32px"
-			/>
-			<UserAvatar
-				username="orisouser"
-				userId="orisouser"
-				size="32px"
-			/>
+			<UserAvatar username="alice" userId="alice" size="32px" />
+			<UserAvatar username="bob" userId="bob" size="32px" />
+			<UserAvatar username="consultant" userId="consultant" size="32px" />
+			<UserAvatar username="orisouser" userId="orisouser" size="32px" />
 		</div>
 	)
 };
-

--- a/src/components/message/VideoCallMessage.stories.tsx
+++ b/src/components/message/VideoCallMessage.stories.tsx
@@ -4,8 +4,9 @@ import { VideoCallMessage } from './VideoCallMessage';
 import { MOCK_CONSULTANT_MATRIX_ID } from './MessageItemComponent.mocks';
 import {
 	mobileParameters,
-	withMessageShell,
-	type MessageStoryParameters
+	phone390Globals,
+	type MessageStoryParameters,
+	withMessageShell
 } from './messageStoryShell';
 import './message.styles.scss';
 
@@ -79,5 +80,6 @@ export const LongParticipantName: Story = {
 
 export const Mobile: Story = {
 	name: 'Mobile (390px)',
-	parameters: mobileParameters
+	parameters: mobileParameters,
+	globals: phone390Globals
 };

--- a/src/components/message/VideoCallMessage.stories.tsx
+++ b/src/components/message/VideoCallMessage.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { VideoCallMessage } from './VideoCallMessage';

--- a/src/components/message/VideoCallMessage.stories.tsx
+++ b/src/components/message/VideoCallMessage.stories.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { VideoCallMessage } from './VideoCallMessage';
+import { MOCK_CONSULTANT_MATRIX_ID } from './MessageItemComponent.mocks';
+import {
+	mobileParameters,
+	withMessageShell,
+	type MessageStoryParameters
+} from './messageStoryShell';
+import './message.styles.scss';
+
+/**
+ * The notice left behind by a video call that was not answered.
+ *
+ * The wording flips on `currentUserWasVideoCallInitiator(initiatorMatrixUserId)`,
+ * which compares against the *logged-in* user — so the two stories below are
+ * the same event seen from the two sides of the conversation.
+ */
+const meta = {
+	title: 'Components/Chat/VideoCallMessage',
+	component: VideoCallMessage,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Wraps `SystemMessage` with the call-off icon. Which of the two sentences is rendered depends on whether the logged-in user started the call, not on a prop — so this component cannot be fully exercised by args alone.'
+			}
+		}
+	},
+	args: {
+		videoCallMessage: {
+			initiatorUserName: 'Karina P',
+			initiatorMatrixUserId: MOCK_CONSULTANT_MATRIX_ID
+		} as any,
+		activeSessionUsername: 'sanftes Alpaka Mika',
+		activeSessionAskerRcId: 'asker-storybook'
+	},
+	decorators: [
+		(Story, ctx) =>
+			withMessageShell(Story, {
+				parameters: ctx.parameters as MessageStoryParameters
+			})
+	]
+} satisfies Meta<typeof VideoCallMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SeenByRecipient: Story = {
+	name: 'Seen by the recipient — "X ignored the call"',
+	parameters: {
+		docs: {
+			description: {
+				story: 'The logged-in user did not start the call, so the initiator is named in bold followed by `videoCall.incomingCall.ignored`.'
+			}
+		}
+	}
+};
+
+export const LongParticipantName: Story = {
+	name: 'Long participant name',
+	args: {
+		videoCallMessage: {
+			initiatorUserName:
+				'außerordentlich nachdenkliches Schnabeltier Alexandra',
+			initiatorMatrixUserId: MOCK_CONSULTANT_MATRIX_ID
+		} as any,
+		activeSessionUsername:
+			'außerordentlich nachdenkliches Schnabeltier Alexandra'
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Generated animal names are long. The bold name sits inline in the sentence, so it must wrap rather than overflow.'
+			}
+		}
+	}
+};
+
+export const Mobile: Story = {
+	name: 'Mobile (390px)',
+	parameters: mobileParameters
+};

--- a/src/components/message/VideoCallMessage.stories.tsx
+++ b/src/components/message/VideoCallMessage.stories.tsx
@@ -64,12 +64,10 @@ export const LongParticipantName: Story = {
 	name: 'Long participant name',
 	args: {
 		videoCallMessage: {
-			initiatorUserName:
-				'außerordentlich nachdenkliches Schnabeltier Alexandra',
+			initiatorUserName: 'absichtslose Schildkröte Andrea',
 			initiatorMatrixUserId: MOCK_CONSULTANT_MATRIX_ID
 		} as any,
-		activeSessionUsername:
-			'außerordentlich nachdenkliches Schnabeltier Alexandra'
+		activeSessionUsername: 'absichtslose Schildkröte Andrea'
 	},
 	parameters: {
 		docs: {

--- a/src/components/message/messageStoryShell.tsx
+++ b/src/components/message/messageStoryShell.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+
+import {
+	ActiveSessionContext,
+	E2EEContext,
+	UserDataContext,
+	type ExtendedSessionInterface
+} from '../../globalState';
+import { ConsultantListContext } from '../../globalState/provider/ConsultantListProvider';
+import { ServerSettingsContext } from '../../globalState/provider/ServerSettingsProvider';
+import type { UserDataInterface } from '../../globalState/interfaces';
+import {
+	mockActiveSession1on1,
+	mockConsultantListContext,
+	mockE2EEContext,
+	mockServerSettingsContext,
+	mockUserData
+} from './MessageItemComponent.mocks';
+
+/**
+ * Shared shell for the chat-message stories.
+ *
+ * Two things it standardises, so individual story files do not re-invent them:
+ *
+ * 1. **Viewport width.** `compact` renders at 390px — the width used by the
+ *    existing `AndroidCompactKebabTouchZone` story and the narrowest phone the
+ *    app targets. Wide renders at 1000px, matching the desktop session view.
+ *    Pair `compact` with `parameters.viewport.defaultViewport: 'mobile1'` so the
+ *    toolbar and the shell agree.
+ * 2. **The provider stack** a message row sits inside in production. Components
+ *    that read `UserDataContext` (delivery ticks) or `ActiveSessionContext`
+ *    (read-status rules) render blank or throw without it.
+ */
+
+export const STORY_WIDTH_COMPACT = 390;
+export const STORY_WIDTH_WIDE = 1000;
+
+export function MessageStoryShell({
+	children,
+	compact = false,
+	background = '#ffffff'
+}: {
+	children: React.ReactNode;
+	compact?: boolean;
+	background?: string;
+}) {
+	return (
+		<div
+			style={{
+				maxWidth: compact ? STORY_WIDTH_COMPACT : STORY_WIDTH_WIDE,
+				padding: compact ? '16px 12px' : '24px 16px',
+				background
+			}}
+		>
+			{children}
+		</div>
+	);
+}
+
+export function MessageContextShell({
+	children,
+	compact = false,
+	activeSession = mockActiveSession1on1(),
+	userData = mockUserData()
+}: {
+	children: React.ReactNode;
+	compact?: boolean;
+	activeSession?: ExtendedSessionInterface;
+	userData?: UserDataInterface;
+}) {
+	return (
+		<ServerSettingsContext.Provider value={mockServerSettingsContext()}>
+			<ConsultantListContext.Provider value={mockConsultantListContext()}>
+				<E2EEContext.Provider value={mockE2EEContext()}>
+					<UserDataContext.Provider
+						value={{
+							userData,
+							setUserData: () => {},
+							reloadUserData: async () => null as any
+						}}
+					>
+						<ActiveSessionContext.Provider
+							value={{
+								activeSession,
+								reloadActiveSession: () => {},
+								readActiveSession: () => {}
+							}}
+						>
+							<MessageStoryShell compact={compact}>
+								{children}
+							</MessageStoryShell>
+						</ActiveSessionContext.Provider>
+					</UserDataContext.Provider>
+				</E2EEContext.Provider>
+			</ConsultantListContext.Provider>
+		</ServerSettingsContext.Provider>
+	);
+}
+
+/** Story parameters honoured by the shared decorators below. */
+export type MessageStoryParameters = {
+	activeSession?: ExtendedSessionInterface;
+	userData?: UserDataInterface;
+	compactShell?: boolean;
+};
+
+/** Decorator for components that need no session context — layout only. */
+export const withMessageShell = (
+	Story: React.ComponentType,
+	{ parameters }: { parameters: MessageStoryParameters }
+) => (
+	<MessageStoryShell compact={Boolean(parameters.compactShell)}>
+		<Story />
+	</MessageStoryShell>
+);
+
+/** Decorator for components that read user/session context. */
+export const withMessageContexts = (
+	Story: React.ComponentType,
+	{ parameters }: { parameters: MessageStoryParameters }
+) => (
+	<MessageContextShell
+		compact={Boolean(parameters.compactShell)}
+		activeSession={parameters.activeSession ?? mockActiveSession1on1()}
+		userData={parameters.userData ?? mockUserData()}
+	>
+		<Story />
+	</MessageContextShell>
+);
+
+/** Shorthand for the mobile parameter block, so every story spells it the same. */
+export const mobileParameters = {
+	compactShell: true,
+	viewport: { defaultViewport: 'mobile1' }
+};

--- a/src/components/message/messageStoryShell.tsx
+++ b/src/components/message/messageStoryShell.tsx
@@ -28,8 +28,9 @@ import {
  *    `(width >= 900px)`. The bubble itself caps at
  *    `min(calc(100% - 41px), 834px)`, so a desktop frame only shows something
  *    new up to roughly 900px — beyond that the bubble stops growing.
- *    Pair `compact` with `parameters.viewport.defaultViewport: 'mobile1'` so the
- *    toolbar and the shell agree.
+ *    Pair `compact` with `mobileParameters` below so the toolbar and the shell
+ *    agree. Do **not** use Storybook's built-in `mobile1` — it is 320px, so a
+ *    story named "390px" would render at a width it does not claim.
  * 2. **The provider stack** a message row sits inside in production. Components
  *    that read `UserDataContext` (delivery ticks) or `ActiveSessionContext`
  *    (read-status rules) render blank or throw without it.
@@ -155,8 +156,17 @@ export const withMessageContexts = (
 	</MessageContextShell>
 );
 
-/** Shorthand for the mobile parameter block, so every story spells it the same. */
-export const mobileParameters = {
-	compactShell: true,
-	viewport: { defaultViewport: 'mobile1' }
-};
+/**
+ * Mobile story setup.
+ *
+ * The viewport lives in **globals**, not in parameters. Storybook 10 ignores the
+ * legacy `parameters.viewport.defaultViewport`, so stories that used it rendered
+ * at the full manager width — measured at 1100px — while their names claimed
+ * 390. The built-in `mobile1` is not registered in this setup at all, so
+ * selecting it silently did nothing either. `phone375` / `phone390` are
+ * registered in `.storybook/preview.tsx`. Verified: `globals=viewport:phone390`
+ * yields a 390px preview frame.
+ */
+export const mobileParameters = { compactShell: true };
+export const phone390Globals = { viewport: { value: 'phone390' } };
+export const phone375Globals = { viewport: { value: 'phone375' } };

--- a/src/components/message/messageStoryShell.tsx
+++ b/src/components/message/messageStoryShell.tsx
@@ -22,9 +22,12 @@ import {
  *
  * Two things it standardises, so individual story files do not re-invent them:
  *
- * 1. **Viewport width.** `compact` renders at 390px — the width used by the
- *    existing `AndroidCompactKebabTouchZone` story and the narrowest phone the
- *    app targets. Wide renders at 1000px, matching the desktop session view.
+ * 1. **Viewport width, taken from the stylesheet rather than guessed.** The
+ *    message layer switches layout at **900px**: `message.styles.scss` carries
+ *    nine `@media screen and (width <= 899px)` blocks against one
+ *    `(width >= 900px)`. The bubble itself caps at
+ *    `min(calc(100% - 41px), 834px)`, so a desktop frame only shows something
+ *    new up to roughly 900px — beyond that the bubble stops growing.
  *    Pair `compact` with `parameters.viewport.defaultViewport: 'mobile1'` so the
  *    toolbar and the shell agree.
  * 2. **The provider stack** a message row sits inside in production. Components
@@ -32,8 +35,32 @@ import {
  *    (read-status rules) render blank or throw without it.
  */
 
+/** Smallest phone still in use (iPhone SE / 8). Several layouts break here. */
+export const STORY_WIDTH_PHONE_SMALL = 375;
+/** Common phone width; the shell's `compact` default. */
 export const STORY_WIDTH_COMPACT = 390;
-export const STORY_WIDTH_WIDE = 1000;
+/** Last pixel of the narrow layout — `width <= 899px` in message.styles.scss. */
+export const STORY_WIDTH_NARROW_MAX = 899;
+/** First pixel of the desktop layout — `width >= 900px`. */
+export const STORY_WIDTH_WIDE = 900;
+/** The bubble's own cap: `min(calc(100% - 41px), 834px)`. */
+export const BUBBLE_MAX_WIDTH = 834;
+
+/**
+ * Realistic generated display names, computed from the shipped tables in
+ * `utils/anonName/data.ts` rather than invented.
+ *
+ * German worst case is **31 characters**: longest adjective (12, "absichtslose")
+ * + longest animal (11, "Schildkröte") + longest given name (6, "Andrea").
+ * Anything longer cannot occur, so testing wrapping with a 50-character name
+ * exercises a case the product never produces.
+ *
+ * Note this is the **display** name. The separate *login* name is capped at
+ * `USERNAME_MAX_LENGTH` (30) and drops the adjective — "katze_mika_1234".
+ */
+export const PSEUDONYM_TYPICAL = 'sanftes Alpaka Mika';
+export const PSEUDONYM_LONGEST = 'absichtslose Schildkröte Andrea';
+export const LOGIN_NAME_EXAMPLE = 'schildkroete_andrea_1234';
 
 export function MessageStoryShell({
 	children,

--- a/src/components/pseudonym/AnonymousConsentGate.stories.tsx
+++ b/src/components/pseudonym/AnonymousConsentGate.stories.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { AnonymousConsentGate } from './AnonymousConsentGate';
+import {
+	STORY_WIDTH_COMPACT,
+	STORY_WIDTH_PHONE_SMALL,
+	STORY_WIDTH_WIDE
+} from '../message/messageStoryShell';
+
+/**
+ * The data-protection consent gate.
+ *
+ * **This is a dialog, not a chat message** — a card over a dimmed screen, shown
+ * before an anonymous participant may write. It is filed under `Dialog` beside
+ * `Atoms/Modal` rather than under `Chat` for that reason. Design reference:
+ * [CAR02 2183-14718](https://www.figma.com/design/NEdjgOkKRrCyWVjRjBruXH/CAR02-live-chat_ORISO?node-id=2183-14718).
+ *
+ * ## Known deviations from the design (tracked in ORISO-Frontend#892)
+ *
+ * | | Figma | Shipped |
+ * |---|---|---|
+ * | Headline | "Herzlich Willkommen" | "Herzlich Willkommen**!**" |
+ * | Modality | "einen **Chat** mit ihnen starten" | "einen **Video-Call** mit Ihnen starten" |
+ * | Reject button | icon-only ✕ | "✕ Ich stimme nicht zu" with label |
+ *
+ * The "Video-Call" wording is the load-bearing one: this gate is what an
+ * anonymous **chat** participant sees, so the shipped German *and* English copy
+ * names the wrong modality. The text-labelled reject button is what makes the
+ * row too wide — see the 375px story.
+ *
+ * It also carries `role="dialog" aria-modal="true"` while being rendered inline
+ * by `SessionItemComponent`, which tells screen readers something that is not
+ * true of its current placement.
+ */
+const meta = {
+	title: 'Components/Dialog/AnonymousConsentGate',
+	component: AnonymousConsentGate,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'padded',
+		docs: {
+			description: {
+				component:
+					'Consent dialog shown before an anonymous participant may write. `consentLabelHtml` is injected as HTML so the privacy-policy link resolves to the tenant’s own document.'
+			}
+		}
+	},
+	args: {
+		consentLabelHtml:
+			'Ich habe die <a href="#privacy">Datenschutzbestimmung</a> zur Kenntnis genommen. Für Authentifizierung und Navigation verwendet diese Website Cookies.',
+		onAccept: () => {}
+	}
+} satisfies Meta<typeof AnonymousConsentGate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DesktopSideBySide: Story = {
+	name: 'Desktop (≥900px) — buttons side by side',
+	render: (args) => (
+		<div style={{ maxWidth: STORY_WIDTH_WIDE }}>
+			<AnonymousConsentGate {...args} />
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'At desktop width the two buttons sit on one row, which is the intended arrangement above the ~575px dialog breakpoint.'
+			}
+		}
+	}
+};
+
+export const Busy: Story = {
+	name: 'Accepting (busy)',
+	args: { busy: true },
+	render: (args) => (
+		<div style={{ maxWidth: STORY_WIDTH_WIDE }}>
+			<AnonymousConsentGate {...args} />
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'In-flight state. If the request fails the gate simply stays up — it has no error state of its own, which matters when the server-side check lands (ORISO-UserService#927).'
+			}
+		}
+	}
+};
+
+export const Mobile390: Story = {
+	name: 'Mobile 390px — fits, without slack',
+	render: (args) => (
+		<div style={{ maxWidth: STORY_WIDTH_COMPACT }}>
+			<AnonymousConsentGate {...args} />
+		</div>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile1' },
+		docs: {
+			description: {
+				story: 'At 390px the two buttons still fit inside the card — but only just. Compare with the 375px story.'
+			}
+		}
+	}
+};
+
+export const Mobile375LayoutDefect: Story = {
+	name: 'Mobile 375px (iPhone SE) — LAYOUT DEFECT',
+	render: (args) => (
+		<div style={{ maxWidth: STORY_WIDTH_PHONE_SMALL }}>
+			<AnonymousConsentGate {...args} />
+		</div>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile1' },
+		docs: {
+			description: {
+				story: '**Two defects at 375px** — the iPhone SE / iPhone 8 width, still a real device.\n\n1. **The button row breaks out of the card**, starting left of the card edge instead of inside its padding. Per the house dialog rule the buttons should stack full-width below ~575px.\n2. **The headline breaks mid-word:** "Herzlich Willkomm|en!" — the shield icon keeps its fixed width and starves the headline column.\n\nRestoring the icon-only reject button from the design would likely resolve the first on its own. Tracked in ORISO-Frontend#892.'
+			}
+		}
+	}
+};
+
+export const StackedButtonsTarget: Story = {
+	name: 'Target: stacked buttons below ~575px',
+	render: (args) => (
+		<div
+			style={{ maxWidth: STORY_WIDTH_PHONE_SMALL }}
+			className="sb-consent-stacked-preview"
+		>
+			<style>{`
+				/* Preview only — not shipped styling. Shows the arrangement the
+				   house dialog rule asks for below ~575px, so the fix in
+				   ORISO-Frontend#892 has something to be compared against. */
+				.sb-consent-stacked-preview .anonymousConsentGate__actions {
+					flex-direction: column;
+					align-items: stretch;
+					gap: 8px;
+				}
+				.sb-consent-stacked-preview .anonymousConsentGate__actions button {
+					width: 100%;
+				}
+			`}</style>
+			<AnonymousConsentGate {...args} />
+		</div>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile1' },
+		docs: {
+			description: {
+				story: '**Not the current behaviour — a target.** Applies the stacked arrangement via a story-local stylesheet so the intended result is visible next to the defect. Nothing here ships; the actual fix belongs in the component.'
+			}
+		}
+	}
+};

--- a/src/components/pseudonym/AnonymousConsentGate.stories.tsx
+++ b/src/components/pseudonym/AnonymousConsentGate.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { AnonymousConsentGate } from './AnonymousConsentGate';
 import {
+	phone375Globals,
+	phone390Globals,
 	STORY_WIDTH_COMPACT,
 	STORY_WIDTH_PHONE_SMALL,
 	STORY_WIDTH_WIDE
@@ -90,6 +92,7 @@ export const Busy: Story = {
 };
 
 export const Mobile390: Story = {
+	globals: phone390Globals,
 	name: 'Mobile 390px — fits, without slack',
 	render: (args) => (
 		<div style={{ maxWidth: STORY_WIDTH_COMPACT }}>
@@ -97,7 +100,6 @@ export const Mobile390: Story = {
 		</div>
 	),
 	parameters: {
-		viewport: { defaultViewport: 'mobile1' },
 		docs: {
 			description: {
 				story: 'At 390px the two buttons still fit inside the card — but only just. Compare with the 375px story.'
@@ -107,6 +109,7 @@ export const Mobile390: Story = {
 };
 
 export const Mobile375LayoutDefect: Story = {
+	globals: phone375Globals,
 	name: 'Mobile 375px (iPhone SE) — LAYOUT DEFECT',
 	render: (args) => (
 		<div style={{ maxWidth: STORY_WIDTH_PHONE_SMALL }}>
@@ -114,7 +117,6 @@ export const Mobile375LayoutDefect: Story = {
 		</div>
 	),
 	parameters: {
-		viewport: { defaultViewport: 'mobile1' },
 		docs: {
 			description: {
 				story: '**Two defects at 375px** — the iPhone SE / iPhone 8 width, still a real device.\n\n1. **The button row breaks out of the card**, starting left of the card edge instead of inside its padding. Per the house dialog rule the buttons should stack full-width below ~575px.\n2. **The headline breaks mid-word:** "Herzlich Willkomm|en!" — the shield icon keeps its fixed width and starves the headline column.\n\nRestoring the icon-only reject button from the design would likely resolve the first on its own. Tracked in ORISO-Frontend#892.'
@@ -124,6 +126,7 @@ export const Mobile375LayoutDefect: Story = {
 };
 
 export const StackedButtonsTarget: Story = {
+	globals: phone375Globals,
 	name: 'Target: stacked buttons below ~575px',
 	render: (args) => (
 		<div
@@ -147,7 +150,6 @@ export const StackedButtonsTarget: Story = {
 		</div>
 	),
 	parameters: {
-		viewport: { defaultViewport: 'mobile1' },
 		docs: {
 			description: {
 				story: '**Not the current behaviour — a target.** Applies the stacked arrangement via a story-local stylesheet so the intended result is visible next to the defect. Nothing here ships; the actual fix belongs in the component.'

--- a/src/components/pseudonym/BotMessageAnimation.stories.tsx
+++ b/src/components/pseudonym/BotMessageAnimation.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { phone390Globals } from '../message/messageStoryShell';
 
 import {
 	TypewriterText,
@@ -161,5 +162,5 @@ export const StagedSequenceMobile: Story = {
 			</TypingReveal>
 		</div>
 	),
-	parameters: { viewport: { defaultViewport: 'mobile1' } }
+	globals: phone390Globals
 };

--- a/src/components/pseudonym/BotMessageAnimation.stories.tsx
+++ b/src/components/pseudonym/BotMessageAnimation.stories.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+	TypewriterText,
+	TypingDots,
+	TypingReveal
+} from './BotMessageAnimation';
+import './PseudonymCard.styles.scss';
+
+/**
+ * The three animation primitives behind every Carimat bubble.
+ *
+ * These are what makes a staged message sequence feel like someone typing
+ * rather than a wall of text appearing at once — the behaviour ADR-018 assumes
+ * for the Erstantwort: a short Baustein must not be immediately followed by the
+ * next one.
+ *
+ * - `TypingDots` — the three-dot bubble shown while "writing"
+ * - `TypewriterText` — reveals a string character by character
+ * - `TypingReveal` — shows dots for `typingMs`, then swaps in its children
+ *
+ * All three are pure and prop-driven, so this is the cheapest place to tune
+ * timing before wiring anything to a real message event.
+ */
+const meta = {
+	title: 'Components/Carimat/BotMessageAnimation',
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'padded',
+		docs: {
+			description: {
+				component:
+					'Typing dots, typewriter text and the dots→content reveal. Timing is in props (`charMs`, `startDelayMs`, `typingMs`), so a staged Erstantwort sequence can be dialled in here without a backend.'
+			}
+		}
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Dots: Story = {
+	name: 'Typing dots',
+	render: () => <TypingDots />,
+	parameters: {
+		docs: {
+			description: {
+				story: 'The standalone "the other side is writing" indicator. This is the fallback the Erstantwort uses between Bausteine.'
+			}
+		}
+	}
+};
+
+export const Typewriter: Story = {
+	name: 'Typewriter — default speed',
+	render: () => (
+		<TypewriterText text="Danke für deine Nachricht und dein Vertrauen." />
+	)
+};
+
+export const TypewriterSlow: Story = {
+	name: 'Typewriter — slow (60ms/char)',
+	render: () => (
+		<TypewriterText
+			charMs={60}
+			text="Innerhalb der nächsten 2 Werktage erhalten Sie eine persönliche Nachricht."
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'Slower than production default. Useful for judging whether a long Baustein reads as considerate or as sluggish — the difference matters for someone in distress.'
+			}
+		}
+	}
+};
+
+export const TypewriterLongGerman: Story = {
+	name: 'Typewriter — long German paragraph',
+	render: () => (
+		<TypewriterText
+			text="Wir unterliegen der Schweigepflicht und behandeln alles vertraulich. Bitte achten Sie darauf, uns keine personenbezogenen Daten zu schicken."
+			charMs={12}
+		/>
+	)
+};
+
+export const Reveal: Story = {
+	name: 'Reveal — dots then content',
+	render: () => (
+		<TypingReveal typingMs={1200}>
+			<p style={{ margin: 0 }}>
+				Hier finden Sie noch einmal die wichtigsten Hinweise zu unserer
+				Online-Beratung.
+			</p>
+		</TypingReveal>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'The pattern a single Erstantwort Baustein uses: dots for `typingMs`, then the content. Chain several with increasing delays to get the staged sequence.'
+			}
+		}
+	}
+};
+
+export const StagedSequence: Story = {
+	name: 'Staged sequence — three Bausteine',
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+			<TypingReveal typingMs={600}>
+				<p style={{ margin: 0 }}>
+					Danke für Ihre Nachricht und Ihr Vertrauen.
+				</p>
+			</TypingReveal>
+			<TypingReveal typingMs={1800}>
+				<p style={{ margin: 0 }}>
+					Innerhalb von 2 Werktagen erhalten Sie eine persönliche
+					Antwort.
+				</p>
+			</TypingReveal>
+			<TypingReveal typingMs={3200}>
+				<p style={{ margin: 0 }}>
+					Wenn Sie schneller Hilfe brauchen: Telefonseelsorge 0800
+					1110111 oder Notruf 112.
+				</p>
+			</TypingReveal>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'Three bubbles with staggered reveals — the shape ADR-018 specifies for the Erstantwort, approximated with hand-set delays. Reload the story to replay. Note the safety-critical last Baustein appearing **last**: worth deciding whether emergency numbers should really wait behind the others.'
+			}
+		}
+	}
+};
+
+export const StagedSequenceMobile: Story = {
+	name: 'Staged sequence — mobile (390px)',
+	render: () => (
+		<div
+			style={{
+				maxWidth: 390,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 12
+			}}
+		>
+			<TypingReveal typingMs={600}>
+				<p style={{ margin: 0 }}>
+					Danke für Ihre Nachricht und Ihr Vertrauen.
+				</p>
+			</TypingReveal>
+			<TypingReveal typingMs={1800}>
+				<p style={{ margin: 0 }}>
+					Innerhalb von 2 Werktagen erhalten Sie eine persönliche
+					Antwort.
+				</p>
+			</TypingReveal>
+		</div>
+	),
+	parameters: { viewport: { defaultViewport: 'mobile1' } }
+};

--- a/src/components/pseudonym/BotMessageAnimation.stories.tsx
+++ b/src/components/pseudonym/BotMessageAnimation.stories.tsx
@@ -24,7 +24,7 @@ import './PseudonymCard.styles.scss';
  * timing before wiring anything to a real message event.
  */
 const meta = {
-	title: 'Components/Carimat/BotMessageAnimation',
+	title: 'Components/Chat/CarimatAnimation',
 	tags: ['autodocs'],
 	parameters: {
 		layout: 'padded',

--- a/src/components/pseudonym/BotMessageAnimation.tsx
+++ b/src/components/pseudonym/BotMessageAnimation.tsx
@@ -35,9 +35,11 @@ export const TypingDots: React.FC<{ className?: string }> = ({ className }) => (
  * Reveals `text` character-by-character with a terminal-style jitter:
  * each character waits 70 + (random 0-100) ms, and the trailing cursor
  * is a "_" that toggles with the current index (visible on odd, empty
- * on even) — same idiom as the reference Typewriter.js. `charMs`/
- * `startDelayMs` are kept in the prop signature for backwards compat
- * but charMs is superseded by the jittered delay.
+ * on even) — same idiom as the reference Typewriter.js.
+ *
+ * `charMs` pins the per-character delay when a caller needs a predictable
+ * speed; leave it unset for the natural jitter. It used to be declared but
+ * never destructured, so it silently did nothing — see ORISO-Frontend#849.
  */
 export const TypewriterText: React.FC<{
 	text: string;
@@ -45,7 +47,7 @@ export const TypewriterText: React.FC<{
 	startDelayMs?: number;
 	onDone?: () => void;
 	className?: string;
-}> = ({ text, startDelayMs = 0, onDone, className }) => {
+}> = ({ text, charMs, startDelayMs = 0, onDone, className }) => {
 	const [visibleLen, setVisibleLen] = useState(0);
 	const doneRef = useRef(false);
 	/* Stash onDone in a ref so a fresh function reference from the
@@ -77,7 +79,14 @@ export const TypewriterText: React.FC<{
 					}
 					return next;
 				});
-				timer = window.setTimeout(tick, 24 + 28 * Math.random());
+				/* `charMs` pins the per-character delay when a caller needs a
+				   predictable speed (Storybook timing comparisons, tests).
+				   Without it, keep the natural 24-52ms jitter that makes the
+				   bot read as typing rather than as a metronome. */
+				timer = window.setTimeout(
+					tick,
+					charMs ?? 24 + 28 * Math.random()
+				);
 			};
 			tick();
 		}, startDelayMs);
@@ -87,7 +96,7 @@ export const TypewriterText: React.FC<{
 			if (timer) window.clearTimeout(timer);
 			window.clearTimeout(start);
 		};
-	}, [text, startDelayMs]);
+	}, [text, charMs, startDelayMs]);
 
 	const done = visibleLen >= text.length;
 	const cursor = visibleLen & 1 ? '_' : ' ';

--- a/src/components/pseudonym/CarimatCards.stories.tsx
+++ b/src/components/pseudonym/CarimatCards.stories.tsx
@@ -2,44 +2,45 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import type { Pseudonym } from '../../utils/pseudonymGenerator';
-import { AnonymousConsentGate } from './AnonymousConsentGate';
+import {
+	PSEUDONYM_LONGEST,
+	PSEUDONYM_TYPICAL,
+	STORY_WIDTH_COMPACT
+} from '../message/messageStoryShell';
 import { PrivacyMessageCard } from './PrivacyMessageCard';
 import { PseudonymCard } from './PseudonymCard';
 import './PseudonymCard.styles.scss';
 
 /**
- * The Carimat bubbles that exist in the product today.
+ * Carimat — the platform's own voice in the chat.
  *
- * Carimat is the platform's own voice: a name, a robot avatar and a kicker line
- * above the bubble. It is a **rendering identity, not a Matrix account**
- * (ADR-018 §3) — nothing here corresponds to a room member.
+ * **Filed under Chat on purpose.** A Carimat bubble is a *kind of chat message*,
+ * a sibling of the system notices, not a separate widget family. Its avatar
+ * therefore has to obey the same circle geometry as `MessageAvatar`
+ * (`size = 32`) — which today it does **not**: `PseudonymCard.styles.scss:34-40`
+ * gives it a bespoke 54×54 frame in a 64px column. Tracked in
+ * OpenResilienceInitiative/ORISO-Frontend#892.
  *
- * Grouped in one file because the three cards share one visual grammar and are
- * meant to be compared: the kicker + bubble layout must stay identical across
- * them, otherwise the sequence reads as three different senders.
+ * Carimat is a **rendering identity, not a Matrix account** (ADR-018 §3) —
+ * nothing here corresponds to a room member.
  *
- * Two things to look for in every story:
+ * The consent gate used to live in this file. It has moved to
+ * `AnonymousConsentGate.stories.tsx` under `Components/Dialog`, because it is a
+ * pop-up dialog over a dimmed screen, not a chat message.
  *
- * 1. **The kicker line.** "Carimat" is currently a **hardcoded JSX string**, not
- *    an i18n key, in all three components. Switching the locale in the toolbar
- *    changes the subtitle but never the name.
- * 2. **The consent gate names the wrong modality.** The shipped copy
- *    (`anonymousConsent.description`) reads "Danach dürfen unsere Beraterinnen
- *    oder Berater einen **Video-Call** mit Ihnen starten" — but this gate is
- *    what an anonymous **chat** participant sees. English has the same defect
- *    ("start a video call with you"). Note that the gendered `Berater_innen`
- *    string in the component source is only the untranslated fallback and never
- *    reaches a user; the shipped text uses the doubled form.
+ * One thing to watch in every story: **the kicker line.** "Carimat" is a
+ * hardcoded JSX string, not an i18n key, in all of these components. Switching
+ * the locale in the toolbar changes the subtitle but never the name.
  */
 const meta = {
-	title: 'Components/Carimat/Cards',
+	title: 'Components/Chat/CarimatMessage',
 	tags: ['autodocs'],
 	parameters: {
 		layout: 'padded',
 		docs: {
 			description: {
 				component:
-					'The shipped Carimat bubbles: choose-a-name, privacy notice, consent gate. Shared kicker + bubble grammar; see the docblock for the two known defects these stories make visible.'
+					'Carimat message bubbles: choose-a-name and the privacy notice. Same message grammar as the other chat rows — kicker line, avatar column, bubble.'
 			}
 		}
 	}
@@ -49,70 +50,64 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const pseudonym: Pseudonym = {
-	displayName: 'sanftes Alpaka Mika',
+	displayName: PSEUDONYM_TYPICAL,
 	animalLabel: 'Alpaka',
 	name: 'Mika',
-	avatar: {
-		file: 'alpaca.svg',
-		bg: '#E8DEF8',
-		iconColor: '#1D1B20'
-	}
+	avatar: { file: 'alpaca.svg', bg: '#E8DEF8', iconColor: '#1D1B20' }
 };
 
+/**
+ * The longest display name the shipped generator can actually produce in
+ * German — 31 characters, computed from `utils/anonName/data.ts`. Longer names
+ * cannot occur, so they are not worth testing against.
+ */
 const longPseudonym: Pseudonym = {
-	displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra',
-	animalLabel: 'Schnabeltier',
-	name: 'Alexandra',
-	avatar: {
-		file: 'platypus.svg',
-		bg: '#21005D',
-		iconColor: '#FFFFFF'
-	}
+	displayName: PSEUDONYM_LONGEST,
+	animalLabel: 'Schildkröte',
+	name: 'Andrea',
+	avatar: { file: 'turtle.svg', bg: '#21005D', iconColor: '#FFFFFF' }
 };
-
-const consentLabelHtml =
-	'Ich habe die <a href="#privacy">Datenschutzbestimmung</a> gelesen und bin einverstanden.';
 
 export const ChooseDisplayName: Story = {
-	name: 'Pseudonym card — typing animation',
+	name: 'Pseudonym message — typing animation',
 	render: () => <PseudonymCard pseudonym={pseudonym} />,
 	parameters: {
 		docs: {
 			description: {
-				story: 'First Carimat bubble. Plays the typing dots, then writes the message. Reload the story to replay the animation.'
+				story: 'Plays the typing dots, then writes the message. Reload the story to replay.'
 			}
 		}
 	}
 };
 
 export const ChooseDisplayNameStatic: Story = {
-	name: 'Pseudonym card — no animation (skipTyping)',
+	name: 'Pseudonym message — no animation (skipTyping)',
 	render: () => <PseudonymCard pseudonym={pseudonym} skipTyping />,
 	parameters: {
 		docs: {
 			description: {
-				story: 'The re-render state. This is the variant to use for visual regression, since the animated one is time-dependent.'
+				story: 'The re-render state — the variant to use for visual regression, since the animated one is time-dependent.'
 			}
 		}
 	}
 };
 
-export const ChooseDisplayNameLongName: Story = {
-	name: 'Pseudonym card — long generated name',
+export const ChooseDisplayNameLongestName: Story = {
+	name: 'Pseudonym message — longest possible name (31 chars)',
 	render: () => <PseudonymCard pseudonym={longPseudonym} skipTyping />,
 	parameters: {
 		docs: {
 			description: {
-				story: 'The generator produces long German compounds. The name must not overflow the bubble or collide with the avatar.'
+				story: '"absichtslose Schildkröte Andrea" is the worst case the generator can produce: longest adjective + longest animal + longest given name. The name must not overflow the bubble or collide with the avatar column.'
 			}
 		}
 	}
 };
 
 export const ChooseDisplayNameMobile: Story = {
-	name: 'Pseudonym card — mobile (390px)',
+	name: 'Pseudonym message — mobile (390px), longest name',
 	render: () => (
-		<div style={{ maxWidth: 390 }}>
+		<div style={{ maxWidth: STORY_WIDTH_COMPACT }}>
 			<PseudonymCard pseudonym={longPseudonym} skipTyping />
 		</div>
 	),
@@ -120,26 +115,26 @@ export const ChooseDisplayNameMobile: Story = {
 };
 
 export const PrivacyNotice: Story = {
-	name: 'Privacy card — typing animation',
+	name: 'Privacy message — typing animation',
 	render: () => <PrivacyMessageCard />
 };
 
 export const PrivacyNoticeStatic: Story = {
-	name: 'Privacy card — no animation',
+	name: 'Privacy message — no animation',
 	render: () => <PrivacyMessageCard skipTyping />
 };
 
 export const PrivacyNoticeMobile: Story = {
-	name: 'Privacy card — mobile (390px)',
+	name: 'Privacy message — mobile (390px)',
 	render: () => (
-		<div style={{ maxWidth: 390 }}>
+		<div style={{ maxWidth: STORY_WIDTH_COMPACT }}>
 			<PrivacyMessageCard skipTyping />
 		</div>
 	),
 	parameters: { viewport: { defaultViewport: 'mobile1' } }
 };
 
-export const TwoCardStack: Story = {
+export const TwoMessageStack: Story = {
 	name: 'Sequence — pseudonym then privacy',
 	render: () => (
 		<div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -150,82 +145,7 @@ export const TwoCardStack: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'How the two cards stack in `SessionItemComponent` once the pseudonym is confirmed. This is the existing precedent for rendering several bubbles from one step — the shape the Erstantwort generalises.'
-			}
-		}
-	}
-};
-
-export const ConsentGate: Story = {
-	name: 'Consent gate — idle',
-	render: () => (
-		<AnonymousConsentGate
-			consentLabelHtml={consentLabelHtml}
-			onAccept={() => {}}
-		/>
-	),
-	parameters: {
-		docs: {
-			description: {
-				story: 'The gate that blocks the composer until data-protection consent is confirmed. Two defects visible here: it carries `role="dialog" aria-modal="true"` although it is an inline card, and the copy promises a **video call** although this gate is what an anonymous *chat* participant sees. Tracked in ORISO-UserService#927.'
-			}
-		}
-	}
-};
-
-export const ConsentGateBusy: Story = {
-	name: 'Consent gate — accepting (busy)',
-	render: () => (
-		<AnonymousConsentGate
-			consentLabelHtml={consentLabelHtml}
-			onAccept={() => {}}
-			busy
-		/>
-	),
-	parameters: {
-		docs: {
-			description: {
-				story: 'In-flight state. If the request fails the gate stays up — there is no error state of its own, which is worth remembering when wiring the server-side check.'
-			}
-		}
-	}
-};
-
-export const ConsentGateMobile: Story = {
-	name: 'Consent gate — mobile (390px)',
-	render: () => (
-		<div style={{ maxWidth: 390 }}>
-			<AnonymousConsentGate
-				consentLabelHtml={consentLabelHtml}
-				onAccept={() => {}}
-			/>
-		</div>
-	),
-	parameters: {
-		viewport: { defaultViewport: 'mobile1' },
-		docs: {
-			description: {
-				story: 'At 390px the two buttons still fit inside the card, but only just — there is no slack left. See the 375px story below, where they break out.'
-			}
-		}
-	}
-};
-
-export const ConsentGateIPhoneSE: Story = {
-	name: 'Consent gate — 375px (iPhone SE) — LAYOUT DEFECT',
-	render: () => (
-		<div style={{ maxWidth: 375 }}>
-			<AnonymousConsentGate
-				consentLabelHtml={consentLabelHtml}
-				onAccept={() => {}}
-			/>
-		</div>
-	),
-	parameters: {
-		viewport: { defaultViewport: 'mobile1' },
-		docs: {
-			description: {
-				story: '**Two layout defects at 375px** — the iPhone SE / iPhone 8 width, still a real device.\n\n1. **The button row breaks out of the card.** It starts left of the card edge instead of inside its padding. Per the house dialog rule the buttons should stack full-width below ~575px rather than staying side by side.\n2. **The headline breaks mid-word:** "Herzlich Willkomm|en!". The shield icon keeps its fixed width, leaving the headline column too narrow to fit "Willkommen".\n\n390px (previous story) still fits, so the breaking point sits between the two widths. Tracked in ORISO-UserService#927.'
+				story: 'How the two stack in `SessionItemComponent` once the pseudonym is confirmed — the existing precedent for rendering several bubbles from one step, which the Erstantwort generalises.'
 			}
 		}
 	}

--- a/src/components/pseudonym/CarimatCards.stories.tsx
+++ b/src/components/pseudonym/CarimatCards.stories.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import type { Pseudonym } from '../../utils/pseudonymGenerator';
+import { AnonymousConsentGate } from './AnonymousConsentGate';
+import { PrivacyMessageCard } from './PrivacyMessageCard';
+import { PseudonymCard } from './PseudonymCard';
+import './PseudonymCard.styles.scss';
+
+/**
+ * The Carimat bubbles that exist in the product today.
+ *
+ * Carimat is the platform's own voice: a name, a robot avatar and a kicker line
+ * above the bubble. It is a **rendering identity, not a Matrix account**
+ * (ADR-018 §3) — nothing here corresponds to a room member.
+ *
+ * Grouped in one file because the three cards share one visual grammar and are
+ * meant to be compared: the kicker + bubble layout must stay identical across
+ * them, otherwise the sequence reads as three different senders.
+ *
+ * Two things to look for in every story:
+ *
+ * 1. **The kicker line.** "Carimat" is currently a **hardcoded JSX string**, not
+ *    an i18n key, in all three components. Switching the locale in the toolbar
+ *    changes the subtitle but never the name.
+ * 2. **The consent gate names the wrong modality.** The shipped copy
+ *    (`anonymousConsent.description`) reads "Danach dürfen unsere Beraterinnen
+ *    oder Berater einen **Video-Call** mit Ihnen starten" — but this gate is
+ *    what an anonymous **chat** participant sees. English has the same defect
+ *    ("start a video call with you"). Note that the gendered `Berater_innen`
+ *    string in the component source is only the untranslated fallback and never
+ *    reaches a user; the shipped text uses the doubled form.
+ */
+const meta = {
+	title: 'Components/Carimat/Cards',
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'padded',
+		docs: {
+			description: {
+				component:
+					'The shipped Carimat bubbles: choose-a-name, privacy notice, consent gate. Shared kicker + bubble grammar; see the docblock for the two known defects these stories make visible.'
+			}
+		}
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const pseudonym: Pseudonym = {
+	displayName: 'sanftes Alpaka Mika',
+	animalLabel: 'Alpaka',
+	name: 'Mika',
+	avatar: {
+		file: 'alpaca.svg',
+		bg: '#E8DEF8',
+		iconColor: '#1D1B20'
+	}
+};
+
+const longPseudonym: Pseudonym = {
+	displayName: 'außerordentlich nachdenkliches Schnabeltier Alexandra',
+	animalLabel: 'Schnabeltier',
+	name: 'Alexandra',
+	avatar: {
+		file: 'platypus.svg',
+		bg: '#21005D',
+		iconColor: '#FFFFFF'
+	}
+};
+
+const consentLabelHtml =
+	'Ich habe die <a href="#privacy">Datenschutzbestimmung</a> gelesen und bin einverstanden.';
+
+export const ChooseDisplayName: Story = {
+	name: 'Pseudonym card — typing animation',
+	render: () => <PseudonymCard pseudonym={pseudonym} />,
+	parameters: {
+		docs: {
+			description: {
+				story: 'First Carimat bubble. Plays the typing dots, then writes the message. Reload the story to replay the animation.'
+			}
+		}
+	}
+};
+
+export const ChooseDisplayNameStatic: Story = {
+	name: 'Pseudonym card — no animation (skipTyping)',
+	render: () => <PseudonymCard pseudonym={pseudonym} skipTyping />,
+	parameters: {
+		docs: {
+			description: {
+				story: 'The re-render state. This is the variant to use for visual regression, since the animated one is time-dependent.'
+			}
+		}
+	}
+};
+
+export const ChooseDisplayNameLongName: Story = {
+	name: 'Pseudonym card — long generated name',
+	render: () => <PseudonymCard pseudonym={longPseudonym} skipTyping />,
+	parameters: {
+		docs: {
+			description: {
+				story: 'The generator produces long German compounds. The name must not overflow the bubble or collide with the avatar.'
+			}
+		}
+	}
+};
+
+export const ChooseDisplayNameMobile: Story = {
+	name: 'Pseudonym card — mobile (390px)',
+	render: () => (
+		<div style={{ maxWidth: 390 }}>
+			<PseudonymCard pseudonym={longPseudonym} skipTyping />
+		</div>
+	),
+	parameters: { viewport: { defaultViewport: 'mobile1' } }
+};
+
+export const PrivacyNotice: Story = {
+	name: 'Privacy card — typing animation',
+	render: () => <PrivacyMessageCard />
+};
+
+export const PrivacyNoticeStatic: Story = {
+	name: 'Privacy card — no animation',
+	render: () => <PrivacyMessageCard skipTyping />
+};
+
+export const PrivacyNoticeMobile: Story = {
+	name: 'Privacy card — mobile (390px)',
+	render: () => (
+		<div style={{ maxWidth: 390 }}>
+			<PrivacyMessageCard skipTyping />
+		</div>
+	),
+	parameters: { viewport: { defaultViewport: 'mobile1' } }
+};
+
+export const TwoCardStack: Story = {
+	name: 'Sequence — pseudonym then privacy',
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+			<PseudonymCard pseudonym={pseudonym} skipTyping />
+			<PrivacyMessageCard skipTyping />
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'How the two cards stack in `SessionItemComponent` once the pseudonym is confirmed. This is the existing precedent for rendering several bubbles from one step — the shape the Erstantwort generalises.'
+			}
+		}
+	}
+};
+
+export const ConsentGate: Story = {
+	name: 'Consent gate — idle',
+	render: () => (
+		<AnonymousConsentGate
+			consentLabelHtml={consentLabelHtml}
+			onAccept={() => {}}
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'The gate that blocks the composer until data-protection consent is confirmed. Two defects visible here: it carries `role="dialog" aria-modal="true"` although it is an inline card, and the copy promises a **video call** although this gate is what an anonymous *chat* participant sees. Tracked in ORISO-UserService#927.'
+			}
+		}
+	}
+};
+
+export const ConsentGateBusy: Story = {
+	name: 'Consent gate — accepting (busy)',
+	render: () => (
+		<AnonymousConsentGate
+			consentLabelHtml={consentLabelHtml}
+			onAccept={() => {}}
+			busy
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'In-flight state. If the request fails the gate stays up — there is no error state of its own, which is worth remembering when wiring the server-side check.'
+			}
+		}
+	}
+};
+
+export const ConsentGateMobile: Story = {
+	name: 'Consent gate — mobile (390px)',
+	render: () => (
+		<div style={{ maxWidth: 390 }}>
+			<AnonymousConsentGate
+				consentLabelHtml={consentLabelHtml}
+				onAccept={() => {}}
+			/>
+		</div>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile1' },
+		docs: {
+			description: {
+				story: '**Layout defect, reproducible here.** At 375px the two-button row breaks out of the card: the card starts at x≈68 while "Ich stimme nicht zu" starts at x≈36, and the confirm button runs to the viewport edge. The buttons should stack full-width below ~575px, per the house dialog rule. Tracked in ORISO-UserService#927.'
+			}
+		}
+	}
+};

--- a/src/components/pseudonym/CarimatCards.stories.tsx
+++ b/src/components/pseudonym/CarimatCards.stories.tsx
@@ -5,7 +5,8 @@ import type { Pseudonym } from '../../utils/pseudonymGenerator';
 import {
 	PSEUDONYM_LONGEST,
 	PSEUDONYM_TYPICAL,
-	STORY_WIDTH_COMPACT
+	STORY_WIDTH_COMPACT,
+	phone390Globals
 } from '../message/messageStoryShell';
 import { PrivacyMessageCard } from './PrivacyMessageCard';
 import { PseudonymCard } from './PseudonymCard';
@@ -111,7 +112,7 @@ export const ChooseDisplayNameMobile: Story = {
 			<PseudonymCard pseudonym={longPseudonym} skipTyping />
 		</div>
 	),
-	parameters: { viewport: { defaultViewport: 'mobile1' } }
+	globals: phone390Globals
 };
 
 export const PrivacyNotice: Story = {
@@ -131,7 +132,7 @@ export const PrivacyNoticeMobile: Story = {
 			<PrivacyMessageCard skipTyping />
 		</div>
 	),
-	parameters: { viewport: { defaultViewport: 'mobile1' } }
+	globals: phone390Globals
 };
 
 export const TwoMessageStack: Story = {

--- a/src/components/pseudonym/CarimatCards.stories.tsx
+++ b/src/components/pseudonym/CarimatCards.stories.tsx
@@ -205,7 +205,27 @@ export const ConsentGateMobile: Story = {
 		viewport: { defaultViewport: 'mobile1' },
 		docs: {
 			description: {
-				story: '**Layout defect, reproducible here.** At 375px the two-button row breaks out of the card: the card starts at x≈68 while "Ich stimme nicht zu" starts at x≈36, and the confirm button runs to the viewport edge. The buttons should stack full-width below ~575px, per the house dialog rule. Tracked in ORISO-UserService#927.'
+				story: 'At 390px the two buttons still fit inside the card, but only just — there is no slack left. See the 375px story below, where they break out.'
+			}
+		}
+	}
+};
+
+export const ConsentGateIPhoneSE: Story = {
+	name: 'Consent gate — 375px (iPhone SE) — LAYOUT DEFECT',
+	render: () => (
+		<div style={{ maxWidth: 375 }}>
+			<AnonymousConsentGate
+				consentLabelHtml={consentLabelHtml}
+				onAccept={() => {}}
+			/>
+		</div>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile1' },
+		docs: {
+			description: {
+				story: '**Two layout defects at 375px** — the iPhone SE / iPhone 8 width, still a real device.\n\n1. **The button row breaks out of the card.** It starts left of the card edge instead of inside its padding. Per the house dialog rule the buttons should stack full-width below ~575px rather than staying side by side.\n2. **The headline breaks mid-word:** "Herzlich Willkomm|en!". The shield icon keeps its fixed width, leaving the headline column too narrow to fit "Willkommen".\n\n390px (previous story) still fits, so the breaking point sits between the two widths. Tracked in ORISO-UserService#927.'
 			}
 		}
 	}


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-Frontend#826 · design source: `0 - Docs/ADR-018-erstantwort-as-one-persisted-event-rendered-as-carimat-bubbles.md`

## Why

The chat message layer had stories for six components. Eleven others shipped with none, and the **Carimat cards — the platform's own voice in the chat — had none at all**. That is exactly the layer ADR-018 rebuilds the Erstantwort on, so it has to be reviewable without an enquiry, a session and a backend.

## What this adds

**68 stories across 11 files**, plus one shared shell so no file re-invents the provider stack or the mobile width.

| File | What it covers |
|---|---|
| `messageStoryShell.tsx` | shared 390px/1000px shell + context decorators (not a story file) |
| `SystemMessage` | icon variants, subject+body, long wrapping subject |
| `MessageDisplayName` | all four types; `system` ignores the name props |
| `MessageMetaData` | all five situations that suppress the read status |
| `E2EEActivatedMessage` | desktop, mobile, dark surface |
| `MasterKeyLostMessage` | both wordings |
| `VideoCallMessage` | recipient view, long generated name |
| `FurtherSteps` | all four CTA combinations + counsellor view |
| `ReassignMessage` | all four states, incl. the accept/decline buttons |
| `Appointment` | all four alias types, note expansion |
| `BotMessageAnimation` | typing dots, typewriter, staged reveal, 3-bubble sequence |
| `CarimatCards` | pseudonym card, privacy card, consent gate |

**Mobile is a first-class axis, not an afterthought.** Every component gets at least one 390px story, reusing the existing `compactShell` + `viewport: mobile1` convention from `AndroidCompactKebabTouchZone` so the toolbar and the container agree instead of drifting apart.

**Dead paths are labelled as dead.** `FurtherSteps`, `ReassignMessage` and `Appointment` sit on the alias path, whose endpoint is not routed to a backend. Their docblocks say so, with the reason, so the stories are not mistaken for documentation of live behaviour.

## Defects this surfaced

Writing the stories was the point; finding these was the dividend.

1. **`ConsultantMatchingAnimation.tsx` is a 0-byte file** on `origin/pre-dev`, imported by nothing. There is nothing to write a story for — it should be deleted. Issue #826 listed it in error.
2. **The anonymous consent gate names the wrong modality.** `anonymousConsent.description` reads *"Danach dürfen unsere Beraterinnen oder Berater einen **Video-Call** mit Ihnen starten"* in German and *"start a video call with you"* in English — but this gate is what an anonymous **chat** participant sees. Captured in `CarimatCards.stories.tsx`.
3. **The consent gate's buttons break out of their card at 375px.** The card starts at x≈68 while "Ich stimme nicht zu" starts at x≈36, and the confirm button runs to the viewport edge. Per the house dialog rule they should stack full-width below ~575px. Reproducible in `Carimat/Cards → Consent gate — mobile (390px)`.
4. **"Carimat" is a hardcoded JSX string**, not an i18n key, in all three cards. Switching the locale changes the subtitle but never the name.

Items 2 and 3 belong to OpenResilienceInitiative/ORISO-UserService#927, which already owns the gate's copy and ARIA fixes. Item 1 is a one-line deletion; say the word and I will fold it in here.

## Verification

- `tsc --noEmit --project tsconfig.storybook.json` — clean
- `npm run build-storybook` — exit 0, no unresolved modules, 456 stories in the built index
- Served the static build and looked at it: the two-card Carimat stack and the consent gate at 375px are the screenshots that produced defects 2 and 3

Not verified: visual regression against Figma, and the a11y addon's findings — neither is in scope for #826.

## Reviewer test plan

- [ ] `npm run build-storybook` passes locally
- [ ] `Components/Carimat/Cards → Sequence — pseudonym then privacy` renders two bubbles with kicker lines and the animal avatar
- [ ] `Components/Carimat/BotMessageAnimation → Staged sequence` plays three bubbles in sequence with typing dots between them
- [ ] `Components/Carimat/Cards → Consent gate — mobile (390px)` reproduces the button overflow described above
- [ ] `Components/Chat/FurtherSteps` — each of the four CTA combinations shows exactly the expected buttons
- [ ] `Components/Chat/MessageMetaData` — the advice-seeker, group, disabled, `type=user` and `t=rm` stories all show **no** checkmark
- [ ] **Mobile:** every `— mobile (390px)` story renders without horizontal overflow (check on a real phone or the mobile1 viewport)
- [ ] No pre-existing story regressed — `MessageItemComponent` stories still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Storybook examples for chat messages, appointments, calls, system notifications, privacy flows, pseudonym cards, and bot animations.
  * Added desktop, mobile, dark-surface, long-content, and state-specific examples to demonstrate responsive and varied interface behavior.
  * Added automated story screenshots with rendering metadata and error reporting.

* **Documentation**
  * Added component guidance and visual examples to Storybook for easier review and exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->