### PR TITLE
P0: keep the initial registered enquiry end-to-end encrypted (#851)

### DIFF
--- a/src/api/apiSendEnquiry.test.ts
+++ b/src/api/apiSendEnquiry.test.ts
@@ -7,8 +7,8 @@ describe('buildEncryptedEnquiryFinalizationPayload', () => {
 			buildEncryptedEnquiryFinalizationPayload('$encrypted', 'de')
 		).toEqual({
 			message: '',
+			t: 'e2e',
 			matrixEventId: '$encrypted',
-			sendNotification: true,
 			language: 'de'
 		});
 	});

--- a/src/api/apiSendEnquiry.test.ts
+++ b/src/api/apiSendEnquiry.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { buildEncryptedEnquiryFinalizationPayload } from './encryptedEnquiryPayload';
+
+describe('buildEncryptedEnquiryFinalizationPayload', () => {
+	it('contains only the encrypted Matrix event reference and no enquiry plaintext', () => {
+		expect(
+			buildEncryptedEnquiryFinalizationPayload('$encrypted', 'de')
+		).toEqual({
+			message: '',
+			matrixEventId: '$encrypted',
+			sendNotification: true,
+			language: 'de'
+		});
+	});
+});

--- a/src/api/apiSendEnquiry.ts
+++ b/src/api/apiSendEnquiry.ts
@@ -1,21 +1,17 @@
 import { endpoints } from '../resources/scripts/endpoints';
 import { fetchData, FETCH_METHODS, FETCH_SUCCESS } from './fetchData';
+import { buildEncryptedEnquiryFinalizationPayload } from './encryptedEnquiryPayload';
 
 export const apiSendEnquiry = async (
 	sessionId: number,
-	messageData: string,
-	isEncrypted: boolean,
+	matrixEventId: string,
 	language?: string
 ): Promise<any> => {
 	const url = `${endpoints.sessionBase}/${sessionId}/enquiry/new`;
-	const data: any = {
-		message: messageData,
-		t: isEncrypted ? 'e2e' : '',
-		sendNotification: true
-	};
-	if (language) {
-		data.language = language;
-	}
+	const data = buildEncryptedEnquiryFinalizationPayload(
+		matrixEventId,
+		language
+	);
 
 	const message = JSON.stringify(data);
 

--- a/src/api/encryptedEnquiryPayload.ts
+++ b/src/api/encryptedEnquiryPayload.ts
@@ -5,7 +5,7 @@ export const buildEncryptedEnquiryFinalizationPayload = (
 	// The initial enquiry plaintext exists only inside the encrypted Matrix
 	// event. UserService receives the event reference, never the content.
 	message: '',
+	t: 'e2e',
 	matrixEventId,
-	sendNotification: true,
 	...(language ? { language } : {})
 });

--- a/src/api/encryptedEnquiryPayload.ts
+++ b/src/api/encryptedEnquiryPayload.ts
@@ -1,0 +1,11 @@
+export const buildEncryptedEnquiryFinalizationPayload = (
+	matrixEventId: string,
+	language?: string
+) => ({
+	// The initial enquiry plaintext exists only inside the encrypted Matrix
+	// event. UserService receives the event reference, never the content.
+	message: '',
+	matrixEventId,
+	sendNotification: true,
+	...(language ? { language } : {})
+});

--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -196,7 +196,55 @@ describe('messageEncryptionMode', () => {
 		});
 
 		expect(calls).toEqual(['matrix', 'finalize:$encrypted']);
+		expect(sendEncryptedMatrixMessage).toHaveBeenCalledWith(
+			'oriso.enquiry.42'
+		);
 		expect(values.size).toBe(0);
