### PR TITLE
fix(enquiry): preserve first-message notification producer (#851)

### DIFF
--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { isAskerEnquirySubmission } from './messageEncryptionMode';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createEnquirySubmissionGuard,
+	dispatchAskerMessageTransport,
+	isAskerEnquirySubmission,
+	resolveAskerMessageTransport
+} from './messageEncryptionMode';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 
 describe('messageEncryptionMode', () => {
@@ -36,7 +41,7 @@ describe('messageEncryptionMode', () => {
 		).toBe(false);
 	});
 
-	it('uses the enquiry endpoint for the first message even when registration pre-created a Matrix room', () => {
+	it('classifies the first message as an enquiry even when registration pre-created a Matrix room', () => {
 		expect(
 			isAskerEnquirySubmission({
 				isEnquiryListType: false,
@@ -48,7 +53,7 @@ describe('messageEncryptionMode', () => {
 		).toBe(true);
 	});
 
-	it('sends follow-up messages through Matrix once the enquiry message is recorded', () => {
+	it('classifies a recorded enquiry message as a follow-up', () => {
 		expect(
 			isAskerEnquirySubmission({
 				isEnquiryListType: false,
@@ -69,5 +74,99 @@ describe('messageEncryptionMode', () => {
 				isAnonymousLiveChat: false
 			})
 		).toBe(false);
+	});
+
+	it('dispatches the first message to the enquiry endpoint exactly once even with a Matrix room', async () => {
+		const sendEnquiry = vi.fn().mockResolvedValue(undefined);
+		const sendMatrix = vi.fn().mockResolvedValue(undefined);
+		const onBlocked = vi.fn();
+		const transport = resolveAskerMessageTransport({
+			isEnquiryListType: false,
+			sessionStatus: STATUS_ENQUIRY,
+			hasAskerAuthority: true,
+			isAnonymousLiveChat: false,
+			hasEnquiryMessage: false,
+			isMatrixSession: true,
+			matrixRoomId: '!precreated:example.org'
+		});
+
+		await dispatchAskerMessageTransport({
+			transport,
+			sendEnquiry,
+			sendMatrix,
+			onBlocked
+		});
+
+		expect(sendEnquiry).toHaveBeenCalledOnce();
+		expect(sendMatrix).not.toHaveBeenCalled();
+		expect(onBlocked).not.toHaveBeenCalled();
+	});
+
+	it('dispatches a recorded enquiry follow-up through Matrix', async () => {
+		const sendEnquiry = vi.fn().mockResolvedValue(undefined);
+		const sendMatrix = vi.fn().mockResolvedValue(undefined);
+		const onBlocked = vi.fn();
+		const transport = resolveAskerMessageTransport({
+			isEnquiryListType: false,
+			sessionStatus: STATUS_ENQUIRY,
+			hasAskerAuthority: true,
+			isAnonymousLiveChat: false,
+			hasEnquiryMessage: true,
+			isMatrixSession: true,
+			matrixRoomId: '!ready:example.org'
+		});
+
+		await dispatchAskerMessageTransport({
+			transport,
+			sendEnquiry,
+			sendMatrix,
+			onBlocked
+		});
+
+		expect(sendMatrix).toHaveBeenCalledOnce();
+		expect(sendEnquiry).not.toHaveBeenCalled();
+		expect(onBlocked).not.toHaveBeenCalled();
+	});
+
+	it('blocks a recorded enquiry follow-up until its Matrix room is ready', async () => {
+		const sendEnquiry = vi.fn().mockResolvedValue(undefined);
+		const sendMatrix = vi.fn().mockResolvedValue(undefined);
+		const onBlocked = vi.fn();
+		const transport = resolveAskerMessageTransport({
+			isEnquiryListType: false,
+			sessionStatus: STATUS_ENQUIRY,
+			hasAskerAuthority: true,
+			isAnonymousLiveChat: false,
+			hasEnquiryMessage: true,
+			isMatrixSession: false
+		});
+
+		await dispatchAskerMessageTransport({
+			transport,
+			sendEnquiry,
+			sendMatrix,
+			onBlocked
+		});
+
+		expect(onBlocked).toHaveBeenCalledOnce();
+		expect(sendEnquiry).not.toHaveBeenCalled();
+		expect(sendMatrix).not.toHaveBeenCalled();
+	});
+
+	it('keeps a successful one-shot enquiry locked until the session changes', () => {
+		const guard = createEnquirySubmissionGuard();
+
+		expect(guard.tryStart()).toBe(true);
+		expect(guard.tryStart()).toBe(false);
+		guard.markSucceeded();
+		expect(guard.tryStart()).toBe(false);
+	});
+
+	it('allows a retry when the one-shot enquiry request fails', () => {
+		const guard = createEnquirySubmissionGuard();
+
+		expect(guard.tryStart()).toBe(true);
+		guard.markFailed();
+		expect(guard.tryStart()).toBe(true);
 	});
 });

--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -36,14 +36,26 @@ describe('messageEncryptionMode', () => {
 		).toBe(false);
 	});
 
-	it('does not use the enquiry endpoint once the session has a Matrix room', () => {
+	it('uses the enquiry endpoint for the first message even when registration pre-created a Matrix room', () => {
 		expect(
 			isAskerEnquirySubmission({
 				isEnquiryListType: false,
 				sessionStatus: STATUS_ENQUIRY,
 				hasAskerAuthority: true,
 				isAnonymousLiveChat: false,
-				hasMatrixRoom: true
+				hasEnquiryMessage: false
+			})
+		).toBe(true);
+	});
+
+	it('sends follow-up messages through Matrix once the enquiry message is recorded', () => {
+		expect(
+			isAskerEnquirySubmission({
+				isEnquiryListType: false,
+				sessionStatus: STATUS_ENQUIRY,
+				hasAskerAuthority: true,
+				isAnonymousLiveChat: false,
+				hasEnquiryMessage: true
 			})
 		).toBe(false);
 	});

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -5,7 +5,7 @@ interface AskerEnquirySubmissionInput {
 	sessionStatus?: number;
 	hasAskerAuthority: boolean;
 	isAnonymousLiveChat: boolean;
-	hasMatrixRoom?: boolean;
+	hasEnquiryMessage?: boolean;
 }
 
 export const isAskerEnquirySubmission = ({
@@ -13,9 +13,9 @@ export const isAskerEnquirySubmission = ({
 	sessionStatus,
 	hasAskerAuthority,
 	isAnonymousLiveChat,
-	hasMatrixRoom
+	hasEnquiryMessage
 }: AskerEnquirySubmissionInput): boolean =>
 	(isEnquiryListType || sessionStatus === STATUS_ENQUIRY) &&
 	hasAskerAuthority &&
 	!isAnonymousLiveChat &&
-	!hasMatrixRoom;
+	!hasEnquiryMessage;

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -8,6 +8,26 @@ interface AskerEnquirySubmissionInput {
 	hasEnquiryMessage?: boolean;
 }
 
+export type AskerMessageTransport = 'enquiry' | 'matrix' | 'blocked' | 'other';
+
+interface AskerMessageTransportInput extends AskerEnquirySubmissionInput {
+	isMatrixSession: boolean;
+	matrixRoomId?: string | null;
+}
+
+interface AskerMessageTransportDispatch {
+	transport: AskerMessageTransport;
+	sendEnquiry: () => Promise<unknown>;
+	sendMatrix: () => Promise<unknown>;
+	onBlocked: () => void;
+}
+
+export interface EnquirySubmissionGuard {
+	markFailed: () => void;
+	markSucceeded: () => void;
+	tryStart: () => boolean;
+}
+
 export const isAskerEnquirySubmission = ({
 	isEnquiryListType,
 	sessionStatus,
@@ -19,3 +39,64 @@ export const isAskerEnquirySubmission = ({
 	hasAskerAuthority &&
 	!isAnonymousLiveChat &&
 	!hasEnquiryMessage;
+
+export const resolveAskerMessageTransport = (
+	input: AskerMessageTransportInput
+): AskerMessageTransport => {
+	if (isAskerEnquirySubmission(input)) {
+		return 'enquiry';
+	}
+	if (
+		!input.hasAskerAuthority ||
+		input.isAnonymousLiveChat ||
+		!input.hasEnquiryMessage
+	) {
+		return 'other';
+	}
+
+	return input.isMatrixSession && Boolean(input.matrixRoomId)
+		? 'matrix'
+		: 'blocked';
+};
+
+export const dispatchAskerMessageTransport = async ({
+	transport,
+	sendEnquiry,
+	sendMatrix,
+	onBlocked
+}: AskerMessageTransportDispatch): Promise<boolean> => {
+	if (transport === 'enquiry') {
+		await sendEnquiry();
+		return true;
+	}
+	if (transport === 'matrix') {
+		await sendMatrix();
+		return true;
+	}
+	if (transport === 'blocked') {
+		onBlocked();
+		return true;
+	}
+	return false;
+};
+
+export const createEnquirySubmissionGuard = (): EnquirySubmissionGuard => {
+	let state: 'idle' | 'inFlight' | 'submitted' = 'idle';
+	return {
+		tryStart: () => {
+			if (state !== 'idle') {
+				return false;
+			}
+			state = 'inFlight';
+			return true;
+		},
+		markSucceeded: () => {
+			state = 'submitted';
+		},
+		markFailed: () => {
+			if (state === 'inFlight') {
+				state = 'idle';
+			}
+		}
+	};
+};

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -651,7 +651,6 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const isAnonymousEnquiryComposer =
 		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
-	const hasMatrixRoom = Boolean(resolvedChatSession.matrixRoomId);
 	const isAskerEnquiry = isAskerEnquirySubmission({
 		isEnquiryListType: type === SESSION_LIST_TYPES.ENQUIRY,
 		sessionStatus: activeSession.item?.status,
@@ -660,7 +659,7 @@ export const MessageSubmitInterfaceComponent = ({
 			userData
 		),
 		isAnonymousLiveChat,
-		hasMatrixRoom
+		hasEnquiryMessage: Boolean(activeSession.item?.messageDate)
 	});
 
 	const {

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -25,7 +25,11 @@ import {
 	getComposerHeightBounds as getComposerHeightBoundsPure,
 	stepComposerHeight
 } from './inputField/composerResize';
-import { isAskerEnquirySubmission } from './messageEncryptionMode';
+import {
+	createEnquirySubmissionGuard,
+	dispatchAskerMessageTransport,
+	resolveAskerMessageTransport
+} from './messageEncryptionMode';
 import { resolveAsideTargetRoomId } from './asideRouting';
 import { reloadSessionAfterSendIfNeeded } from './sessionRefreshAfterSend';
 import { chatTransportService } from '../../services/chatTransportService';
@@ -404,6 +408,18 @@ export const MessageSubmitInterfaceComponent = ({
 		() => chatTransportService.resolveSession(activeSession),
 		[activeSession]
 	);
+	const enquirySubmissionGuardRef = useRef<ReturnType<
+		typeof createEnquirySubmissionGuard
+	> | null>(null);
+	const enquirySubmissionSessionIdRef = useRef(activeSession.item.id);
+	if (
+		!enquirySubmissionGuardRef.current ||
+		enquirySubmissionSessionIdRef.current !== activeSession.item.id
+	) {
+		enquirySubmissionGuardRef.current = createEnquirySubmissionGuard();
+		enquirySubmissionSessionIdRef.current = activeSession.item.id;
+	}
+	const enquirySubmissionGuard = enquirySubmissionGuardRef.current;
 
 	const [activeInfo, setActiveInfo] = useState(null);
 	const [attachmentSelected, setAttachmentSelected] = useState<File | null>(
@@ -651,7 +667,7 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const isAnonymousEnquiryComposer =
 		type === SESSION_LIST_TYPES.ENQUIRY && isAnonymousChat;
-	const isAskerEnquiry = isAskerEnquirySubmission({
+	const askerMessageTransport = resolveAskerMessageTransport({
 		isEnquiryListType: type === SESSION_LIST_TYPES.ENQUIRY,
 		sessionStatus: activeSession.item?.status,
 		hasAskerAuthority: hasUserAuthority(
@@ -659,7 +675,9 @@ export const MessageSubmitInterfaceComponent = ({
 			userData
 		),
 		isAnonymousLiveChat,
-		hasEnquiryMessage: Boolean(activeSession.item?.messageDate)
+		hasEnquiryMessage: Boolean(activeSession.item?.messageDate),
+		isMatrixSession: resolvedChatSession.isMatrixSession,
+		matrixRoomId: resolvedChatSession.matrixRoomId
 	});
 
 	const {
@@ -1163,19 +1181,26 @@ export const MessageSubmitInterfaceComponent = ({
 
 	const sendEnquiry = useCallback(
 		(message, isEncrypted) => {
+			if (!enquirySubmissionGuard.tryStart()) {
+				setIsRequestInProgress(false);
+				return Promise.resolve();
+			}
 			return apiSendEnquiry(
 				activeSession.item.id,
 				message,
 				isEncrypted,
 				language
 			)
-				.then((response) =>
-					encryptRoom(setE2EEState, response.matrixRoomId).then(
-						() => {
-							onSendButton && onSendButton(response);
-						}
-					)
-				)
+				.then((response) => {
+					enquirySubmissionGuard.markSucceeded();
+					reloadActiveSession?.();
+					return encryptRoom(
+						setE2EEState,
+						response.matrixRoomId
+					).then(() => {
+						onSendButton && onSendButton(response);
+					});
+				})
 				.then(async () => {
 					setEditorState(EditorState.createEmpty());
 					setComposerText('');
@@ -1185,6 +1210,7 @@ export const MessageSubmitInterfaceComponent = ({
 				})
 				.then(() => setIsRequestInProgress(false))
 				.catch((error) => {
+					enquirySubmissionGuard.markFailed();
 					setIsRequestInProgress(false);
 					setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
 					apiPostError({
@@ -1198,10 +1224,12 @@ export const MessageSubmitInterfaceComponent = ({
 		},
 		[
 			activeSession.item.id,
+			enquirySubmissionGuard,
 			encryptRoom,
 			language,
 			onSendButton,
 			clearDraftMessage,
+			reloadActiveSession,
 			setE2EEState
 		]
 	);
@@ -1598,11 +1626,6 @@ export const MessageSubmitInterfaceComponent = ({
 			// chatTransportService signature.
 			const isEncrypted = false;
 
-			if (isAskerEnquiry) {
-				await sendEnquiry(message, isEncrypted);
-				return;
-			}
-
 			// Shortcut: edit an existing message via Matrix m.replace
 			if (editingMessageId && !retryOfId) {
 				const matrixRoomId = resolvedChatSession.matrixRoomId;
@@ -1625,17 +1648,38 @@ export const MessageSubmitInterfaceComponent = ({
 				return;
 			}
 
-			await sendMessage(
-				message,
-				attachment,
-				isEncrypted,
-				isAside,
-				retryOfId,
-				currentTypedMessage,
-				preserveComposerOnSuccess,
-				retryContext?.replyToEventId || null,
-				retryContext?.mentionedUserIds || []
-			);
+			const sendCurrentMessage = () =>
+				sendMessage(
+					message,
+					attachment,
+					isEncrypted,
+					isAside,
+					retryOfId,
+					currentTypedMessage,
+					preserveComposerOnSuccess,
+					retryContext?.replyToEventId || null,
+					retryContext?.mentionedUserIds || []
+				);
+			const handledAskerTransport = await dispatchAskerMessageTransport({
+				transport: askerMessageTransport,
+				sendEnquiry: () => sendEnquiry(message, isEncrypted),
+				sendMatrix: sendCurrentMessage,
+				onBlocked: () => {
+					setIsRequestInProgress(false);
+					setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
+					apiPostError({
+						name: 'MatrixRoomNotReadyForAskerFollowup',
+						message:
+							'Blocked an asker follow-up until its encrypted Matrix room is ready',
+						level: ERROR_LEVEL_WARN
+					}).then();
+				}
+			});
+			if (handledAskerTransport) {
+				return;
+			}
+
+			await sendCurrentMessage();
 		},
 		[
 			attachmentSelected,
@@ -1645,7 +1689,7 @@ export const MessageSubmitInterfaceComponent = ({
 			encodeHighlightColorsForTransport,
 			getTypedMarkdownMessage,
 			hasMessageContent,
-			isAskerEnquiry,
+			askerMessageTransport,
 			isSupervisor,
 			matrixClientService,
 			onLocalMessageEdit,
@@ -1941,7 +1985,7 @@ export const MessageSubmitInterfaceComponent = ({
 					? 'anonymous'
 					: 'oneOnOne';
 	const hasUploadFunctionality =
-		!isAskerEnquiry &&
+		askerMessageTransport !== 'enquiry' &&
 		hasMediaUploadFeature(tenant?.settings, currentChatType);
 	const {
 		featureVoiceMessagesEnabled = true,


### PR DESCRIPTION
Fixes #851

## Root cause

Registration now pre-creates the encrypted Matrix room. The composer still used `hasMatrixRoom` as the boundary between the one-shot initial enquiry and Matrix follow-ups, an assumption introduced by #387 before that registration behavior existed. Therefore the first message bypassed `/sessions/{id}/enquiry/new`, leaving `message_date=NULL` and producing no `request.new` timeline event.

## Fix

Use the backend-backed `messageDate` boundary instead:

- no recorded enquiry message -> one-shot enquiry endpoint, even with a Matrix room;
- recorded enquiry message -> normal encrypted Matrix follow-up path.

## Live failing evidence

PreDev session 7, Homer Simpson -> Apu Nahasapeemapetilon:

- encrypted first message survived reload and appeared in Apus request list;
- DB remained `status=ENQUIRY`, `message_date=NULL`;
- zero `event_notification` rows for source session 7;
- Apus feed stayed `items: []`, `unreadCount: 0`.

## TDD / verification

Red before implementation:

- `uses the enquiry endpoint for the first message even when registration pre-created a Matrix room` -> expected true, received false.

Green after implementation:

- `npm run test:unit -- --run src/components/messageSubmitInterface/messageEncryptionMode.test.ts` -> 6 passed
- targeted ESLint -> pass
- `npx tsc --noEmit` -> pass
- `git diff --check` -> pass

## Browser acceptance still required

After deploying this branch to PreDev, register a fresh Simpsons advice seeker and assert all of the following on the newly created session: encrypted message survives reload, backend `message_date` is non-null, exactly one `request.new` is written for each eligible consultant, and the consultant Notification Center shows it. Follow-up message must then use Matrix without retrying the one-shot endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected enquiry submission handling for initial and follow-up messages.
  * The first message is submitted as an enquiry even when a conversation room already exists.
  * Follow-up messages are no longer incorrectly classified as enquiry submissions once an enquiry has been recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->