### PR TITLE
fix(chat): send the Matrix event id with message-event notifications (#942)

### DIFF
--- a/src/api/apiPostMessageEventNotification.test.ts
+++ b/src/api/apiPostMessageEventNotification.test.ts
@@ -32,6 +32,25 @@ describe('buildMessageEventNotificationBody', () => {
 		expect(body.mentionedUserIds).toBeNull();
 	});
 
+	it('carries the matrix event id for backend deduplication (#942)', () => {
+		const body = buildMessageEventNotificationBody({
+			roomId: '!room:oriso',
+			matrixRoom: true,
+			matrixEventId: '$evt-42'
+		});
+
+		expect(body.matrixEventId).toBe('$evt-42');
+	});
+
+	it('defaults the matrix event id to null (legacy callers)', () => {
+		const body = buildMessageEventNotificationBody({
+			roomId: '!room:oriso',
+			matrixRoom: true
+		});
+
+		expect(body.matrixEventId).toBeNull();
+	});
+
 	it('never includes plaintext previews for matrix rooms, also for team discussions', () => {
 		const body = buildMessageEventNotificationBody({
 			roomId: '!discussion:oriso',

--- a/src/api/apiPostMessageEventNotification.ts
+++ b/src/api/apiPostMessageEventNotification.ts
@@ -11,6 +11,8 @@ export interface MessageEventNotificationInput {
 	threadParentPreview?: string | null;
 	teamDiscussion?: boolean;
 	mentionedUserIds?: string[] | null;
+	/** Matrix event id of the sent message (#942, backend dedup key). */
+	matrixEventId?: string | null;
 }
 
 export interface MessageEventNotificationBody {
@@ -23,6 +25,7 @@ export interface MessageEventNotificationBody {
 	threadParentPreview: string | null;
 	teamDiscussion: boolean;
 	mentionedUserIds: string[] | null;
+	matrixEventId: string | null;
 }
 
 const MAX_LEGACY_MESSAGE_PREVIEW_LENGTH = 100;
@@ -36,7 +39,8 @@ export const buildMessageEventNotificationBody = ({
 	senderDisplayName,
 	threadParentPreview,
 	teamDiscussion = false,
-	mentionedUserIds
+	mentionedUserIds,
+	matrixEventId
 }: MessageEventNotificationInput): MessageEventNotificationBody => {
 	const canIncludePlaintextPreview = matrixRoom === false;
 	return {
@@ -52,7 +56,8 @@ export const buildMessageEventNotificationBody = ({
 			? threadParentPreview || null
 			: null,
 		teamDiscussion,
-		mentionedUserIds: mentionedUserIds?.length ? mentionedUserIds : null
+		mentionedUserIds: mentionedUserIds?.length ? mentionedUserIds : null,
+		matrixEventId: matrixEventId || null
 	};
 };
 

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -172,7 +172,10 @@ class ChatTransportService {
 			supervisorMessage: !!supervisorMessage,
 			senderDisplayName: senderDisplayName || null,
 			teamDiscussion: !!teamDiscussion,
-			mentionedUserIds: mentionedUserIds || null
+			mentionedUserIds: mentionedUserIds || null,
+			// #942: the event id keys backend deduplication against the
+			// server-side Matrix listener announcing the same message.
+			matrixEventId: response?.event_id || null
 		}).catch(() => undefined);
 
 		return { success: true, event_id: response.event_id };
@@ -265,7 +268,8 @@ class ChatTransportService {
 			matrixRoom: true,
 			threadRootId: options.threadRootId || null,
 			supervisorMessage: !!options.supervisorMessage,
-			senderDisplayName: options.senderDisplayName || null
+			senderDisplayName: options.senderDisplayName || null,
+			matrixEventId: response?.event_id || null
 		}).catch(() => undefined);
 
 		return response;


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-UserService#942 (closed by the backend half, OpenResilienceInitiative/ORISO-UserService#947)
Refs OpenResilienceInitiative/ORISO-Frontend#844 (bug epic)

## Why

The backend now derives a deduplication key from the Matrix event id so its sync listener and this client-side producer collapse into one timeline row per recipient (US#947). This PR makes the frontend send that id.

## What changed

- `MessageEventNotificationInput`/`Body` carry an optional `matrixEventId` (`null` for legacy callers).
- Text sends (`chatTransportService.sendMessage`) and file sends (`sendFileMessage`) pass `response.event_id` from the Matrix send response.
- No content crosses the privacy boundary — the event id is routing metadata (ADR-AT-01 unchanged).

## Verification

- Full unit suite: **1428 tests green** (2 new body-builder cases), `tsc --noEmit` clean
- End-to-end dedup proof happens on Pre-Dev with US#947 — see its reviewer test plan

### Reviewer test plan

- [ ] With both #942 PRs on Pre-Dev: send one message into an accepted session → the recipient's timeline shows exactly one "Neue Nachricht" row for it
- [ ] Send a file attachment → same: one row
- [ ] Network tab: `POST /users/event-notifications/message-events` payload contains `matrixEventId` starting with `$`, and never a plaintext `messagePreview` for Matrix rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