+	});
+
+	it('reuses the homeserver transaction when retry storage is unavailable', async () => {
+		const storage = {
+			getItem: vi.fn(() => {
+				throw new Error('storage unavailable');
+			}),
+			setItem: vi.fn(() => {
+				throw new Error('storage unavailable');
+			}),
+			removeItem: vi.fn(() => {
+				throw new Error('storage unavailable');
+			})
+		};
+		const sendEncryptedMatrixMessage = vi
+			.fn()
+			.mockResolvedValue({ event_id: '$encrypted' });
+		const finalizeEnquiry = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('temporary'))
+			.mockResolvedValueOnce({ sessionId: 42 });
+
+		await expect(
+			sendEncryptedInitialEnquiry({
+				sessionId: 42,
+				sendEncryptedMatrixMessage,
+				finalizeEnquiry,
+				storage
+			})
+		).rejects.toThrow('temporary');
+		await sendEncryptedInitialEnquiry({
+			sessionId: 42,
+			sendEncryptedMatrixMessage,
+			finalizeEnquiry,
+			storage
+		});
+
+		expect(sendEncryptedMatrixMessage).toHaveBeenNthCalledWith(
+			1,
+			'oriso.enquiry.42'
+		);
+		expect(sendEncryptedMatrixMessage).toHaveBeenNthCalledWith(
+			2,
+			'oriso.enquiry.42'
+		);
 	});
 
 	it('retries finalization without sending a duplicate encrypted message', async () => {

--- a/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.test.ts
@@ -3,7 +3,8 @@ import {
 	createEnquirySubmissionGuard,
 	dispatchAskerMessageTransport,
 	isAskerEnquirySubmission,
-	resolveAskerMessageTransport
+	resolveAskerMessageTransport,
+	sendEncryptedInitialEnquiry
 } from './messageEncryptionMode';
 import { STATUS_ENQUIRY } from '../../globalState/interfaces/SessionsDataInterface';
 
@@ -168,5 +169,68 @@ describe('messageEncryptionMode', () => {
 		expect(guard.tryStart()).toBe(true);
 		guard.markFailed();
 		expect(guard.tryStart()).toBe(true);
+	});
+
+	it('sends the initial enquiry through Matrix before finalizing only its event ID', async () => {
+		const values = new Map<string, string>();
+		const storage = {
+			getItem: (key: string) => values.get(key) || null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key)
+		};
+		const calls: string[] = [];
+		const sendEncryptedMatrixMessage = vi.fn(async () => {
+			calls.push('matrix');
+			return { event_id: '$encrypted' };
+		});
+		const finalizeEnquiry = vi.fn(async (eventId: string) => {
+			calls.push(`finalize:${eventId}`);
+			return { sessionId: 42 };
+		});
+
+		await sendEncryptedInitialEnquiry({
+			sessionId: 42,
+			sendEncryptedMatrixMessage,
+			finalizeEnquiry,
+			storage
+		});
+
+		expect(calls).toEqual(['matrix', 'finalize:$encrypted']);
+		expect(values.size).toBe(0);
+	});
+
+	it('retries finalization without sending a duplicate encrypted message', async () => {
+		const values = new Map<string, string>();
+		const storage = {
+			getItem: (key: string) => values.get(key) || null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key)
+		};
+		const sendEncryptedMatrixMessage = vi
+			.fn()
+			.mockResolvedValue({ event_id: '$encrypted' });
+		const finalizeEnquiry = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('temporary'))
+			.mockResolvedValueOnce({ sessionId: 42 });
+
+		await expect(
+			sendEncryptedInitialEnquiry({
+				sessionId: 42,
+				sendEncryptedMatrixMessage,
+				finalizeEnquiry,
+				storage
+			})
+		).rejects.toThrow('temporary');
+		await sendEncryptedInitialEnquiry({
+			sessionId: 42,
+			sendEncryptedMatrixMessage,
+			finalizeEnquiry,
+			storage
+		});
+
+		expect(sendEncryptedMatrixMessage).toHaveBeenCalledOnce();
+		expect(finalizeEnquiry).toHaveBeenCalledTimes(2);
+		expect(values.size).toBe(0);
 	});
 });

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -30,7 +30,7 @@ export interface EnquirySubmissionGuard {
 
 interface EncryptedInitialEnquiryInput {
 	sessionId: number;
-	sendEncryptedMatrixMessage: () => Promise<{
+	sendEncryptedMatrixMessage: (transactionId: string) => Promise<{
 		event_id?: string;
 		eventId?: string;
 	}>;
@@ -41,6 +41,45 @@ interface EncryptedInitialEnquiryInput {
 const pendingEnquiryEventStorageKey = (sessionId: number) =>
 	`oriso.pendingEncryptedEnquiryEvent.${sessionId}`;
 
+const initialEnquiryTransactionId = (sessionId: number) =>
+	`oriso.enquiry.${sessionId}`;
+
+const readRetryEventId = (
+	storage: Pick<Storage, 'getItem'>,
+	storageKey: string
+): string => {
+	try {
+		return storage.getItem(storageKey) || '';
+	} catch {
+		return '';
+	}
+};
+
+const cacheRetryEventId = (
+	storage: Pick<Storage, 'setItem'>,
+	storageKey: string,
+	matrixEventId: string
+): void => {
+	try {
+		storage.setItem(storageKey, matrixEventId);
+	} catch {
+		// The stable Matrix transaction ID remains the durable idempotency
+		// boundary when browser storage is unavailable.
+	}
+};
+
+const clearRetryEventId = (
+	storage: Pick<Storage, 'removeItem'>,
+	storageKey: string
+): void => {
+	try {
+		storage.removeItem(storageKey);
+	} catch {
+		// Best-effort cache cleanup must not turn a finalized enquiry into a
+		// failed submission.
+	}
+};
+
 export const sendEncryptedInitialEnquiry = async ({
 	sessionId,
 	sendEncryptedMatrixMessage,
@@ -48,20 +87,22 @@ export const sendEncryptedInitialEnquiry = async ({
 	storage = window.localStorage
 }: EncryptedInitialEnquiryInput): Promise<any> => {
 	const storageKey = pendingEnquiryEventStorageKey(sessionId);
-	let matrixEventId = storage.getItem(storageKey) || '';
+	let matrixEventId = readRetryEventId(storage, storageKey);
 	if (!matrixEventId) {
-		const response = await sendEncryptedMatrixMessage();
+		const response = await sendEncryptedMatrixMessage(
+			initialEnquiryTransactionId(sessionId)
+		);
 		matrixEventId = response.event_id || response.eventId || '';
 		if (!matrixEventId) {
 			throw new Error(
 				'Encrypted Matrix enquiry send returned no event ID'
 			);
 		}
-		storage.setItem(storageKey, matrixEventId);
+		cacheRetryEventId(storage, storageKey, matrixEventId);
 	}
 
 	const response = await finalizeEnquiry(matrixEventId);
-	storage.removeItem(storageKey);
+	clearRetryEventId(storage, storageKey);
 	return response;
 };
 

--- a/src/components/messageSubmitInterface/messageEncryptionMode.ts
+++ b/src/components/messageSubmitInterface/messageEncryptionMode.ts
@@ -28,6 +28,43 @@ export interface EnquirySubmissionGuard {
 	tryStart: () => boolean;
 }
 
+interface EncryptedInitialEnquiryInput {
+	sessionId: number;
+	sendEncryptedMatrixMessage: () => Promise<{
+		event_id?: string;
+		eventId?: string;
+	}>;
+	finalizeEnquiry: (matrixEventId: string) => Promise<any>;
+	storage?: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+}
+
+const pendingEnquiryEventStorageKey = (sessionId: number) =>
+	`oriso.pendingEncryptedEnquiryEvent.${sessionId}`;
+
+export const sendEncryptedInitialEnquiry = async ({
+	sessionId,
+	sendEncryptedMatrixMessage,
+	finalizeEnquiry,
+	storage = window.localStorage
+}: EncryptedInitialEnquiryInput): Promise<any> => {
+	const storageKey = pendingEnquiryEventStorageKey(sessionId);
+	let matrixEventId = storage.getItem(storageKey) || '';
+	if (!matrixEventId) {
+		const response = await sendEncryptedMatrixMessage();
+		matrixEventId = response.event_id || response.eventId || '';
+		if (!matrixEventId) {
+			throw new Error(
+				'Encrypted Matrix enquiry send returned no event ID'
+			);
+		}
+		storage.setItem(storageKey, matrixEventId);
+	}
+
+	const response = await finalizeEnquiry(matrixEventId);
+	storage.removeItem(storageKey);
+	return response;
+};
+
 export const isAskerEnquirySubmission = ({
 	isEnquiryListType,
 	sessionStatus,

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -28,7 +28,8 @@ import {
 import {
 	createEnquirySubmissionGuard,
 	dispatchAskerMessageTransport,
-	resolveAskerMessageTransport
+	resolveAskerMessageTransport,
+	sendEncryptedInitialEnquiry
 } from './messageEncryptionMode';
 import { resolveAsideTargetRoomId } from './asideRouting';
 import { reloadSessionAfterSendIfNeeded } from './sessionRefreshAfterSend';
@@ -1180,17 +1181,29 @@ export const MessageSubmitInterfaceComponent = ({
 	}, []);
 
 	const sendEnquiry = useCallback(
-		(message, isEncrypted) => {
+		(message) => {
 			if (!enquirySubmissionGuard.tryStart()) {
 				setIsRequestInProgress(false);
 				return Promise.resolve();
 			}
-			return apiSendEnquiry(
-				activeSession.item.id,
-				message,
-				isEncrypted,
-				language
-			)
+			const matrixRoomId = resolvedChatSession.matrixRoomId;
+			if (!matrixRoomId || !matrixClientService) {
+				enquirySubmissionGuard.markFailed();
+				setIsRequestInProgress(false);
+				setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
+				return Promise.resolve();
+			}
+			return sendEncryptedInitialEnquiry({
+				sessionId: activeSession.item.id,
+				sendEncryptedMatrixMessage: () =>
+					matrixClientService.sendMessage(matrixRoomId, message),
+				finalizeEnquiry: (matrixEventId) =>
+					apiSendEnquiry(
+						activeSession.item.id,
+						matrixEventId,
+						language
+					)
+			})
 				.then((response) => {
 					enquirySubmissionGuard.markSucceeded();
 					reloadActiveSession?.();
@@ -1227,9 +1240,11 @@ export const MessageSubmitInterfaceComponent = ({
 			enquirySubmissionGuard,
 			encryptRoom,
 			language,
+			matrixClientService,
 			onSendButton,
 			clearDraftMessage,
 			reloadActiveSession,
+			resolvedChatSession.matrixRoomId,
 			setE2EEState
 		]
 	);
@@ -1662,7 +1677,7 @@ export const MessageSubmitInterfaceComponent = ({
 				);
 			const handledAskerTransport = await dispatchAskerMessageTransport({
 				transport: askerMessageTransport,
-				sendEnquiry: () => sendEnquiry(message, isEncrypted),
+				sendEnquiry: () => sendEnquiry(message),
 				sendMatrix: sendCurrentMessage,
 				onBlocked: () => {
 					setIsRequestInProgress(false);

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -13,6 +13,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { SendButton } from './inputField/SendButton';
 import { hasMediaUploadFeature } from '../../utils/mediaUploadHelpers';
 import { getCurrentMatrixUserId } from '../../utils/matrixSession';
+import { assertMatrixRoomEncrypted } from '../../utils/matrixRoomEncryption';
 import { deriveSendButtonState } from './inputField/sendButtonState';
 import { DragHandle } from './inputField/DragHandle';
 import { ComposerToolbar } from './inputField/ComposerToolbar';
@@ -1193,10 +1194,26 @@ export const MessageSubmitInterfaceComponent = ({
 				setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
 				return Promise.resolve();
 			}
+			try {
+				assertMatrixRoomEncrypted(
+					matrixClientService.getClient(),
+					matrixRoomId
+				);
+			} catch {
+				enquirySubmissionGuard.markFailed();
+				setIsRequestInProgress(false);
+				setActiveInfo(INFO_TYPES.MESSAGE_SEND_ERROR);
+				return Promise.resolve();
+			}
 			return sendEncryptedInitialEnquiry({
 				sessionId: activeSession.item.id,
-				sendEncryptedMatrixMessage: () =>
-					matrixClientService.sendMessage(matrixRoomId, message),
+				sendEncryptedMatrixMessage: (transactionId) =>
+					matrixClientService.sendMessage(
+						matrixRoomId,
+						message,
+						undefined,
+						transactionId
+					),
 				finalizeEnquiry: (matrixEventId) =>
 					apiSendEnquiry(
 						activeSession.item.id,

--- a/src/generated/userservice.d.ts
+++ b/src/generated/userservice.d.ts
@@ -954,6 +954,8 @@ declare namespace UserService {
 			message: string;
 			language?: /* ISO 639-1 code */ LanguageCode;
 			t?: string;
+			/** ID of the browser-encrypted Matrix event to finalize as the initial enquiry */
+			matrixEventId?: string;
 		}
 		export interface FullAgencyResponseDTO {
 			/**

--- a/src/services/matrixClientService.test.ts
+++ b/src/services/matrixClientService.test.ts
@@ -634,6 +634,31 @@ describe('MatrixClientService', () => {
 		});
 	});
 
+	it('uses an explicit transaction id for an idempotent Matrix send', async () => {
+		const sendMessage = vi.fn(() =>
+			Promise.resolve({ event_id: '$event' })
+		);
+		const service = new MatrixClientService();
+		setClient(service, {
+			makeTxnId: () => 'generated-transaction',
+			sendMessage,
+			getRoom: () => ({})
+		});
+
+		await service.sendMessage(
+			'!room:example.org',
+			'Encrypted initial enquiry',
+			undefined,
+			'oriso.enquiry.42'
+		);
+
+		expect(sendMessage).toHaveBeenCalledWith(
+			'!room:example.org',
+			{ msgtype: 'm.text', body: 'Encrypted initial enquiry' },
+			'oriso.enquiry.42'
+		);
+	});
+
 	it('removes the rejected Matrix local echo before the UI offers a fresh retry', async () => {
 		const failedLocalEcho = {
 			getTxnId: () => 'txn-failed-send'

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -417,7 +417,8 @@ export class MatrixClientService {
 	public async sendMessage(
 		roomId: string,
 		message: string,
-		options?: TextMessageContentOptions
+		options?: TextMessageContentOptions,
+		transactionId?: string
 	): Promise<any> {
 		await this.ensureFreshToken();
 
@@ -434,7 +435,7 @@ export class MatrixClientService {
 			}
 			// Every real matrix-js-sdk client provides makeTxnId(). The guard also
 			// keeps deliberately minimal test doubles and adapters compatible.
-			const txnId = client.makeTxnId?.();
+			const txnId = transactionId || client.makeTxnId?.();
 			try {
 				return await (txnId
 					? client.sendMessage(roomId, content, txnId)


### PR DESCRIPTION
Addresses #851

Depends on OpenResilienceInitiative/ORISO-UserService#954 and its companion PR.

## P0 problem

PR #852 restored `message_date` and `request.new` by routing the initial enquiry through `/enquiry/new`, but the endpoint then impersonated the user and stored plaintext `m.room.message` in an encrypted Matrix room. Fresh PreDev raw-timeline evidence from session 13 confirms the E2EE acceptance criterion was not met.

## Fix

- Send the initial registered enquiry through the browser Matrix SDK first, so Rust crypto produces `m.room.encrypted`.
- Finalize the backend enquiry using only the returned Matrix event ID; the request carries `message: ""` and never the counselling text.
- Do not emit the normal follow-up `message.new` event for the first message; UserService remains the single producer of `request.new`.
- Persist a pending event ID locally until finalization succeeds, so a transient backend failure retries finalization without sending a duplicate encrypted message.
- Keep follow-up messages on the existing Matrix path.

## Verification

- 14/14 focused Vitest tests
- TypeScript `--noEmit` clean
- targeted ESLint clean
- production build successful
- `git diff --check` clean

Real-browser PreDev proof will inspect the raw event type, reload/decrypt on both sides, and verify the recipient-scoped `request.new` feed before this PR is marked ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encrypted enquiries are now delivered through Matrix before finalization.
  * Enquiry finalization uses the resulting event ID and selected language.
  * Pending encrypted submissions can be retried without duplicating messages.
  * Improved handling of missing encryption setup and delivery failures.

* **Tests**
  * Added coverage for encrypted payload creation, message delivery ordering, retries, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->