### PR TITLE
fix(matrix): recover from stale crypto device conflicts

### DIFF
--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	clearPersistedMatrixDeviceId,
 	createMatrixClient,
 	getMatrixAccessToken,
 	persistMatrixLoginData
@@ -93,6 +94,25 @@ describe('persistMatrixLoginData', () => {
 		expect(localStorage.getItem('matrix_token_expires_at')).toBe(
 			(Date.parse('2026-06-26T00:00:00.000Z') + 3_300_000).toString()
 		);
+	});
+});
+
+describe('clearPersistedMatrixDeviceId', () => {
+	it('removes both request and user-scoped ids before stale-device recovery', () => {
+		localStorage.setItem('matrix_device_id', 'STALE_DEVICE');
+		localStorage.setItem(
+			'matrix_device_id:@consultant:matrix.example.test',
+			'STALE_DEVICE'
+		);
+
+		clearPersistedMatrixDeviceId('@consultant:matrix.example.test');
+
+		expect(localStorage.getItem('matrix_device_id')).toBeNull();
+		expect(
+			localStorage.getItem(
+				'matrix_device_id:@consultant:matrix.example.test'
+			)
+		).toBeNull();
 	});
 });
 

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -2,7 +2,10 @@ import { createClient, MatrixClient } from 'matrix-js-sdk';
 import { endpoints } from '../../resources/scripts/endpoints';
 import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { fetchData, FETCH_ERRORS, FETCH_METHODS } from '../../api/fetchData';
-import { getMatrixClientLogger } from '../../utils/matrixLogging';
+import {
+	createMatrixErrorAwareLogger,
+	getMatrixClientLogger
+} from '../../utils/matrixLogging';
 import { secretStorageKeyCallback } from '../../services/matrixKeyBackupService';
 import {
 	MATRIX_ACCESS_TOKEN_STORAGE_KEY,
@@ -140,17 +143,26 @@ export const persistMatrixLoginData = (loginData: MatrixLoginData): void => {
 	}
 };
 
