### PR TITLE
Keep MatrixRTC group calls active across participant rejoin

### DIFF
--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -158,6 +158,7 @@ export const GroupCallWidget: React.FC = () => {
 		const currentCall = callManager.getCurrentCall();
 		setCallData(currentCall);
 		setCallState(currentCall?.state || null);
+		setIsDismissed(currentCall?.state === 'left');
 		return () => unsubscribe();
 	}, []);
 

--- a/src/components/call/GroupCallWidget.tsx
+++ b/src/components/call/GroupCallWidget.tsx
@@ -42,11 +42,12 @@ export const GroupCallWidget: React.FC = () => {
 			iframeRef.current.src = 'about:blank';
 		}
 		setElementCallUrl('');
-		setCallData(null);
-		setCallState(null);
 		setIsDismissed(true);
 		if (callManager.hasActiveCall()) {
-			callManager.endCall();
+			callManager.leaveCall();
+		} else {
+			setCallData(null);
+			setCallState(null);
 		}
 	}, []);
 
@@ -57,6 +58,7 @@ export const GroupCallWidget: React.FC = () => {
 		: null;
 	const shouldPrepareWidget =
 		!!callData &&
+		callState !== 'left' &&
 		(!callData.isIncoming ||
 			callState === 'connecting' ||
 			callState === 'in_call');
@@ -147,7 +149,7 @@ export const GroupCallWidget: React.FC = () => {
 			setCallData(newCallData);
 			setCallState(newCallData?.state || null);
 			if (newCallData) {
-				setIsDismissed(false);
+				setIsDismissed(newCallData.state === 'left');
 			}
 			if (!newCallData) {
 				setElementCallUrl('');

--- a/src/services/CallManager.participantLeave.test.ts
+++ b/src/services/CallManager.participantLeave.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { callManager } from './CallManager';
+import { setMatrixClientServiceRef } from './matrixClientRegistry';
+
+const CALL_ROOM = '!call:oriso.example';
+const SIGNAL_ROOM = '!group:oriso.example';
+
+describe('Element Call participant leave', () => {
+	const sendEvent = vi.fn().mockResolvedValue({});
+
+	beforeEach(() => {
+		sendEvent.mockClear();
+		setMatrixClientServiceRef({
+			getClient: () => ({ sendEvent })
+		} as never);
+	});
+
+	afterEach(() => {
+		callManager.endCall(false);
+	});
+
+	it('does not end the group call for remote participants', () => {
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'group-call',
+			'@patty:oriso.example',
+			true,
+			SIGNAL_ROOM,
+			true
+		);
+
+		callManager.endCall();
+
+		expect(callManager.getCurrentCall()).toBeNull();
+		expect(sendEvent).not.toHaveBeenCalled();
+	});
+
+	it('still notifies the remote participant when a one-to-one call ends', () => {
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'one-to-one-call',
+			'@patty:oriso.example',
+			false,
+			SIGNAL_ROOM,
+			true
+		);
+
+		callManager.endCall();
+
+		expect(sendEvent).toHaveBeenCalledWith(
+			SIGNAL_ROOM,
+			'org.oriso.call.hangup',
+			expect.objectContaining({ call_id: 'one-to-one-call' })
+		);
+	});
+});

--- a/src/services/CallManager.participantLeave.test.ts
+++ b/src/services/CallManager.participantLeave.test.ts
@@ -71,6 +71,51 @@ describe('Element Call participant leave', () => {
 		expect(sendEvent).not.toHaveBeenCalled();
 	});
 
+	it('replaces left metadata when starting a group call in a different room', async () => {
+		const invite = vi.fn().mockResolvedValue(undefined);
+		createRoom.mockResolvedValue({
+			room_id: '!replacement-call:oriso.example'
+		});
+		vi.stubEnv(
+			'REACT_APP_MATRIXRTC_MEMBERSHIP_READER_USER_ID',
+			'@matrixrtc-auth:oriso.example'
+		);
+		setMatrixClientServiceRef({
+			getClient: () => ({
+				sendEvent,
+				createRoom,
+				invite,
+				getUserId: () => '@patty:oriso.example',
+				getRoom: () => null
+			})
+		} as never);
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'group-call',
+			'@patty:oriso.example',
+			true,
+			SIGNAL_ROOM,
+			true
+		);
+		callManager.leaveCall();
+
+		callManager.startCall('!different-group:oriso.example', true, true);
+
+		await vi.waitFor(() =>
+			expect(callManager.getCurrentCall()).toEqual(
+				expect.objectContaining({
+					roomId: '!replacement-call:oriso.example',
+					signalRoomId: '!different-group:oriso.example',
+					state: 'connecting'
+				})
+			)
+		);
+		expect(callManager.getCurrentCall()?.callId).not.toBe('group-call');
+		expect(createRoom).toHaveBeenCalledTimes(1);
+		vi.unstubAllEnvs();
+	});
+
 	it('accepts a different incoming call after the participant left a group call', () => {
 		callManager.receiveCall(
 			CALL_ROOM,

--- a/src/services/CallManager.participantLeave.test.ts
+++ b/src/services/CallManager.participantLeave.test.ts
@@ -42,6 +42,7 @@ describe('Element Call participant leave', () => {
 				state: 'left'
 			})
 		);
+		expect(callManager.hasActiveCall()).toBe(false);
 		expect(sendEvent).not.toHaveBeenCalled();
 	});
 

