### PR TITLE
Fix group participant picker for agency ID 0

### DIFF
--- a/src/components/conversationCreate/CreateConversationView.editmode.test.tsx
+++ b/src/components/conversationCreate/CreateConversationView.editmode.test.tsx
@@ -336,6 +336,22 @@ describe('CreateConversationView internal card (finding 2)', () => {
 		] as any);
 	});
 
+	it('loads colleagues when the selected agency id is zero', async () => {
+		renderInUserContext([{ id: 0, name: 'Agency Zero' }]);
+
+		await waitFor(() =>
+			expect(apiGetTenantConsultantList).toHaveBeenCalledTimes(1)
+		);
+	});
+
+	it('does not load colleagues without a selected agency', async () => {
+		renderInUserContext([]);
+
+		await waitFor(() =>
+			expect(apiGetTenantConsultantList).not.toHaveBeenCalled()
+		);
+	});
+
 	it('clears the selected colleagues when the agency changes', async () => {
 		renderInUserContext([
 			{ id: 1, name: 'Agency One' },

--- a/src/components/conversationCreate/CreateConversationView.tsx
+++ b/src/components/conversationCreate/CreateConversationView.tsx
@@ -263,7 +263,7 @@ const CreateConversationFlow = () => {
 	// user, deduplicated by consultantId.
 	const loadConsultants = useCallback(() => {
 		if (
-			!selectedAgency ||
+			selectedAgency === null ||
 			(!availability.internal && !availability.circle)
 		) {
 			setAvailableConsultants([]);


### PR DESCRIPTION
## Why

A real PreDev consultant in agency ID `0` cannot add colleagues while creating an internal group chat or moderated circle. The picker guard treated numeric zero as a missing agency and skipped the consultant request.

## What changed

- Check explicitly for `null` instead of falsiness when deciding whether an agency is selected.
- Add regression coverage for agency ID `0` and for the unchanged no-agency path.

## Verification

- Focused Vitest: 6/6 passed (red proof before the fix: zero consultant API calls).
- Full unit suite: 219 files, 1,461 tests passed.
- ESLint, TypeScript and Stylelint passed.
- Production build passed with existing CRA/autoprefixer/bundle-size warnings.
- PreDev desktop/mobile after-proof is pending before Ready for review.

Closes OpenResilienceInitiative/ORISO-Frontend#914
Refs OpenResilienceInitiative/ORISO-Frontend#408

### Reviewer test plan

- [ ] Sign in as a consultant whose agency ID is `0`, open **Create conversation**, and choose **Add person** → colleagues from that agency are listed.
- [ ] Select two colleagues and create an internal group chat → the chat opens with the selected members.
- [ ] Select a co-moderator for a moderated circle → the selected colleague remains attached to the draft.
- [ ] Repeat the picker flow at 320 px and 412 px widths → names and controls remain readable and usable.
- [ ] Navigate the picker with the keyboard and a screen reader → the add-person control and colleague options have understandable names and focus.

## Screenshot evidence

Before/after desktop and mobile screenshots will be attached from the running PreDev repair gate before this draft is marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consultant loading when an internal agency with ID `0` is selected.
  * Prevented unnecessary consultant loading when no agency is selected.

* **Tests**
  * Added coverage for valid and unselected agency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->