### PR TITLE
fix(session-list): show locally decrypted Matrix previews (#912)

### DIFF
--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -85,6 +85,9 @@ import LegalLinks from '../legalLinks/LegalLinks';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { LegalLinkModal } from '../legalLinks/LegalLinkModal';
 import { getSessionDropdownPosition } from './sessionDropdownPosition';
+import { getMatrixClientService } from '../../services/matrixClientRegistry';
+import { matrixLiveEventBridge } from '../../services/matrixLiveEventBridge';
+import { getLatestDecryptedMatrixMessage } from '../../utils/matrixSessionPreview';
 import {
 	isCaseHandoverAccessControlled,
 	isCaseHandoverCandidate,
@@ -224,8 +227,56 @@ export const SessionListItemComponent = ({
 		}
 
 		if (isMatrixBackedSession) {
-			setPlainTextLastMessage(translate('e2ee.message.encryption.text'));
-			return;
+			const roomId = sessionItem?.matrixRoomId;
+			const watchedEncryptedEvents = new Set<any>();
+			const fallback = () =>
+				setPlainTextLastMessage(
+					translate('e2ee.message.encryption.text')
+				);
+			const toPlainText = (message: string) => {
+				const rawMessageObject = markdownToDraft(message);
+				return convertFromRaw(rawMessageObject).getPlainText();
+			};
+			const updatePreview = () => {
+				const client = getMatrixClientService()?.getClient?.();
+				const events =
+					client
+						?.getRoom?.(roomId)
+						?.getLiveTimeline?.()
+						?.getEvents?.() || [];
+
+				events.forEach((event: any) => {
+					if (
+						event?.getType?.() === 'm.room.encrypted' &&
+						!watchedEncryptedEvents.has(event)
+					) {
+						watchedEncryptedEvents.add(event);
+						event.on?.('Event.decrypted', updatePreview);
+					}
+				});
+
+				const latest = getLatestDecryptedMatrixMessage(events);
+				if (latest) {
+					setPlainTextLastMessage(toPlainText(latest));
+				} else {
+					fallback();
+				}
+			};
+			const handleDirectMessage = (event: { roomId?: string }) => {
+				if (event?.roomId === roomId) {
+					updatePreview();
+				}
+			};
+
+			fallback();
+			updatePreview();
+			matrixLiveEventBridge.on('directMessage', handleDirectMessage);
+			return () => {
+				matrixLiveEventBridge.off('directMessage', handleDirectMessage);
+				watchedEncryptedEvents.forEach((event) =>
+					event.off?.('Event.decrypted', updatePreview)
+				);
+			};
 		}
 
 		if (!ready) {

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -85,8 +85,6 @@ import LegalLinks from '../legalLinks/LegalLinks';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { LegalLinkModal } from '../legalLinks/LegalLinkModal';
 import { getSessionDropdownPosition } from './sessionDropdownPosition';
-import { getMatrixClientService } from '../../services/matrixClientRegistry';
-import { matrixLiveEventBridge } from '../../services/matrixLiveEventBridge';
 import { getLatestDecryptedMatrixMessage } from '../../utils/matrixSessionPreview';
 import {
 	isCaseHandoverAccessControlled,

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -85,7 +85,7 @@ import LegalLinks from '../legalLinks/LegalLinks';
 import { LegalLinksContext } from '../../globalState/provider/LegalLinksProvider';
 import { LegalLinkModal } from '../legalLinks/LegalLinkModal';
 import { getSessionDropdownPosition } from './sessionDropdownPosition';
-import { getLatestDecryptedMatrixMessage } from '../../utils/matrixSessionPreview';
+import { useMatrixSessionPreview } from '../../hooks/useMatrixSessionPreview';
 import {
 	isCaseHandoverAccessControlled,
 	isCaseHandoverCandidate,
@@ -96,7 +96,6 @@ import {
 	CaseHandoverActionButton,
 	CaseHandoverActionState
 } from './CaseHandoverActionButton';
-import { chatTransportService } from '../../services/chatTransportService';
 interface SessionListItemProps {
 	defaultLanguage: string;
 	itemRef?: any;
@@ -216,6 +215,10 @@ export const SessionListItemComponent = ({
 	});
 	const caseHandoverContentLocked =
 		caseHandoverAccessControlled && !caseHandoverStatus?.canViewContent;
+	const matrixSessionPreview = useMatrixSessionPreview(
+		sessionItem?.matrixRoomId,
+		isMatrixBackedSession && !caseHandoverContentLocked
+	);
 
 	useEffect(() => {
 		if (caseHandoverContentLocked) {
@@ -226,23 +229,21 @@ export const SessionListItemComponent = ({
 		}
 
 		if (isMatrixBackedSession) {
-			const roomId = sessionItem?.matrixRoomId;
-			const updatePreview = () => {
-				const events =
-					chatTransportService.getMatrixRoomMessages(roomId, 50) ||
-					[];
-				const latest = getLatestDecryptedMatrixMessage(events);
-				setPlainTextLastMessage(
-					latest ?? translate('e2ee.message.encryption.text')
-				);
-			};
-
-			updatePreview();
-			const detach = chatTransportService.onMatrixTimeline(
-				roomId,
-				updatePreview
+			setPlainTextLastMessage(
+				matrixSessionPreview ??
+					translate('e2ee.message.encryption.text')
 			);
-			return () => detach?.();
+		}
+	}, [
+		caseHandoverContentLocked,
+		isMatrixBackedSession,
+		matrixSessionPreview,
+		translate
+	]);
+
+	useEffect(() => {
+		if (caseHandoverContentLocked || isMatrixBackedSession) {
+			return;
 		}
 
 		if (!ready) {

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -98,6 +98,7 @@ import {
 	CaseHandoverActionButton,
 	CaseHandoverActionState
 } from './CaseHandoverActionButton';
+import { chatTransportService } from '../../services/chatTransportService';
 interface SessionListItemProps {
 	defaultLanguage: string;
 	itemRef?: any;
@@ -228,55 +229,22 @@ export const SessionListItemComponent = ({
 
 		if (isMatrixBackedSession) {
 			const roomId = sessionItem?.matrixRoomId;
-			const watchedEncryptedEvents = new Set<any>();
-			const fallback = () =>
-				setPlainTextLastMessage(
-					translate('e2ee.message.encryption.text')
-				);
-			const toPlainText = (message: string) => {
-				const rawMessageObject = markdownToDraft(message);
-				return convertFromRaw(rawMessageObject).getPlainText();
-			};
 			const updatePreview = () => {
-				const client = getMatrixClientService()?.getClient?.();
 				const events =
-					client
-						?.getRoom?.(roomId)
-						?.getLiveTimeline?.()
-						?.getEvents?.() || [];
-
-				events.forEach((event: any) => {
-					if (
-						event?.getType?.() === 'm.room.encrypted' &&
-						!watchedEncryptedEvents.has(event)
-					) {
-						watchedEncryptedEvents.add(event);
-						event.on?.('Event.decrypted', updatePreview);
-					}
-				});
-
+					chatTransportService.getMatrixRoomMessages(roomId, 50) ||
+					[];
 				const latest = getLatestDecryptedMatrixMessage(events);
-				if (latest) {
-					setPlainTextLastMessage(toPlainText(latest));
-				} else {
-					fallback();
-				}
-			};
-			const handleDirectMessage = (event: { roomId?: string }) => {
-				if (event?.roomId === roomId) {
-					updatePreview();
-				}
-			};
-
-			fallback();
-			updatePreview();
-			matrixLiveEventBridge.on('directMessage', handleDirectMessage);
-			return () => {
-				matrixLiveEventBridge.off('directMessage', handleDirectMessage);
-				watchedEncryptedEvents.forEach((event) =>
-					event.off?.('Event.decrypted', updatePreview)
+				setPlainTextLastMessage(
+					latest ?? translate('e2ee.message.encryption.text')
 				);
 			};
+
+			updatePreview();
+			const detach = chatTransportService.onMatrixTimeline(
+				roomId,
+				updatePreview
+			);
+			return () => detach?.();
 		}
 
 		if (!ready) {

--- a/src/hooks/useMatrixSessionPreview.test.tsx
+++ b/src/hooks/useMatrixSessionPreview.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chatTransportService } from '../services/chatTransportService';
+import { useMatrixSessionPreview } from './useMatrixSessionPreview';
+
+vi.mock('../services/chatTransportService', () => ({
+	chatTransportService: {
+		getMatrixRoomMessages: vi.fn(),
+		onMatrixTimeline: vi.fn()
+	}
+}));
+
+describe('useMatrixSessionPreview', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(chatTransportService.getMatrixRoomMessages).mockReturnValue([]);
+		vi.mocked(chatTransportService.onMatrixTimeline).mockReturnValue(
+			vi.fn()
+		);
+	});
+
+	it('keeps the timeline subscription stable across unrelated rerenders', () => {
+		const { rerender } = renderHook(
+			({ roomId, unrelated }) => {
+				void unrelated;
+				return useMatrixSessionPreview(roomId, true);
+			},
+			{
+				initialProps: { roomId: '!room:example.org', unrelated: 1 }
+			}
+		);
+
+		rerender({ roomId: '!room:example.org', unrelated: 2 });
+
+		expect(chatTransportService.onMatrixTimeline).toHaveBeenCalledTimes(1);
+	});
+
+	it('refreshes from decrypted timeline updates and detaches on disable', () => {
+		const detach = vi.fn();
+		let timelineListener: (() => void) | undefined;
+		vi.mocked(chatTransportService.onMatrixTimeline).mockImplementation(
+			(_roomId, listener) => {
+				timelineListener = listener;
+				return detach;
+			}
+		);
+		vi.mocked(chatTransportService.getMatrixRoomMessages)
+			.mockReturnValueOnce([])
+			.mockReturnValueOnce([
+				{
+					getType: () => 'm.room.message',
+					getContent: () => ({ body: 'decrypted later' })
+				} as never
+			]);
+
+		const { result, rerender } = renderHook(
+			({ enabled }) =>
+				useMatrixSessionPreview('!room:example.org', enabled),
+			{ initialProps: { enabled: true } }
+		);
+
+		expect(result.current).toBeNull();
+		act(() => timelineListener?.());
+		expect(result.current).toBe('decrypted later');
+
+		rerender({ enabled: false });
+		expect(detach).toHaveBeenCalledTimes(1);
+		expect(result.current).toBeNull();
+	});
+});

--- a/src/hooks/useMatrixSessionPreview.ts
+++ b/src/hooks/useMatrixSessionPreview.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { chatTransportService } from '../services/chatTransportService';
+import { getLatestDecryptedMatrixMessage } from '../utils/matrixSessionPreview';
+
+type MatrixSessionPreviewState = {
+	roomId: string;
+	message: string | null;
+};
+
+/**
+ * Keep a session-card preview in sync with the local decrypted Matrix
+ * timeline. The subscription depends only on the room identity and whether
+ * preview access is allowed, so unrelated legacy E2EE state cannot reattach it.
+ */
+export const useMatrixSessionPreview = (
+	roomId: string | null | undefined,
+	enabled: boolean
+): string | null => {
+	const [preview, setPreview] = useState<MatrixSessionPreviewState | null>(
+		null
+	);
+
+	useEffect(() => {
+		if (!enabled || !roomId) {
+			setPreview(null);
+			return;
+		}
+
+		const updatePreview = () => {
+			const events =
+				chatTransportService.getMatrixRoomMessages(roomId, 50) || [];
+			setPreview({
+				roomId,
+				message: getLatestDecryptedMatrixMessage(events)
+			});
+		};
+
+		updatePreview();
+		const detach = chatTransportService.onMatrixTimeline(
+			roomId,
+			updatePreview
+		);
+
+		return () => detach?.();
+	}, [enabled, roomId]);
+
+	return enabled && roomId && preview?.roomId === roomId
+		? preview.message
+		: null;
+};

--- a/src/utils/matrixSessionPreview.test.ts
+++ b/src/utils/matrixSessionPreview.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { getLatestDecryptedMatrixMessage } from './matrixSessionPreview';
+
+const event = (type: string, body?: string) => ({
+	getType: () => type,
+	getContent: () => (body === undefined ? {} : { body })
+});
+
+describe('getLatestDecryptedMatrixMessage', () => {
+	it('returns the newest locally decrypted Matrix message', () => {
+		expect(
+			getLatestDecryptedMatrixMessage([
+				event('m.room.message', 'older'),
+				event('m.room.encrypted'),
+				event('m.room.message', 'newest')
+			])
+		).toBe('newest');
+	});
+
+	it('keeps the protected fallback contract while events are encrypted', () => {
+		expect(
+			getLatestDecryptedMatrixMessage([
+				event('m.room.encryption'),
+				event('m.room.encrypted')
+			])
+		).toBeNull();
+	});
+
+	it('becomes readable after the SDK mutates an event on delayed decryption', () => {
+		let type = 'm.room.encrypted';
+		let content: Record<string, unknown> = {};
+		const delayedEvent = {
+			getType: () => type,
+			getContent: () => content
+		};
+
+		expect(getLatestDecryptedMatrixMessage([delayedEvent])).toBeNull();
+		type = 'm.room.message';
+		content = { body: 'decrypted later' };
+		expect(getLatestDecryptedMatrixMessage([delayedEvent])).toBe(
+			'decrypted later'
+		);
+	});
+});

--- a/src/utils/matrixSessionPreview.test.ts
+++ b/src/utils/matrixSessionPreview.test.ts
@@ -55,4 +55,21 @@ describe('getLatestDecryptedMatrixMessage', () => {
 			])
 		).toBe('corrected text');
 	});
+
+	it.each(['', '   '])(
+		'falls back to the original body when the replacement is %j',
+		(replacementBody) => {
+			expect(
+				getLatestDecryptedMatrixMessage([
+					{
+						getType: () => 'm.room.message',
+						getContent: () => ({
+							body: '* original text',
+							'm.new_content': { body: replacementBody }
+						})
+					}
+				])
+			).toBe('* original text');
+		}
+	);
 });

--- a/src/utils/matrixSessionPreview.test.ts
+++ b/src/utils/matrixSessionPreview.test.ts
@@ -41,4 +41,18 @@ describe('getLatestDecryptedMatrixMessage', () => {
 			'decrypted later'
 		);
 	});
+
+	it('uses the clean replacement body for edited messages', () => {
+		expect(
+			getLatestDecryptedMatrixMessage([
+				{
+					getType: () => 'm.room.message',
+					getContent: () => ({
+						body: '* corrected text',
+						'm.new_content': { body: 'corrected text' }
+					})
+				}
+			])
+		).toBe('corrected text');
+	});
 });

--- a/src/utils/matrixSessionPreview.ts
+++ b/src/utils/matrixSessionPreview.ts
@@ -17,7 +17,13 @@ export const getLatestDecryptedMatrixMessage = (
 			continue;
 		}
 
-		const body = event.getContent?.()?.body;
+		const content = event.getContent?.() ?? {};
+		const replacement = content['m.new_content'];
+		const replacementBody =
+			typeof replacement === 'object' && replacement !== null
+				? (replacement as Record<string, unknown>).body
+				: undefined;
+		const body = replacementBody ?? content.body;
 		if (typeof body === 'string' && body.trim()) {
 			return body;
 		}

--- a/src/utils/matrixSessionPreview.ts
+++ b/src/utils/matrixSessionPreview.ts
@@ -23,7 +23,10 @@ export const getLatestDecryptedMatrixMessage = (
 			typeof replacement === 'object' && replacement !== null
 				? (replacement as Record<string, unknown>).body
 				: undefined;
-		const body = replacementBody ?? content.body;
+		const body =
+			typeof replacementBody === 'string' && replacementBody.trim()
+				? replacementBody
+				: content.body;
 		if (typeof body === 'string' && body.trim()) {
 			return body;
 		}

--- a/src/utils/matrixSessionPreview.ts
+++ b/src/utils/matrixSessionPreview.ts
@@ -1,0 +1,27 @@
+type MatrixPreviewEvent = {
+	getType?: () => string;
+	getContent?: () => Record<string, unknown>;
+};
+
+/**
+ * Return the newest text that the local Matrix SDK has already decrypted.
+ * Encrypted events deliberately have no preview until their clear event is
+ * available on this device.
+ */
+export const getLatestDecryptedMatrixMessage = (
+	events: MatrixPreviewEvent[] = []
+): string | null => {
+	for (let index = events.length - 1; index >= 0; index -= 1) {
+		const event = events[index];
+		if (event?.getType?.() !== 'm.room.message') {
+			continue;
+		}
+
+		const body = event.getContent?.()?.body;
+		if (typeof body === 'string' && body.trim()) {
+			return body;
+		}
+	}
+
+	return null;
+};


### PR DESCRIPTION
Closes #912.

## What changed
- derives enquiry/session card previews from the local Matrix SDK timeline
- reacts to new timeline events and delayed `Event.decrypted` completion
- keeps `Message encrypted` as the safe fallback while no clear event exists
- never adds plaintext to UserService or the session-list API

## Verification
- `npm run test:unit -- src/utils/matrixSessionPreview.test.ts` — 3/3
- `npx tsc --noEmit`
- `npm run build`

## Live evidence
PreDev browser proof will be attached from run `e2e-20260803-025044` after the combined #911/#912 image is rolled out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session previews now display the latest available decrypted message from Matrix conversations.
  * Previews refresh when new messages arrive or encrypted messages become readable.
  * Up to 50 recent messages are checked for more current information.
  * Edited messages use their updated text.

* **Bug Fixes**
  * Improved handling of encrypted, empty, unavailable, and non-message events.
  * Locked handover sessions continue to hide their previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->