### PR TITLE
docs(agents): align task docs path and parent workspace routing

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"hooks": {
+		"beforeShellExecution": [
+			{
+				"command": "bash .cursor/hooks/guard-destructive.sh",
+				"timeout": 10,
+				"failClosed": true
+			}
+		],
+		"beforeReadFile": [
+			{
+				"command": "bash .cursor/hooks/guard-secrets-read.sh",
+				"timeout": 10,
+				"failClosed": true
+			}
+		]
+	}
+}

--- a/.cursor/hooks/guard-destructive.sh
+++ b/.cursor/hooks/guard-destructive.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# beforeShellExecution: ask on narrowly matched destructive commands.
+# stdin: hook JSON; stdout: permission JSON. Requires jq.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Safety hook requires jq","agent_message":"Install jq; destructive-command guard could not parse input."}'
+  exit 0
+fi
+
+input="$(cat || true)"
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Malformed hook input","agent_message":"beforeShellExecution input was not valid JSON."}'
+  exit 0
+fi
+
+command="$(printf '%s' "$input" | jq -r '.command // empty')"
+if [[ -z "$command" ]]; then
+  printf '%s\n' '{"permission":"allow"}'
+  exit 0
+fi
+
+patterns=(
+  'rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)'
+  'git[[:space:]]+push[[:space:]].*(--force([^-]|$)|[[:space:]]-f([[:space:]]|$))'
+  'git[[:space:]]+reset[[:space:]].*--hard'
+  'git[[:space:]]+clean[[:space:]].*-[a-zA-Z]*f'
+  'git[[:space:]]+branch[[:space:]].*-D[[:space:]]'
+  'DROP[[:space:]]+(TABLE|DATABASE|SCHEMA)'
+  'drop[[:space:]]+(table|database|schema)'
+  'terraform[[:space:]]+destroy'
+  'kubectl[[:space:]]+delete'
+  'docker[[:space:]]+(system|volume)[[:space:]]+prune'
+  'chmod[[:space:]]+-R[[:space:]]+777'
+  'mkfs\.'
+  '>([[:space:]]*)/dev/(sd|disk|nvme)'
+)
+
+for p in "${patterns[@]}"; do
+  if [[ "$command" =~ $p ]]; then
+    jq -n --arg cmd "$command" '{
+      permission: "ask",
+      user_message: ("Potentially destructive command flagged by safety hook — review before running:\n" + $cmd),
+      agent_message: "A safety hook flagged this command as potentially destructive. It requires explicit user approval. Do not bypass by rephrasing."
+    }'
+    exit 0
+  fi
+done
+
+printf '%s\n' '{"permission":"allow"}'
+exit 0

--- a/.cursor/hooks/guard-secrets-read.sh
+++ b/.cursor/hooks/guard-secrets-read.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# beforeReadFile: deny known secret / private-key paths.
+# stdin: hook JSON; stdout: { permission: allow|deny, ... }. Requires jq.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Secret-path guard requires jq"}'
+  exit 0
+fi
+
+input="$(cat || true)"
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Malformed beforeReadFile input"}'
+  exit 0
+fi
+
+file_path="$(printf '%s' "$input" | jq -r '.file_path // empty')"
+if [[ -z "$file_path" ]]; then
+  printf '%s\n' '{"permission":"allow"}'
+  exit 0
+fi
+
+base="$(basename "$file_path")"
+lower="$(printf '%s' "$file_path" | tr '[:upper:]' '[:lower:]')"
+
+is_example=0
+if [[ "$base" == *.example || "$base" == *.sample || "$base" == *.template || "$base" == *.example.* ]]; then
+  is_example=1
+fi
+
+deny=0
+
+if [[ "$is_example" -eq 0 ]]; then
+  if [[ "$base" == ".env" || "$base" == .env.* || "$base" == *.secrets.env || "$base" == "config.env" ]]; then
+    deny=1
+  fi
+fi
+
+if [[ "$base" == *.pem || "$base" == *.key || "$base" == "id_rsa" || "$base" == "id_ed25519" ]]; then
+  deny=1
+fi
+
+if [[ "$base" == realm.json.backup* || "$lower" == *"/backup/"*realm* ]]; then
+  deny=1
+fi
+
+if [[ "$deny" -eq 1 ]]; then
+  jq -n --arg p "$file_path" '{
+    permission: "deny",
+    user_message: ("Blocked read of sensitive path: " + $p),
+    agent_message: "Do not read secret or private-key files. Use *.example templates or ask the user to provide redacted values."
+  }'
+  exit 0
+fi
+
+printf '%s\n' '{"permission":"allow"}'
+exit 0

