### PR TITLE
P0: authenticate Matrix device-signing during recovery

### DIFF
--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -137,7 +137,8 @@ export const AuthenticatedApp = ({
 										const matrixLoginData =
 											await getMatrixAccessToken();
 										persistMatrixLoginData(matrixLoginData);
-										const { homeserverUrl } = matrixLoginData;
+										const { homeserverUrl } =
+											matrixLoginData;
 										if (homeserverUrl) {
 											const { MatrixClientService } =
 												await import(
@@ -151,7 +152,11 @@ export const AuthenticatedApp = ({
 													hasUserAuthority(
 														AUTHORITIES.ANONYMOUS_DEFAULT,
 														userProfileData
-													)
+													) ||
+														hasUserAuthority(
+															AUTHORITIES.ASKER_DEFAULT,
+															userProfileData
+														)
 												)
 											);
 											if (

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -25,11 +25,11 @@ import { useCall } from '../../globalState/provider/CallProvider';
 import { useAppConfig } from '../../hooks/useAppConfig';
 import { E2EEncryptionSupportBanner } from '../E2EEncryptionSupportBanner/E2EEncryptionSupportBanner';
 import { KeyBackupRecoveryPrompt } from '../E2EEncryptionSupportBanner/KeyBackupRecoveryPrompt';
-import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import {
 	getMatrixAccessToken,
 	persistMatrixLoginData
 } from '../sessionCookie/getMatrixAccessToken';
+import { withAuthenticatedSessionContext } from './authenticatedMatrixLoginData';
 import { getPlatformVersion } from '../../resources/scripts/runtimeConfig';
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
 import {
@@ -137,8 +137,7 @@ export const AuthenticatedApp = ({
 										const matrixLoginData =
 											await getMatrixAccessToken();
 										persistMatrixLoginData(matrixLoginData);
-										const homeserverUrl =
-											getMatrixHomeserverUrl();
+										const { homeserverUrl } = matrixLoginData;
 										if (homeserverUrl) {
 											const { MatrixClientService } =
 												await import(
@@ -147,19 +146,13 @@ export const AuthenticatedApp = ({
 											const matrixClientService =
 												new MatrixClientService();
 											await matrixClientService.initializeClient(
-												{
-													userId: matrixLoginData.userId,
-													accessToken:
-														matrixLoginData.accessToken,
-													deviceId:
-														matrixLoginData.deviceId,
-													homeserverUrl,
-													isAnonymous:
-														hasUserAuthority(
-															AUTHORITIES.ANONYMOUS_DEFAULT,
-															userProfileData
-														)
-												}
+												withAuthenticatedSessionContext(
+													matrixLoginData,
+													hasUserAuthority(
+														AUTHORITIES.ANONYMOUS_DEFAULT,
+														userProfileData
+													)
+												)
 											);
 											if (
 												!matrixBootstrapActive.current ||

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -137,8 +137,7 @@ export const AuthenticatedApp = ({
 										const matrixLoginData =
 											await getMatrixAccessToken();
 										persistMatrixLoginData(matrixLoginData);
-										const { homeserverUrl } =
-											matrixLoginData;
+										const { homeserverUrl } = matrixLoginData;
 										if (homeserverUrl) {
 											const { MatrixClientService } =
 												await import(
@@ -152,11 +151,7 @@ export const AuthenticatedApp = ({
 													hasUserAuthority(
 														AUTHORITIES.ANONYMOUS_DEFAULT,
 														userProfileData
-													) ||
-														hasUserAuthority(
-															AUTHORITIES.ASKER_DEFAULT,
-															userProfileData
-														)
+													)
 												)
 											);
 											if (

--- a/src/components/app/authenticatedMatrixLoginData.test.ts
+++ b/src/components/app/authenticatedMatrixLoginData.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { withAuthenticatedSessionContext } from './authenticatedMatrixLoginData';
 
 describe('withAuthenticatedSessionContext', () => {
-	it('preserves the transient device-signing UIA password', () => {
+	it('preserves UIA and marks an advice seeker for compatible key sharing', () => {
 		const result = withAuthenticatedSessionContext(
 			{
 				accessToken: 'matrix-access-token',
@@ -16,7 +16,7 @@ describe('withAuthenticatedSessionContext', () => {
 
 		expect(result).toMatchObject({
 			uiaPassword: 'transient-password',
-			isAnonymous: true
+			shareMegolmWithAllDevices: true
 		});
 	});
 });

--- a/src/components/app/authenticatedMatrixLoginData.test.ts
+++ b/src/components/app/authenticatedMatrixLoginData.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { withAuthenticatedSessionContext } from './authenticatedMatrixLoginData';
+
+describe('withAuthenticatedSessionContext', () => {
+	it('preserves the transient device-signing UIA password', () => {
+		const result = withAuthenticatedSessionContext(
+			{
+				accessToken: 'matrix-access-token',
+				userId: '@marge:predev.oriso.org',
+				deviceId: 'ORISO_WEB_MARGE',
+				homeserverUrl: 'https://predev.oriso.org/matrix',
+				uiaPassword: 'transient-password'
+			},
+			true
+		);
+
+		expect(result).toMatchObject({
+			uiaPassword: 'transient-password',
+			isAnonymous: true
+		});
+	});
+});

--- a/src/components/app/authenticatedMatrixLoginData.test.ts
+++ b/src/components/app/authenticatedMatrixLoginData.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { withAuthenticatedSessionContext } from './authenticatedMatrixLoginData';
 
 describe('withAuthenticatedSessionContext', () => {
-	it('preserves UIA and marks an advice seeker for compatible key sharing', () => {
+	it('preserves the transient device-signing UIA password', () => {
 		const result = withAuthenticatedSessionContext(
 			{
 				accessToken: 'matrix-access-token',
@@ -16,7 +16,7 @@ describe('withAuthenticatedSessionContext', () => {
 
 		expect(result).toMatchObject({
 			uiaPassword: 'transient-password',
-			shareMegolmWithAllDevices: true
+			isAnonymous: true
 		});
 	});
 });

--- a/src/components/app/authenticatedMatrixLoginData.ts
+++ b/src/components/app/authenticatedMatrixLoginData.ts
@@ -1,0 +1,10 @@
+import type { MatrixLoginData } from '../sessionCookie/getMatrixAccessToken';
+
+/** Keep transient login fields (notably UIA) when adding app-session context. */
+export const withAuthenticatedSessionContext = (
+	loginData: MatrixLoginData,
+	isAnonymous: boolean
+): MatrixLoginData => ({
+	...loginData,
+	isAnonymous
+});

--- a/src/components/app/authenticatedMatrixLoginData.ts
+++ b/src/components/app/authenticatedMatrixLoginData.ts
@@ -3,8 +3,8 @@ import type { MatrixLoginData } from '../sessionCookie/getMatrixAccessToken';
 /** Keep transient login fields (notably UIA) when adding app-session context. */
 export const withAuthenticatedSessionContext = (
 	loginData: MatrixLoginData,
-	shareMegolmWithAllDevices: boolean
+	isAnonymous: boolean
 ): MatrixLoginData => ({
 	...loginData,
-	shareMegolmWithAllDevices
+	isAnonymous
 });

--- a/src/components/app/authenticatedMatrixLoginData.ts
+++ b/src/components/app/authenticatedMatrixLoginData.ts
@@ -3,8 +3,8 @@ import type { MatrixLoginData } from '../sessionCookie/getMatrixAccessToken';
 /** Keep transient login fields (notably UIA) when adding app-session context. */
 export const withAuthenticatedSessionContext = (
 	loginData: MatrixLoginData,
-	isAnonymous: boolean
+	shareMegolmWithAllDevices: boolean
 ): MatrixLoginData => ({
 	...loginData,
-	isAnonymous
+	shareMegolmWithAllDevices
 });

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -3315,7 +3315,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		if (isAskerUser && !isConsultantUser) {
 			return;
 		}
-		if (!isNotificationActiveViewRoute(location.pathname)) {
+		if (
+			!isNotificationActiveViewRoute(location.pathname, location.search)
+		) {
 			return;
 		}
 		const roomId =
@@ -3364,7 +3366,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		activeThreadRootId,
 		isAskerUser,
 		isConsultantUser,
-		location.pathname
+		location.pathname,
+		location.search
 	]);
 
 	// Track the decryption success because we have a short timing issue when

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -82,6 +82,7 @@ import { MessageSubmitErrorBoundary } from '../messageSubmitInterface/MessageSub
 import { EncryptionBanner } from './EncryptionBanner';
 import { apiGetSessionSupervisors } from '../../api/apiGetSessionSupervisors';
 import { apiPatchNotificationActiveView } from '../../api/apiPatchNotificationActiveView';
+import { isNotificationActiveViewRoute } from './notificationActiveView';
 import { apiRegisterMatrixRoomForSync } from '../../api/apiMatrixSyncRegister';
 import { apiPatchUserData } from '../../api/apiPatchUserData';
 import { apiPutSessionData } from '../../api/apiPutSessionData';
@@ -3314,6 +3315,9 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		if (isAskerUser && !isConsultantUser) {
 			return;
 		}
+		if (!isNotificationActiveViewRoute(location.pathname)) {
+			return;
+		}
 		const roomId =
 			(isMatrixRoom(activeSession.rid)
 				? activeSession.rid
@@ -3324,21 +3328,29 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 			return;
 		}
 
-		apiPatchNotificationActiveView({
-			roomId,
-			threadRootId: activeThreadRootId,
-			active: true
-		}).catch(() => undefined);
-
-		const heartbeat = window.setInterval(() => {
+		let disposed = false;
+		const markActive = () => {
+			// clearInterval cannot cancel a callback that is already queued. The
+			// guard prevents that stale heartbeat from racing after cleanup and
+			// re-enabling suppression while the user is on Notifications.
+			if (disposed) {
+				return;
+			}
 			apiPatchNotificationActiveView({
 				roomId,
 				threadRootId: activeThreadRootId,
 				active: true
 			}).catch(() => undefined);
+		};
+
+		markActive();
+
+		const heartbeat = window.setInterval(() => {
+			markActive();
 		}, 10000);
 
 		return () => {
+			disposed = true;
 			window.clearInterval(heartbeat);
 			apiPatchNotificationActiveView({
 				roomId,
@@ -3351,7 +3363,8 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		activeSession.item?.matrixRoomId,
 		activeThreadRootId,
 		isAskerUser,
-		isConsultantUser
+		isConsultantUser,
+		location.pathname
 	]);
 
 	// Track the decryption success because we have a short timing issue when

--- a/src/components/session/notificationActiveView.test.ts
+++ b/src/components/session/notificationActiveView.test.ts
@@ -25,4 +25,13 @@ describe('isNotificationActiveViewRoute', () => {
 			expect(isNotificationActiveViewRoute(path)).toBe(false);
 		}
 	);
+
+	it('does not suppress notifications for the embedded conversation preview', () => {
+		expect(
+			isNotificationActiveViewRoute(
+				'/sessions/consultant/sessionView/!room:matrix.localhost/13',
+				'?embeddedNotifications=1'
+			)
+		).toBe(false);
+	});
 });

--- a/src/components/session/notificationActiveView.test.ts
+++ b/src/components/session/notificationActiveView.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isNotificationActiveViewRoute } from './notificationActiveView';
+
+describe('isNotificationActiveViewRoute', () => {
+	it.each([
+		'/sessions/consultant/sessionView/!room:matrix.localhost/13',
+		'/sessions/consultant/sessionPreview/session/13',
+		'/sessions/user/view/!room:matrix.localhost/13'
+	])(
+		'keeps active-view suppression on a visible conversation route %s',
+		(path) => {
+			expect(isNotificationActiveViewRoute(path)).toBe(true);
+		}
+	);
+
+	it.each([
+		'/notifications',
+		'/profile/einstellungen/sicherheit',
+		'/sessions/consultant/sessionView',
+		'/sessions/consultant/sessionView/',
+		'/sessions/consultant/sessionView/session/13/userProfile'
+	])(
+		'deactivates notification suppression away from a conversation %s',
+		(path) => {
+			expect(isNotificationActiveViewRoute(path)).toBe(false);
+		}
+	);
+});

--- a/src/components/session/notificationActiveView.ts
+++ b/src/components/session/notificationActiveView.ts
@@ -1,0 +1,9 @@
+const SESSION_DETAIL_ROUTE =
+	/^\/sessions\/[^/]+\/(?:sessionView|sessionPreview|view)\/.+/;
+const NON_CONVERSATION_SUFFIX =
+	/(?:userProfile|editGroupChat|groupChatInfo)\/?$/;
+
+/** True only while the route visibly owns a conversation detail surface. */
+export const isNotificationActiveViewRoute = (pathname: string): boolean =>
+	SESSION_DETAIL_ROUTE.test(pathname) &&
+	!NON_CONVERSATION_SUFFIX.test(pathname);

--- a/src/components/session/notificationActiveView.ts
+++ b/src/components/session/notificationActiveView.ts
@@ -4,6 +4,10 @@ const NON_CONVERSATION_SUFFIX =
 	/(?:userProfile|editGroupChat|groupChatInfo)\/?$/;
 
 /** True only while the route visibly owns a conversation detail surface. */
-export const isNotificationActiveViewRoute = (pathname: string): boolean =>
+export const isNotificationActiveViewRoute = (
+	pathname: string,
+	search = ''
+): boolean =>
 	SESSION_DETAIL_ROUTE.test(pathname) &&
-	!NON_CONVERSATION_SUFFIX.test(pathname);
+	!NON_CONVERSATION_SUFFIX.test(pathname) &&
+	new URLSearchParams(search).get('embeddedNotifications') !== '1';

--- a/src/components/sessionCookie/getMatrixAccessToken.test.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.test.ts
@@ -11,6 +11,7 @@ import { getMatrixHomeserverUrl } from '../../resources/scripts/runtimeConfig';
 import { createClient } from 'matrix-js-sdk';
 import { getMatrixClientLogger } from '../../utils/matrixLogging';
 import { secretStorageKeyCallback } from '../../services/matrixKeyBackupService';
+import { getDeviceSigningAuth } from '../../services/matrixInteractiveAuth';
 
 vi.mock('../../resources/scripts/endpoints', () => ({
 	endpoints: {
@@ -131,6 +132,7 @@ describe('getMatrixAccessToken', () => {
 			accessToken: 'matrix-token',
 			deviceId: 'RESPONSE_DEVICE',
 			expiresInMs: 120_000,
+			uiaPassword: 'ephemeral-uia-password',
 			userId: '@user:matrix.example.test'
 		});
 
@@ -139,6 +141,7 @@ describe('getMatrixAccessToken', () => {
 			deviceId: 'RESPONSE_DEVICE',
 			expiresInMs: 120_000,
 			homeserverUrl: 'https://matrix.example.test',
+			uiaPassword: 'ephemeral-uia-password',
 			userId: '@user:matrix.example.test'
 		});
 
@@ -230,11 +233,24 @@ describe('getMatrixAccessToken', () => {
 		expect(localStorage.getItem('matrix_token_expires_at')).toBeNull();
 	});
 
+	it('never persists the transient UIA password', () => {
+		persistMatrixLoginData({
+			accessToken: 'matrix-token',
+			deviceId: 'ORISO_WEB_TEST_DEVICE',
+			homeserverUrl: 'https://matrix.example.test',
+			uiaPassword: 'must-stay-in-memory',
+			userId: '@consultant:matrix.example.test'
+		});
+
+		expect([...storage.values()]).not.toContain('must-stay-in-memory');
+	});
+
 	it('creates a Matrix client from stored credentials', () => {
 		const client = createMatrixClient({
 			accessToken: 'matrix-token',
 			deviceId: 'ORISO_WEB_TEST_DEVICE',
 			homeserverUrl: 'https://matrix.example.test',
+			uiaPassword: 'ephemeral-uia-password',
 			userId: '@consultant:matrix.example.test'
 		});
 
@@ -262,5 +278,6 @@ describe('getMatrixAccessToken', () => {
 				}
 			}
 		});
+		expect(getDeviceSigningAuth(client)).toBeTypeOf('function');
 	});
 });

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -31,6 +31,11 @@ export interface MatrixLoginData {
 	// (verified-only) would silently make their messages undecryptable for the
 	// consultant. See matrixClientService.initializeClient.
 	isAnonymous?: boolean;
+	/**
+	 * Advice-seeker clients must distribute Megolm keys to the consultant's
+	 * devices. Consultants keep verified-only device isolation.
+	 */
+	shareMegolmWithAllDevices?: boolean;
 }
 
 const MATRIX_DEVICE_ID_PREFIX = 'ORISO_WEB_';

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -31,11 +31,6 @@ export interface MatrixLoginData {
 	// (verified-only) would silently make their messages undecryptable for the
 	// consultant. See matrixClientService.initializeClient.
 	isAnonymous?: boolean;
-	/**
-	 * Advice-seeker clients must distribute Megolm keys to the consultant's
-	 * devices. Consultants keep verified-only device isolation.
-	 */
-	shareMegolmWithAllDevices?: boolean;
 }
 
 const MATRIX_DEVICE_ID_PREFIX = 'ORISO_WEB_';

--- a/src/components/sessionCookie/getMatrixAccessToken.ts
+++ b/src/components/sessionCookie/getMatrixAccessToken.ts
@@ -13,6 +13,10 @@ import {
 	MATRIX_TOKEN_EXPIRY_STORAGE_KEY,
 	MATRIX_USER_ID_STORAGE_KEY
 } from '../../utils/matrixStorageKeys';
+import {
+	createPasswordUiAuth,
+	registerDeviceSigningAuth
+} from '../../services/matrixInteractiveAuth';
 
 export interface MatrixLoginData {
 	accessToken: string;
@@ -20,6 +24,8 @@ export interface MatrixLoginData {
 	deviceId: string;
 	homeserverUrl: string;
 	expiresInMs?: number;
+	/** Transient Matrix password for device-signing UIA; never persisted. */
+	uiaPassword?: string;
 	// Anonymous live-chat users can never cross-sign a consultant's device, so
 	// their client must share Megolm keys to all devices; invisible crypto
 	// (verified-only) would silently make their messages undecryptable for the
@@ -119,7 +125,8 @@ export const getMatrixAccessToken = (
 				response.deviceId
 			),
 			homeserverUrl,
-			expiresInMs: response.expiresInMs
+			expiresInMs: response.expiresInMs,
+			uiaPassword: response.uiaPassword
 		};
 	});
 };
@@ -154,7 +161,7 @@ export const createMatrixClient = (
 	onSdkError?: (...messages: unknown[]) => void
 ): MatrixClient => {
 	const baseLogger = getMatrixClientLogger();
-	return createClient({
+	const client = createClient({
 		baseUrl: loginData.homeserverUrl,
 		accessToken: loginData.accessToken,
 		userId: loginData.userId,
@@ -170,4 +177,13 @@ export const createMatrixClient = (
 			getSecretStorageKey: secretStorageKeyCallback
 		}
 	});
+
+	if (loginData.uiaPassword) {
+		registerDeviceSigningAuth(
+			client,
+			createPasswordUiAuth(loginData.userId, loginData.uiaPassword)
+		);
+	}
+
+	return client;
 };

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -151,6 +151,28 @@ describe('MatrixClientService', () => {
 		setAppConfig(null as any);
 	});
 
+	it('shares to all devices for a registered advice seeker while consultants stay verified-only (#551)', async () => {
+		const { setAppConfig } = await import('../utils/appConfig');
+		setAppConfig({
+			releaseToggles: { enableInvisibleCrypto: true }
+		} as any);
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@marge:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_MARGE',
+			homeserverUrl: 'http://matrix.localhost:18008',
+			shareMegolmWithAllDevices: true
+		});
+
+		expect(mockedCrypto.setDeviceIsolationMode).toHaveBeenCalledTimes(1);
+		expect(mockedCrypto.setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+		setAppConfig(null as any);
+	});
+
 	it('preserves the anonymous flag across a token refresh so decryption keeps working (#774)', async () => {
 		const { setAppConfig } = await import('../utils/appConfig');
 		setAppConfig({
@@ -180,6 +202,36 @@ describe('MatrixClientService', () => {
 
 		// The refreshed client must still share to all devices, not fall back to
 		// verified-only isolation and re-break decryption.
+		const lastCall = mockedCrypto.setDeviceIsolationMode.mock.calls.at(-1);
+		expect(lastCall?.[0].kind).toBe(
+			DeviceIsolationModeKind.AllDevicesIsolationMode
+		);
+		setAppConfig(null as any);
+	});
+
+	it('preserves registered advice-seeker key sharing across a token refresh (#551)', async () => {
+		const { setAppConfig } = await import('../utils/appConfig');
+		setAppConfig({
+			releaseToggles: { enableInvisibleCrypto: true }
+		} as any);
+		const service = new MatrixClientService();
+
+		await service.initializeClient({
+			userId: '@marge:matrix.localhost',
+			accessToken: 'access-token',
+			deviceId: 'DEVICE_MARGE',
+			homeserverUrl: 'http://matrix.localhost:18008',
+			shareMegolmWithAllDevices: true
+		});
+		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
+			userId: '@marge:matrix.localhost',
+			accessToken: 'refreshed-token',
+			deviceId: 'DEVICE_MARGE',
+			homeserverUrl: 'http://matrix.localhost:18008'
+		});
+
+		await service.refreshMatrixToken();
+
 		const lastCall = mockedCrypto.setDeviceIsolationMode.mock.calls.at(-1);
 		expect(lastCall?.[0].kind).toBe(
 			DeviceIsolationModeKind.AllDevicesIsolationMode

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -151,28 +151,6 @@ describe('MatrixClientService', () => {
 		setAppConfig(null as any);
 	});
 
-	it('shares to all devices for a registered advice seeker while consultants stay verified-only (#551)', async () => {
-		const { setAppConfig } = await import('../utils/appConfig');
-		setAppConfig({
-			releaseToggles: { enableInvisibleCrypto: true }
-		} as any);
-		const service = new MatrixClientService();
-
-		await service.initializeClient({
-			userId: '@marge:matrix.localhost',
-			accessToken: 'access-token',
-			deviceId: 'DEVICE_MARGE',
-			homeserverUrl: 'http://matrix.localhost:18008',
-			shareMegolmWithAllDevices: true
-		});
-
-		expect(mockedCrypto.setDeviceIsolationMode).toHaveBeenCalledTimes(1);
-		expect(mockedCrypto.setDeviceIsolationMode.mock.calls[0][0].kind).toBe(
-			DeviceIsolationModeKind.AllDevicesIsolationMode
-		);
-		setAppConfig(null as any);
-	});
-
 	it('preserves the anonymous flag across a token refresh so decryption keeps working (#774)', async () => {
 		const { setAppConfig } = await import('../utils/appConfig');
 		setAppConfig({
@@ -202,36 +180,6 @@ describe('MatrixClientService', () => {
 
 		// The refreshed client must still share to all devices, not fall back to
 		// verified-only isolation and re-break decryption.
-		const lastCall = mockedCrypto.setDeviceIsolationMode.mock.calls.at(-1);
-		expect(lastCall?.[0].kind).toBe(
-			DeviceIsolationModeKind.AllDevicesIsolationMode
-		);
-		setAppConfig(null as any);
-	});
-
-	it('preserves registered advice-seeker key sharing across a token refresh (#551)', async () => {
-		const { setAppConfig } = await import('../utils/appConfig');
-		setAppConfig({
-			releaseToggles: { enableInvisibleCrypto: true }
-		} as any);
-		const service = new MatrixClientService();
-
-		await service.initializeClient({
-			userId: '@marge:matrix.localhost',
-			accessToken: 'access-token',
-			deviceId: 'DEVICE_MARGE',
-			homeserverUrl: 'http://matrix.localhost:18008',
-			shareMegolmWithAllDevices: true
-		});
-		vi.mocked(getMatrixAccessToken).mockResolvedValueOnce({
-			userId: '@marge:matrix.localhost',
-			accessToken: 'refreshed-token',
-			deviceId: 'DEVICE_MARGE',
-			homeserverUrl: 'http://matrix.localhost:18008'
-		});
-
-		await service.refreshMatrixToken();
-
 		const lastCall = mockedCrypto.setDeviceIsolationMode.mock.calls.at(-1);
 		expect(lastCall?.[0].kind).toBe(
 			DeviceIsolationModeKind.AllDevicesIsolationMode
@@ -684,6 +632,53 @@ describe('MatrixClientService', () => {
 			msgtype: 'm.text',
 			body: 'Hello Matrix'
 		});
+	});
+
+	it('refreshes tracked room-member device keys before the first encrypted send (#551)', async () => {
+		const request = { type: 'keys-query' };
+		const clonedApu = { id: '@apu:matrix.localhost' };
+		const trackedApu = {
+			toString: () => '@apu:matrix.localhost',
+			clone: vi.fn(() => clonedApu)
+		};
+		const makeOutgoingRequest = vi.fn().mockResolvedValue(undefined);
+		const queryKeysForUsers = vi.fn(() => request);
+		const sendMessage = vi.fn().mockResolvedValue({ event_id: '$event' });
+		const room = {
+			getEncryptionTargetMembers: vi
+				.fn()
+				.mockResolvedValue([
+					{ userId: '@marge:matrix.localhost' },
+					{ userId: '@apu:matrix.localhost' }
+				])
+		};
+		const client = {
+			getUserId: () => '@marge:matrix.localhost',
+			getRoom: vi.fn(() => room),
+			getCrypto: () => ({
+				olmMachine: {
+					trackedUsers: vi
+						.fn()
+						.mockResolvedValue(new Set([trackedApu])),
+					queryKeysForUsers
+				},
+				outgoingRequestProcessor: { makeOutgoingRequest }
+			}),
+			sendMessage
+		};
+		const service = new MatrixClientService();
+		setClient(service, client);
+
+		await service.sendMessage('!room:matrix.localhost', 'hello');
+		await service.sendMessage('!room:matrix.localhost', 'again');
+
+		expect(room.getEncryptionTargetMembers).toHaveBeenCalledOnce();
+		expect(trackedApu.clone).toHaveBeenCalledOnce();
+		expect(queryKeysForUsers).toHaveBeenCalledWith([clonedApu]);
+		expect(makeOutgoingRequest).toHaveBeenCalledWith(request);
+		expect(makeOutgoingRequest.mock.invocationCallOrder[0]).toBeLessThan(
+			sendMessage.mock.invocationCallOrder[0]
+		);
 	});
 
 	it('removes the rejected Matrix local echo before the UI offers a fresh retry', async () => {

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -170,15 +170,18 @@ export class MatrixClientService {
 
 		// #438 MSC4153 invisible crypto: once the rust crypto stack is up, share
 		// Megolm keys only with cross-signed devices when the toggle is on.
-		// Anonymous live-chat users are exempt: they can never cross-sign the
-		// consultant's device, so verified-only isolation would leave the
-		// consultant seeing only undecryptable noise. They always share to all
-		// devices so the accepted consultant can read the conversation (#774).
+		// Advice seekers are exempt on their sending client: they cannot verify a
+		// consultant's identity as part of the counselling flow, and a consultant
+		// device may only become cross-signed after the room/device list was first
+		// cached. Verified-only key distribution would then silently leave the
+		// consultant seeing undecryptable noise (#551, #774). Consultant clients
+		// remain in verified-only isolation.
 		// Best-effort — never breaks client startup.
 		applyDeviceIsolationMode(
 			client,
 			appConfig?.releaseToggles?.enableInvisibleCrypto === true &&
-				loginData.isAnonymous !== true
+				loginData.isAnonymous !== true &&
+				loginData.shareMegolmWithAllDevices !== true
 		);
 
 		(client as any).on(
@@ -287,14 +290,15 @@ export class MatrixClientService {
 		this.refreshingToken = getMatrixAccessToken()
 			.then(async (loginData) => {
 				// getMatrixAccessToken only returns transport fields. A session's
-				// anonymity is stable across refreshes, so carry the existing flag
-				// forward — otherwise invisible crypto would re-apply verified-only
-				// isolation on the refreshed client and make an anonymous asker's
-				// messages undecryptable for the consultant again (#774).
+				// Role-derived key-sharing policy is stable across refreshes, so carry
+				// it forward with the legacy anonymous compatibility flag.
 				const refreshedLoginData: MatrixLoginData = {
 					...loginData,
 					isAnonymous:
-						loginData.isAnonymous ?? this.loginData?.isAnonymous
+						loginData.isAnonymous ?? this.loginData?.isAnonymous,
+					shareMegolmWithAllDevices:
+						loginData.shareMegolmWithAllDevices ??
+						this.loginData?.shareMegolmWithAllDevices
 				};
 				persistMatrixLoginData(refreshedLoginData);
 				await this.initializeClient(refreshedLoginData);
@@ -337,7 +341,10 @@ export class MatrixClientService {
 				const recoveredLoginData: MatrixLoginData = {
 					...loginData,
 					isAnonymous:
-						loginData.isAnonymous ?? staleLoginData.isAnonymous
+						loginData.isAnonymous ?? staleLoginData.isAnonymous,
+					shareMegolmWithAllDevices:
+						loginData.shareMegolmWithAllDevices ??
+						staleLoginData.shareMegolmWithAllDevices
 				};
 				persistMatrixLoginData(recoveredLoginData);
 				await this.initializeClient(recoveredLoginData);

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -28,6 +28,21 @@ const TOKEN_REFRESH_BUFFER_MS = 2 * 60 * 1000;
 const isPreparedSyncState = (state: string | null): boolean =>
 	state === 'PREPARED' || state === 'SYNCING';
 
+type RustTrackedUser = {
+	clone: () => unknown;
+	toString: () => string;
+};
+
+type RefreshableRustCrypto = {
+	olmMachine?: {
+		queryKeysForUsers?: (users: unknown[]) => unknown;
+		trackedUsers?: () => Promise<Set<RustTrackedUser>>;
+	};
+	outgoingRequestProcessor?: {
+		makeOutgoingRequest?: (request: unknown) => Promise<unknown>;
+	};
+};
+
 export interface MatrixFileMessageOptions {
 	abortController?: AbortController;
 	uploadProgress?: (percentUpload: number) => void;
@@ -128,6 +143,10 @@ export class MatrixClientService {
 	private staleDeviceRecoveryVersion = 0;
 	private syncState: string | null = null;
 	private initializedServicesClient: MatrixClient | null = null;
+	private readonly deviceListRefreshes = new WeakMap<
+		MatrixClient,
+		Map<string, Promise<boolean>>
+	>();
 	private syncStateListeners = new Set<(state: string | null) => void>();
 	private clientChangeListeners = new Set<
 		(client: MatrixClient | null) => void
@@ -170,18 +189,15 @@ export class MatrixClientService {
 
 		// #438 MSC4153 invisible crypto: once the rust crypto stack is up, share
 		// Megolm keys only with cross-signed devices when the toggle is on.
-		// Advice seekers are exempt on their sending client: they cannot verify a
-		// consultant's identity as part of the counselling flow, and a consultant
-		// device may only become cross-signed after the room/device list was first
-		// cached. Verified-only key distribution would then silently leave the
-		// consultant seeing undecryptable noise (#551, #774). Consultant clients
-		// remain in verified-only isolation.
+		// Anonymous live-chat users are exempt: they can never cross-sign the
+		// consultant's device, so verified-only isolation would leave the
+		// consultant seeing only undecryptable noise. They always share to all
+		// devices so the accepted consultant can read the conversation (#774).
 		// Best-effort — never breaks client startup.
 		applyDeviceIsolationMode(
 			client,
 			appConfig?.releaseToggles?.enableInvisibleCrypto === true &&
-				loginData.isAnonymous !== true &&
-				loginData.shareMegolmWithAllDevices !== true
+				loginData.isAnonymous !== true
 		);
 
 		(client as any).on(
@@ -290,15 +306,14 @@ export class MatrixClientService {
 		this.refreshingToken = getMatrixAccessToken()
 			.then(async (loginData) => {
 				// getMatrixAccessToken only returns transport fields. A session's
-				// Role-derived key-sharing policy is stable across refreshes, so carry
-				// it forward with the legacy anonymous compatibility flag.
+				// anonymity is stable across refreshes, so carry the existing flag
+				// forward — otherwise invisible crypto would re-apply verified-only
+				// isolation on the refreshed client and make an anonymous asker's
+				// messages undecryptable for the consultant again (#774).
 				const refreshedLoginData: MatrixLoginData = {
 					...loginData,
 					isAnonymous:
-						loginData.isAnonymous ?? this.loginData?.isAnonymous,
-					shareMegolmWithAllDevices:
-						loginData.shareMegolmWithAllDevices ??
-						this.loginData?.shareMegolmWithAllDevices
+						loginData.isAnonymous ?? this.loginData?.isAnonymous
 				};
 				persistMatrixLoginData(refreshedLoginData);
 				await this.initializeClient(refreshedLoginData);
@@ -341,10 +356,7 @@ export class MatrixClientService {
 				const recoveredLoginData: MatrixLoginData = {
 					...loginData,
 					isAnonymous:
-						loginData.isAnonymous ?? staleLoginData.isAnonymous,
-					shareMegolmWithAllDevices:
-						loginData.shareMegolmWithAllDevices ??
-						staleLoginData.shareMegolmWithAllDevices
+						loginData.isAnonymous ?? staleLoginData.isAnonymous
 				};
 				persistMatrixLoginData(recoveredLoginData);
 				await this.initializeClient(recoveredLoginData);
@@ -420,6 +432,91 @@ export class MatrixClientService {
 		await this.refreshMatrixToken();
 	}
 
+	/**
+	 * Refresh already-tracked room members before the first send in a client
+	 * generation. A full sync does not replay historical device-list changes,
+	 * so a room created before the recipient recovered/cross-signed a device can
+	 * otherwise keep an indefinitely stale cache and omit that device from
+	 * Megolm key sharing (#551).
+	 *
+	 * matrix-js-sdk exposes forced downloads only for untracked users. The Rust
+	 * backend already owns the supported query and response processing path, but
+	 * currently narrows it out of CryptoApi. Runtime guards make this best-effort
+	 * and upgrade-safe; a missing internal never blocks normal SDK encryption.
+	 */
+	private async refreshTrackedRoomMemberDevices(
+		client: MatrixClient,
+		roomId: string
+	): Promise<boolean> {
+		let roomRefreshes = this.deviceListRefreshes.get(client);
+		if (!roomRefreshes) {
+			roomRefreshes = new Map<string, Promise<boolean>>();
+			this.deviceListRefreshes.set(client, roomRefreshes);
+		}
+
+		const existing = roomRefreshes.get(roomId);
+		if (existing) {
+			return existing;
+		}
+
+		const refresh = (async () => {
+			const room = client.getRoom(roomId);
+			const crypto = client.getCrypto?.() as
+				| RefreshableRustCrypto
+				| undefined;
+			const olmMachine = crypto?.olmMachine;
+			const makeOutgoingRequest =
+				crypto?.outgoingRequestProcessor?.makeOutgoingRequest;
+			if (
+				!room ||
+				typeof room.getEncryptionTargetMembers !== 'function' ||
+				typeof olmMachine?.trackedUsers !== 'function' ||
+				typeof olmMachine.queryKeysForUsers !== 'function' ||
+				typeof makeOutgoingRequest !== 'function'
+			) {
+				return false;
+			}
+
+			const ownUserId = client.getUserId?.();
+			const members = await room.getEncryptionTargetMembers();
+			const targetUserIds = new Set(
+				members
+					.map((member) => member.userId)
+					.filter((userId) => userId && userId !== ownUserId)
+			);
+			if (targetUserIds.size === 0) {
+				return true;
+			}
+
+			const trackedUsers = await olmMachine.trackedUsers();
+			const queryUsers = Array.from(trackedUsers)
+				.filter((user) => targetUserIds.has(user.toString()))
+				.map((user) => user.clone());
+			if (queryUsers.length === 0) {
+				return false;
+			}
+
+			const request = olmMachine.queryKeysForUsers(queryUsers);
+			await makeOutgoingRequest.call(
+				crypto.outgoingRequestProcessor,
+				request
+			);
+			return true;
+		})();
+
+		roomRefreshes.set(roomId, refresh);
+		try {
+			const refreshed = await refresh;
+			if (!refreshed) {
+				roomRefreshes.delete(roomId);
+			}
+			return refreshed;
+		} catch {
+			roomRefreshes.delete(roomId);
+			return false;
+		}
+	}
+
 	// Send message to a room
 	public async sendMessage(
 		roomId: string,
@@ -439,6 +536,7 @@ export class MatrixClientService {
 			if (!client.getRoom(roomId)) {
 				await client.joinRoom(roomId);
 			}
+			await this.refreshTrackedRoomMemberDevices(client, roomId);
 			// Every real matrix-js-sdk client provides makeTxnId(). The guard also
 			// keeps deliberately minimal test doubles and adapters compatible.
 			const txnId = client.makeTxnId?.();
@@ -571,6 +669,7 @@ export class MatrixClientService {
 		}
 
 		try {
+			await this.refreshTrackedRoomMemberDevices(this.client, roomId);
 			const content = await this.uploadFileMessageContent(file, options);
 			return await this.client.sendMessage(roomId, content as any);
 		} catch (error) {
@@ -583,6 +682,7 @@ export class MatrixClientService {
 				throw new Error('Matrix client not initialized');
 			}
 
+			await this.refreshTrackedRoomMemberDevices(this.client, roomId);
 			const content = await this.uploadFileMessageContent(file, options);
 			return this.client.sendMessage(roomId, content as any);
 		}

--- a/src/services/matrixInteractiveAuth.test.ts
+++ b/src/services/matrixInteractiveAuth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MatrixClient } from 'matrix-js-sdk';
+import {
+	createPasswordUiAuth,
+	getDeviceSigningAuth,
+	registerDeviceSigningAuth
+} from './matrixInteractiveAuth';
+
+describe('createPasswordUiAuth', () => {
+	it('retries the device-signing upload with password UIA and the server session', async () => {
+		const makeRequest = vi
+			.fn()
+			.mockRejectedValueOnce({ data: { session: 'uia-session' } })
+			.mockResolvedValueOnce(undefined);
+		const authenticate = createPasswordUiAuth(
+			'@herb-powell:predev.oriso.org',
+			'ephemeral-uia-password'
+		);
+
+		await authenticate(makeRequest);
+
+		expect(makeRequest).toHaveBeenNthCalledWith(1, null);
+		expect(makeRequest).toHaveBeenNthCalledWith(2, {
+			type: 'm.login.password',
+			identifier: {
+				type: 'm.id.user',
+				user: '@herb-powell:predev.oriso.org'
+			},
+			password: 'ephemeral-uia-password',
+			session: 'uia-session'
+		});
+	});
+
+	it('does not send the password after a non-UIA failure', async () => {
+		const failure = new Error('network failed');
+		const makeRequest = vi.fn().mockRejectedValueOnce(failure);
+		const authenticate = createPasswordUiAuth(
+			'@herb-powell:predev.oriso.org',
+			'ephemeral-uia-password'
+		);
+
+		await expect(authenticate(makeRequest)).rejects.toBe(failure);
+		expect(makeRequest).toHaveBeenCalledOnce();
+		expect(makeRequest).toHaveBeenCalledWith(null);
+	});
+});
+
+describe('device-signing auth registry', () => {
+	it('keeps UIA credentials in memory and scoped to the Matrix client', () => {
+		const firstClient = {} as MatrixClient;
+		const secondClient = {} as MatrixClient;
+		const authenticate = createPasswordUiAuth('@user:example.org', 'secret');
+
+		registerDeviceSigningAuth(firstClient, authenticate);
+
+		expect(getDeviceSigningAuth(firstClient)).toBe(authenticate);
+		expect(getDeviceSigningAuth(secondClient)).toBeUndefined();
+	});
+});

--- a/src/services/matrixInteractiveAuth.ts
+++ b/src/services/matrixInteractiveAuth.ts
@@ -1,0 +1,46 @@
+import type { MatrixClient } from 'matrix-js-sdk';
+import type { UIAuthCallback } from 'matrix-js-sdk/lib/interactive-auth';
+
+type MatrixUiAuthError = {
+	data?: { session?: string };
+};
+
+const deviceSigningAuthByClient = new WeakMap<
+	MatrixClient,
+	UIAuthCallback<void>
+>();
+
+/** Password UIA for the device-signing upload, matching Matrix's two-step flow. */
+export const createPasswordUiAuth = (
+	userId: string,
+	password: string
+): UIAuthCallback<void> =>
+	async (makeRequest) => {
+		try {
+			return await makeRequest(null);
+		} catch (error) {
+			const session = (error as MatrixUiAuthError)?.data?.session;
+			if (!session) {
+				throw error;
+			}
+			return makeRequest({
+				type: 'm.login.password',
+				identifier: { type: 'm.id.user', user: userId },
+				password,
+				session
+			});
+		}
+	};
+
+/** Keep the transient password closure in memory and scoped to its client. */
+export const registerDeviceSigningAuth = (
+	client: MatrixClient,
+	authenticate: UIAuthCallback<void>
+): void => {
+	deviceSigningAuthByClient.set(client, authenticate);
+};
+
+export const getDeviceSigningAuth = (
+	client: MatrixClient
+): UIAuthCallback<void> | undefined =>
+	deviceSigningAuthByClient.get(client);

--- a/src/services/matrixKeyBackupService.test.ts
+++ b/src/services/matrixKeyBackupService.test.ts
@@ -10,6 +10,7 @@ import {
 	CryptoUnavailableError,
 	RecoverySetupPhaseError
 } from './matrixKeyBackupService';
+import { registerDeviceSigningAuth } from './matrixInteractiveAuth';
 
 /**
  * #437 Key backup + recovery UX — service layer over matrix-js-sdk's CryptoApi
@@ -48,7 +49,11 @@ const buildCrypto = (overrides: Record<string, unknown> = {}) => ({
 	...overrides
 });
 
-const buildClient = (crypto: unknown) => ({ getCrypto: () => crypto }) as any;
+const buildClient = (crypto: unknown) => {
+	const client = { getCrypto: () => crypto } as any;
+	registerDeviceSigningAuth(client, vi.fn());
+	return client;
+};
 
 describe('matrixKeyBackupService (#437)', () => {
 	beforeEach(async () => {
@@ -96,10 +101,15 @@ describe('matrixKeyBackupService (#437)', () => {
 	describe('setUpRecovery', () => {
 		it('creates key backup inside secret-storage bootstrap and verifies the durable state before displaying the key', async () => {
 			const crypto = buildCrypto();
-			const encoded = await setUpRecovery(buildClient(crypto));
+			const client = buildClient(crypto);
+			const authenticate = vi.fn();
+			registerDeviceSigningAuth(client, authenticate);
+			const encoded = await setUpRecovery(client);
 
 			expect(encoded).toBe(VALID_ENCODED_KEY);
-			expect(crypto.bootstrapCrossSigning).toHaveBeenCalled();
+			expect(crypto.bootstrapCrossSigning).toHaveBeenCalledWith({
+				authUploadDeviceSigningKeys: authenticate
+			});
 			expect(crypto.bootstrapSecretStorage).toHaveBeenCalledWith(
 				expect.objectContaining({ setupNewKeyBackup: true })
 			);

--- a/src/services/matrixKeyBackupService.ts
+++ b/src/services/matrixKeyBackupService.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient } from 'matrix-js-sdk';
 import type { SecretStorageKeyDescription } from 'matrix-js-sdk/lib/secret-storage';
 import { decodeRecoveryKey } from 'matrix-js-sdk/lib/crypto-api';
+import { getDeviceSigningAuth } from './matrixInteractiveAuth';
 
 /**
  * #437 Key backup + recovery UX — thin service layer over matrix-js-sdk's
@@ -149,12 +150,16 @@ export const getEncryptionStatus = async (
  */
 export const setUpRecovery = async (client: MatrixClient): Promise<string> => {
 	const crypto = getCryptoOrThrow(client);
+	const authUploadDeviceSigningKeys = getDeviceSigningAuth(client);
+	if (!authUploadDeviceSigningKeys) {
+		throw new Error('Matrix device-signing authentication is unavailable');
+	}
 
 	const generated = await crypto.createRecoveryKeyFromPassphrase();
 	setPendingKey(generated.privateKey);
 	try {
 		await runRecoverySetupPhase('cross-signing', () =>
-			crypto.bootstrapCrossSigning({})
+			crypto.bootstrapCrossSigning({ authUploadDeviceSigningKeys })
 		);
 		await runRecoverySetupPhase('secret-storage', () =>
 			crypto.bootstrapSecretStorage({
@@ -192,6 +197,10 @@ export const recoverWithKey = async (
 	encodedRecoveryKey: string
 ): Promise<{ imported: number; total: number }> => {
 	const crypto = getCryptoOrThrow(client);
+	const authUploadDeviceSigningKeys = getDeviceSigningAuth(client);
+	if (!authUploadDeviceSigningKeys) {
+		throw new Error('Matrix device-signing authentication is unavailable');
+	}
 
 	let privateKey: Uint8Array;
 	try {
@@ -205,7 +214,7 @@ export const recoverWithKey = async (
 		await crypto.loadSessionBackupPrivateKeyFromSecretStorage();
 		const result = await crypto.restoreKeyBackup();
 		// Self-verify this device against the recovered cross-signing identity.
-		await crypto.bootstrapCrossSigning({});
+		await crypto.bootstrapCrossSigning({ authUploadDeviceSigningKeys });
 		return { imported: result.imported, total: result.total };
 	} finally {
 		setPendingKey(null);
@@ -222,7 +231,9 @@ export const resetCryptoIdentity = async (
 	client: MatrixClient
 ): Promise<void> => {
 	const crypto = getCryptoOrThrow(client);
-	await crypto.resetEncryption(async (makeRequest) => {
-		await makeRequest(null);
-	});
+	const authUploadDeviceSigningKeys = getDeviceSigningAuth(client);
+	if (!authUploadDeviceSigningKeys) {
+		throw new Error('Matrix device-signing authentication is unavailable');
+	}
+	await crypto.resetEncryption(authUploadDeviceSigningKeys);
 };


### PR DESCRIPTION
## Summary
- consume UserService transient Matrix UIA credential in memory only
- bind password UIA to the exact Matrix client
- pass the callback to setup, recovery, and reset device-signing operations
- refuse to send the credential after non-UIA failures

## Verification
- unit: 1,463 passed
- lint:scripts: passed
- lint:style: passed
- production build: passed before final guard refinement; final rebuild in progress

Backend dependency: OpenResilienceInitiative/ORISO-UserService#950 / PR OpenResilienceInitiative/ORISO-UserService#951

Closes #903