### PR TITLE
feat(session): inline client consent card for case-handover requests

### DIFF
--- a/src/components/caseHandover/CaseHandoverClientCards.stories.tsx
+++ b/src/components/caseHandover/CaseHandoverClientCards.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useTranslation } from 'react-i18next';
 import {
 	CaseHandoverAcceptedCard,
+	CaseHandoverConsentCard,
 	CaseHandoverSystemMessageCard
 } from './CaseHandoverClientCards';
 import {
@@ -67,6 +68,17 @@ export const InquiryAcceptedMobile: Story = {
 				organisationName="Caritas Mainz"
 				onViewConversation={() => {}}
 				compact
+			/>
+		</div>
+	)
+};
+
+export const PendingClientConsentInConversation: Story = {
+	render: () => (
+		<div style={{ ...shell, backgroundColor: '#f7f2f1' }}>
+			<CaseHandoverConsentCard
+				onApprove={() => {}}
+				onDecline={() => {}}
 			/>
 		</div>
 	)

--- a/src/components/caseHandover/CaseHandoverClientCards.tsx
+++ b/src/components/caseHandover/CaseHandoverClientCards.tsx
@@ -166,3 +166,65 @@ export const CaseHandoverSystemMessageCard = ({
 		</div>
 	);
 };
+
+interface CaseHandoverConsentCardProps {
+	isSubmitting?: boolean;
+	error?: string;
+	onApprove: () => void;
+	onDecline: () => void;
+}
+
+/** Client-side continuation for a handover request that requires explicit consent. */
+export const CaseHandoverConsentCard = ({
+	isSubmitting = false,
+	error,
+	onApprove,
+	onDecline
+}: CaseHandoverConsentCardProps) => {
+	const { t: translate } = useTranslation();
+
+	return (
+		<div
+			className="caseHandoverInlineConsent"
+			data-testid="case-handover-inline-consent"
+		>
+			<CaseHandoverSystemMessageCard
+				title={translate(
+					'caseHandover.consent.title',
+					'A counsellor requested access to this conversation'
+				)}
+				subtitle={translate(
+					'caseHandover.consent.copy',
+					'Please approve or decline the request to continue the handover.'
+				)}
+			>
+				<div className="caseHandoverInlineConsent__actions">
+					<button
+						type="button"
+						className="caseHandoverInlineConsent__button caseHandoverInlineConsent__button--approve"
+						onClick={onApprove}
+						disabled={isSubmitting}
+					>
+						{translate('caseHandover.consent.approve')}
+					</button>
+					<button
+						type="button"
+						className="caseHandoverInlineConsent__button"
+						onClick={onDecline}
+						disabled={isSubmitting}
+					>
+						{translate('caseHandover.consent.decline')}
+					</button>
+				</div>
+				{error && (
+					<p
+						className="caseHandoverInlineConsent__error"
+						role="alert"
+					>
+						{error}
+					</p>
+				)}
+			</CaseHandoverSystemMessageCard>
+		</div>
+	);
+};

--- a/src/components/caseHandover/caseHandoverClientCards.styles.scss
+++ b/src/components/caseHandover/caseHandoverClientCards.styles.scss
@@ -163,3 +163,43 @@
 	font-size: 12px;
 	color: var(--m3-on-surface-variant, #6d747d);
 }
+
+.caseHandoverInlineConsent {
+	display: flex;
+	justify-content: center;
+	padding: 16px 20px 0;
+}
+
+.caseHandoverInlineConsent__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.caseHandoverInlineConsent__button {
+	min-height: 40px;
+	padding: 0 18px;
+	border: 1px solid var(--m3-outline, #79747e);
+	border-radius: 20px;
+	background: transparent;
+	color: var(--m3-on-surface, #1b1b1c);
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+
+	&--approve {
+		border-color: var(--m3-primary, #a5000a);
+		background: var(--m3-primary, #a5000a);
+		color: var(--m3-on-primary, #ffffff);
+	}
+
+	&:disabled {
+		opacity: 0.55;
+		cursor: wait;
+	}
+}
+
+.caseHandoverInlineConsent__error {
+	margin: 10px 0 0;
+	color: var(--m3-error, #ba1a1a);
+}

--- a/src/components/session/SessionStream.test.tsx
+++ b/src/components/session/SessionStream.test.tsx
@@ -1,6 +1,14 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import {
+	render,
+	screen,
+	waitFor,
+	act,
+	cleanup,
+	fireEvent,
+	within
+} from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -12,6 +20,8 @@ import {
 import { SESSION_LIST_TYPES } from './sessionHelpers';
 import { SessionStream } from './SessionStream';
 import { chatTransportService } from '../../services/chatTransportService';
+import { NotificationsContext } from '../../globalState/provider/NotificationsProvider';
+import { apiDecideCaseHandoverClientConsent } from '../../api';
 
 const ROOM_ID = '!session:matrix.oriso.org';
 const LIST_PATH = '/sessions/user/view';
@@ -80,6 +90,7 @@ vi.mock('../../api', () => ({
 	apiGetAgencyConsultantList: vi.fn(() => Promise.resolve([])),
 	apiGetSessionSupervisors: mocks.getSessionSupervisors,
 	apiGetCaseHandoverStatus: mocks.getCaseHandoverStatus,
+	apiDecideCaseHandoverClientConsent: vi.fn(() => Promise.resolve({})),
 	FETCH_ERRORS: { ABORT: 'ABORT' }
 }));
 
@@ -187,7 +198,13 @@ const askerUserData = {
 	grantedAuthorities: ['AUTHORIZATION_USER_DEFAULT']
 } as any;
 
-const renderSessionStream = ({ isGroup }: { isGroup: boolean }) => {
+const renderSessionStream = ({
+	isGroup,
+	notificationFeed = []
+}: {
+	isGroup: boolean;
+	notificationFeed?: any[];
+}) => {
 	const activeSession = {
 		rid: ROOM_ID,
 		isGroup,
@@ -201,42 +218,55 @@ const renderSessionStream = ({ isGroup }: { isGroup: boolean }) => {
 
 	return render(
 		<MemoryRouter>
-			<UserDataContext.Provider
+			<NotificationsContext.Provider
 				value={
-					{ userData: askerUserData, setUserData: () => {} } as any
+					{
+						notificationFeed,
+						markNotificationAsRead: vi.fn(),
+						refreshNotificationFeed: vi.fn()
+					} as any
 				}
 			>
-				<SessionTypeContext.Provider
-					value={{
-						type: SESSION_LIST_TYPES.MY_SESSION,
-						path: LIST_PATH
-					}}
+				<UserDataContext.Provider
+					value={
+						{
+							userData: askerUserData,
+							setUserData: () => {}
+						} as any
+					}
 				>
-					<ConsultantListContext.Provider
-						value={
-							{
-								consultantList: [],
-								setConsultantList: () => {}
-							} as any
-						}
+					<SessionTypeContext.Provider
+						value={{
+							type: SESSION_LIST_TYPES.MY_SESSION,
+							path: LIST_PATH
+						}}
 					>
-						<ActiveSessionContext.Provider
+						<ConsultantListContext.Provider
 							value={
 								{
-									activeSession,
-									readActiveSession: () => {}
+									consultantList: [],
+									setConsultantList: () => {}
 								} as any
 							}
 						>
-							<SessionStream
-								readonly={false}
-								checkMutedUserForThisSession={() => {}}
-								bannedUsers={[]}
-							/>
-						</ActiveSessionContext.Provider>
-					</ConsultantListContext.Provider>
-				</SessionTypeContext.Provider>
-			</UserDataContext.Provider>
+							<ActiveSessionContext.Provider
+								value={
+									{
+										activeSession,
+										readActiveSession: () => {}
+									} as any
+								}
+							>
+								<SessionStream
+									readonly={false}
+									checkMutedUserForThisSession={() => {}}
+									bannedUsers={[]}
+								/>
+							</ActiveSessionContext.Provider>
+						</ConsultantListContext.Provider>
+					</SessionTypeContext.Provider>
+				</UserDataContext.Provider>
+			</NotificationsContext.Provider>
 		</MemoryRouter>
 	);
 };
@@ -265,6 +295,96 @@ describe('SessionStream Matrix room lifecycle', () => {
 
 	afterEach(() => {
 		cleanup();
+	});
+
+	it('lets the asker decide pending case-handover consent inside the conversation', async () => {
+		renderSessionStream({
+			isGroup: false,
+			notificationFeed: [
+				{
+					id: '1481',
+					eventType: 'case.handover.consent.requested',
+					sourceSessionId: '1',
+					actionPath:
+						'/sessions/user/view/session/1?caseHandoverRequestId=11'
+				}
+			]
+		});
+
+		const consentCard = await screen.findByTestId(
+			'case-handover-inline-consent'
+		);
+		fireEvent.click(
+			within(consentCard).getByRole('button', {
+				name: 'caseHandover.consent.approve'
+			})
+		);
+
+		await waitFor(() => {
+			expect(apiDecideCaseHandoverClientConsent).toHaveBeenCalledWith(
+				1,
+				11,
+				true
+			);
+		});
+	});
+
+	it('lets the asker decline the request and removes the card afterwards', async () => {
+		renderSessionStream({
+			isGroup: false,
+			notificationFeed: [
+				{
+					id: '1481',
+					eventType: 'case.handover.consent.requested',
+					sourceSessionId: '1',
+					actionPath:
+						'/sessions/user/view/session/1?caseHandoverRequestId=11'
+				}
+			]
+		});
+
+		const consentCard = await screen.findByTestId(
+			'case-handover-inline-consent'
+		);
+		fireEvent.click(
+			within(consentCard).getByRole('button', {
+				name: 'caseHandover.consent.decline'
+			})
+		);
+
+		await waitFor(() => {
+			expect(apiDecideCaseHandoverClientConsent).toHaveBeenCalledWith(
+				1,
+				11,
+				false
+			);
+		});
+		await waitFor(() => {
+			expect(
+				screen.queryByTestId('case-handover-inline-consent')
+			).toBeNull();
+		});
+	});
+
+	it('does not resurface the card for an already-answered (read) request', async () => {
+		renderSessionStream({
+			isGroup: false,
+			notificationFeed: [
+				{
+					id: '1481',
+					eventType: 'case.handover.consent.requested',
+					sourceSessionId: '1',
+					readAt: '2026-08-01T10:00:00.000Z',
+					actionPath:
+						'/sessions/user/view/session/1?caseHandoverRequestId=11'
+				}
+			]
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId('session-item')).toBeDefined();
+		});
+		expect(screen.queryByTestId('case-handover-inline-consent')).toBeNull();
 	});
 
 	it('redirects a removed 1:1 participant back to the session list', async () => {

--- a/src/components/session/SessionStream.tsx
+++ b/src/components/session/SessionStream.tsx
@@ -21,6 +21,7 @@ import {
 import {
 	apiGetAgencyConsultantList,
 	apiGetCaseHandoverStatus,
+	apiDecideCaseHandoverClientConsent,
 	apiGetSessionSupervisors,
 	CaseHandoverStatus,
 	FETCH_ERRORS
@@ -64,6 +65,22 @@ import {
 	isUndecryptedRoomEvent,
 	matrixRoomHistoryKeyTransfer
 } from '../../services/matrixRoomHistoryKeyTransfer';
+import { NotificationsContext } from '../../globalState/provider/NotificationsProvider';
+import { CaseHandoverConsentCard } from '../caseHandover/CaseHandoverClientCards';
+
+const caseHandoverRequestIdFromPath = (actionPath?: string): number | null => {
+	if (!actionPath?.includes('?')) {
+		return null;
+	}
+	const value = new URLSearchParams(actionPath.split('?')[1]).get(
+		'caseHandoverRequestId'
+	);
+	if (!value || !/^\d+$/.test(value)) {
+		return null;
+	}
+	const requestId = Number(value);
+	return Number.isSafeInteger(requestId) ? requestId : null;
+};
 
 interface SessionStreamProps {
 	readonly: boolean;
@@ -121,10 +138,55 @@ export const SessionStream = ({
 
 	const { activeSession, readActiveSession } =
 		useContext(ActiveSessionContext);
+	const notificationsContext = useContext(NotificationsContext);
 	const [caseHandoverStatus, setCaseHandoverStatus] =
 		useState<CaseHandoverStatus | null>(null);
 	const [caseHandoverStatusLoading, setCaseHandoverStatusLoading] =
 		useState(false);
+	const [caseHandoverConsentSubmitting, setCaseHandoverConsentSubmitting] =
+		useState(false);
+	const [caseHandoverConsentError, setCaseHandoverConsentError] =
+		useState('');
+	const [
+		resolvedCaseHandoverNotificationId,
+		setResolvedCaseHandoverNotificationId
+	] = useState<string | null>(null);
+	const pendingCaseHandoverConsent = useMemo(() => {
+		if (
+			!hasUserAuthority(AUTHORITIES.ASKER_DEFAULT, userData) ||
+			activeSession.isGroup
+		) {
+			return null;
+		}
+		const sessionId = activeSession.item?.id;
+		return (
+			notificationsContext?.notificationFeed.find((item) => {
+				if (
+					item.id === resolvedCaseHandoverNotificationId ||
+					item.eventType !== 'case.handover.consent.requested' ||
+					// already answered elsewhere — a read notification must
+					// not resurface the consent card on remount
+					!!item.readAt
+				) {
+					return false;
+				}
+				return String(item.sourceSessionId) === String(sessionId);
+			}) || null
+		);
+	}, [
+		activeSession.isGroup,
+		activeSession.item?.id,
+		notificationsContext?.notificationFeed,
+		resolvedCaseHandoverNotificationId,
+		userData
+	]);
+	const pendingCaseHandoverRequestId = useMemo(
+		() =>
+			caseHandoverRequestIdFromPath(
+				pendingCaseHandoverConsent?.actionPath
+			),
+		[pendingCaseHandoverConsent?.actionPath]
+	);
 
 	const { setConsultantList } = useContext(ConsultantListContext);
 
@@ -1054,6 +1116,38 @@ export const SessionStream = ({
 		}
 	};
 
+	const handleCaseHandoverConsentDecision = (approved: boolean) => {
+		if (
+			!pendingCaseHandoverConsent ||
+			pendingCaseHandoverRequestId === null
+		) {
+			setCaseHandoverConsentError(translate('caseHandover.error.failed'));
+			return;
+		}
+		setCaseHandoverConsentSubmitting(true);
+		setCaseHandoverConsentError('');
+		apiDecideCaseHandoverClientConsent(
+			activeSession.item.id,
+			pendingCaseHandoverRequestId,
+			approved
+		)
+			.then(() => {
+				notificationsContext?.markNotificationAsRead(
+					pendingCaseHandoverConsent.id
+				);
+				setResolvedCaseHandoverNotificationId(
+					pendingCaseHandoverConsent.id
+				);
+				notificationsContext?.refreshNotificationFeed();
+			})
+			.catch(() => {
+				setCaseHandoverConsentError(
+					translate('caseHandover.error.failed')
+				);
+			})
+			.finally(() => setCaseHandoverConsentSubmitting(false));
+	};
+
 	if (caseHandoverCurtainNeeded && !caseHandoverStatus?.canViewContent) {
 		return (
 			<div className="session__wrapper">
@@ -1080,6 +1174,19 @@ export const SessionStream = ({
 
 	return (
 		<div className="session__wrapper">
+			{pendingCaseHandoverConsent &&
+				pendingCaseHandoverRequestId !== null && (
+					<CaseHandoverConsentCard
+						isSubmitting={caseHandoverConsentSubmitting}
+						error={caseHandoverConsentError}
+						onApprove={() =>
+							handleCaseHandoverConsentDecision(true)
+						}
+						onDecline={() =>
+							handleCaseHandoverConsentDecision(false)
+						}
+					/>
+				)}
 			{showTeamDiscussion && (
 				<TeamDiscussionPanel
 					key={activeSession.item.id}

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -2641,6 +2641,8 @@
 			"title": "Mehrfach-Zugriffsanfrage"
 		},
 		"consent": {
+			"title": "Eine Beratungskraft bittet um Zugriff auf diese Unterhaltung",
+			"copy": "Bitte geben Sie den Zugriff frei oder lehnen Sie ihn ab, damit die Fallübergabe fortgesetzt werden kann.",
 			"approve": "Zugriff freigeben",
 			"decline": "Zugriff ablehnen"
 		},

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -2581,6 +2581,8 @@
 			"title": "Batch access request"
 		},
 		"consent": {
+			"title": "A counsellor requested access to this conversation",
+			"copy": "Please approve or decline the request to continue the handover.",
 			"approve": "Approve access",
 			"decline": "Decline access"
 		},


### PR DESCRIPTION
## Why

When a case-handover request requires client consent, the asker had no way to answer it inside the conversation — the request stalled until they found the separate surface. This lands the rescued WIP branch `save/case-handover-uat-fix-wip` as a finished feature.

## What

- New `CaseHandoverConsentCard` (in `src/components/caseHandover/CaseHandoverClientCards.tsx`, plus styles and a Storybook story): an inline system-message card with Approve / Decline actions, submitting state, and an error line.
- Wired into `SessionStream`: a pending `case.handover.consent.requested` notification for the active session renders the card above the stream; a decision calls `apiDecideCaseHandoverClientConsent`, marks the notification read, and refreshes the feed. The card is only shown to askers in 1:1 sessions.
- Already-answered guard: notifications with `readAt` set never resurface the card on remount (one-line filter added on top of the rescued branch).
- Rebased onto `pre-dev`; adopted the upstream `caseHandoverCurtainNeeded` / `caseHandoverGateNeeded` split from the supervision work.
- i18n complete (de + en): `caseHandover.consent.{title,copy,approve,decline}` and `caseHandover.error.failed`.

## Testing

- `npx vitest run src/components/session/SessionStream.test.tsx` — 12/12 passed (was 10 on the rescued branch; added the two missing acceptance paths: decline updates the request and removes the card; an already-answered read notification does not render the card).
- `npx tsc --noEmit` — clean.
- Coverage now spans all four #954 acceptance paths: render, approve, decline, already-answered.

Closes OpenResilienceInitiative/ORISO-Frontend#954
Refs OpenResilienceInitiative/ORISO-Frontend#496

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-session consent prompts for counsellor case handover requests.
  * Users can approve or decline requests directly within eligible conversations.
  * Added loading and accessible error states during consent decisions.
  * Added English and German translations for the consent prompt.

* **Tests**
  * Added coverage for approving, declining, and dismissing previously read consent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->