--- a/.cursor/rules/orchestrator-core.mdc
+++ b/.cursor/rules/orchestrator-core.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 Before coding, classify the task:
 
 - **Trivial** (one file, no new behavior, no UI/security impact): just do it, no docs required.
-- **Non-trivial** (anything else): follow the goal-loop workflow — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/cursor-orchestrator/YYYY-MM-DD_short-feature-name/`.
+- **Non-trivial** (anything else): follow the goal-loop workflow — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only).
 
 When the user says "loop" or asks to iterate until done, use the `goal-loop` skill.
 

--- a/.cursor/skills/goal-loop/SKILL.md
+++ b/.cursor/skills/goal-loop/SKILL.md
@@ -64,4 +64,4 @@ One short block per iteration in `03-progress-log.md`:
 
 ## Artifacts
 
-All docs live in `docs/cursor-orchestrator/YYYY-MM-DD_short-feature-name/`. Reference file paths; do not copy large file contents into docs.
+All docs live in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only). Reference file paths; do not copy large file contents into docs.

--- a/.cursor/skills/problem-intake/SKILL.md
+++ b/.cursor/skills/problem-intake/SKILL.md
@@ -5,7 +5,7 @@ description: Normalize problem statements from tickets, GitHub issues, raw docs,
 
 # Problem Intake
 
-Create `docs/cursor-orchestrator/YYYY-MM-DD_short-feature-name/00-problem-brief.md`.
+Create `docs/agent-tasks/YYYY-MM-DD_short-feature-name/00-problem-brief.md`.
 
 Include only:
 

--- a/.cursor/skills/spike-doc/SKILL.md
+++ b/.cursor/skills/spike-doc/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze existing implementation and produce a concise spike documen
 
 # Spike Document
 
-Create `01-spike.md` in the current task folder under `docs/cursor-orchestrator/`.
+Create `01-spike.md` in the current task folder under `docs/agent-tasks/`.
 
 Before writing, analyze the existing implementation:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,21 @@
 
 ## Parent Router First
 
-- This file is a repo-local supplement for `${PROJECT_ORISO_ROOT}/ORISO-Frontend`.
-- Before using these repo-specific rules, load `${PROJECT_ORISO_ROOT}/AGENTS.md` and the ORISO parent project files it points to. Resolve `PROJECT_ORISO_ROOT` through the machine-local routing configuration described by the parent router.
-- Keep durable cross-project ORISO rules in the parent project files or parent `skills/`, not in this repo-local supplement.
+- This file is a repo-local supplement for `ORISO-Frontend`.
+- Before using these repo-specific rules, load the workspace parent map at `../AGENTS.md`. Resolve `PROJECT_ORISO_ROOT` as the parent directory of this repository (the ORISO multi-repo workspace root).
+- Keep durable cross-project ORISO rules in the parent `AGENTS.md`, `ARCHITECTURE.md`, and parent `.cursor/` skills/agents — not duplicated here.
 
 ## Orchestration
 
-- For non-trivial tasks, or whenever the user says "loop", run the `goal-loop` skill: intake → plan → iterate think/implement/verify until acceptance criteria pass → regression-check → pr-prep. Task docs live in `docs/cursor-orchestrator/YYYY-MM-DD_short-feature-name/`.
+- For non-trivial tasks, or whenever the user says "loop", run the `goal-loop` skill: intake → plan → iterate think/implement/verify until acceptance criteria pass → regression-check → pr-prep.
+- **New** task docs: `docs/agent-tasks/YYYY-MM-DD_short-feature-name/`. Legacy folders under `docs/cursor-orchestrator/` are historical — do not add new tasks there.
 - Delegate broad exploration to the `codebase-explorer` subagent, planning to `planner`, post-implementation validation to `verifier`, and touched-scope security review to `security-auditor`.
 - Stop for confirmation before: credentials, external service setup, destructive commands, and opening/updating a PR.
 - Capture reusable lessons in `.learnings/LEARNINGS.md`; promote to this file only if broadly applicable.
 
 ## Context First
 
-- Treat `pre-dev` as the normal integration branch for ORISO feature PRs unless the task says otherwise. Keep `dev` stable for QA, as defined by the parent ORISO router.
+- Treat `pre-dev` as the normal integration branch for ORISO feature PRs unless the task says otherwise. Keep `dev` stable for QA, as defined by the parent ORISO map.
 - Before non-trivial changes, skim `.understand-anything/README.md`, `.understand-anything/ARCHITECTURE.md`, and `.understand-anything/knowledge-graph.json` for fast repo context.
 - Use `CONTEXT.md` for Activity Timeline and notification vocabulary; avoid inventing parallel terms.
 
@@ -29,13 +30,14 @@
 ## Validation
 
 - Prefer red-green TDD for behavior changes: add or update the smallest test that would fail without the fix, then implement.
-- Useful commands:
+- Useful commands (CI Node **18**; install with `npm ci --legacy-peer-deps`):
     - `npm run test:unit`
     - `npm run lint:scripts`
     - `npm run lint:style`
     - `npm run build`
+- From workspace root: `REPO=ORISO-Frontend ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
 - **Hard gate before opening a PR:** `npm run test:unit`, `npm run lint:scripts`, `npm run lint:style`, and `npm run build` must pass. A PR without this passing output is not done.