+export const clearPersistedMatrixDeviceId = (userId: string): void => {
+	localStorage.removeItem(MATRIX_DEVICE_ID_STORAGE_KEY);
+	localStorage.removeItem(`${MATRIX_DEVICE_ID_STORAGE_KEY}:${userId}`);
+};
+
 // Helper function to create Matrix client with stored credentials
 export const createMatrixClient = (
-	loginData: MatrixLoginData
+	loginData: MatrixLoginData,
+	onSdkError?: (...messages: unknown[]) => void
 ): MatrixClient => {
+	const baseLogger = getMatrixClientLogger();
 	return createClient({
 		baseUrl: loginData.homeserverUrl,
 		accessToken: loginData.accessToken,
 		userId: loginData.userId,
 		deviceId: loginData.deviceId,
 		fallbackICEServerAllowed: true,
-		logger: getMatrixClientLogger(),
+		logger: onSdkError
+			? createMatrixErrorAwareLogger(baseLogger, onSdkError)
+			: baseLogger,
 		// #437 key backup + recovery: the SDK pulls the secret-storage key
 		// through this callback during setup/recovery flows (one-shot in-memory
 		// cache, never persisted).

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeviceIsolationModeKind } from 'matrix-js-sdk/lib/crypto-api';
-import { getMatrixAccessToken } from '../components/sessionCookie/getMatrixAccessToken';
+import {
+	clearPersistedMatrixDeviceId,
+	createMatrixClient,
+	getMatrixAccessToken,
+	persistMatrixLoginData
+} from '../components/sessionCookie/getMatrixAccessToken';
 import { buildMatrixCryptoStorePrefix } from './matrixCrypto';
 import {
 	MatrixClientService,
@@ -24,6 +29,7 @@ const mockedMatrixClient = vi.hoisted(() => ({
 }));
 
 vi.mock('../components/sessionCookie/getMatrixAccessToken', () => ({
+	clearPersistedMatrixDeviceId: vi.fn(),
 	createMatrixClient: vi.fn(() => mockedMatrixClient),
 	getMatrixAccessToken: vi.fn(),
 	persistMatrixLoginData: vi.fn()
@@ -253,6 +259,46 @@ describe('MatrixClientService', () => {
 		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 
 		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
+	});
+
+	it('recovers once with a fresh device when Rust crypto reports an OTK conflict', async () => {
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'fresh-token',
+			deviceId: 'DEVICE_TWO',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const service = new MatrixClientService();
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'stale-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const errorObserver = vi.mocked(createMatrixClient).mock.calls[0]?.[1];
+
+		errorObserver?.(
+			'Failed to process outgoing request 0: M_UNKNOWN: MatrixError: [400] One time key signed_curve25519:AAAAAAAAAAQ already exists.'
+		);
+		errorObserver?.(
+			'Failed to process outgoing request 0: M_UNKNOWN: MatrixError: [400] One time key signed_curve25519:AAAAAAAAAAQ already exists.'
+		);
+		await vi.waitFor(() => {
+			expect(createMatrixClient).toHaveBeenCalledTimes(2);
+		});
+
+		expect(clearPersistedMatrixDeviceId).toHaveBeenCalledOnce();
+		expect(clearPersistedMatrixDeviceId).toHaveBeenCalledWith(
+			'@alice:matrix.localhost'
+		);
+		expect(getMatrixAccessToken).toHaveBeenCalledOnce();
+		expect(persistMatrixLoginData).toHaveBeenCalledWith(
+			expect.objectContaining({ deviceId: 'DEVICE_TWO' })
+		);
+		expect(createMatrixClient).toHaveBeenLastCalledWith(
+			expect.objectContaining({ deviceId: 'DEVICE_TWO' }),
+			expect.any(Function)
+		);
 	});
 
 	it('refreshes the token when sync fails with M_UNKNOWN_TOKEN (invalidated access token)', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -1,6 +1,7 @@
 import { MatrixClient, Room, MatrixEvent } from 'matrix-js-sdk';
 import {
 	MatrixLoginData,
+	clearPersistedMatrixDeviceId,
 	createMatrixClient,
 	getMatrixAccessToken,
 	persistMatrixLoginData
@@ -106,11 +107,22 @@ export const isMatrixExpiredTokenError = (error: unknown): boolean => {
 	);
 };
 
+export const isMatrixOneTimeKeyConflictLog = (messages: unknown[]): boolean => {
+	const message = messages.map(String).join(' ').toLowerCase();
+	return (
+		message.includes('failed to process outgoing request') &&
+		message.includes('m_unknown') &&
+		message.includes('one time key') &&
+		message.includes('already exists')
+	);
+};
+
 export class MatrixClientService {
 	private client: MatrixClient | null = null;
 	private loginData: MatrixLoginData | null = null;
 	private refreshTimer: number | null = null;
 	private refreshingToken: Promise<void> | null = null;
+	private staleDeviceRecovery: Promise<void> | null = null;
 	private syncState: string | null = null;
 	private initializedServicesClient: MatrixClient | null = null;
 	private syncStateListeners = new Set<(state: string | null) => void>();
@@ -122,7 +134,9 @@ export class MatrixClientService {
 	public async initializeClient(loginData: MatrixLoginData): Promise<void> {
 		this.stopCurrentClient();
 		this.loginData = loginData;
-		this.client = createMatrixClient(loginData);
+		this.client = createMatrixClient(loginData, (...messages) => {
+			this.handleMatrixSdkError(loginData.deviceId, messages);
+		});
 		this.syncState = null;
 		this.initializedServicesClient = null;
 		this.notifySyncStateListeners();
@@ -254,6 +268,45 @@ export class MatrixClientService {
 
 	private refreshMatrixTokenSafely(): void {
 		void this.refreshMatrixToken().catch(() => undefined);
+	}
+
+	private handleMatrixSdkError(deviceId: string, messages: unknown[]): void {
+		if (
+			this.loginData?.deviceId !== deviceId ||
+			!isMatrixOneTimeKeyConflictLog(messages)
+		) {
+			return;
+		}
+
+		void this.recoverFromStaleMatrixDevice().catch(() => undefined);
+	}
+
+	private recoverFromStaleMatrixDevice(): Promise<void> {
+		if (this.staleDeviceRecovery) {
+			return this.staleDeviceRecovery;
+		}
+
+		const staleLoginData = this.loginData;
+		if (!staleLoginData) {
+			return Promise.resolve();
+		}
+
+		clearPersistedMatrixDeviceId(staleLoginData.userId);
+		this.staleDeviceRecovery = getMatrixAccessToken()
+			.then(async (loginData) => {
+				const recoveredLoginData: MatrixLoginData = {
+					...loginData,
+					isAnonymous:
+						loginData.isAnonymous ?? staleLoginData.isAnonymous
+				};
+				persistMatrixLoginData(recoveredLoginData);
+				await this.initializeClient(recoveredLoginData);
+			})
+			.finally(() => {
+				this.staleDeviceRecovery = null;
+			});
+
+		return this.staleDeviceRecovery;
 	}
 
 	public async ensureFreshToken(): Promise<void> {

--- a/src/utils/matrixLogging.test.ts
+++ b/src/utils/matrixLogging.test.ts
@@ -22,6 +22,7 @@ vi.mock('matrix-js-sdk/lib/logger', () => ({
 
 // eslint-disable-next-line import/first -- must load after vi.mock
 import {
+	createMatrixErrorAwareLogger,
 	configureMatrixLogging,
 	getMatrixClientLogger,
 	resetMatrixLoggingForTests
@@ -69,5 +70,45 @@ describe('matrixLogging', () => {
 		configureMatrixLogging();
 
 		expect(rootSetLevel).toHaveBeenCalledTimes(1);
+	});
+
+	it('observes child logger errors while preserving the SDK log output', () => {
+		const rootError = vi.fn();
+		const childError = vi.fn();
+		const childLogger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: childError,
+			getChild: vi.fn()
+		};
+		const rootLogger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: rootError,
+			getChild: vi.fn(() => childLogger)
+		};
+		const observer = vi.fn();
+		const observedLogger = createMatrixErrorAwareLogger(
+			rootLogger,
+			observer
+		);
+
+		observedLogger
+			.getChild('[room encryption]')
+			.error('Failed to process outgoing request', 0);
+
+		expect(observer).toHaveBeenCalledWith(
+			'Failed to process outgoing request',
+			0
+		);
+		expect(childError).toHaveBeenCalledWith(
+			'Failed to process outgoing request',
+			0
+		);
+		expect(rootError).not.toHaveBeenCalled();
 	});
 });

--- a/src/utils/matrixLogging.ts
+++ b/src/utils/matrixLogging.ts
@@ -62,6 +62,27 @@ export const configureMatrixLogging = (
 /** Logger instance passed to Matrix client construction. */
 export const getMatrixClientLogger = (): MatrixLogger => logger;
 
+/**
+ * Preserve the SDK's normal logging while observing errors from every child
+ * logger. Rust crypto reports outgoing-request failures only through its
+ * room-scoped logger, so observing the root logger alone misses them (#551).
+ */
+export const createMatrixErrorAwareLogger = (
+	baseLogger: Logger,
+	onError: (...messages: unknown[]) => void
+): Logger => ({
+	trace: (...messages: unknown[]) => baseLogger.trace(...messages),
+	debug: (...messages: unknown[]) => baseLogger.debug(...messages),
+	info: (...messages: unknown[]) => baseLogger.info(...messages),
+	warn: (...messages: unknown[]) => baseLogger.warn(...messages),
+	error: (...messages: unknown[]) => {
+		onError(...messages);
+		baseLogger.error(...messages);
+	},
+	getChild: (namespace: string) =>
+		createMatrixErrorAwareLogger(baseLogger.getChild(namespace), onError)
+});
+
 /** @internal test helper */
 export const resetMatrixLoggingForTests = (): void => {
 	configured = false;


### PR DESCRIPTION
## Summary

- observe Rust-Crypto child logger failures without changing SDK log output
- detect the exact stale-device one-time-key conflict from #551
- clear only the persisted Matrix device id, request a fresh device-bound token, and reinitialize crypto once
- preserve anonymous-session crypto isolation semantics across recovery

## PreDev reproduction

Apu on PreDev repeatedly receives `400 M_UNKNOWN` from `/_matrix/client/v3/keys/upload`: the same `signed_curve25519` key id already exists with different key material. Both sender and recipient then see only “Message encrypted”, including newly sent messages.

## Verification

- `npm run test:unit -- src/services/matrix*.test.ts src/components/sessionCookie/getMatrixAccessToken.test.ts src/utils/matrixLogging.test.ts` — 97 passed
- `npx tsc --noEmit`
- targeted ESLint on all six changed files
- `git diff --check`

Browser acceptance remains pending regular review, merge, and PreDev deployment.

Fixes #551