### PR TITLE
fix(matrix): wait for recovered sync readiness

### DIFF
--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -19,6 +19,7 @@ const mockedCrypto = vi.hoisted(() => ({
 const mockedMatrixClient = vi.hoisted(() => ({
 	initRustCrypto: vi.fn(),
 	on: vi.fn(),
+	off: vi.fn(),
 	removeAllListeners: vi.fn(),
 	getRoom: vi.fn(),
 	getCrypto: vi.fn(),
@@ -262,6 +263,14 @@ describe('MatrixClientService', () => {
 	});
 
 	it('recovers once with a fresh device when Rust crypto reports an OTK conflict', async () => {
+		const syncListeners: Array<
+			(state: string, previous: string | null, error?: unknown) => void
+		> = [];
+		mockedMatrixClient.on.mockImplementation((event, listener) => {
+			if (event === 'sync') {
+				syncListeners.push(listener);
+			}
+		});
 		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
 			userId: '@alice:matrix.localhost',
 			accessToken: 'fresh-token',
@@ -286,6 +295,7 @@ describe('MatrixClientService', () => {
 		await vi.waitFor(() => {
 			expect(createMatrixClient).toHaveBeenCalledTimes(2);
 		});
+		syncListeners.at(-1)?.('PREPARED', null);
 
 		expect(clearPersistedMatrixDeviceId).toHaveBeenCalledOnce();
 		expect(clearPersistedMatrixDeviceId).toHaveBeenCalledWith(
@@ -299,6 +309,45 @@ describe('MatrixClientService', () => {
 			expect.objectContaining({ deviceId: 'DEVICE_TWO' }),
 			expect.any(Function)
 		);
+	});
+
+	it('blocks outbound sends until the recovered client reaches PREPARED', async () => {
+		const syncListeners: Array<
+			(state: string, previous: string | null, error?: unknown) => void
+		> = [];
+		mockedMatrixClient.on.mockImplementation((event, listener) => {
+			if (event === 'sync') {
+				syncListeners.push(listener);
+			}
+		});
+		mockedMatrixClient.sendMessage.mockResolvedValue({ event_id: '$sent' });
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'fresh-token',
+			deviceId: 'DEVICE_TWO',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const service = new MatrixClientService();
+		await service.initializeClient({
+			userId: '@alice:matrix.localhost',
+			accessToken: 'stale-token',
+			deviceId: 'DEVICE_ONE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+		const errorObserver = vi.mocked(createMatrixClient).mock.calls[0]?.[1];
+
+		errorObserver?.(
+			'Failed to process outgoing request 0: M_UNKNOWN: MatrixError: [400] One time key signed_curve25519:AAAAAAAAAAQ already exists.'
+		);
+		const send = service.sendMessage('!room:matrix.localhost', 'hello');
+		await vi.waitFor(() => {
+			expect(createMatrixClient).toHaveBeenCalledTimes(2);
+		});
+
+		expect(mockedMatrixClient.sendMessage).not.toHaveBeenCalled();
+		syncListeners.at(-1)?.('PREPARED', null);
+		await send;
+		expect(mockedMatrixClient.sendMessage).toHaveBeenCalledOnce();
 	});
 
 	it('refreshes the token when sync fails with M_UNKNOWN_TOKEN (invalidated access token)', async () => {

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -350,6 +350,37 @@ describe('MatrixClientService', () => {
 		expect(mockedMatrixClient.sendMessage).toHaveBeenCalledOnce();
 	});
 
+	it('fails a recovered-client readiness wait immediately when that client is replaced', async () => {
+		const service = new MatrixClientService();
+		const recoveredClient = {
+			...mockedMatrixClient
+		};
+		const replacementClient = {
+			...mockedMatrixClient
+		};
+		setClient(service, recoveredClient);
+
+		const wait = (
+			service as unknown as {
+				waitForClientPrepared: (
+					client: Record<string, unknown>,
+					timeoutMs: number
+				) => Promise<void>;
+			}
+		).waitForClientPrepared(recoveredClient, 30_000);
+
+		setClient(service, replacementClient);
+		(
+			service as unknown as {
+				notifySyncStateListeners: () => void;
+			}
+		).notifySyncStateListeners();
+
+		await expect(wait).rejects.toThrow(
+			'Recovered Matrix client was replaced before reaching PREPARED'
+		);
+	});
+
 	it('refreshes the token when sync fails with M_UNKNOWN_TOKEN (invalidated access token)', async () => {
 		let syncListener:
 			| ((

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -301,6 +301,13 @@ export class MatrixClientService {
 				};
 				persistMatrixLoginData(recoveredLoginData);
 				await this.initializeClient(recoveredLoginData);
+				const recoveredClient = this.client;
+				if (!recoveredClient) {
+					throw new Error(
+						'Recovered Matrix client was not initialized'
+					);
+				}
+				await this.waitForClientPrepared(recoveredClient);
 			})
 			.finally(() => {
 				this.staleDeviceRecovery = null;
@@ -309,7 +316,40 @@ export class MatrixClientService {
 		return this.staleDeviceRecovery;
 	}
 
+	private waitForClientPrepared(
+		expectedClient: MatrixClient,
+		timeoutMs: number = 30_000
+	): Promise<void> {
+		if (this.client === expectedClient && this.syncState === 'PREPARED') {
+			return Promise.resolve();
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			const listener = (state: string | null) => {
+				if (this.client !== expectedClient || state !== 'PREPARED') {
+					return;
+				}
+
+				window.clearTimeout(timeout);
+				this.syncStateListeners.delete(listener);
+				resolve();
+			};
+			const timeout = window.setTimeout(() => {
+				this.syncStateListeners.delete(listener);
+				reject(
+					new Error('Recovered Matrix client did not reach PREPARED')
+				);
+			}, timeoutMs);
+			this.syncStateListeners.add(listener);
+			listener(this.syncState);
+		});
+	}
+
 	public async ensureFreshToken(): Promise<void> {
+		if (this.staleDeviceRecovery) {
+			await this.staleDeviceRecovery;
+		}
+
 		const expiresAt = this.getStoredTokenExpiresAt();
 		if (!expiresAt || Date.now() + TOKEN_REFRESH_BUFFER_MS < expiresAt) {
 			return;

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -326,7 +326,18 @@ export class MatrixClientService {
 
 		return new Promise<void>((resolve, reject) => {
 			const listener = (state: string | null) => {
-				if (this.client !== expectedClient || state !== 'PREPARED') {
+				if (this.client !== expectedClient) {
+					window.clearTimeout(timeout);
+					this.syncStateListeners.delete(listener);
+					reject(
+						new Error(
+							'Recovered Matrix client was replaced before reaching PREPARED'
+						)
+					);
+					return;
+				}
+
+				if (state !== 'PREPARED') {
 					return;
 				}
 


### PR DESCRIPTION
## Summary

- keep stale-device recovery pending until the replacement Matrix client reaches sync state `PREPARED`
- make the shared outbound readiness gate await that recovery before text, edits, reactions, files, room creation, redaction, or typing can continue
- add a regression proving the first post-recovery message cannot leave through the stale or not-yet-ready client

## PreDev acceptance failure after #853

Regular Frontend digest `sha256:111de1ceca645af0078a9504e5107a941c799736125cf5dac62d6a713694a444` successfully detected the exact #551 conflict, rotated both restored Simpsons browser states, and reached `POST /keys/upload -> 200` on the replacement devices.

However, `recoverFromStaleMatrixDevice()` resolved immediately after `initializeClient()` started the replacement client. Before its sync reached `PREPARED`, Ned could submit the first post-recovery message to Herb. Recipient-scoped `message.new` was produced, but Herb could not decrypt the text live.

## TDD

Red before implementation:

- `blocks outbound sends until the recovered client reaches PREPARED`
- failure: `sendMessage` was called once before the replacement sync listener emitted `PREPARED`

Green after implementation:

- Matrix-related unit suite: 98 passed
- `npx tsc --noEmit`: pass
- targeted ESLint: pass
- `npm run build`: pass (existing CRA/autoprefixer and bundle-size warnings only)
- `git diff --check`: pass

## Browser acceptance required

After human review, merge, regular PreDev build and regular deploy:

1. restore separate Simpsons consultant/advice-seeker contexts with persisted Matrix device IDs and empty IndexedDB crypto stores;
2. verify the exact OTK conflict triggers a device rotation and the replacement client reaches successful key upload;
3. send one new distinct consultant message only after recovery and prove it decrypts live for the advice seeker;
4. verify recipient-scoped `message.new` against the same session;
5. send one distinct reply in the other direction, verify live decryption and recipient notification while the consultant is outside the active room;
6. continue with encrypted voice and paired audio/video signalling only after text passes.

Continues #551

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from stale-device conflicts by waiting for the replacement connection to be fully ready before sending messages.
  - Prevented messages from being sent prematurely during device recovery.
  - Improved token refresh handling while recovery is in progress.
  - Added timeout and replacement checks to avoid stalled recovery attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->