-- For changes that need a running backend, use the canonical repo integration tests plus the parent `oriso-e2e-quality-gate` flow. There is currently no workspace-root `Makefile`; do not cite `make verify` as an available gate until a real harness is added and routed by the parent project.
+- For changes that need a running backend, use the canonical repo integration tests plus any workspace e2e flow that actually exists — do not cite `make verify` unless a real Makefile is added.
 - The narrowest-relevant-command shortcut applies to intermediate iterations only. If the final gate is blocked by pre-existing unrelated failures, state the blocker precisely in the PR body.
 
 ## Review Expectations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,10 @@
 ## Parent Router First
 
 - This file is a repo-local supplement for `ORISO-Frontend`.
-- Before using these repo-specific rules, load the workspace parent map at `../AGENTS.md`. Resolve `PROJECT_ORISO_ROOT` as the parent directory of this repository (the ORISO multi-repo workspace root).
-- Keep durable cross-project ORISO rules in the parent `AGENTS.md`, `ARCHITECTURE.md`, and parent `.cursor/` skills/agents — not duplicated here.
+- In the ORISO multi-repo Cursor workspace, load the parent map at `../AGENTS.md` first.
+  `PROJECT_ORISO_ROOT` is that parent directory (sibling of this repo).
+- If this repository is cloned alone (no parent workspace), skip `../AGENTS.md` and use this file plus the commands below.
+- Keep durable cross-project ORISO rules in the parent workspace `AGENTS.md`, `ARCHITECTURE.md`, and parent `.cursor/` skills/agents — not duplicated here.
 
 ## Orchestration
 
@@ -35,7 +37,11 @@
     - `npm run lint:scripts`
     - `npm run lint:style`
     - `npm run build`
-- From workspace root: `REPO=ORISO-Frontend ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+- From this repository root (multi-repo workspace only):
+  `REPO=ORISO-Frontend ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+- From `PROJECT_ORISO_ROOT`:
+  `REPO=ORISO-Frontend ./scripts/harness/verify-fast.sh`.
+- Standalone Frontend clone: use the `npm run …` commands above (no workspace harness).
 - **Hard gate before opening a PR:** `npm run test:unit`, `npm run lint:scripts`, `npm run lint:style`, and `npm run build` must pass. A PR without this passing output is not done.
 - For changes that need a running backend, use the canonical repo integration tests plus any workspace e2e flow that actually exists — do not cite `make verify` unless a real Makefile is added.
 - The narrowest-relevant-command shortcut applies to intermediate iterations only. If the final gate is blocked by pre-existing unrelated failures, state the blocker precisely in the PR body.


### PR DESCRIPTION
## Summary
- Point `AGENTS.md` and orchestrator skills/rules at `docs/agent-tasks/` (legacy `docs/cursor-orchestrator/` remains historical only).
- Clarify parent workspace routing via `../AGENTS.md` / `PROJECT_ORISO_ROOT`.
- Add Cursor safety hooks for destructive shell commands and secret-file reads.

## Test plan
- [ ] Confirm `AGENTS.md` paths match the multi-repo workspace layout
- [ ] Confirm `.cursor/skills/*` and `orchestrator-core.mdc` reference `docs/agent-tasks/`
- [ ] Spot-check `.cursor/hooks.json` loads `guard-destructive.sh` and `guard-secrets-read.sh`
- [ ] No app runtime/behavior change expected (docs + local agent hooks only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance to store task artifacts under `docs/agent-tasks/`.
  * Clarified that the previous documentation location is historical.
  * Expanded repository guidance for goal-loop workflows, integration branches, validation, installation, and workspace verification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->