### PR TITLE
fix(2fa): put the setup success card on the M3 scheme

### DIFF
--- a/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
+++ b/src/components/twoFactorAuth/TwoFactorSetupDialog.test.tsx
@@ -208,6 +208,11 @@ vi.mock('../../resources/img/icons/two-factor/confirm_filled.svg', () => ({
 		<svg aria-hidden="true" {...props} />
 	)
 }));
+vi.mock('../../resources/img/icons/checkmark_filled.svg', () => ({
+	ReactComponent: (props: React.SVGProps<SVGSVGElement>) => (
+		<svg data-testid="success-checkmark" {...props} />
+	)
+}));
 
 const clickButton = (name: string) => {
 	fireEvent.click(screen.getByRole('button', { name }));
@@ -353,6 +358,17 @@ describe('TwoFactorSetupDialog', () => {
 				'twoFactorAuth.setupDialog.app.success.title'
 			)
 		).toBeTruthy();
+
+		// Success uses ORISO's own checkmark (themable via CSS), and its lone
+		// close action switches the footer to the single-column row.
+		expect(screen.getByTestId('success-checkmark')).toBeTruthy();
+		const actions = document.querySelector(
+			'.twoFactorSetupDialog__actions'
+		);
+		expect(
+			actions?.classList.contains('twoFactorSetupDialog__actions--single')
+		).toBe(true);
+		expect(actions?.querySelectorAll('button')).toHaveLength(1);
 	});
 
 	it('keeps the success step when refreshed user data changes the current type', async () => {

--- a/src/components/twoFactorAuth/TwoFactorSetupDialog.tsx
+++ b/src/components/twoFactorAuth/TwoFactorSetupDialog.tsx
@@ -19,9 +19,9 @@ import {
 	Tooltip,
 	Typography
 } from '@mui/material';
+import clsx from 'clsx';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
-import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
@@ -67,6 +67,9 @@ import { ReactComponent as VerificationIcon } from '../../resources/img/icons/tw
 import { ReactComponent as VerificationFilledIcon } from '../../resources/img/icons/two-factor/verification_filled.svg';
 import { ReactComponent as ConfirmIcon } from '../../resources/img/icons/two-factor/confirm_400.svg';
 import { ReactComponent as ConfirmFilledIcon } from '../../resources/img/icons/two-factor/confirm_filled.svg';
+// ORISO's own filled checkmark — no baked-in fill, so it takes the M3 role
+// colour from CSS instead of MUI's green success default.
+import { ReactComponent as SuccessCheckIcon } from '../../resources/img/icons/checkmark_filled.svg';
 import './twoFactorSetupDialog.styles.scss';
 
 type IconComponent = React.FunctionComponent<
@@ -713,7 +716,10 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 
 	const renderSuccess = () => (
 		<div className="twoFactorSetupDialog__success">
-			<CheckCircleRoundedIcon className="twoFactorSetupDialog__successIcon" />
+			<SuccessCheckIcon
+				aria-hidden="true"
+				className="twoFactorSetupDialog__successIcon"
+			/>
 			<Typography className="twoFactorSetupDialog__successTitle">
 				{translate(
 					isAppFlow
@@ -834,7 +840,13 @@ export const TwoFactorSetupDialog: React.FC<TwoFactorSetupDialogProps> = ({
 				)}
 			</Box>
 			{step !== 'decision' && (
-				<div className="twoFactorSetupDialog__actions">
+				<div
+					className={clsx('twoFactorSetupDialog__actions', {
+						// Success hides both icon buttons, so the remaining
+						// close action gets its own right-aligned single row.
+						'twoFactorSetupDialog__actions--single': isSuccess
+					})}
+				>
 					{canClose && !isSuccess && (
 						<Tooltip
 							title={translate(

--- a/src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss
+++ b/src/components/twoFactorAuth/twoFactorSetupDialog.styles.scss
@@ -317,7 +317,9 @@
 	&__successIcon {
 		width: 120px !important;
 		height: 120px !important;
-		color: var(--m3-success, #0a882f);
+		// M3 brand role, not a traffic-light green: ORISO signals success with
+		// the scheme's primary colour (same rule as the voice-note player).
+		fill: var(--m3-primary, #a5000a);
 	}
 
 	&__successTitle {
@@ -330,6 +332,13 @@
 		grid-template-columns: 72px 72px 1fr;
 		gap: 10px;
 		margin-top: 28px;
+	}
+
+	// Success step: the two icon buttons are gone, so the lone close action
+	// must not inherit the 72px icon track (it wrapped mid-word there).
+	&__actions--single {
+		grid-template-columns: 1fr;
+		justify-items: end;
 	}
 
 	&__iconAction,
@@ -347,6 +356,11 @@
 	&__primaryAction {
 		text-transform: none !important;
 		font-weight: 600 !important;
+		white-space: nowrap !important;
+	}
+
+	&__actions--single &__primaryAction {
+		min-width: 160px !important;
 	}
 
 	@media (width <= 520px) {
@@ -397,6 +411,10 @@
 
 		&__actions {
 			grid-template-columns: 64px 64px 1fr;
+		}
+
+		&__actions--single {
+			grid-template-columns: 1fr;
 		}
 	}
 }

--- a/src/components/twoFactorAuth/twoFactorSetupDialog.styles.test.ts
+++ b/src/components/twoFactorAuth/twoFactorSetupDialog.styles.test.ts
@@ -32,3 +32,38 @@ describe('two-factor setup dialog responsive layout', () => {
 		);
 	});
 });
+
+describe('two-factor setup dialog success step', () => {
+	it('paints the success checkmark with the M3 brand role, not success green', () => {
+		const scss = dialogStyles();
+		const iconStart = scss.indexOf('&__successIcon');
+		const successIcon = scss.slice(
+			iconStart,
+			scss.indexOf('}', iconStart) + 1
+		);
+
+		expect(successIcon).toContain('fill: var(--m3-primary, #a5000a);');
+		expect(successIcon).not.toContain('--m3-success');
+		expect(successIcon).not.toContain('#0a882f');
+	});
+
+	it('keeps the lone close action on one right-aligned row, desktop and mobile', () => {
+		const scss = dialogStyles();
+
+		expect(scss).toMatch(
+			/&__actions--single\s*\{[^}]*grid-template-columns:\s*1fr;[^}]*justify-items:\s*end;/
+		);
+		expect(scss).toMatch(
+			/&__primaryAction\s*\{[^}]*white-space:\s*nowrap\s*!important;/
+		);
+
+		// The mobile block re-declares the icon tracks, so it has to re-declare
+		// the single-action override too or it silently wins by source order.
+		const mobileStyles = scss.slice(
+			scss.indexOf('@media (width <= 520px)')
+		);
+		expect(mobileStyles).toMatch(
+			/&__actions--single\s*\{[^}]*grid-template-columns:\s*1fr;/
+		);
+	});
+});


### PR DESCRIPTION
Closes #854

The last screen of the two-factor setup flow was the only surface in that dialog ignoring the tenant scheme, and its single action button was squeezed into an icon-sized grid track.

### Changes

- `renderSuccess` now uses ORISO's own `checkmark_filled.svg` instead of MUI's `CheckCircleRounded`. The asset carries no baked-in `fill`, so the SCSS paints it with `--m3-primary` — the same move the voice-note player already made away from `--m3-success` green.
- New `twoFactorSetupDialog__actions--single` modifier, applied on the success step, collapses the `72px 72px 1fr` action row to one right-aligned column. It is re-declared inside the `@media (width <= 520px)` block, because the mobile rule re-declares the icon tracks and would otherwise win by source order.
- `__primaryAction` gets `white-space: nowrap` plus a `min-width` in the single-action row, so the label can never break mid-word again.

### Tests

- `twoFactorSetupDialog.styles.test.ts`: two new cases pin the brand-role fill (and assert the green is gone) and the single-row override for both desktop and mobile.
- `TwoFactorSetupDialog.test.tsx`: the app-success case now asserts the ORISO checkmark renders and that the footer carries the `--single` class with exactly one button.
- `npx vitest run src/components/twoFactorAuth/` — 21 passed, 5 files.

### Reviewer test plan

- [ ] Complete the authenticator-app setup path to the success step: the checkmark is brand-coloured, not green.
- [ ] Complete the e-mail-code setup path to its success step: same checkmark treatment.
- [ ] On the success step, "Schließen" sits on a single line, right-aligned, and closes the dialog.
- [ ] Repeat the success step at ≤520px width (mobile): still one line, still right-aligned, no horizontal overflow.
- [ ] Step back to a non-success step (e.g. verification): close and back icon buttons plus the primary action still share one row as before.
- [ ] With a tenant whose primary colour is not the default red, the checkmark follows that tenant colour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the two-factor authentication success screen with the primary brand color.
  * Improved success-state action layout with a single, right-aligned button.
  * Added responsive behavior for mobile displays and prevented button text wrapping.

* **Tests**
  * Added coverage for success icon styling and action alignment across desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->