### PR TITLE
Fix Matrix attachments for group session ID 0

### DIFF
--- a/src/components/messageSubmitInterface/matrixSessionId.test.ts
+++ b/src/components/messageSubmitInterface/matrixSessionId.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMatrixSessionId } from './matrixSessionId';
+
+describe('resolveMatrixSessionId', () => {
+	it.each([
+		['zero', '0', 0],
+		['positive', '42', 42],
+		['numeric input', 7, 7]
+	])('preserves a valid %s session id', (_label, value, expected) => {
+		expect(resolveMatrixSessionId(value)).toBe(expected);
+	});
+
+	it.each([undefined, null, '', 'not-a-number', -1, 1.5])(
+		'rejects the invalid session id %s',
+		(value) => {
+			expect(resolveMatrixSessionId(value)).toBeUndefined();
+		}
+	);
+});

--- a/src/components/messageSubmitInterface/matrixSessionId.test.ts
+++ b/src/components/messageSubmitInterface/matrixSessionId.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveMatrixSessionId } from './matrixSessionId';
+import { hasMatrixSessionId, resolveMatrixSessionId } from './matrixSessionId';
 
 describe('resolveMatrixSessionId', () => {
 	it.each([
@@ -16,4 +16,14 @@ describe('resolveMatrixSessionId', () => {
 			expect(resolveMatrixSessionId(value)).toBeUndefined();
 		}
 	);
+});
+
+describe('hasMatrixSessionId', () => {
+	it('accepts zero as a defined Matrix session id', () => {
+		expect(hasMatrixSessionId(0)).toBe(true);
+	});
+
+	it('rejects an undefined Matrix session id', () => {
+		expect(hasMatrixSessionId(undefined)).toBe(false);
+	});
 });

--- a/src/components/messageSubmitInterface/matrixSessionId.ts
+++ b/src/components/messageSubmitInterface/matrixSessionId.ts
@@ -1,0 +1,8 @@
+export const resolveMatrixSessionId = (value: unknown): number | undefined => {
+	if (value === null || value === undefined || value === '') {
+		return undefined;
+	}
+
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+};

--- a/src/components/messageSubmitInterface/matrixSessionId.ts
+++ b/src/components/messageSubmitInterface/matrixSessionId.ts
@@ -6,3 +6,7 @@ export const resolveMatrixSessionId = (value: unknown): number | undefined => {
 	const parsed = Number(value);
 	return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
 };
+
+export const hasMatrixSessionId = (
+	value: number | undefined
+): value is number => value !== undefined;

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -105,7 +105,7 @@ import {
 } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { getIconForAttachmentType } from '../message/messageHelpers';
 import { resolveAttachmentForSend } from './resolveAttachmentForSend';
-import { resolveMatrixSessionId } from './matrixSessionId';
+import { hasMatrixSessionId, resolveMatrixSessionId } from './matrixSessionId';
 import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
 import { useImagePreviewUrl } from './useImagePreviewUrl';
 import { HIGHLIGHT_SNIPPET_SELECTED_EVENT } from './highlightSnippetEvents';
@@ -1373,7 +1373,7 @@ export const MessageSubmitInterfaceComponent = ({
 
 			if (attachment) {
 				// Matrix attachments stay on the SDK media path.
-				if (matrixSessionId) {
+				if (hasMatrixSessionId(matrixSessionId)) {
 					try {
 						if (!matrixRoomId) {
 							throw new Error('Matrix room ID is missing');
@@ -1435,7 +1435,8 @@ export const MessageSubmitInterfaceComponent = ({
 			// on the editor state having committed before deciding whether to send.
 			const hasTextContent = hasMessageContent(message);
 			const shouldSendTextMessage =
-				hasTextContent && (!attachment || !matrixSessionId);
+				hasTextContent &&
+				(!attachment || !hasMatrixSessionId(matrixSessionId));
 
 			if (shouldSendTextMessage) {
 				// Intentional mentions (#435): read from the composer's own

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -105,6 +105,7 @@ import {
 } from '../../globalState/interfaces/AppConfig/OverlaysConfigInterface';
 import { getIconForAttachmentType } from '../message/messageHelpers';
 import { resolveAttachmentForSend } from './resolveAttachmentForSend';
+import { resolveMatrixSessionId } from './matrixSessionId';
 import { TipTapComposer, TipTapComposerRef } from './TipTapComposer';
 import { useImagePreviewUrl } from './useImagePreviewUrl';
 import { HIGHLIGHT_SNIPPET_SELECTED_EVENT } from './highlightSnippetEvents';
@@ -1304,7 +1305,7 @@ export const MessageSubmitInterfaceComponent = ({
 			// Some sessions still have a legacy rid while exposing matrixRoomId.
 			const isMatrixSession = resolvedChatSession.isMatrixSession;
 			const matrixSessionId = isMatrixSession
-				? Number(resolvedChatSession.sessionId) || undefined
+				? resolveMatrixSessionId(resolvedChatSession.sessionId)
 				: undefined;
 			const clientRoomId = isMatrixSession
 				? resolvedChatSession.matrixRoomId

--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -31,6 +31,32 @@ vi.mock('../api/apiGetSessionRooms', () => ({
 const ROOM_ID = '!room:matrix.oriso.org';
 const OTHER_ROOM_ID = '!other:matrix.oriso.org';
 
+describe('chatTransportService session resolution', () => {
+	it('preserves session id zero for Matrix-backed group attachments', () => {
+		expect(
+			chatTransportService.resolveSession({
+				item: { id: 0, matrixRoomId: ROOM_ID }
+			})
+		).toEqual({
+			isMatrixSession: true,
+			matrixRoomId: ROOM_ID,
+			sessionId: 0
+		});
+	});
+
+	it('uses null when a session id is absent', () => {
+		expect(
+			chatTransportService.resolveSession({
+				item: { matrixRoomId: ROOM_ID }
+			})
+		).toEqual({
+			isMatrixSession: true,
+			matrixRoomId: ROOM_ID,
+			sessionId: null
+		});
+	});
+});
+
 type Listener = (...args: any[]) => void;
 
 /**

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -106,7 +106,7 @@ class ChatTransportService {
 		const matrixRoomId = isMatrixRoom(rid)
 			? rid
 			: session?.item?.matrixRoomId || null;
-		const sessionId = session?.item?.id || null;
+		const sessionId = session?.item?.id ?? null;
 
 		return {
 			isMatrixSession: Boolean(


### PR DESCRIPTION
## Why

The real PreDev internal group accepts encrypted text, but every voice/file attachment fails locally when the valid group session route ends in `/0`. Zero was discarded at three boundaries: numeric parsing, attachment branch selection, and upstream chat-session resolution. Consequently the recorder stopped with a generic upload error before any Matrix media request.

## What changed

- Resolve Matrix session IDs explicitly, preserving integer zero.
- Treat zero as a defined Matrix session in the attachment branch.
- Preserve zero in `chatTransportService.resolveSession()` with nullish rather than truthy fallback.
- Reject missing, invalid, negative, and fractional route values.
- Add focused regression coverage at both the resolver and transport boundaries.

## Verification

- Red browser proof: session `/0` displayed the upload error and emitted no `/_matrix/media/v3/upload` request.
- Diagnostic correction: the observed `204 EMPTY` is the expected empty remote-draft lookup; the upload abort was the lost session ID.
- Final focused Vitest: 47/47 passed across the Matrix-session helper and transport service.
- ESLint and TypeScript passed at head `904d3c64`.
- Earlier full suite on the first two commits: 220 files, 1,468 tests passed; Stylelint and production build passed.
- CI and repaired PreDev two-way voice-message proof are pending before Ready for review.

Closes OpenResilienceInitiative/ORISO-Frontend#916
Refs OpenResilienceInitiative/ORISO-Frontend#408

### Reviewer test plan

- [ ] Open a Matrix-backed internal group whose session route ends in `/0`, record a voice message, and stop recording → the message uploads and appears in the room.
- [ ] Open the same room as a second consultant → the encrypted voice message can be decrypted and played.
- [ ] Send a reply voice message from the second consultant → the first consultant receives and can play it.
- [ ] Repeat the send/read flow at 320 px and 412 px widths → recorder, error state and player remain usable.
- [ ] Navigate recorder and player controls by keyboard and screen reader → controls expose understandable names and focus.

## Screenshot evidence

Before/after desktop and mobile screenshots will be attached from the running PreDev repair gate before this draft is marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
