### PR TITLE
fix(call): enable per-participant media E2EE by default

### DIFF
--- a/src/components/call/widget/useElementCallWidget.test.tsx
+++ b/src/components/call/widget/useElementCallWidget.test.tsx
@@ -164,17 +164,15 @@ describe('useElementCallWidget', () => {
 		expect(fragment.has('accessToken')).toBe(false);
 		expect(fragment.has('password')).toBe(false);
 		expect(fragment.has('enableE2EE')).toBe(false);
-		// Media E2EE is opt-in per environment: the media keys ride the MatrixRTC
-		// to-device transport, so a gap in the host's Olm path would connect the
-		// call with no audio and no error (ORISO-ElementCall#35).
-		expect(fragment.get('perParticipantE2EE')).toBeNull();
+		// ADR-018 default: host asks Element Call for per-participant media E2EE.
+		expect(fragment.get('perParticipantE2EE')).toBe('true');
 	});
 
-	it('asks Element Call for media E2EE once the environment enables it', async () => {
-		// The off path alone would still pass if the parameter were dropped
-		// unconditionally, which would silently make the toggle unusable.
+	it('omits media E2EE when the environment kill-switch is false', async () => {
+		// The on path alone would still pass if the parameter were always set,
+		// which would silently make the kill-switch unusable (ElementCall#35).
 		setAppConfig({
-			releaseToggles: { enableCallMediaE2EE: true }
+			releaseToggles: { enableCallMediaE2EE: false }
 		} as never);
 		const client = createClient();
 
@@ -189,7 +187,7 @@ describe('useElementCallWidget', () => {
 		const fragment = new URLSearchParams(
 			new URL(result.current.url!).hash.slice(2)
 		);
-		expect(fragment.get('perParticipantE2EE')).toBe('true');
+		expect(fragment.get('perParticipantE2EE')).toBeNull();
 	});
 
 	it('fails closed when the host cannot join the call room', async () => {

--- a/src/components/call/widget/useElementCallWidget.ts
+++ b/src/components/call/widget/useElementCallWidget.ts
@@ -162,12 +162,13 @@ export const useElementCallWidget = (
 					confineToRoom: 'true',
 					header: 'none',
 					skipLobby: String(skipLobby),
-					// See releaseToggles.enableCallMediaE2EE: Element Call only
-					// encrypts media when the host asks for it, because the host
-					// owns the crypto stack that distributes the media keys.
-					...(appConfig?.releaseToggles?.enableCallMediaE2EE === true
-						? { perParticipantE2EE: 'true' }
-						: {}),
+					// Per-participant media E2EE is the ADR-018 default. Element
+					// Call only encrypts LiveKit media when the host asks for it
+					// (the host owns the Olm path that distributes media keys).
+					// Kill-switch: releaseToggles.enableCallMediaE2EE === false.
+					...(appConfig?.releaseToggles?.enableCallMediaE2EE === false
+						? {}
+						: { perParticipantE2EE: 'true' }),
 					intent: 'start_call',
 					callIntent: isVideo ? 'video' : 'audio'
 				}).toString()}`;

--- a/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfig/AppConfigInterface.ts
@@ -78,13 +78,13 @@ interface ReleaseToggles {
 	 */
 	enableInvisibleCrypto?: boolean;
 	/**
-	 * Per-participant media E2EE for calls: when on, the LiveKit SFU only ever
-	 * sees ciphertext. Off by default because media keys ride the MatrixRTC
-	 * to-device transport, so any gap in the host's Olm path makes a call
-	 * connect with no audio in either direction and no error anywhere
-	 * (ORISO-ElementCall#35). Turn it on per environment once a two-browser
-	 * call has proven key distribution end to end; call signalling and room
-	 * events are encrypted by the host regardless of this toggle.
+	 * Kill-switch for per-participant call media E2EE (ADR-018).
+	 * Default / unset = ON: the host asks Element Call for
+	 * `perParticipantE2EE`, so the LiveKit SFU only ever sees ciphertext.
+	 * Set to `false` to fall back to transport-only media if MatrixRTC
+	 * to-device key distribution fails in an environment (ORISO-ElementCall#35:
+	 * call connects with no audio and no UI error). Call signalling and room
+	 * events stay encrypted by the host regardless of this toggle.
 	 */
 	enableCallMediaE2EE?: boolean;
 	/**


### PR DESCRIPTION
## Summary
- Restore ADR-018 default: Element Call widgets request `perParticipantE2EE=true` so LiveKit media is end-to-end encrypted
- Keep `releaseToggles.enableCallMediaE2EE === false` as an emergency kill-switch (ORISO-ElementCall#35 silent no-audio)
- Update widget unit tests for default-on / kill-switch-off paths

## Context
After PR #832, media E2EE was opt-in and unset in settings, so calls correctly showed **Not encrypted** because media was genuinely unencrypted. Signalling/room Megolm was unrelated. Issue #551 (stale device/OTK) is already on `pre-dev` via #853/#883 and is out of scope here.

## Test plan
- [x] `vitest` `src/components/call/widget/useElementCallWidget.test.tsx` (11 passed)
- [ ] PreDev two-browser video call: encrypted indicator + audio/video both directions
- [ ] Kill-switch: `enableCallMediaE2EE: false` omits `perParticipantE2EE` if needed
- [ ] Confirm deployed Element Call honours host `perParticipantE2EE` (EC#36)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media end-to-end encryption is now enabled by default for Element Call.
  * Transport-only media is used only when the encryption setting is explicitly disabled.

* **Documentation**
  * Clarified the encryption setting’s default behavior and fallback when key distribution fails. Call signalling and room events remain encrypted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->