### PR TITLE
fix(storybook): stop public/ being copied twice into the build (#939)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -32,6 +32,18 @@ const config: StorybookConfig = {
 	framework: { name: '@storybook/react-vite', options: {} },
 	async viteFinal(cfg) {
 		return mergeConfig(cfg, {
+			// `../public` is already a staticDir above, and Vite's default
+			// publicDir points at that very same folder. builder-vite never turns
+			// publicDir off, so the build copied public/ into storybook-static
+			// twice at once: Storybook's staticDirs copy and Vite's own
+			// copyPublicDir. Both create storybook-static/static, and node's
+			// fs.cp mkdirs each directory non-recursively, so whichever loses the
+			// race dies with `EEXIST ... mkdir './storybook-static/static'`.
+			// Local builds usually won the race; the emulated linux/arm64 leg of
+			// the Docker job is slow enough to lose it intermittently.
+			// Disabling publicDir leaves staticDirs as the single copier, which
+			// Storybook runs sequentially and therefore deterministically.
+			publicDir: false,
 			plugins: [
 				// The virtual project-annotations module imports @storybook/react's
 				// dist files by absolute /node_modules/... path. Vite doesn't map


### PR DESCRIPTION
Fixes #939.

## What was wrong

`public/` was copied into `storybook-static/` **twice, concurrently**:

1. Storybook copies it — it is listed in `staticDirs: ['./static', '../public']`.
2. Vite copies it again as its own `publicDir`, which defaults to that same folder. `@storybook/builder-vite` never sets `publicDir: false`, so `copyPublicDir` stays on.

Storybook runs the staticDirs copy and the preview build in one `Promise.all`, and node's `fs.cp` creates each subdirectory with a non-recursive `mkdir` after a separate existence check. Whichever copy lost that check-then-act window died with:

```
Error: EEXIST: file already exists, mkdir './storybook-static/static'
```

`static` is incidental — it is just the first `public/` subdirectory hit.

## Why it looked like flaky infrastructure

The two copies usually land far apart. In a local build the staticDirs copy runs at t≈66s while Vite's copy happens minutes later. In the failing CI run the staticDirs copy was starved by the CPU-bound Vite build and landed at t≈685s, right on top of Vite's own copy.

`.github/actions/docker-build-push` builds `linux/amd64,linux/arm64`, and on the amd64 runners the arm64 leg runs under QEMU at roughly 10× the wall time (1200s vs 130s for the same step). That is where the overlap becomes likely — in run [30793916706](https://github.com/OpenResilienceInitiative/ORISO-Frontend/actions/runs/30793916706) the `linux/arm64` leg failed while `linux/amd64` succeeded in the same build.

## The change

One line plus a comment: `publicDir: false` in `viteFinal`. `staticDirs` stays the single copier, and Storybook copies its entries sequentially, so the result is deterministic.

Not an upstream bug to wait out: `copyAllStaticFilesRelativeToMain` already copies `staticDirs` sequentially (`reduce` + `await acc`) in 10.4.6, 10.5.0, 10.5.5 and 10.6.0-alpha.4. The duplication is ours — the same folder handed to two copiers.

## Verification

- **`publicDir: false` genuinely removes the second copier.** With `staticDirs` reduced to `['./static']` and publicDir left at its default, `public/` content (`config.js`, `releases/`, `static/`, …) still lands in `storybook-static` — that is Vite. With `publicDir: false` added, it is all gone. So on this branch exactly one copier remains.
- **Output is unchanged.** `storybook build` before vs after: same 613 files, byte-identical except `project.json` (carries a `generatedAt` timestamp) and `manifests/components.*` — and those two also differ between two consecutive runs of the *same* config, so they are inherently nondeterministic. `pattern.jpg` precedence is preserved (`public/` still wins over `.storybook/static/`, which differ).
- **Mechanism reproduced in isolation.** Two concurrent recursive `fs.cp` calls of `public/` into one destination fail on 5/5 runs with exactly this error shape (`EEXIST … mkdir '…/releases'`).
- **Docker.** The full multi-platform build (`linux/amd64,linux/arm64`, `--no-cache`, as CI runs it) passed 3/3 with the fix. An unfixed run also passed — the flake is rare enough that a handful of runs cannot decide it either way, which is why the control test above is the load-bearing evidence rather than the pass count.

## Gate

`npm run test:unit` (1496 tests / 225 files), `npm run lint:scripts`, `npm run lint:style`, `npm run build` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
