### PR TITLE
Fix internal group creation when agency topics is empty

### DIFF
--- a/src/api/apiGetTenantAgenciesTopics.test.ts
+++ b/src/api/apiGetTenantAgenciesTopics.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiGetTenantAgenciesTopics } from './apiGetTenantAgenciesTopics';
+import { fetchData } from './fetchData';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: {
+		agencyTopics: 'https://api.example/service/agencies/topics'
+	}
+}));
+
+vi.mock('./fetchData', () => ({
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_METHODS: { GET: 'GET' },
+	fetchData: vi.fn()
+}));
+
+describe('apiGetTenantAgenciesTopics', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('keeps a topic array from the agency service', async () => {
+		vi.mocked(fetchData).mockResolvedValue([
+			{ id: 7, name: 'Children and young people' }
+		]);
+
+		await expect(apiGetTenantAgenciesTopics()).resolves.toEqual([
+			{ id: 7, name: 'Children and young people' }
+		]);
+	});
+
+	it('normalizes the empty 204 response object to an empty topic array', async () => {
+		// fetchData resolves 204 No Content as `{}` unless EMPTY handling is
+		// requested. The API boundary promises an array to its render callers.
+		vi.mocked(fetchData).mockResolvedValue({});
+
+		await expect(apiGetTenantAgenciesTopics()).resolves.toEqual([]);
+	});
+});

--- a/src/api/apiGetTenantAgenciesTopics.test.ts
+++ b/src/api/apiGetTenantAgenciesTopics.test.ts
@@ -9,7 +9,7 @@ vi.mock('../resources/scripts/endpoints', () => ({
 }));
 
 vi.mock('./fetchData', () => ({
-	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL', EMPTY: 'EMPTY' },
 	FETCH_METHODS: { GET: 'GET' },
 	fetchData: vi.fn()
 }));
@@ -29,11 +29,23 @@ describe('apiGetTenantAgenciesTopics', () => {
 		]);
 	});
 
-	it('normalizes the empty 204 response object to an empty topic array', async () => {
-		// fetchData resolves 204 No Content as `{}` unless EMPTY handling is
-		// requested. The API boundary promises an array to its render callers.
-		vi.mocked(fetchData).mockResolvedValue({});
+	it('maps an explicit 204/EMPTY response to an empty topic array', async () => {
+		vi.mocked(fetchData).mockRejectedValue(new Error('EMPTY'));
 
 		await expect(apiGetTenantAgenciesTopics()).resolves.toEqual([]);
+		expect(fetchData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				responseHandling: expect.arrayContaining(['EMPTY'])
+			})
+		);
+	});
+
+	it('does not disguise an unexpected successful response envelope as no topics', async () => {
+		const unexpectedResponse = { unexpected: true };
+		vi.mocked(fetchData).mockResolvedValue(unexpectedResponse);
+
+		await expect(apiGetTenantAgenciesTopics()).resolves.toBe(
+			unexpectedResponse
+		);
 	});
 });

--- a/src/api/apiGetTenantAgenciesTopics.ts
+++ b/src/api/apiGetTenantAgenciesTopics.ts
@@ -9,9 +9,11 @@ export interface TenantAgenciesTopicsInterface {
 export const apiGetTenantAgenciesTopics = async (): Promise<
 	TenantAgenciesTopicsInterface[]
 > => {
-	return fetchData({
+	const response = await fetchData({
 		url: `${endpoints.agencyTopics}`,
 		method: FETCH_METHODS.GET,
 		responseHandling: [FETCH_ERRORS.CATCH_ALL]
 	});
+
+	return Array.isArray(response) ? response : [];
 };

--- a/src/api/apiGetTenantAgenciesTopics.ts
+++ b/src/api/apiGetTenantAgenciesTopics.ts
@@ -1,19 +1,20 @@
 import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
 import { endpoints } from '../resources/scripts/endpoints';
 
-export interface TenantAgenciesTopicsInterface {
-	id: number;
-	name: string;
-}
+export type TenantAgenciesTopicsInterface =
+	AgencyService.Schemas.AgencyTopicsDTO;
 
 export const apiGetTenantAgenciesTopics = async (): Promise<
 	TenantAgenciesTopicsInterface[]
 > => {
-	const response = await fetchData({
+	return fetchData({
 		url: `${endpoints.agencyTopics}`,
 		method: FETCH_METHODS.GET,
-		responseHandling: [FETCH_ERRORS.CATCH_ALL]
+		responseHandling: [FETCH_ERRORS.EMPTY, FETCH_ERRORS.CATCH_ALL]
+	}).catch((error) => {
+		if (error?.message === FETCH_ERRORS.EMPTY) {
+			return [];
+		}
+		return Promise.reject(error);
 	});
-
-	return Array.isArray(response) ? response : [];
 };

--- a/src/components/conversationCreate/agencyTopics.ts
+++ b/src/components/conversationCreate/agencyTopics.ts
@@ -43,7 +43,9 @@ export const filterTopicsForAgencies = (
 	if (!topicIds) {
 		return topics;
 	}
-	const offered = topics.filter((topic) => topicIds.includes(topic.id));
+	const offered = topics.filter(
+		(topic) => topic.id !== undefined && topicIds.includes(topic.id)
+	);
 	// A selected agency whose topics are unknown to the tenant list would
 	// otherwise strand the counsellor without any choice.
 	return offered.length ? offered : topics;


### PR DESCRIPTION
## Why

Creating a fresh internal group crashed with the generic 500 page when the agency-topics endpoint legitimately returned 204 No Content. The API wrapper promised an array but exposed the shared fetch helper's empty object, so the create screen later called filter on a non-array.

## What changed

- Use the generated AgencyService `AgencyTopicsDTO[]` contract at the API boundary.
- Request explicit `EMPTY` handling and map only the real 204/EMPTY case to an empty list.
- Keep valid arrays and unexpected successful response envelopes unchanged instead of disguising them as no topics.
- Add regression coverage for all three cases and safely handle optional generated topic IDs in agency filtering.

## Verification

- RED: the focused tests rejected EMPTY instead of resolving an empty array and showed unexpected successful envelopes being silently normalized.
- GREEN: 9 directly related API and agency-topic filtering tests passed.
- Changed-file ESLint passed.
- TypeScript passed.
- Production build passed.
- PreDev hot proof: the endpoint still returned 204, the create form rendered without error, and Patty created the encrypted three-person group "E2EE Dreiergespräch 941" with Jacqueline and Homer at desktop and mobile widths.

Closes #941
Refs #302

### Reviewer test plan

- [ ] Configure an agency with no topic rows so GET /service/agencies/topics returns 204.
- [ ] Open Interner Gruppenchat and choose Erstellen; the form renders rather than the error page.
- [ ] Create a group with three consultants and open it from each account.
- [ ] Repeat with a non-empty topic response; the available topics remain selectable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topic data handling by returning an empty list when no valid topic array is available.

* **Tests**
  * Added coverage for preserving topic lists and handling empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->