### PR TITLE
fix(timeline): enquiry base path + shared params contract (#846)

### DIFF
--- a/src/components/notificationsCenter/NotificationsCenter.stories.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.stories.tsx
@@ -265,7 +265,17 @@ export const AllEventTypes: Story = {
 					eventType,
 					createdAt: minutesAgo(5 + index * 7),
 					sourceSessionId: '101',
-					actionPath: '/sessions/consultant/sessionView/room-101/101'
+					actionPath: '/sessions/consultant/sessionView/room-101/101',
+					// #846: mirror the backend params contract so interpolated
+					// templates ({{senderDisplayName}}) render realistically.
+					params:
+						eventType === 'team.discussion.new'
+							? {
+									roomRef: '!team:matrix.example',
+									senderDisplayName: 'Marge Bouvier',
+									mentioned: false
+								}
+							: undefined
 				})
 			)
 		)

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -21,7 +21,10 @@ import {
 	isKnownEventType
 } from './eventDescriptors';
 import { EventFamily } from './eventDescriptors/types';
-import { resolveNotificationActionPath } from './notificationActionTarget';
+import {
+	resolveNotificationActionPath,
+	toInterpolationValues
+} from './notificationActionTarget';
 import { useActiveListItem } from '../../hooks/useActiveListItem';
 import { pickActiveItemKey } from '../../utils/listItemSelection';
 import {
@@ -111,7 +114,10 @@ const describeItem = (
 	const descriptor = getEventDescriptor(item?.eventType);
 	const { title, text } = renderEventStrings(descriptor, translate, {
 		fallbackTitle: item?.title,
-		fallbackText: item?.text
+		fallbackText: item?.text,
+		// #846: params metadata feeds template placeholders such as
+		// {{senderDisplayName}} — previously they rendered unresolved.
+		interpolation: toInterpolationValues(item?.params)
 	});
 	return { descriptor, title, text };
 };
@@ -379,12 +385,25 @@ export const NotificationsCenter = () => {
 				: '/sessions/user/view',
 		[userData]
 	);
+	// #846: request-origin events (request.new, waiting_room.client.joined)
+	// live in the consultant's enquiry list, not the sessions list.
+	const getDefaultRequestsPath = useCallback(
+		() =>
+			hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData)
+				? '/sessions/consultant/sessionPreview'
+				: '/sessions/user/view',
+		[userData]
+	);
 	const getNotificationActionPath = useCallback(
 		(item: (typeof notificationFeed)[number]) =>
 			toNonEmbeddedPath(
-				resolveNotificationActionPath(item, getDefaultSessionsPath())
+				resolveNotificationActionPath(
+					item,
+					getDefaultSessionsPath(),
+					getDefaultRequestsPath()
+				)
 			),
-		[getDefaultSessionsPath]
+		[getDefaultSessionsPath, getDefaultRequestsPath]
 	);
 	const embeddedChatPath = useMemo(() => {
 		if (!canShowChatPreview) {

--- a/src/components/notificationsCenter/eventDescriptors/types.ts
+++ b/src/components/notificationsCenter/eventDescriptors/types.ts
@@ -94,6 +94,24 @@ export interface EventActionParams {
 	callRoomId?: string | null;
 	/** Whether a live call is video (Slice 5). */
 	isVideo?: boolean | null;
+	/** Sender label (metadata only, ADR-AT-01 — never message content). */
+	senderName?: string | null;
+	/** Sender display name for i18n interpolation ({{senderDisplayName}}). */
+	senderDisplayName?: string | null;
+	/** Coarse content class (text / attachment / …), metadata only. */
+	contentClass?: string | null;
+	/** Which role received this row (user / consultant). */
+	recipientRole?: string | null;
+	/** Agency the enquiry belongs to (request events). */
+	agencyId?: string | number | null;
+	/** Main topic of the enquiry (request events). */
+	topicId?: string | number | null;
+	/** Consulting type of the enquiry (request events). */
+	consultingTypeId?: string | number | null;
+	/** Occurrence index for recurring group chats. */
+	occurrenceIndex?: string | number | null;
+	/** ISO start timestamp for group-chat occurrences. */
+	start?: string | null;
 	/**
 	 * Base path for the signed-in user's conversation list, e.g.
 	 * `/sessions/consultant/sessionView` or `/sessions/user/view`. The consumer

--- a/src/components/notificationsCenter/notificationActionTarget.test.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+	EVENT_PARAM_KEYS,
 	parseEventActionParams,
-	resolveNotificationActionPath
+	resolveNotificationActionPath,
+	toInterpolationValues
 } from './notificationActionTarget';
 
 describe('notification action targets', () => {
@@ -48,5 +50,124 @@ describe('notification action targets', () => {
 				'/sessions/user/view'
 			)
 		).toBe('/sessions/user/view/session/7');
+	});
+});
+
+describe('shared params contract (#846)', () => {
+	it('accepts the backend message params (sessionId, sender metadata)', () => {
+		const params = parseEventActionParams(
+			'{"sessionId":100,"roomRef":"!room-1:matrix.example","senderName":"Klient:in","contentClass":"TEXT","recipientRole":"consultant"}'
+		);
+		expect(params.sourceSessionId).toBe(100);
+		expect(params.roomRef).toBe('!room-1:matrix.example');
+		expect(params.senderName).toBe('Klient:in');
+		expect(params.contentClass).toBe('TEXT');
+		expect(params.recipientRole).toBe('consultant');
+	});
+
+	it('accepts team-discussion params (roomId as room ref, mentioned flag)', () => {
+		const params = parseEventActionParams(
+			'{"roomId":"!team:matrix.example","senderDisplayName":"Marge","mentioned":true}'
+		);
+		expect(params.roomRef).toBe('!team:matrix.example');
+		expect(params.senderDisplayName).toBe('Marge');
+		expect(params.mentioned).toBe(true);
+	});
+
+	it('accepts enquiry params (agency, topic, consulting type)', () => {
+		const params = parseEventActionParams(
+			'{"sessionId":100,"agencyId":42,"topicId":5,"consultingTypeId":1}'
+		);
+		expect(params.agencyId).toBe(42);
+		expect(params.topicId).toBe(5);
+		expect(params.consultingTypeId).toBe(1);
+	});
+
+	it('pins the shared key set mirrored by the backend contract test', () => {
+		// ORISO-UserService EventNotificationServiceTest
+		// .allEmittedParamKeysStayInsideTheSharedFrontendContract pins the
+		// identical set — update BOTH sides together.
+		expect([...EVENT_PARAM_KEYS].sort()).toEqual(
+			[
+				'sessionId',
+				'sourceSessionId',
+				'roomRef',
+				'roomId',
+				'agencyId',
+				'topicId',
+				'consultingTypeId',
+				'senderName',
+				'senderDisplayName',
+				'contentClass',
+				'recipientRole',
+				'threadRootId',
+				'mentioned',
+				'seriesId',
+				'occurrenceIndex',
+				'start',
+				'callRoomId',
+				'isVideo',
+				'forcedScopeKey'
+			].sort()
+		);
+	});
+});
+
+describe('request-origin deep links (#846)', () => {
+	it('routes a room-less waiting-room event to the enquiry list', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'waiting_room.client.joined',
+					actionPath: null,
+					params: {}
+				},
+				'/sessions/consultant/sessionView',
+				'/sessions/consultant/sessionPreview'
+			)
+		).toBe('/sessions/consultant/sessionPreview');
+	});
+
+	it('keeps a stored enquiry action path authoritative', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'request.new',
+					actionPath:
+						'/sessions/consultant/sessionPreview/!room-1:matrix.example/100',
+					params: {}
+				},
+				'/sessions/consultant/sessionView',
+				'/sessions/consultant/sessionPreview'
+			)
+		).toBe(
+			'/sessions/consultant/sessionPreview/!room-1:matrix.example/100'
+		);
+	});
+
+	it('still returns null without any request base (no silent sessions-root)', () => {
+		expect(
+			resolveNotificationActionPath(
+				{
+					eventType: 'request.new',
+					actionPath: null,
+					params: {}
+				},
+				'/sessions/consultant/sessionView'
+			)
+		).toBeNull();
+	});
+});
+
+describe('interpolation values (#846)', () => {
+	it('exposes string/number metadata and falls back senderDisplayName → senderName', () => {
+		const values = toInterpolationValues({
+			senderName: 'Marge',
+			mentioned: true,
+			sourceSessionId: 100
+		});
+		expect(values.senderDisplayName).toBe('Marge');
+		expect(values.sourceSessionId).toBe(100);
+		expect('mentioned' in values).toBe(false);
 	});
 });

--- a/src/components/notificationsCenter/notificationActionTarget.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.ts
@@ -121,9 +121,10 @@ export const toInterpolationValues = (
 		}
 	});
 	// The team-discussion template renders {{senderDisplayName}} — fall back
-	// to the plain sender label so older events don't render an empty name.
-	if (!values.senderDisplayName && values.senderName) {
-		values.senderDisplayName = values.senderName;
+	// to the plain sender label, and always define the key so a missing
+	// value renders empty instead of a raw "{{senderDisplayName}}".
+	if (!values.senderDisplayName) {
+		values.senderDisplayName = values.senderName ?? '';
 	}
 	return values;
 };

--- a/src/components/notificationsCenter/notificationActionTarget.ts
+++ b/src/components/notificationsCenter/notificationActionTarget.ts
@@ -18,6 +18,34 @@ const asNullableString = (value: unknown): string | null | undefined =>
 		? (value as string | null)
 		: undefined;
 
+/**
+ * The shared params contract (#846). Every key the backend emits is listed
+ * here, and ORISO-UserService pins the same set in
+ * EventNotificationServiceTest.allEmittedParamKeysStayInsideTheSharedFrontendContract —
+ * a key missing on either side is a contract break, not a silent drop.
+ */
+export const EVENT_PARAM_KEYS = [
+	'sessionId',
+	'sourceSessionId',
+	'roomRef',
+	'roomId',
+	'agencyId',
+	'topicId',
+	'consultingTypeId',
+	'senderName',
+	'senderDisplayName',
+	'contentClass',
+	'recipientRole',
+	'threadRootId',
+	'mentioned',
+	'seriesId',
+	'occurrenceIndex',
+	'start',
+	'callRoomId',
+	'isVideo',
+	'forcedScopeKey'
+] as const;
+
 /** Parse only the known, non-content fields accepted by action-target resolvers. */
 export const parseEventActionParams = (raw: unknown): EventActionParams => {
 	let value: unknown = raw;
@@ -36,11 +64,17 @@ export const parseEventActionParams = (raw: unknown): EventActionParams => {
 	const params: EventActionParams = {};
 	if (isIdentifier(source.sourceSessionId)) {
 		params.sourceSessionId = source.sourceSessionId;
+	} else if (isIdentifier(source.sessionId)) {
+		// #846: the backend emits `sessionId`; accept it as the session ref.
+		params.sourceSessionId = source.sessionId;
 	}
 	if (isIdentifier(source.seriesId)) {
 		params.seriesId = source.seriesId;
 	}
-	params.roomRef = asNullableString(source.roomRef);
+	params.roomRef =
+		asNullableString(source.roomRef) ??
+		// #846: team-discussion events carry the room as `roomId`.
+		asNullableString(source.roomId);
 	params.forcedScopeKey = asNullableString(source.forcedScopeKey);
 	params.threadRootId = asNullableString(source.threadRootId);
 	params.callRoomId = asNullableString(source.callRoomId);
@@ -50,18 +84,64 @@ export const parseEventActionParams = (raw: unknown): EventActionParams => {
 	if (typeof source.mentioned === 'boolean') {
 		params.mentioned = source.mentioned;
 	}
+	// #846: display metadata (never message content, ADR-AT-01) — feeds the
+	// i18n interpolation ({{senderDisplayName}}) and future list rendering.
+	params.senderName = asNullableString(source.senderName);
+	params.senderDisplayName = asNullableString(source.senderDisplayName);
+	params.contentClass = asNullableString(source.contentClass);
+	params.recipientRole = asNullableString(source.recipientRole);
+	if (isIdentifier(source.agencyId)) {
+		params.agencyId = source.agencyId;
+	}
+	if (isIdentifier(source.topicId)) {
+		params.topicId = source.topicId;
+	}
+	if (isIdentifier(source.consultingTypeId)) {
+		params.consultingTypeId = source.consultingTypeId;
+	}
+	if (isIdentifier(source.occurrenceIndex)) {
+		params.occurrenceIndex = source.occurrenceIndex;
+	}
+	params.start = asNullableString(source.start);
 	return params;
+};
+
+/**
+ * String/number values from parsed params, for i18n interpolation. i18next
+ * escapes interpolated values by default, and params never carry message
+ * content (ADR-AT-01).
+ */
+export const toInterpolationValues = (
+	params: EventActionParams | undefined
+): Record<string, string | number> => {
+	const values: Record<string, string | number> = {};
+	Object.entries(params || {}).forEach(([key, value]) => {
+		if (typeof value === 'string' || typeof value === 'number') {
+			values[key] = value;
+		}
+	});
+	// The team-discussion template renders {{senderDisplayName}} — fall back
+	// to the plain sender label so older events don't render an empty name.
+	if (!values.senderDisplayName && values.senderName) {
+		values.senderDisplayName = values.senderName;
+	}
+	return values;
 };
 
 export const resolveNotificationActionPath = (
 	item: NotificationActionInput,
-	sessionsBasePath: string
+	sessionsBasePath: string,
+	// #846: request-origin events resolve against the enquiry list — without
+	// this, requestTarget fell through to null and the consumer navigated to
+	// the bare sessions root.
+	requestsBasePath?: string | null
 ): string | null => {
 	const target = getEventDescriptor(item.eventType).resolveActionTarget({
 		...(item.params || {}),
 		actionPath: item.actionPath,
 		sourceSessionId: item.sourceSessionId ?? item.params?.sourceSessionId,
-		sessionsBasePath
+		sessionsBasePath,
+		requestsBasePath
 	});
 
 	return target.kind === 'conversation' ||


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Frontend#846
Refs OpenResilienceInitiative/ORISO-Frontend#844 (bug epic)
Backend counterpart: OpenResilienceInitiative/ORISO-UserService#943

## Why

Frontend half of the deep-link fix (timeline audit 2026-08-01): the event registry wanted `params.requestsBasePath`, which the timeline never supplied, and the params whitelist shared almost no keys with what the backend actually emits — every param was discarded, so no room resolution, and `{{senderDisplayName}}` rendered as a raw placeholder in team-discussion rows.

## What changed

1. **Enquiry base path**: `resolveNotificationActionPath` accepts a `requestsBasePath`; the timeline passes `/sessions/consultant/sessionPreview`. Request-origin events without a stored `actionPath` now land on the enquiry list — never the bare sessions root.
2. **Params contract**: `parseEventActionParams` speaks the backend's dialect — `sessionId` maps to the session ref, `roomId` (team discussions) to `roomRef`, and the metadata keys (`senderName`, `senderDisplayName`, `contentClass`, `recipientRole`, `agencyId`, `topicId`, `consultingTypeId`, `occurrenceIndex`, `start`) are parsed instead of discarded.
3. **`EVENT_PARAM_KEYS`** pins the shared contract (19 keys). The backend pins the identical set in `EventNotificationServiceTest.allEmittedParamKeysStayInsideTheSharedFrontendContract` — update both sides together.
4. **Interpolation**: event templates receive params metadata, so `{{senderDisplayName}}` renders the sender's name (with `senderName` fallback for older events).

## Verification

- Full unit suite: **1434 tests green** (8 new contract/deep-link/interpolation tests)
- `tsc --noEmit` clean
- Storybook screenshot of the resolved team-discussion sender label in the comments

### Reviewer test plan

Add a screenshot of each tested screen to the comments.

- [ ] On Pre-Dev (both #846 PRs deployed): consultant clicks "Chat öffnen" on a new-enquiry card → the enquiry opens in first-enquiries (sessionPreview), not an empty sessions view
- [ ] Waiting-room card without a room → the action lands on the enquiry list, never the bare sessions root
- [ ] Post in a Team-Besprechung → the timeline card shows "«Name» hat in der Team-Besprechung geschrieben", no `{{senderDisplayName}}` placeholder
- [ ] Message deep links on accepted sessions behave as before (sessionView)
- [ ] Same enquiry-card check at 412px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