--- a/src/services/CallManager.participantLeave.test.ts
+++ b/src/services/CallManager.participantLeave.test.ts
@@ -70,6 +70,54 @@ describe('Element Call participant leave', () => {
 		expect(sendEvent).not.toHaveBeenCalled();
 	});
 
+	it('accepts a different incoming call after the participant left a group call', () => {
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'group-call',
+			'@patty:oriso.example',
+			true,
+			SIGNAL_ROOM,
+			true
+		);
+		callManager.leaveCall();
+
+		callManager.receiveCall(
+			'!other-call:oriso.example',
+			true,
+			'other-call',
+			'@jacqueline:oriso.example',
+			false,
+			'!other-signal:oriso.example',
+			true
+		);
+
+		expect(callManager.getCurrentCall()).toEqual(
+			expect.objectContaining({
+				callId: 'other-call',
+				roomId: '!other-call:oriso.example',
+				state: 'ringing'
+			})
+		);
+	});
+
+	it('does not notify the room when a group Element Call is ended directly', () => {
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'group-call',
+			'@patty:oriso.example',
+			true,
+			SIGNAL_ROOM,
+			true
+		);
+
+		callManager.endCall();
+
+		expect(callManager.getCurrentCall()).toBeNull();
+		expect(sendEvent).not.toHaveBeenCalled();
+	});
+
 	it('still notifies the remote participant when a one-to-one call is left', () => {
 		callManager.receiveCall(
 			CALL_ROOM,

--- a/src/services/CallManager.participantLeave.test.ts
+++ b/src/services/CallManager.participantLeave.test.ts
@@ -8,11 +8,13 @@ const SIGNAL_ROOM = '!group:oriso.example';
 
 describe('Element Call participant leave', () => {
 	const sendEvent = vi.fn().mockResolvedValue({});
+	const createRoom = vi.fn();
 
 	beforeEach(() => {
 		sendEvent.mockClear();
+		createRoom.mockClear();
 		setMatrixClientServiceRef({
-			getClient: () => ({ sendEvent })
+			getClient: () => ({ sendEvent, createRoom })
 		} as never);
 	});
 
@@ -20,7 +22,7 @@ describe('Element Call participant leave', () => {
 		callManager.endCall(false);
 	});
 
-	it('does not end the group call for remote participants', () => {
+	it('keeps the group-call room available after the local participant leaves', () => {
 		callManager.receiveCall(
 			CALL_ROOM,
 			false,
@@ -31,13 +33,44 @@ describe('Element Call participant leave', () => {
 			true
 		);
 
-		callManager.endCall();
+		callManager.leaveCall();
 
-		expect(callManager.getCurrentCall()).toBeNull();
+		expect(callManager.getCurrentCall()).toEqual(
+			expect.objectContaining({
+				callId: 'group-call',
+				roomId: CALL_ROOM,
+				state: 'left'
+			})
+		);
 		expect(sendEvent).not.toHaveBeenCalled();
 	});
 
-	it('still notifies the remote participant when a one-to-one call ends', () => {
+	it('rejoins that same group-call room instead of creating a new call', () => {
+		callManager.receiveCall(
+			CALL_ROOM,
+			false,
+			'group-call',
+			'@patty:oriso.example',
+			true,
+			SIGNAL_ROOM,
+			true
+		);
+		callManager.leaveCall();
+
+		callManager.startCall(SIGNAL_ROOM, false, true);
+
+		expect(callManager.getCurrentCall()).toEqual(
+			expect.objectContaining({
+				callId: 'group-call',
+				roomId: CALL_ROOM,
+				state: 'connecting'
+			})
+		);
+		expect(createRoom).not.toHaveBeenCalled();
+		expect(sendEvent).not.toHaveBeenCalled();
+	});
+
+	it('still notifies the remote participant when a one-to-one call is left', () => {
 		callManager.receiveCall(
 			CALL_ROOM,
 			false,
@@ -48,7 +81,7 @@ describe('Element Call participant leave', () => {
 			true
 		);
 
-		callManager.endCall();
+		callManager.leaveCall();
 
 		expect(sendEvent).toHaveBeenCalledWith(
 			SIGNAL_ROOM,

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -130,9 +130,12 @@ class CallManager {
 		) {
 			// Reopen the existing MatrixRTC room. Creating another dedicated room
 			// here would strand the participants who stayed in the active call.
-			this.currentCall.isVideo = isVideo;
-			this.currentCall.isIncoming = false;
-			this.currentCall.state = 'connecting';
+			this.currentCall = {
+				...this.currentCall,
+				isVideo,
+				isIncoming: false,
+				state: 'connecting'
+			};
 			this.notifyListeners();
 			return;
 		}
@@ -727,7 +730,7 @@ class CallManager {
 	 */
 	public leaveCall(): void {
 		if (this.currentCall?.usesElementCall && this.currentCall.isGroup) {
-			this.currentCall.state = 'left';
+			this.currentCall = { ...this.currentCall, state: 'left' };
 			releaseAllCallWarmupStreams();
 			this.notifyListeners();
 			return;

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -125,7 +125,8 @@ class CallManager {
 			this.currentCall.isGroup &&
 			this.currentCall.state === 'left' &&
 			forceIsGroup === true &&
-			(this.currentCall.signalRoomId || this.currentCall.roomId) === roomId
+			(this.currentCall.signalRoomId || this.currentCall.roomId) ===
+				roomId
 		) {
 			// Reopen the existing MatrixRTC room. Creating another dedicated room
 			// here would strand the participants who stayed in the active call.
@@ -590,6 +591,13 @@ class CallManager {
 		}
 		// console.log("   Is Video:", isVideo);
 		// console.log("   Caller:", callerUserId);
+
+		// A left group call is retained only so the same room can be reopened from
+		// its own conversation. It must not make the client busy for a different
+		// incoming call.
+		if (this.currentCall?.state === 'left') {
+			this.currentCall = null;
+		}
 
 		if (this.currentCall) {
 			// console.warn("⚠️  Already have an active call, ignoring incoming call");

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -21,6 +21,7 @@ export type CallState =
 	| 'ringing'
 	| 'connecting'
 	| 'connected'
+	| 'left'
 	| 'ended';
 
 export interface CallData {
@@ -118,6 +119,22 @@ class CallManager {
 		// console.log("   Room ID:", roomId);
 		// console.log("   Is Video:", isVideo);
 		// console.log("   Force Group:", forceIsGroup);
+
+		if (
+			this.currentCall?.usesElementCall &&
+			this.currentCall.isGroup &&
+			this.currentCall.state === 'left' &&
+			forceIsGroup === true &&
+			(this.currentCall.signalRoomId || this.currentCall.roomId) === roomId
+		) {
+			// Reopen the existing MatrixRTC room. Creating another dedicated room
+			// here would strand the participants who stayed in the active call.
+			this.currentCall.isVideo = isVideo;
+			this.currentCall.isIncoming = false;
+			this.currentCall.state = 'connecting';
+			this.notifyListeners();
+			return;
+		}
 
 		if (this.currentCall) {
 			// console.warn("⚠️  Already have an active call, cleaning up first...");
@@ -693,6 +710,22 @@ class CallManager {
 		releaseAllCallWarmupStreams();
 
 		this.notifyListeners();
+	}
+
+	/**
+	 * Leave this browser's media session without destroying a MatrixRTC group
+	 * call that other room members are still using. The retained call metadata
+	 * lets the normal room call button rejoin the exact same call room.
+	 */
+	public leaveCall(): void {
+		if (this.currentCall?.usesElementCall && this.currentCall.isGroup) {
+			this.currentCall.state = 'left';
+			releaseAllCallWarmupStreams();
+			this.notifyListeners();
+			return;
+		}
+
+		this.endCall();
 	}
 
 	/**

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -825,7 +825,7 @@ class CallManager {
 	 * Check if there's an active call
 	 */
 	public hasActiveCall(): boolean {
-		return this.currentCall !== null;
+		return this.currentCall !== null && this.currentCall.state !== 'left';
 	}
 }
 

--- a/src/services/CallManager.ts
+++ b/src/services/CallManager.ts
@@ -669,7 +669,12 @@ class CallManager {
 		}
 		this.currentCall = null;
 
-		if (notifyRemote && call.usesElementCall) {
+		// A MatrixRTC group call belongs to the room, not to the participant who
+		// originally invited everyone. Leaving it must clear only this browser's
+		// local call surface. Broadcasting the legacy ORISO hangup event here
+		// used to make every other participant tear down the same active call.
+		// One-to-one Element Call still needs the remote hangup notification.
+		if (notifyRemote && call.usesElementCall && !call.isGroup) {
 			this.sendElementCallHangup(call);
 		}
 

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -277,6 +277,51 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		membershipSpy.mockRestore();
 	});
 
+	it('retries a stale Element Call invite after membership state finishes syncing', () => {
+		const callRoomId = '!late-membership:matrix.oriso.org';
+		const historicalInvite = makeEvent({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'call-late-membership',
+				is_element_call: true,
+				is_group_call: false,
+				is_video: false,
+				call_room_id: callRoomId
+			},
+			ts: Date.now() - 60_000
+		});
+		(client as any).getRoom = vi.fn(() => null);
+
+		client.emit('Room.timeline', historicalInvite, room, false);
+		expect(receiveCall).not.toHaveBeenCalled();
+
+		(client as any).getRooms = vi.fn(() => [
+			{
+				roomId: ROOM_ID,
+				getLiveTimeline: () => ({ getEvents: () => [historicalInvite] })
+			}
+		]);
+		(client as any).getRoom = vi.fn((roomId: string) =>
+			roomId === callRoomId ? { roomId } : null
+		);
+		const membershipSpy = vi
+			.spyOn(MatrixRTCSession, 'sessionMembershipsForRoom')
+			.mockReturnValue([{} as any]);
+
+		client.emit('sync', 'SYNCING', null);
+
+		expect(receiveCall).toHaveBeenCalledWith(
+			callRoomId,
+			false,
+			'call-late-membership',
+			OTHER_USER_ID,
+			false,
+			ROOM_ID,
+			true
+		);
+		membershipSpy.mockRestore();
+	});
+
 	it('scans the synced timeline after reload for an active Element Call invite', () => {
 		const callRoomId = '!active-call:matrix.oriso.org';
 		const historicalInvite = makeEvent({

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -277,6 +277,46 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		membershipSpy.mockRestore();
 	});
 
+	it('scans the synced timeline after reload for an active Element Call invite', () => {
+		const callRoomId = '!active-call:matrix.oriso.org';
+		const historicalInvite = makeEvent({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'call-active-in-sync',
+				is_element_call: true,
+				is_group_call: false,
+				is_video: false,
+				call_room_id: callRoomId
+			},
+			ts: Date.now() - 60_000
+		});
+		const syncedSignalRoom = {
+			roomId: ROOM_ID,
+			getLiveTimeline: () => ({ getEvents: () => [historicalInvite] })
+		};
+		const activeCallRoom = { roomId: callRoomId };
+		(client as any).getRooms = vi.fn(() => [syncedSignalRoom]);
+		(client as any).getRoom = vi.fn((roomId: string) =>
+			roomId === callRoomId ? activeCallRoom : null
+		);
+		const membershipSpy = vi
+			.spyOn(MatrixRTCSession, 'sessionMembershipsForRoom')
+			.mockReturnValue([{} as any]);
+
+		client.emit('sync', 'PREPARED', null);
+
+		expect(receiveCall).toHaveBeenCalledWith(
+			callRoomId,
+			false,
+			'call-active-in-sync',
+			OTHER_USER_ID,
+			false,
+			ROOM_ID,
+			true
+		);
+		membershipSpy.mockRestore();
+	});
+
 	it('ignores our own call invites', () => {
 		emitInvite({
 			content: { call_id: 'call-mine' },

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRequire } from 'module';
+import { MatrixRTCSession } from 'matrix-js-sdk/lib/matrixrtc/MatrixRTCSession';
 import { MatrixLiveEventBridge } from './matrixLiveEventBridge';
 
 // Hoisted above the imports by vitest: endpoints/runtimeConfig read these
@@ -241,6 +242,39 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		});
 
 		expect(receiveCall).not.toHaveBeenCalled();
+	});
+
+	it('recovers an old Element Call invite when the call room still has active MatrixRTC membership', () => {
+		const callRoomId = '!active-call:matrix.oriso.org';
+		const activeCallRoom = { roomId: callRoomId };
+		(client as any).getRoom = vi.fn((roomId: string) =>
+			roomId === callRoomId ? activeCallRoom : null
+		);
+		const membershipSpy = vi
+			.spyOn(MatrixRTCSession, 'sessionMembershipsForRoom')
+			.mockReturnValue([{} as any]);
+
+		emitInvite({
+			content: {
+				call_id: 'call-active-after-reload',
+				is_element_call: true,
+				is_group_call: false,
+				is_video: false,
+				call_room_id: callRoomId
+			},
+			ts: Date.now() - 60_000
+		});
+
+		expect(receiveCall).toHaveBeenCalledWith(
+			callRoomId,
+			false,
+			'call-active-after-reload',
+			OTHER_USER_ID,
+			false,
+			ROOM_ID,
+			true
+		);
+		membershipSpy.mockRestore();
 	});
 
 	it('ignores our own call invites', () => {

--- a/src/services/matrixLiveEventBridge.test.ts
+++ b/src/services/matrixLiveEventBridge.test.ts
@@ -317,6 +317,76 @@ describe('MatrixLiveEventBridge call-invite de-dupe & stale handling', () => {
 		membershipSpy.mockRestore();
 	});
 
+	it('stops active-call recovery after two sync scans without a candidate', () => {
+		const getRooms = vi.fn(() => []);
+		(client as any).getRooms = getRooms;
+
+		client.emit('sync', 'PREPARED', null);
+		client.emit('sync', 'SYNCING', 'PREPARED');
+		client.emit('sync', 'SYNCING', 'SYNCING');
+
+		expect(getRooms).toHaveBeenCalledTimes(2);
+		expect(receiveCall).not.toHaveBeenCalled();
+	});
+
+	it('recovers an older active invite when the newest candidate was already processed', () => {
+		const newestCallRoomId = '!newest-call:matrix.oriso.org';
+		const olderCallRoomId = '!older-call:matrix.oriso.org';
+		emitInvite({
+			content: {
+				call_id: 'already-processed',
+				is_element_call: true,
+				call_room_id: newestCallRoomId
+			},
+			ts: Date.now()
+		});
+		receiveCall.mockClear();
+
+		const newestInvite = makeEvent({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'already-processed',
+				is_element_call: true,
+				call_room_id: newestCallRoomId
+			},
+			ts: Date.now()
+		});
+		const olderInvite = makeEvent({
+			type: 'org.oriso.call.invite',
+			content: {
+				call_id: 'recoverable-older',
+				is_element_call: true,
+				call_room_id: olderCallRoomId
+			},
+			ts: Date.now() - 60_000
+		});
+		(client as any).getRooms = vi.fn(() => [
+			{
+				roomId: ROOM_ID,
+				getLiveTimeline: () => ({
+					getEvents: () => [olderInvite, newestInvite]
+				})
+			}
+		]);
+		(client as any).getRoom = vi.fn((roomId: string) => ({ roomId }));
+		const membershipSpy = vi
+			.spyOn(MatrixRTCSession, 'sessionMembershipsForRoom')
+			.mockReturnValue([{} as any]);
+
+		client.emit('sync', 'PREPARED', null);
+
+		expect(receiveCall).toHaveBeenCalledWith(
+			olderCallRoomId,
+			true,
+			'recoverable-older',
+			OTHER_USER_ID,
+			false,
+			ROOM_ID,
+			true
+		);
+		membershipSpy.mockRestore();
+	});
+
 	it('ignores our own call invites', () => {
 		emitInvite({
 			content: { call_id: 'call-mine' },

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -1,4 +1,5 @@
 import { MatrixClient, Room, MatrixEvent } from 'matrix-js-sdk';
+import { MatrixRTCSession } from 'matrix-js-sdk/lib/matrixrtc/MatrixRTCSession';
 
 type CallManagerModule = typeof import('./CallManager');
 
@@ -217,6 +218,13 @@ export class MatrixLiveEventBridge {
 		const now = Date.now();
 		const ageSeconds = Math.floor((now - eventTimestamp) / 1000);
 		const callRoomId = content.call_room_id || room.roomId;
+		const isGroupCall = content.is_group_call === true;
+		const isElementCall = content.is_element_call === true || isGroupCall;
+		const isVideo = isElementCall
+			? content.is_video !== false
+			: isVideoCallInvite(content);
+		const hasActiveMatrixRtcMembership =
+			isElementCall && this.hasActiveMatrixRtcMembership(callRoomId);
 
 		// console.log("═══════════════════════════════════════════════");
 		// console.log("🔔 CALL INVITE EVENT RECEIVED");
@@ -228,9 +236,12 @@ export class MatrixLiveEventBridge {
 		// console.log("⏱️  Age:", ageSeconds, "seconds old");
 		// console.log("═══════════════════════════════════════════════");
 
-		// CRITICAL: Ignore old call invites (> 10 seconds = from history/replay!)
-		// This prevents phantom notifications on login/reload
-		if (ageSeconds > 10) {
+		// Historical invites normally must not ring again. MatrixRTC is the
+		// exception: after a page reload the original invite is historical even
+		// though another participant is still publishing in the dedicated call
+		// room. The SDK's non-expired membership view is the authoritative active
+		// signal and avoids reviving calls whose invite merely remains in history.
+		if (ageSeconds > 10 && !hasActiveMatrixRtcMembership) {
 			// console.log("🚫 IGNORING OLD CALL INVITE (from history, not a new call!)");
 			// console.log("═══════════════════════════════════════════════");
 			this.processedCallInvites.add(callId);
@@ -254,13 +265,6 @@ export class MatrixLiveEventBridge {
 			this.processedCallInvites.add(callId);
 			return;
 		}
-
-		// Check if this is an Element Call / LiveKit call (custom field)
-		const isGroupCall = content.is_group_call === true;
-		const isElementCall = content.is_element_call === true || isGroupCall;
-		const isVideo = isElementCall
-			? content.is_video !== false
-			: isVideoCallInvite(content);
 
 		if (isElementCall) {
 			// console.log("✅ LIVEKIT GROUP CALL DETECTED!");
@@ -309,6 +313,24 @@ export class MatrixLiveEventBridge {
 			false,
 			room.roomId
 		);
+	}
+
+	private hasActiveMatrixRtcMembership(callRoomId: string): boolean {
+		try {
+			const callRoom = this.client?.getRoom(callRoomId);
+			if (!callRoom) return false;
+
+			return (
+				MatrixRTCSession.sessionMembershipsForRoom(callRoom, {
+					id: '',
+					application: 'm.call'
+				}).length > 0
+			);
+		} catch {
+			// A partially synced call room is not evidence that a historical invite
+			// is still active. Fail closed and wait for a new live invite instead.
+			return false;
+		}
 	}
 
 	/**

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -324,7 +324,13 @@ export class MatrixLiveEventBridge {
 		if (ageSeconds > 10 && !hasActiveMatrixRtcMembership) {
 			// console.log("🚫 IGNORING OLD CALL INVITE (from history, not a new call!)");
 			// console.log("═══════════════════════════════════════════════");
-			this.processedCallInvites.add(callId);
+			// A partially synced Element Call room can gain active MatrixRTC
+			// membership on the next sync. Keep that invite recoverable. Legacy
+			// Matrix WebRTC invites have no equivalent active-membership signal and
+			// remain permanently stale once rejected.
+			if (!isElementCall) {
+				this.processedCallInvites.add(callId);
+			}
 			return;
 		}
 

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -26,6 +26,7 @@ export class MatrixLiveEventBridge {
 	private eventCallbacks: Map<string, Set<(event: any) => void>> = new Map();
 	private initialized: boolean = false;
 	private processedCallInvites: Set<string> = new Set(); // Track processed call IDs
+	private activeCallRecoveryScans = 0;
 	private pendingEncryptedEvents = new Map<
 		MatrixEvent,
 		{
@@ -56,6 +57,7 @@ export class MatrixLiveEventBridge {
 
 		this.client = client;
 		this.processedCallInvites.clear();
+		this.activeCallRecoveryScans = 0;
 		this.setupEventListeners();
 		this.initialized = true;
 
@@ -88,8 +90,76 @@ export class MatrixLiveEventBridge {
 			'sync' as any,
 			(state: string, prevState: string | null) => {
 				// console.log("🔄 Matrix sync state:", state, "(previous:", prevState, ")");
+				if (
+					(state === 'PREPARED' || state === 'SYNCING') &&
+					this.activeCallRecoveryScans < 2
+				) {
+					this.activeCallRecoveryScans += 1;
+					if (this.recoverActiveElementCallFromTimeline()) {
+						this.activeCallRecoveryScans = 2;
+					}
+				}
 			}
 		);
+	}
+
+	private recoverActiveElementCallFromTimeline(): boolean {
+		if (!this.client) return false;
+
+		const candidates = this.client
+			.getRooms()
+			.flatMap((room) => {
+				const events = room.getLiveTimeline().getEvents();
+				const hangups = new Map<string, number>();
+				events.forEach((event) => {
+					if (
+						event.getType() === 'm.call.hangup' ||
+						event.getType() === 'org.oriso.call.hangup'
+					) {
+						const callId = event.getContent().call_id;
+						if (callId) {
+							hangups.set(
+								callId,
+								Math.max(hangups.get(callId) ?? 0, event.getTs())
+							);
+						}
+					}
+				});
+
+				return events
+					.filter((event) => {
+						if (
+							event.getType() !== 'm.call.invite' &&
+							event.getType() !== 'org.oriso.call.invite'
+						) {
+							return false;
+						}
+						const content = event.getContent();
+						const callId = content.call_id;
+						const endedAt = callId ? hangups.get(callId) : undefined;
+						return (
+							(content.is_element_call === true ||
+								content.is_group_call === true) &&
+							(!endedAt || endedAt < event.getTs())
+						);
+					})
+					.map((event) => ({ event, room }));
+			})
+			.sort((a, b) => b.event.getTs() - a.event.getTs());
+
+		for (const { event, room } of candidates) {
+			const content = event.getContent();
+			const callRoomId = content.call_room_id || room.roomId;
+			if (
+				event.getSender() !== this.client.getUserId() &&
+				this.hasActiveMatrixRtcMembership(callRoomId)
+			) {
+				this.handleCallInvite(event, room);
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private dispatchTimelineEvent(

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -134,25 +134,29 @@ export class MatrixLiveEventBridge {
 					}
 				});
 
-				return events
-					.filter((event) => {
+				return events.reduce<{ event: MatrixEvent; room: Room }[]>(
+					(candidatesForRoom, event) => {
 						if (
 							event.getType() !== 'm.call.invite' &&
 							event.getType() !== 'org.oriso.call.invite'
 						) {
-							return false;
+							return candidatesForRoom;
 						}
 						const content = event.getContent();
 						const callId = content.call_id;
 						const endedAt = callId
 							? hangups.get(callId)
 							: undefined;
-						return (
+						if (
 							isElementOrGroupCallInvite(content) &&
 							(!endedAt || endedAt < event.getTs())
-						);
-					})
-					.map((event) => ({ event, room }));
+						) {
+							candidatesForRoom.push({ event, room });
+						}
+						return candidatesForRoom;
+					},
+					[]
+				);
 			})
 			.sort((a, b) => b.event.getTs() - a.event.getTs());
 

--- a/src/services/matrixLiveEventBridge.ts
+++ b/src/services/matrixLiveEventBridge.ts
@@ -16,6 +16,11 @@ const isVideoCallInvite = (content: Record<string, unknown>): boolean => {
 	return isVideoCallFromMatrixInviteContent(content);
 };
 
+const isElementOrGroupCallInvite = (
+	content: Record<string, unknown>
+): boolean =>
+	content.is_element_call === true || content.is_group_call === true;
+
 /**
  * Bridge between Matrix events and the existing LiveService WebSocket system.
  * This service listens to Matrix Room.timeline events and triggers appropriate
@@ -120,7 +125,10 @@ export class MatrixLiveEventBridge {
 						if (callId) {
 							hangups.set(
 								callId,
-								Math.max(hangups.get(callId) ?? 0, event.getTs())
+								Math.max(
+									hangups.get(callId) ?? 0,
+									event.getTs()
+								)
 							);
 						}
 					}
@@ -136,10 +144,11 @@ export class MatrixLiveEventBridge {
 						}
 						const content = event.getContent();
 						const callId = content.call_id;
-						const endedAt = callId ? hangups.get(callId) : undefined;
+						const endedAt = callId
+							? hangups.get(callId)
+							: undefined;
 						return (
-							(content.is_element_call === true ||
-								content.is_group_call === true) &&
+							isElementOrGroupCallInvite(content) &&
 							(!endedAt || endedAt < event.getTs())
 						);
 					})
@@ -152,6 +161,7 @@ export class MatrixLiveEventBridge {
 			const callRoomId = content.call_room_id || room.roomId;
 			if (
 				event.getSender() !== this.client.getUserId() &&
+				!this.processedCallInvites.has(content.call_id) &&
 				this.hasActiveMatrixRtcMembership(callRoomId)
 			) {
 				this.handleCallInvite(event, room);
@@ -289,7 +299,7 @@ export class MatrixLiveEventBridge {
 		const ageSeconds = Math.floor((now - eventTimestamp) / 1000);
 		const callRoomId = content.call_room_id || room.roomId;
 		const isGroupCall = content.is_group_call === true;
-		const isElementCall = content.is_element_call === true || isGroupCall;
+		const isElementCall = isElementOrGroupCallInvite(content);
 		const isVideo = isElementCall
 			? content.is_video !== false
 			: isVideoCallInvite(content);


### PR DESCRIPTION
## Why

A participant leaving an Element Call group call caused the ORISO host to broadcast a conversation-wide hangup, which removed the call surface for everyone. Suppressing that broadcast kept the remaining users connected, but the leaver then lost the active call-room metadata and could only create a different call.

A separate real-browser robustness test found that reloading the invited participant during an active 1:1 call also lost the call surface permanently: the original invite was historical and therefore never replayed, although the caller still had active MatrixRTC membership and media.

## What changed

- Do not broadcast the legacy remote-hangup event when an individual leaves a MatrixRTC group call; one-to-one behavior remains unchanged.
- Retain a local `left` state and the existing dedicated MatrixRTC room.
- Make the normal group audio/video action reopen that exact room instead of creating a replacement call.
- Keep iframe/device teardown local to the leaving browser.
- Treat a historical Element Call invite as recoverable only when the dedicated call room still has a non-expired MatrixRTC membership.
- On the first Matrix syncs after reload, scan the synced timeline for the newest unended active Element Call invite so it can be answered again.
- Add regression coverage for local group leave, inactive-state reporting, exact-room rejoin, accepting a different call after leaving, immutable subscriber transitions, unchanged 1:1 hangup notification, stale invite rejection, processed-invite fallback, late MatrixRTC membership sync, and active-call reload recovery.

## Verification

- 42 directly related CallManager, bridge, widget-driver, and Matrix credential-boundary tests passed in the final local verification.
- Changed-file ESLint passed.
- TypeScript passed.
- Production build passed.
- PreDev three-browser group proof with Element Call PR #41: Homer left while Patty and Jacqueline remote audio advanced another 3.2 seconds, then Homer rejoined the exact same MatrixRTC room `!ycYCIlFzyeoUlljuXY:predev.oriso.org`. All three again received two advancing remote audio tracks.
- LiveKit kept SFU room `RM_Qw3FpRpNCmPV`; Homer's republished audio stayed `encryption: 1`. All three then published GCM VP8 video and all nine video elements advanced over a timed 3.3-second sample.
- PreDev 1:1 reload proof: Cyrus reloaded while Moe stayed connected. The recovered incoming call joined the exact original MatrixRTC room `!LKckZIWxwAmRmKQLIc:predev.oriso.org`; both remote audio elements then advanced by about 3.2 seconds.

Refs #920
Refs OpenResilienceInitiative/ORISO-ElementCall#41

### Reviewer test plan

- [ ] Start a three-person encrypted group audio call and confirm two remote audio tracks per browser.
- [ ] Have one non-host participant press Element Call's hangup button.
- [ ] Confirm the other two surfaces remain open and their remote audio continues.
- [ ] From the leaver's conversation header, start audio again and confirm the widget URL contains the original call-room id.
- [ ] Confirm all three participant rosters and two remote tracks converge again.
- [ ] Repeat with video enabled and verify local camera release after each final local leave.
- [ ] End a 1:1 Element Call and confirm the remote participant still receives its hangup.
- [ ] During a new 1:1 call, reload the invited participant after the invite is older than ten seconds.
- [ ] Confirm the active call is offered again, answer it, and verify the widget reuses the same MatrixRTC room with advancing remote audio.
- [ ] Confirm an old invite with no active MatrixRTC membership does not ring after reload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for leaving and rejoining active group calls without ending the call for other participants.
  * Group calls can now be restored after reload when an active session is detected.
  * Improved recovery of ongoing calls from recent call invitations.

* **Bug Fixes**
  * Prevented leaving a group call from notifying others that the shared call ended.
  * Improved handling of dismissed call widgets after leaving a call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->