### PR TITLE
fix: clear empty live chat queue after polling

### DIFF
--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -80,6 +80,7 @@ import {
 import { FutureTimelinePanel } from './FutureTimelinePanel';
 import { canModerateGroupChat } from '../groupChat/groupChatHelpers';
 import { ChatOccurrence } from '../../api/apiGetChatOccurrences';
+import { refetchEnquiryListState } from './refetchEnquiryList';
 
 function buildSessionSearchHaystack(
 	raw: ListItemInterface,
@@ -592,17 +593,18 @@ export const SessionsList = ({
 			return Promise.resolve();
 		}
 
-		return fetchEnquirySessionsWithAutoPage(0)
-			.then(({ sessions, total }) => {
+		return refetchEnquiryListState({
+			fetchPage: () => fetchEnquirySessionsWithAutoPage(0),
+			replaceSessions: (sessions) => {
 				dispatch({
 					type: SET_SESSIONS,
 					ready: true,
 					sessions
 				});
-				setTotalItems(total);
-				setCurrentOffset(0);
-			})
-			.catch(() => {});
+			},
+			setTotalItems,
+			setCurrentOffset
+		});
 	}, [dispatch, fetchEnquirySessionsWithAutoPage, type]);
 
 	const refetchSessionList = useCallback(() => {

--- a/src/components/sessionsList/refetchEnquiryList.test.ts
+++ b/src/components/sessionsList/refetchEnquiryList.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { refetchEnquiryListState } from './refetchEnquiryList';
+
+describe('refetchEnquiryListState', () => {
+	it('clears a previously visible queue when both enquiry feeds return EMPTY', async () => {
+		const replaceSessions = vi.fn();
+		const setTotalItems = vi.fn();
+		const setCurrentOffset = vi.fn();
+
+		await refetchEnquiryListState({
+			fetchPage: () => Promise.reject(new Error('EMPTY')),
+			replaceSessions,
+			setTotalItems,
+			setCurrentOffset
+		});
+
+		expect(replaceSessions).toHaveBeenCalledWith([]);
+		expect(setTotalItems).toHaveBeenCalledWith(0);
+		expect(setCurrentOffset).toHaveBeenCalledWith(0);
+	});
+});

--- a/src/components/sessionsList/refetchEnquiryList.ts
+++ b/src/components/sessionsList/refetchEnquiryList.ts
@@ -1,0 +1,38 @@
+type EnquiryListPage<T> = {
+	sessions: T[];
+	total: number;
+};
+
+type RefetchEnquiryListStateOptions<T> = {
+	fetchPage: () => Promise<EnquiryListPage<T>>;
+	replaceSessions: (sessions: T[]) => void;
+	setTotalItems: (total: number) => void;
+	setCurrentOffset: (offset: number) => void;
+};
+
+/**
+ * Replaces the visible enquiry queue with the latest backend state.
+ * A 204 response is surfaced by the API layer as `Error('EMPTY')`; that is a
+ * successful empty snapshot and must clear stale sessions from the UI.
+ */
+export const refetchEnquiryListState = async <T>({
+	fetchPage,
+	replaceSessions,
+	setTotalItems,
+	setCurrentOffset
+}: RefetchEnquiryListStateOptions<T>): Promise<void> => {
+	try {
+		const { sessions, total } = await fetchPage();
+		replaceSessions(sessions);
+		setTotalItems(total);
+		setCurrentOffset(0);
+	} catch (error) {
+		if (!(error instanceof Error) || error.message !== 'EMPTY') {
+			return;
+		}
+
+		replaceSessions([]);
+		setTotalItems(0);
+		setCurrentOffset(0);
+	}
+};


### PR DESCRIPTION
Closes #907

## Why

When the anonymous Live Chat queue endpoint returned an empty result, the polling path converted it to `Error('EMPTY')` and then swallowed that result. A consultant in another eligible agency could therefore retain a departed client indefinitely.

## What changed

- make an empty queue response an authoritative empty snapshot
- keep genuine polling failures non-destructive
- isolate the polling decision in a tested helper

## Verification

- focused RED/GREEN regression: PASS (9/9)
- full frontend unit suite: PASS (1,460 tests)
- ESLint, TypeScript, production build: PASS
- real-browser PreDev proof with consultants from agency 0 and agency 3: the same waiting client appeared in both queues and disappeared from both after leaving
- near-simultaneous acceptance proof: exactly one consultant won; the other received the already-accepted state

## Reviewer test plan

- [x] Open consultant queues for two different eligible agencies.
- [x] Join as a fresh anonymous client and verify both consultants see the username.
- [x] Leave before acceptance and wait for the next poll.
- [x] Verify both queues are empty without reloading either consultant app.
- [x] Repeat with simultaneous acceptance and verify exactly one consultant succeeds.

## Browser evidence

Captured at desktop and 412 px widths in the linked parent E2E run; an evidence comment with screenshots follows on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
