### PR TITLE
chore(storybook): add generated icon and avatar catalog page

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,9 +246,11 @@
 		"dtsgen": "ts-node dtsgen.ts",
 		"prepare": "husky install",
 		"browserstack": "browserstack-cypress run --sync --env BROWSER=none,REACT_APP_API_URL=http://127.0.0.1:9001,HTTPS=0,PORT=9001,WDS_SOCKET_PORT=9001",
+		"generate:icon-catalog": "node scripts/generateIconCatalog.mjs",
+		"prestorybook": "npm run generate:icon-catalog",
 		"storybook": "storybook dev -p 6006",
 		"typecheck:storybook": "tsc --noEmit --project tsconfig.storybook.json",
-		"prebuild-storybook": "npm run typecheck:storybook",
+		"prebuild-storybook": "npm run generate:icon-catalog && npm run typecheck:storybook",
 		"build-storybook": "storybook build",
 		"generate:call-theme": "vite-node -c vitest.config.mts scripts/generate-call-theme.ts"
 	},

--- a/scripts/generateIconCatalog.mjs
+++ b/scripts/generateIconCatalog.mjs
@@ -1,0 +1,204 @@
+/**
+ * Icon catalog generator for the Storybook "Design System/Icons & Avatars" page.
+ *
+ * Scans the repository asset roots (UI icons, MD3 topic icons, legacy pseudonym
+ * animals, anon-animal avatars) and cross-references every asset against the
+ * app source (excluding tests and Storybook files) to mark it as `app-used`
+ * or `catalogued-only`. The output is deterministic for a given tree.
+ *
+ * Regenerate with:
+ *   npm run generate:icon-catalog
+ * (also runs automatically via the `prestorybook` and `prebuild-storybook`
+ * hooks). Commit the refreshed
+ * `src/components/IconCatalog/iconCatalog.generated.json` whenever assets or
+ * their usages change.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import * as prettier from 'prettier';
+
+const repoRoot = process.cwd();
+const outputPath = path.join(
+	repoRoot,
+	'src/components/IconCatalog/iconCatalog.generated.json'
+);
+
+const assetRoots = [
+	'src/resources/img/icons',
+	'src/resources/img/registration-md3/icons',
+	'src/components/pseudonym/animals',
+	'public/static/anon-animals'
+];
+
+const sourceExtensions = new Set([
+	'.ts',
+	'.tsx',
+	'.js',
+	'.jsx',
+	'.scss',
+	'.sass',
+	'.less',
+	'.css'
+]);
+const assetExtensions = new Set(['.svg', '.png', '.jpg', '.jpeg', '.webp']);
+
+const walk = (directory) => {
+	if (!fs.existsSync(directory)) return [];
+	return fs
+		.readdirSync(directory, { withFileTypes: true })
+		.flatMap((entry) => {
+			const absolutePath = path.join(directory, entry.name);
+			return entry.isDirectory() ? walk(absolutePath) : [absolutePath];
+		});
+};
+
+const toRepoPath = (absolutePath) =>
+	path.relative(repoRoot, absolutePath).split(path.sep).join('/');
+
+const sourceFiles = walk(path.join(repoRoot, 'src')).filter((absolutePath) => {
+	const repoPath = toRepoPath(absolutePath);
+	return (
+		sourceExtensions.has(path.extname(absolutePath)) &&
+		!repoPath.includes('/IconCatalog/') &&
+		!repoPath.match(/\.(stories|test|spec)\.[^.]+$/)
+	);
+});
+
+const sourceContents = sourceFiles.map((absolutePath) => ({
+	path: toRepoPath(absolutePath),
+	content: fs.readFileSync(absolutePath, 'utf8')
+}));
+
+const barrelPath = path.join(repoRoot, 'src/resources/img/icons.ts');
+const barrelAliases = new Map();
+if (fs.existsSync(barrelPath)) {
+	const barrel = fs.readFileSync(barrelPath, 'utf8');
+	for (const match of barrel.matchAll(
+		/export\s*\{\s*ReactComponent\s+as\s+([A-Za-z0-9_]+)\s*\}\s*from\s*['"]([^'"]+\.svg)['"]/g
+	)) {
+		const [, alias, source] = match;
+		const fileName = path.basename(source);
+		barrelAliases.set(fileName, [
+			...(barrelAliases.get(fileName) ?? []),
+			alias
+		]);
+	}
+}
+
+const normalizeFamily = (fileName) =>
+	path
+		.basename(fileName, path.extname(fileName))
+		.toLowerCase()
+		.replace(
+			/(?:^|[_\s-])(200|400|filled|active|inactive|hover|outline)(?=[_\s-]|$)/g,
+			'_'
+		)
+		.replace(/[_\s-](?:20|24|32|40|48)(?:px)?$/g, '')
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+
+const getState = (fileName) => {
+	const normalized = path
+		.basename(fileName, path.extname(fileName))
+		.toLowerCase();
+	if (/(?:^|[_\s-])(filled|active)(?=[_\s-]|$)/.test(normalized))
+		return 'filled';
+	if (/(?:^|[_\s-])400(?=[_\s-]|$)/.test(normalized)) return '400';
+	if (/(?:^|[_\s-])200(?=[_\s-]|$)/.test(normalized)) return '200';
+	if (/(?:^|[_\s-])hover(?=[_\s-]|$)/.test(normalized)) return 'hover';
+	if (/(?:^|[_\s-])(outline|inactive)(?=[_\s-]|$)/.test(normalized))
+		return 'outline';
+	return 'base';
+};
+
+const getRole = (state) => {
+	if (state === 'filled') return 'selected';
+	if (state === '200') return 'alternate-outline';
+	if (state === 'hover') return 'hover';
+	return 'default';
+};
+
+const getKind = (repoPath) => {
+	if (repoPath.startsWith('public/static/anon-animals/'))
+		return 'client-avatar';
+	if (repoPath.startsWith('src/components/pseudonym/animals/'))
+		return 'legacy-client-avatar';
+	if (
+		repoPath.includes('/registration-md3/icons/t-') ||
+		repoPath.includes('/registration-md3/icons/cat-')
+	) {
+		return 'topic-icon';
+	}
+	if (
+		repoPath.includes('/navigation/') ||
+		/\/(?:drafts|inbox|language|logout|messages|profil|teams)_(?:filled|outline)\./.test(
+			repoPath
+		)
+	) {
+		return 'sidebar-icon';
+	}
+	return 'ui-icon';
+};
+
+const getSize = (fileName) => {
+	const match = path
+		.basename(fileName, path.extname(fileName))
+		.match(/[_\s-](20|24|32|40|48)(?:px)?$/i);
+	return match ? Number(match[1]) : null;
+};
+
+const assetPaths = assetRoots
+	.flatMap((root) => walk(path.join(repoRoot, root)))
+	.filter((absolutePath) =>
+		assetExtensions.has(path.extname(absolutePath).toLowerCase())
+	)
+	.map(toRepoPath)
+	.sort((a, b) => a.localeCompare(b));
+
+const entries = assetPaths.map((sourcePath) => {
+	const fileName = path.basename(sourcePath);
+	const kind = getKind(sourcePath);
+	const aliases = barrelAliases.get(fileName) ?? [];
+	const usageFiles = sourceContents
+		.filter(({ content }) => {
+			if (content.includes(fileName)) return true;
+			return aliases.some((alias) =>
+				new RegExp(`\\b${alias}\\b`).test(content)
+			);
+		})
+		.map(({ path: sourcePath }) => sourcePath)
+		.filter(
+			(sourcePath, index, values) => values.indexOf(sourcePath) === index
+		)
+		.sort((a, b) => a.localeCompare(b));
+	const state = getState(fileName);
+
+	return {
+		id: `${kind}:${normalizeFamily(fileName)}:${state}`,
+		family: normalizeFamily(fileName),
+		state,
+		role: getRole(state),
+		kind,
+		size: getSize(fileName),
+		fileName,
+		sourcePath,
+		exportNames: aliases,
+		usageFiles,
+		usage: usageFiles.length > 0 ? 'app-used' : 'catalogued-only'
+	};
+});
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+// Format with the repository Prettier config so the lint-staged prettier pass
+// leaves the generated file byte-identical (regeneration stays reproducible).
+const prettierConfig = await prettier.resolveConfig(outputPath);
+const formatted = await prettier.format(JSON.stringify(entries), {
+	...prettierConfig,
+	parser: 'json'
+});
+fs.writeFileSync(outputPath, formatted);
+
+const usedCount = entries.filter(({ usage }) => usage === 'app-used').length;
+console.log(
+	`Generated ${entries.length} icon catalog entries (${usedCount} app-used).`
+);

--- a/src/components/IconCatalog/IconCatalog.stories.tsx
+++ b/src/components/IconCatalog/IconCatalog.stories.tsx
@@ -1,0 +1,352 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+import { useMemo, useState } from 'react';
+import catalog from './iconCatalog.generated.json';
+import './iconCatalog.styles.scss';
+
+type CatalogEntry = (typeof catalog)[number];
+type FilterValue =
+	| 'all'
+	| CatalogEntry['kind']
+	| CatalogEntry['state']
+	| CatalogEntry['usage'];
+
+const uiIconUrls = import.meta.glob(
+	'../../resources/img/icons/**/*.{svg,png,jpg,jpeg,webp}',
+	{
+		eager: true,
+		query: '?url',
+		import: 'default'
+	}
+) as Record<string, string>;
+const topicIconUrls = import.meta.glob(
+	'../../resources/img/registration-md3/icons/**/*.{svg,png,jpg,jpeg,webp}',
+	{
+		eager: true,
+		query: '?url',
+		import: 'default'
+	}
+) as Record<string, string>;
+const legacyAvatarUrls = import.meta.glob(
+	'../pseudonym/animals/**/*.{svg,png,jpg,jpeg,webp}',
+	{
+		eager: true,
+		query: '?url',
+		import: 'default'
+	}
+) as Record<string, string>;
+
+const toSourcePath = (globPath: string) => {
+	if (globPath.startsWith('../../'))
+		return `src/${globPath.slice('../../'.length)}`;
+	if (globPath.startsWith('../'))
+		return `src/components/${globPath.slice('../'.length)}`;
+	return globPath;
+};
+
+const assetUrls = new Map(
+	Object.entries({
+		...uiIconUrls,
+		...topicIconUrls,
+		...legacyAvatarUrls
+	}).map(([globPath, url]) => [toSourcePath(globPath), url])
+);
+
+const figmaReferences = [
+	{
+		label: '24px icon baseline (431 Figma symbols)',
+		href: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=55594-2485&m=dev'
+	},
+	{
+		label: 'Sidebar icons, including 200 / 400 / filled (32 symbols)',
+		href: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=61102-6480&m=dev'
+	},
+	{
+		label: 'Default topic icons (29 assets)',
+		href: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=61093-22600&m=dev'
+	},
+	{
+		label: 'Client avatar source set (64 animals)',
+		href: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=61391-5229&m=dev'
+	},
+	{
+		label: 'Consultant avatar source set (64 animals)',
+		href: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=61391-5556&m=dev'
+	}
+];
+
+const aiPrompt = `Use only an asset from the ORISO Storybook icon catalog.
+
+Selection rules:
+1. Use the exact catalog ID or sourcePath named in the task; do not substitute a similar MUI icon, emoji, Unicode glyph, or hand-written SVG.
+2. For ordinary UI, prefer the 400 variant as the default outline state. Use filled for selected/active. Use 200 only when the linked Figma component or an existing ORISO interaction explicitly calls for the lighter outline.
+3. Sidebar items are the exception: verify all available 200, 400, and filled states against the sidebar Figma node before editing the navigation.
+4. Topic icons and client/consultant avatars are separate asset families; do not replace them with ordinary UI icons.
+5. Before changing code, confirm the exact sourcePath and inspect the listed usageFiles. Reuse the existing export name when one is available.
+6. After implementation, verify the component in Storybook and, when it affects a real flow, in the running app as a separate evidence step.
+
+Return the chosen catalog ID, sourcePath, state mapping, and verification performed.`;
+
+const kindLabels: Record<CatalogEntry['kind'], string> = {
+	'ui-icon': 'UI icon',
+	'sidebar-icon': 'Sidebar',
+	'topic-icon': 'Topic',
+	'client-avatar': 'Client avatar',
+	'legacy-client-avatar': 'Legacy avatar'
+};
+
+const resolveAssetUrl = (entry: CatalogEntry) => {
+	if (entry.sourcePath.startsWith('public/')) {
+		return `/${entry.sourcePath.slice('public/'.length)}`;
+	}
+	return assetUrls.get(entry.sourcePath);
+};
+
+const copyText = async (text: string) => {
+	await navigator.clipboard.writeText(text);
+};
+
+function IconCatalog() {
+	const [query, setQuery] = useState('');
+	const [kind, setKind] = useState<FilterValue>('all');
+	const [state, setState] = useState<FilterValue>('all');
+	const [usage, setUsage] = useState<FilterValue>('all');
+	const [copied, setCopied] = useState<string | null>(null);
+
+	const visibleEntries = useMemo(() => {
+		const normalizedQuery = query.trim().toLowerCase();
+		return catalog.filter((entry) => {
+			const matchesQuery =
+				!normalizedQuery ||
+				[
+					entry.id,
+					entry.family,
+					entry.fileName,
+					entry.sourcePath,
+					...entry.exportNames
+				]
+					.join(' ')
+					.toLowerCase()
+					.includes(normalizedQuery);
+			return (
+				matchesQuery &&
+				(kind === 'all' || entry.kind === kind) &&
+				(state === 'all' || entry.state === state) &&
+				(usage === 'all' || entry.usage === usage)
+			);
+		});
+	}, [kind, query, state, usage]);
+
+	const appUsedCount = catalog.filter(
+		(entry) => entry.usage === 'app-used'
+	).length;
+
+	const handleCopy = async (key: string, value: string) => {
+		await copyText(value);
+		setCopied(key);
+		window.setTimeout(() => setCopied(null), 1600);
+	};
+
+	return (
+		<main className="iconCatalog">
+			<header className="iconCatalog__header">
+				<div>
+					<p className="iconCatalog__eyebrow">
+						ORISO Frontend · generated from the repository
+					</p>
+					<h1>Icons, topics and avatars</h1>
+					<p>
+						<strong>400</strong> is the normal outline baseline,{' '}
+						<strong>filled</strong> is selected/active, and{' '}
+						<strong>200</strong> is an explicit lighter outline.
+						Sidebar components may define all three.
+					</p>
+				</div>
+				<button
+					type="button"
+					className="iconCatalog__primaryAction"
+					onClick={() => handleCopy('ai-prompt', aiPrompt)}
+				>
+					{copied === 'ai-prompt'
+						? 'Prompt copied'
+						: 'Copy AI selection prompt'}
+				</button>
+			</header>
+
+			<section
+				className="iconCatalog__summary"
+				aria-label="Catalog summary"
+			>
+				<div>
+					<strong>{catalog.length}</strong>
+					<span>repository assets</span>
+				</div>
+				<div>
+					<strong>{appUsedCount}</strong>
+					<span>referenced by app source</span>
+				</div>
+				<div>
+					<strong>{catalog.length - appUsedCount}</strong>
+					<span>catalogued only</span>
+				</div>
+				<div>
+					<strong>{visibleEntries.length}</strong>
+					<span>currently shown</span>
+				</div>
+			</section>
+
+			<details className="iconCatalog__references">
+				<summary>Figma reference sets</summary>
+				<ul>
+					{figmaReferences.map((reference) => (
+						<li key={reference.href}>
+							<a
+								href={reference.href}
+								target="_blank"
+								rel="noreferrer"
+							>
+								{reference.label}
+							</a>
+						</li>
+					))}
+				</ul>
+			</details>
+
+			<section
+				className="iconCatalog__filters"
+				aria-label="Filter icon catalog"
+			>
+				<label>
+					Search
+					<input
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+						placeholder="ID, filename, export or path"
+					/>
+				</label>
+				<label>
+					Family
+					<select
+						value={kind}
+						onChange={(event) =>
+							setKind(event.target.value as FilterValue)
+						}
+					>
+						<option value="all">All</option>
+						{Object.entries(kindLabels).map(([value, label]) => (
+							<option key={value} value={value}>
+								{label}
+							</option>
+						))}
+					</select>
+				</label>
+				<label>
+					State
+					<select
+						value={state}
+						onChange={(event) =>
+							setState(event.target.value as FilterValue)
+						}
+					>
+						<option value="all">All</option>
+						{[
+							'base',
+							'200',
+							'400',
+							'filled',
+							'outline',
+							'hover'
+						].map((value) => (
+							<option key={value} value={value}>
+								{value}
+							</option>
+						))}
+					</select>
+				</label>
+				<label>
+					Usage
+					<select
+						value={usage}
+						onChange={(event) =>
+							setUsage(event.target.value as FilterValue)
+						}
+					>
+						<option value="all">All</option>
+						<option value="app-used">App-used</option>
+						<option value="catalogued-only">Catalogued only</option>
+					</select>
+				</label>
+			</section>
+
+			<section className="iconCatalog__grid" aria-live="polite">
+				{visibleEntries.map((entry) => {
+					const assetUrl = resolveAssetUrl(entry);
+					const selectionPrompt = `Use ORISO icon ${entry.id} from ${entry.sourcePath}. Treat it as ${entry.role}. Do not substitute or redraw it.`;
+					return (
+						<article
+							className="iconCatalog__card"
+							key={entry.sourcePath}
+						>
+							<div
+								className={`iconCatalog__preview iconCatalog__preview--${entry.kind}`}
+							>
+								{assetUrl ? (
+									<img src={assetUrl} alt="" />
+								) : (
+									<span>Preview unavailable</span>
+								)}
+							</div>
+							<div className="iconCatalog__badges">
+								<span>{kindLabels[entry.kind]}</span>
+								<span>{entry.state}</span>
+								<span>{entry.usage}</span>
+							</div>
+							<h2>{entry.id}</h2>
+							<code>{entry.sourcePath}</code>
+							{entry.exportNames.length > 0 && (
+								<p>Export: {entry.exportNames.join(', ')}</p>
+							)}
+							<p>
+								{entry.usageFiles.length} app reference
+								{entry.usageFiles.length === 1 ? '' : 's'}
+							</p>
+							<button
+								type="button"
+								onClick={() =>
+									handleCopy(
+										entry.sourcePath,
+										selectionPrompt
+									)
+								}
+							>
+								{copied === entry.sourcePath
+									? 'Copied'
+									: 'Copy selection'}
+							</button>
+						</article>
+					);
+				})}
+			</section>
+		</main>
+	);
+}
+
+const meta = {
+	title: 'Design System/Icons & Avatars',
+	component: IconCatalog,
+	parameters: {
+		layout: 'fullscreen',
+		design: { type: 'figma', url: figmaReferences[0].href },
+		docs: {
+			description: {
+				component:
+					'Searchable, machine-readable catalog generated from ORISO Frontend assets. App-used excludes tests and Storybook-only references. Data lives in `src/components/IconCatalog/iconCatalog.generated.json`; regenerate it with `npm run generate:icon-catalog` (runs automatically before `storybook` and `build-storybook`) and commit the result whenever assets or their usages change.'
+			}
+		}
+	}
+} satisfies Meta<typeof IconCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};

--- a/src/components/IconCatalog/iconCatalog.generated.json
+++ b/src/components/IconCatalog/iconCatalog.generated.json
@@ -1,0 +1,4537 @@
+[
+	{
+		"id": "client-avatar:alpaca:base",
+		"family": "alpaca",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "alpaca.svg",
+		"sourcePath": "public/static/anon-animals/alpaca.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:ant:base",
+		"family": "ant",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "ant.svg",
+		"sourcePath": "public/static/anon-animals/ant.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/message/FurtherSteps.tsx",
+			"src/utils/anonName/data.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:antelope:base",
+		"family": "antelope",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "antelope.svg",
+		"sourcePath": "public/static/anon-animals/antelope.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:bear:base",
+		"family": "bear",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "bear.svg",
+		"sourcePath": "public/static/anon-animals/bear.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:bee:base",
+		"family": "bee",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "bee.svg",
+		"sourcePath": "public/static/anon-animals/bee.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:beetle:base",
+		"family": "beetle",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "beetle.svg",
+		"sourcePath": "public/static/anon-animals/beetle.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:butterfly:base",
+		"family": "butterfly",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "butterfly.svg",
+		"sourcePath": "public/static/anon-animals/butterfly.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:camel:base",
+		"family": "camel",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "camel.svg",
+		"sourcePath": "public/static/anon-animals/camel.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:cat:base",
+		"family": "cat",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "cat.svg",
+		"sourcePath": "public/static/anon-animals/cat.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:chameleon:base",
+		"family": "chameleon",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "chameleon.svg",
+		"sourcePath": "public/static/anon-animals/chameleon.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:coral:base",
+		"family": "coral",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "coral.svg",
+		"sourcePath": "public/static/anon-animals/coral.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:crane:base",
+		"family": "crane",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "crane.svg",
+		"sourcePath": "public/static/anon-animals/crane.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:deer:base",
+		"family": "deer",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "deer.svg",
+		"sourcePath": "public/static/anon-animals/deer.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:dog:base",
+		"family": "dog",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "dog.svg",
+		"sourcePath": "public/static/anon-animals/dog.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:dolphin:base",
+		"family": "dolphin",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "dolphin.svg",
+		"sourcePath": "public/static/anon-animals/dolphin.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:dragonfly:base",
+		"family": "dragonfly",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "dragonfly.svg",
+		"sourcePath": "public/static/anon-animals/dragonfly.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:duck:base",
+		"family": "duck",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "duck.svg",
+		"sourcePath": "public/static/anon-animals/duck.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:eagle:base",
+		"family": "eagle",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "eagle.svg",
+		"sourcePath": "public/static/anon-animals/eagle.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:firefly:base",
+		"family": "firefly",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "firefly.svg",
+		"sourcePath": "public/static/anon-animals/firefly.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:fish:base",
+		"family": "fish",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "fish.svg",
+		"sourcePath": "public/static/anon-animals/fish.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:fox:base",
+		"family": "fox",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "fox.svg",
+		"sourcePath": "public/static/anon-animals/fox.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:frog:base",
+		"family": "frog",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "frog.svg",
+		"sourcePath": "public/static/anon-animals/frog.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:gecko:base",
+		"family": "gecko",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "gecko.svg",
+		"sourcePath": "public/static/anon-animals/gecko.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:giraffe:base",
+		"family": "giraffe",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "giraffe.svg",
+		"sourcePath": "public/static/anon-animals/giraffe.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:guinea-pig:base",
+		"family": "guinea-pig",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "guinea-pig.svg",
+		"sourcePath": "public/static/anon-animals/guinea-pig.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:hare:base",
+		"family": "hare",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "hare.svg",
+		"sourcePath": "public/static/anon-animals/hare.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:hawk:base",
+		"family": "hawk",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "hawk.svg",
+		"sourcePath": "public/static/anon-animals/hawk.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:hedgehog:base",
+		"family": "hedgehog",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "hedgehog.svg",
+		"sourcePath": "public/static/anon-animals/hedgehog.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:horse:base",
+		"family": "horse",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "horse.svg",
+		"sourcePath": "public/static/anon-animals/horse.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:hummingbird:base",
+		"family": "hummingbird",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "hummingbird.svg",
+		"sourcePath": "public/static/anon-animals/hummingbird.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:kangaroo:base",
+		"family": "kangaroo",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "kangaroo.svg",
+		"sourcePath": "public/static/anon-animals/kangaroo.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:koala:base",
+		"family": "koala",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "koala.svg",
+		"sourcePath": "public/static/anon-animals/koala.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:ladybird:base",
+		"family": "ladybird",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "ladybird.svg",
+		"sourcePath": "public/static/anon-animals/ladybird.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:lamb:base",
+		"family": "lamb",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "lamb.svg",
+		"sourcePath": "public/static/anon-animals/lamb.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:lark:base",
+		"family": "lark",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "lark.svg",
+		"sourcePath": "public/static/anon-animals/lark.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:lion:base",
+		"family": "lion",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "lion.svg",
+		"sourcePath": "public/static/anon-animals/lion.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:magpie:base",
+		"family": "magpie",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "magpie.svg",
+		"sourcePath": "public/static/anon-animals/magpie.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:mouflon:base",
+		"family": "mouflon",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "mouflon.svg",
+		"sourcePath": "public/static/anon-animals/mouflon.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:mouse:base",
+		"family": "mouse",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "mouse.svg",
+		"sourcePath": "public/static/anon-animals/mouse.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:nightingale:base",
+		"family": "nightingale",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "Nightingale.svg",
+		"sourcePath": "public/static/anon-animals/Nightingale.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:okapi:base",
+		"family": "okapi",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "okapi.svg",
+		"sourcePath": "public/static/anon-animals/okapi.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:otter:base",
+		"family": "otter",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "otter.svg",
+		"sourcePath": "public/static/anon-animals/otter.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:owl:base",
+		"family": "owl",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "owl.svg",
+		"sourcePath": "public/static/anon-animals/owl.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:panda:base",
+		"family": "panda",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "panda.svg",
+		"sourcePath": "public/static/anon-animals/panda.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:parrot:base",
+		"family": "parrot",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "parrot.svg",
+		"sourcePath": "public/static/anon-animals/parrot.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:penguin:base",
+		"family": "penguin",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "penguin.svg",
+		"sourcePath": "public/static/anon-animals/penguin.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:platypus:base",
+		"family": "platypus",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "platypus.svg",
+		"sourcePath": "public/static/anon-animals/platypus.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:puppy:base",
+		"family": "puppy",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "puppy.svg",
+		"sourcePath": "public/static/anon-animals/puppy.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:rabbit:base",
+		"family": "rabbit",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "rabbit.svg",
+		"sourcePath": "public/static/anon-animals/rabbit.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:raven:base",
+		"family": "raven",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "raven.svg",
+		"sourcePath": "public/static/anon-animals/raven.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:seahorse:base",
+		"family": "seahorse",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "seahorse.svg",
+		"sourcePath": "public/static/anon-animals/seahorse.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:seal:base",
+		"family": "seal",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "seal.svg",
+		"sourcePath": "public/static/anon-animals/seal.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:sparrow:base",
+		"family": "sparrow",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "sparrow.svg",
+		"sourcePath": "public/static/anon-animals/sparrow.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:squirrel:base",
+		"family": "squirrel",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "squirrel.svg",
+		"sourcePath": "public/static/anon-animals/squirrel.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:stork:base",
+		"family": "stork",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "stork.svg",
+		"sourcePath": "public/static/anon-animals/stork.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:swallow:base",
+		"family": "swallow",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "swallow.svg",
+		"sourcePath": "public/static/anon-animals/swallow.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:swan:base",
+		"family": "swan",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "swan.svg",
+		"sourcePath": "public/static/anon-animals/swan.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:trout:base",
+		"family": "trout",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "trout.svg",
+		"sourcePath": "public/static/anon-animals/trout.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:turtle:base",
+		"family": "turtle",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "turtle.svg",
+		"sourcePath": "public/static/anon-animals/turtle.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:wolf:base",
+		"family": "wolf",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "wolf.svg",
+		"sourcePath": "public/static/anon-animals/wolf.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:yak:base",
+		"family": "yak",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "yak.svg",
+		"sourcePath": "public/static/anon-animals/yak.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "client-avatar:zebra:base",
+		"family": "zebra",
+		"state": "base",
+		"role": "default",
+		"kind": "client-avatar",
+		"size": null,
+		"fileName": "zebra.svg",
+		"sourcePath": "public/static/anon-animals/zebra.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:bear:base",
+		"family": "bear",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "bear.svg",
+		"sourcePath": "src/components/pseudonym/animals/bear.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:butterfly:base",
+		"family": "butterfly",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "butterfly.svg",
+		"sourcePath": "src/components/pseudonym/animals/butterfly.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:cat:base",
+		"family": "cat",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "cat.svg",
+		"sourcePath": "src/components/pseudonym/animals/cat.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:chameleon:base",
+		"family": "chameleon",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "chameleon.svg",
+		"sourcePath": "src/components/pseudonym/animals/chameleon.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:dolphin:base",
+		"family": "dolphin",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "dolphin.svg",
+		"sourcePath": "src/components/pseudonym/animals/dolphin.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:firefly:base",
+		"family": "firefly",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "firefly.svg",
+		"sourcePath": "src/components/pseudonym/animals/firefly.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:fox:base",
+		"family": "fox",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "fox.svg",
+		"sourcePath": "src/components/pseudonym/animals/fox.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:frog:base",
+		"family": "frog",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "frog.svg",
+		"sourcePath": "src/components/pseudonym/animals/frog.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:hedgehog:base",
+		"family": "hedgehog",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "hedgehog.svg",
+		"sourcePath": "src/components/pseudonym/animals/hedgehog.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:hummingbird:base",
+		"family": "hummingbird",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "hummingbird.svg",
+		"sourcePath": "src/components/pseudonym/animals/hummingbird.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:koala:base",
+		"family": "koala",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "koala.svg",
+		"sourcePath": "src/components/pseudonym/animals/koala.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:otter:base",
+		"family": "otter",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "otter.svg",
+		"sourcePath": "src/components/pseudonym/animals/otter.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:owl:base",
+		"family": "owl",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "owl.svg",
+		"sourcePath": "src/components/pseudonym/animals/owl.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:panda:base",
+		"family": "panda",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "panda.svg",
+		"sourcePath": "src/components/pseudonym/animals/panda.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:penguin:base",
+		"family": "penguin",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "penguin.svg",
+		"sourcePath": "src/components/pseudonym/animals/penguin.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:rabbit:base",
+		"family": "rabbit",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "rabbit.svg",
+		"sourcePath": "src/components/pseudonym/animals/rabbit.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:seahorse:base",
+		"family": "seahorse",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "seahorse.svg",
+		"sourcePath": "src/components/pseudonym/animals/seahorse.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:squirrel:base",
+		"family": "squirrel",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "squirrel.svg",
+		"sourcePath": "src/components/pseudonym/animals/squirrel.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:swan:base",
+		"family": "swan",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "swan.svg",
+		"sourcePath": "src/components/pseudonym/animals/swan.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "legacy-client-avatar:turtle:base",
+		"family": "turtle",
+		"state": "base",
+		"role": "default",
+		"kind": "legacy-client-avatar",
+		"size": null,
+		"fileName": "turtle.svg",
+		"sourcePath": "src/components/pseudonym/animals/turtle.svg",
+		"exportNames": [],
+		"usageFiles": ["src/utils/anonName/data.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:add-shield:base",
+		"family": "add-shield",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "add-shield.svg",
+		"sourcePath": "src/resources/img/icons/add-shield.svg",
+		"exportNames": ["AddShieldIcon"],
+		"usageFiles": ["src/resources/img/icons.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:add:base",
+		"family": "add",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "add.svg",
+		"sourcePath": "src/resources/img/icons/add.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:apple:base",
+		"family": "apple",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "apple.svg",
+		"sourcePath": "src/resources/img/icons/apple.svg",
+		"exportNames": ["AppleIcon"],
+		"usageFiles": [
+			"src/containers/bookings/components/AddCalendar/addCalendar.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-double-down:base",
+		"family": "arrow-double-down",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-double-down.svg",
+		"sourcePath": "src/resources/img/icons/arrow-double-down.svg",
+		"exportNames": ["ArrowDoubleDownIcon"],
+		"usageFiles": [
+			"src/components/session/SessionItemComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-down-light:base",
+		"family": "arrow-down-light",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-down-light.svg",
+		"sourcePath": "src/resources/img/icons/arrow-down-light.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/select/LanguageSelectDropdown.tsx",
+			"src/components/select/SelectDropdown.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-down:base",
+		"family": "arrow-down",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-down.svg",
+		"sourcePath": "src/resources/img/icons/arrow-down.svg",
+		"exportNames": ["ArrowDownIcon"],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/select/LanguageSelectDropdown.tsx",
+			"src/components/select/select.styles.scss",
+			"src/components/select/select2.styles.scss",
+			"src/components/select/SelectDropdown.tsx",
+			"src/containers/bookings/components/BookingDescription/bookingDescription.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-forward:base",
+		"family": "arrow-forward",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-forward.svg",
+		"sourcePath": "src/resources/img/icons/arrow-forward.svg",
+		"exportNames": ["ArrowForwardIcon"],
+		"usageFiles": ["src/resources/img/icons.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-left:base",
+		"family": "arrow-left",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-left.svg",
+		"sourcePath": "src/resources/img/icons/arrow-left.svg",
+		"exportNames": ["BackIcon"],
+		"usageFiles": [
+			"src/components/askerInfo/AskerInfo.tsx",
+			"src/components/conversationCreate/BackPill.tsx",
+			"src/components/datepicker/datepicker.styles.scss",
+			"src/components/groupChat/GroupChatInfo.tsx",
+			"src/components/profile/Profile.tsx",
+			"src/components/sessionHeader/GroupChatHeader/index.tsx",
+			"src/components/sessionHeader/SessionHeaderComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-right-m3:base",
+		"family": "arrow-right-m3",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-right-m3.svg",
+		"sourcePath": "src/resources/img/icons/arrow-right-m3.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-right:base",
+		"family": "arrow-right",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-right.svg",
+		"sourcePath": "src/resources/img/icons/arrow-right.svg",
+		"exportNames": ["ArrowRightIcon"],
+		"usageFiles": [
+			"src/components/datepicker/datepicker.styles.scss",
+			"src/components/mobile/linkMenu/LinkMenu.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-up-light:base",
+		"family": "arrow-up-light",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-up-light.svg",
+		"sourcePath": "src/resources/img/icons/arrow-up-light.svg",
+		"exportNames": ["ArrowUpIcon"],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/select/LanguageSelectDropdown.tsx",
+			"src/components/select/SelectDropdown.tsx",
+			"src/containers/bookings/components/BookingDescription/bookingDescription.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:arrow-up:base",
+		"family": "arrow-up",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "arrow-up.svg",
+		"sourcePath": "src/resources/img/icons/arrow-up.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/containers/bookings/components/BookingDescription/bookingDescription.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:audio-off:base",
+		"family": "audio-off",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "audio-off.svg",
+		"sourcePath": "src/resources/img/icons/audio-off.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:audio-on:base",
+		"family": "audio-on",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "audio-on.svg",
+		"sourcePath": "src/resources/img/icons/audio-on.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:bell-off:base",
+		"family": "bell-off",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "bell-off.svg",
+		"sourcePath": "src/resources/img/icons/bell-off.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/NavigationBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:breath-level-emojis:base",
+		"family": "breath-level-emojis",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "breath-level-emojis.svg",
+		"sourcePath": "src/resources/img/icons/breath-level-emojis.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/session/SessionItemComponent.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:caldav:base",
+		"family": "caldav",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "caldav.svg",
+		"sourcePath": "src/resources/img/icons/caldav.svg",
+		"exportNames": ["CalDav"],
+		"usageFiles": [
+			"src/containers/bookings/components/AddCalendar/addCalendar.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar:filled",
+		"family": "calendar",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar_filled.svg",
+		"sourcePath": "src/resources/img/icons/calendar_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar:outline",
+		"family": "calendar",
+		"state": "outline",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar_outline.svg",
+		"sourcePath": "src/resources/img/icons/calendar_outline.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-cancel:base",
+		"family": "calendar-cancel",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-cancel.svg",
+		"sourcePath": "src/resources/img/icons/calendar-cancel.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/message/Appointment.tsx",
+			"src/containers/bookings/components/Event/event.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-check:base",
+		"family": "calendar-check",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-check.svg",
+		"sourcePath": "src/resources/img/icons/calendar-check.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/message/Appointment.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-ics:base",
+		"family": "calendar-ics",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-ics.svg",
+		"sourcePath": "src/resources/img/icons/calendar-ics.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/downloadICSFile/downloadICSFile.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-month-navigation:base",
+		"family": "calendar-month-navigation",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-month-navigation.svg",
+		"sourcePath": "src/resources/img/icons/calendar-month-navigation.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-month:base",
+		"family": "calendar-month",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-month.svg",
+		"sourcePath": "src/resources/img/icons/calendar-month.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:calendar-plus:base",
+		"family": "calendar-plus",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-plus.svg",
+		"sourcePath": "src/resources/img/icons/calendar-plus.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/containers/bookings/components/BookingEvents/bookingEvents.tsx",
+			"src/containers/bookings/components/NoBookings/noBookingsBooked.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar-reschedule:base",
+		"family": "calendar-reschedule",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar-reschedule.svg",
+		"sourcePath": "src/resources/img/icons/calendar-reschedule.svg",
+		"exportNames": [],
+		"usageFiles": ["src/containers/bookings/components/Event/event.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:calendar:base",
+		"family": "calendar",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "calendar.svg",
+		"sourcePath": "src/resources/img/icons/calendar.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/ScheduleRows.tsx",
+			"src/components/datepicker/datepicker.styles.scss",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:call-off:base",
+		"family": "call-off",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "call-off.svg",
+		"sourcePath": "src/resources/img/icons/call-off.svg",
+		"exportNames": ["CallOffIcon"],
+		"usageFiles": [
+			"src/components/incomingVideoCall/IncomingVideoCall.tsx",
+			"src/components/message/SystemMessage.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/sessionsListItem/SessionListItemVideoCall.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:call-on:base",
+		"family": "call-on",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "call-on.svg",
+		"sourcePath": "src/resources/img/icons/call-on.svg",
+		"exportNames": ["CallOnIcon"],
+		"usageFiles": [
+			"src/components/incomingVideoCall/IncomingVideoCall.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:call:base",
+		"family": "call",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "call.svg",
+		"sourcePath": "src/resources/img/icons/call.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/message/VideoChatDetails/index.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/containers/bookings/components/Event/LocationType/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:camera-off:base",
+		"family": "camera-off",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "camera-off.svg",
+		"sourcePath": "src/resources/img/icons/camera-off.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:camera-on:base",
+		"family": "camera-on",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "camera-on.svg",
+		"sourcePath": "src/resources/img/icons/camera-on.svg",
+		"exportNames": ["CameraOnIcon"],
+		"usageFiles": [
+			"src/components/incomingVideoCall/IncomingVideoCall.tsx",
+			"src/containers/overview/components/BookingEvent/index.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:camera-plus:base",
+		"family": "camera-plus",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "camera-plus.svg",
+		"sourcePath": "src/resources/img/icons/camera-plus.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:case-accepted:base",
+		"family": "case-accepted",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "case-accepted.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/case-accepted.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/caseHandover/CaseHandoverClientCards.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:case-handover:base",
+		"family": "case-handover",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "case-handover.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/case-handover.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/session/CaseHandoverCurtain.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:data-policy:base",
+		"family": "data-policy",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "data-policy.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/data-policy.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:feature-access:base",
+		"family": "feature-access",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "feature-access.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/feature-access.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:front-hand:base",
+		"family": "front-hand",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "front-hand.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/front-hand.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:tutorial:base",
+		"family": "tutorial",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "tutorial.svg",
+		"sourcePath": "src/resources/img/icons/case-handover/tutorial.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/session/CaseHandoverCurtain.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:category-search:base",
+		"family": "category-search",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "category-search.svg",
+		"sourcePath": "src/resources/img/icons/category-search.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/CircleSettingsView.tsx",
+			"src/components/conversationCreate/CreateConversationView.tsx",
+			"src/components/conversationCreate/ScreenIntro.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:chat-booking:base",
+		"family": "chat-booking",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "chat-booking.svg",
+		"sourcePath": "src/resources/img/icons/chat-booking.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/containers/bookings/components/Event/LocationType/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:chat:base",
+		"family": "chat",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "chat.svg",
+		"sourcePath": "src/resources/img/icons/chat.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionsList/SessionToolbarFilterIcons.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:add-icon:base",
+		"family": "add-icon",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "add_icon.svg",
+		"sourcePath": "src/resources/img/icons/chatroom/add_icon.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionHeader/ChatroomMainInteractionIcon.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:internal-conversation:200",
+		"family": "internal-conversation",
+		"state": "200",
+		"role": "alternate-outline",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "internal_conversation_200.svg",
+		"sourcePath": "src/resources/img/icons/chatroom/internal_conversation_200.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionHeader/ChatroomMainInteractionIcon.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:live-conv-type:200",
+		"family": "live-conv-type",
+		"state": "200",
+		"role": "alternate-outline",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "live_conv_type_200.svg",
+		"sourcePath": "src/resources/img/icons/chatroom/live_conv_type_200.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionHeader/ChatroomMainInteractionIcon.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:nearby-conv-type:200",
+		"family": "nearby-conv-type",
+		"state": "200",
+		"role": "alternate-outline",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "nearby_conv_type_200.svg",
+		"sourcePath": "src/resources/img/icons/chatroom/nearby_conv_type_200.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionHeader/ChatroomMainInteractionIcon.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:check:base",
+		"family": "check",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "check.svg",
+		"sourcePath": "src/resources/img/icons/check.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/animatedIllustration/AnimatedIllustration.tsx",
+			"src/components/banUser/BanUser.tsx",
+			"src/components/conversationCreate/internal/PersonSelectMenu.tsx",
+			"src/components/message/Appointment.tsx",
+			"src/components/message/FurtherSteps.tsx",
+			"src/components/passwordResetRequest/PasswordResetSentView.tsx",
+			"src/components/profile/AskerAboutMeData.tsx",
+			"src/components/profile/DeleteAccount.tsx",
+			"src/components/session/DeleteSession.tsx",
+			"src/components/session/SessionStream.tsx",
+			"src/components/sessionMenu/sessionMenuHelpers.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:checkmark-circle:base",
+		"family": "checkmark-circle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "checkmark_circle.svg",
+		"sourcePath": "src/resources/img/icons/checkmark_circle.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:checkmark:filled",
+		"family": "checkmark",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "checkmark_filled.svg",
+		"sourcePath": "src/resources/img/icons/checkmark_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:checkmark-white:base",
+		"family": "checkmark-white",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "checkmark-white.svg",
+		"sourcePath": "src/resources/img/icons/checkmark-white.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notice/Notice.tsx",
+			"src/components/notifications/Notification.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:checkmark:base",
+		"family": "checkmark",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "checkmark.svg",
+		"sourcePath": "src/resources/img/icons/checkmark.svg",
+		"exportNames": ["CheckmarkIcon", "ValidIcon"],
+		"usageFiles": [
+			"src/components/checkbox/Checkbox.tsx",
+			"src/components/message/MessageMetaData.tsx",
+			"src/components/twoFactorAuth/TwoFactorAuthResendMail.tsx",
+			"src/containers/overview/components/EmptyState/index.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:clip:base",
+		"family": "clip",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "clip.svg",
+		"sourcePath": "src/resources/img/icons/clip.svg",
+		"exportNames": ["ClipIcon"],
+		"usageFiles": ["src/resources/img/icons.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:clock:base",
+		"family": "clock",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "clock.svg",
+		"sourcePath": "src/resources/img/icons/clock.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/ScheduleRows.tsx",
+			"src/components/datepicker/datepicker.styles.scss"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:close-circle:base",
+		"family": "close-circle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "close-circle.svg",
+		"sourcePath": "src/resources/img/icons/close-circle.svg",
+		"exportNames": ["CloseCircle"],
+		"usageFiles": [
+			"src/components/select/LanguageSelectDropdown.tsx",
+			"src/components/select/SelectDropdown.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:close:base",
+		"family": "close",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "close.svg",
+		"sourcePath": "src/resources/img/icons/close.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/internal/PersonSelectMenu.tsx",
+			"src/components/groupChat/RuleChipsEditor.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:corner-left-down:base",
+		"family": "corner-left-down",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "corner-left-down.svg",
+		"sourcePath": "src/resources/img/icons/corner-left-down.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:corner-right-up:base",
+		"family": "corner-right-up",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "corner-right-up.svg",
+		"sourcePath": "src/resources/img/icons/corner-right-up.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:corner-up-left:base",
+		"family": "corner-up-left",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "corner-up-left.svg",
+		"sourcePath": "src/resources/img/icons/corner-up-left.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/pseudonym/WaitingQueueActionBar.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:deleted:base",
+		"family": "deleted",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "deleted.svg",
+		"sourcePath": "src/resources/img/icons/deleted.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/message/MessageItemComponent.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:delivery-failed:base",
+		"family": "delivery-failed",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "delivery-failed.svg",
+		"sourcePath": "src/resources/img/icons/delivery-failed.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/message/MessageItemComponent.tsx",
+			"src/components/message/MessageSendFailed.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:delivery-read:base",
+		"family": "delivery-read",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "delivery-read.svg",
+		"sourcePath": "src/resources/img/icons/delivery-read.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/message/MessageItemComponent.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:delivery-sent:base",
+		"family": "delivery-sent",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "delivery-sent.svg",
+		"sourcePath": "src/resources/img/icons/delivery-sent.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/message/MessageItemComponent.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:diversity-2:base",
+		"family": "diversity-2",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "diversity-2.svg",
+		"sourcePath": "src/resources/img/icons/diversity-2.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/ScheduleRows.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:documents:base",
+		"family": "documents",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "documents.svg",
+		"sourcePath": "src/resources/img/icons/documents.svg",
+		"exportNames": ["CopyIcon"],
+		"usageFiles": [
+			"src/components/E2EEncryptionSupportHelp/E2EEncryptionSupportHelp.tsx",
+			"src/components/groupChat/GroupChatCopyLinks.tsx",
+			"src/components/help/HelpVideoCall.tsx",
+			"src/components/profile/ConsultantAgencies.tsx",
+			"src/components/profile/ConsultantInformation.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:dot:base",
+		"family": "dot",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "dot.svg",
+		"sourcePath": "src/resources/img/icons/dot.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:download:base",
+		"family": "download",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "download.svg",
+		"sourcePath": "src/resources/img/icons/download.svg",
+		"exportNames": ["DownloadIcon"],
+		"usageFiles": [
+			"src/components/generateQrCode/GenerateQrCode.tsx",
+			"src/components/profile/ConsultantStatistics.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:drafts-navigation:base",
+		"family": "drafts-navigation",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "drafts_navigation.svg",
+		"sourcePath": "src/resources/img/icons/drafts_navigation.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:envelope-open:base",
+		"family": "envelope-open",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "envelope-open.svg",
+		"sourcePath": "src/resources/img/icons/envelope-open.svg",
+		"exportNames": ["OpenEnvelopeIcon"],
+		"usageFiles": [
+			"src/components/sessionsListItem/sessionsListItemHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:envelope:base",
+		"family": "envelope",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "envelope.svg",
+		"sourcePath": "src/resources/img/icons/envelope.svg",
+		"exportNames": ["ClosedEnvelopeIcon", "EnvelopeIcon"],
+		"usageFiles": [
+			"src/components/message/FurtherSteps.tsx",
+			"src/components/profile/EmailNotifications/SetEmailModal/index.tsx",
+			"src/components/serviceExplanation/ServiceExplanation.tsx",
+			"src/components/sessionsListItem/sessionsListItemHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:exclamation-mark:base",
+		"family": "exclamation-mark",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "exclamation-mark.svg",
+		"sourcePath": "src/resources/img/icons/exclamation-mark.svg",
+		"exportNames": ["ErrorIcon", "InvalidIcon"],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/MessageSubmitInfo.tsx",
+			"src/components/notice/Notice.tsx",
+			"src/components/notifications/Notification.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:eye-closed:base",
+		"family": "eye-closed",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "eye-closed.svg",
+		"sourcePath": "src/resources/img/icons/eye-closed.svg",
+		"exportNames": ["HidePasswordIcon"],
+		"usageFiles": [
+			"src/components/inputField/InputField.tsx",
+			"src/components/login/Login.tsx",
+			"src/components/passwordResetRequest/SetNewPassword.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:eye:base",
+		"family": "eye",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "eye.svg",
+		"sourcePath": "src/resources/img/icons/eye.svg",
+		"exportNames": ["ShowPasswordIcon"],
+		"usageFiles": [
+			"src/components/inputField/InputField.tsx",
+			"src/components/login/Login.tsx",
+			"src/components/message/MessageItemComponent.tsx",
+			"src/components/passwordResetRequest/SetNewPassword.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:file-doc:base",
+		"family": "file-doc",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "file-doc.svg",
+		"sourcePath": "src/resources/img/icons/file-doc.svg",
+		"exportNames": ["FileDocIcon"],
+		"usageFiles": [
+			"src/components/message/messageHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:file-image:base",
+		"family": "file-image",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "file-image.svg",
+		"sourcePath": "src/resources/img/icons/file-image.svg",
+		"exportNames": ["FileImageIcon"],
+		"usageFiles": [
+			"src/components/message/messageHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:file-pdf:base",
+		"family": "file-pdf",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "file-pdf.svg",
+		"sourcePath": "src/resources/img/icons/file-pdf.svg",
+		"exportNames": ["FilePdfIcon"],
+		"usageFiles": [
+			"src/components/message/messageHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:file-xls:base",
+		"family": "file-xls",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "file-xls.svg",
+		"sourcePath": "src/resources/img/icons/file-xls.svg",
+		"exportNames": ["FileXlsIcon"],
+		"usageFiles": [
+			"src/components/message/messageHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:gear:base",
+		"family": "gear",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "gear.svg",
+		"sourcePath": "src/resources/img/icons/gear.svg",
+		"exportNames": ["EditGroupChatIcon"],
+		"usageFiles": [
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:googlecalendar:base",
+		"family": "googlecalendar",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "googlecalendar.svg",
+		"sourcePath": "src/resources/img/icons/googlecalendar.svg",
+		"exportNames": ["GoogleCalendar"],
+		"usageFiles": [
+			"src/containers/bookings/components/AddCalendar/addCalendar.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:group-chat-avatar:base",
+		"family": "group-chat-avatar",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "group-chat-avatar.svg",
+		"sourcePath": "src/resources/img/icons/group-chat-avatar.svg",
+		"exportNames": ["GroupChatAvatarIcon"],
+		"usageFiles": ["src/resources/img/icons.ts"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:heart:base",
+		"family": "heart",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "heart.svg",
+		"sourcePath": "src/resources/img/icons/heart.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:hourglass-top-queue:base",
+		"family": "hourglass-top-queue",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "hourglass-top-queue.svg",
+		"sourcePath": "src/resources/img/icons/hourglass-top-queue.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:i:base",
+		"family": "i",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "i.svg",
+		"sourcePath": "src/resources/img/icons/i.svg",
+		"exportNames": ["GroupChatInfoIcon", "InfoIcon", "WarningIcon"],
+		"usageFiles": [
+			"src/components/askerInfo/AskerInfoToolsOptions.tsx",
+			"src/components/conversationCreate/PanelHeader.tsx",
+			"src/components/groupChat/JoinGroupChatView.tsx",
+			"src/components/groupChat/RuleChipsEditor.tsx",
+			"src/components/infoTooltip/InfoTooltip.tsx",
+			"src/components/message/SystemMessage.tsx",
+			"src/components/messageSubmitInterface/MessageSubmitInfo.tsx",
+			"src/components/notice/Notice.tsx",
+			"src/components/notifications/Notification.tsx",
+			"src/components/profile/ConsultantInformation.tsx",
+			"src/components/profile/EmailNotifications/NoEmailSet/index.tsx",
+			"src/components/registration/metaInfo/MetaInfo.tsx",
+			"src/components/sessionHeader/GroupChatHeader/index.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/containers/bookings/components/Event/LocationType/index.tsx",
+			"src/resources/img/icons.ts",
+			"src/utils/anonName/data.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:icon:base",
+		"family": "icon",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "icon.svg",
+		"sourcePath": "src/resources/img/icons/icon.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionHeader/ChatroomMainInteractionIcon.tsx",
+			"src/containers/overview/components/EmptyState/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:imprint:base",
+		"family": "imprint",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "imprint.svg",
+		"sourcePath": "src/resources/img/icons/imprint.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:in:base",
+		"family": "in",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "in.svg",
+		"sourcePath": "src/resources/img/icons/in.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/resources/img/icons.ts",
+			"src/utils/anonName/data.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:inbox:filled",
+		"family": "inbox",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "inbox_filled.svg",
+		"sourcePath": "src/resources/img/icons/inbox_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:inbox:outline",
+		"family": "inbox",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "inbox_outline.svg",
+		"sourcePath": "src/resources/img/icons/inbox_outline.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:inbox:base",
+		"family": "inbox",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "inbox.svg",
+		"sourcePath": "src/resources/img/icons/inbox.svg",
+		"exportNames": ["InboxIcon"],
+		"usageFiles": [
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:internal-conversation:base",
+		"family": "internal-conversation",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "internal-conversation.svg",
+		"sourcePath": "src/resources/img/icons/internal-conversation.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/CreateConversationView.tsx",
+			"src/components/conversationCreate/internal/InternalChatCreateCard.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:keyboard-arrow-down:base",
+		"family": "keyboard-arrow-down",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "keyboard_arrow_down.svg",
+		"sourcePath": "src/resources/img/icons/keyboard_arrow_down.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/splitButton/SplitButton.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:keyboard-arrow-up:base",
+		"family": "keyboard-arrow-up",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "keyboard_arrow_up.svg",
+		"sourcePath": "src/resources/img/icons/keyboard_arrow_up.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/splitButton/SplitButton.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:language:filled",
+		"family": "language",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "language_filled.svg",
+		"sourcePath": "src/resources/img/icons/language_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/profile/Locale.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:language:outline",
+		"family": "language",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "language_outline.svg",
+		"sourcePath": "src/resources/img/icons/language_outline.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/ScheduleRows.tsx",
+			"src/components/localeSwitch/LocaleSwitch.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:list:base",
+		"family": "list",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "list.svg",
+		"sourcePath": "src/resources/img/icons/list.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:live-chats:base",
+		"family": "live-chats",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "live-chats.svg",
+		"sourcePath": "src/resources/img/icons/live-chats.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:local-counselor-house:base",
+		"family": "local-counselor-house",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "local-counselor-house.svg",
+		"sourcePath": "src/resources/img/icons/local-counselor-house.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:location:base",
+		"family": "location",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "location.svg",
+		"sourcePath": "src/resources/img/icons/location.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/containers/bookings/components/Event/LocationType/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:lock:base",
+		"family": "lock",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "lock.svg",
+		"sourcePath": "src/resources/img/icons/lock.svg",
+		"exportNames": ["LockIcon"],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/ScheduleRows.tsx",
+			"src/components/datepicker/datepicker.styles.scss",
+			"src/components/login/Login.tsx",
+			"src/components/passwordResetRequest/SetNewPassword.tsx",
+			"src/components/registration/welcomeScreen/WelcomeScreen.tsx",
+			"src/components/serviceExplanation/ServiceExplanation.tsx",
+			"src/components/session/EncryptionBanner.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:logout:filled",
+		"family": "logout",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "logout_filled.svg",
+		"sourcePath": "src/resources/img/icons/logout_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/NavigationBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:logout:outline",
+		"family": "logout",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "logout_outline.svg",
+		"sourcePath": "src/resources/img/icons/logout_outline.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/NavigationBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:messages:filled",
+		"family": "messages",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "messages_filled.svg",
+		"sourcePath": "src/resources/img/icons/messages_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:messages:outline",
+		"family": "messages",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "messages_outline.svg",
+		"sourcePath": "src/resources/img/icons/messages_outline.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:counsellor-request:400",
+		"family": "counsellor-request",
+		"state": "400",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "counsellor_request_400.svg",
+		"sourcePath": "src/resources/img/icons/navigation/counsellor_request_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:counsellor-request:filled",
+		"family": "counsellor-request",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "counsellor_request_filled.svg",
+		"sourcePath": "src/resources/img/icons/navigation/counsellor_request_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:door-open:400",
+		"family": "door-open",
+		"state": "400",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "door_open_400.svg",
+		"sourcePath": "src/resources/img/icons/navigation/door_open_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/NavigationBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:door-open:filled",
+		"family": "door-open",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "door_open_filled.svg",
+		"sourcePath": "src/resources/img/icons/navigation/door_open_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/NavigationBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:drafts:400",
+		"family": "drafts",
+		"state": "400",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "drafts_400.svg",
+		"sourcePath": "src/resources/img/icons/navigation/drafts_400.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:drafts:filled",
+		"family": "drafts",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "drafts_filled.svg",
+		"sourcePath": "src/resources/img/icons/navigation/drafts_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:new-window:base",
+		"family": "new-window",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "new-window.svg",
+		"sourcePath": "src/resources/img/icons/new-window.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/askerInfo/AskerInfoTools.tsx",
+			"src/components/help/HelpVideoCall.tsx",
+			"src/components/mobile/linkMenu/LinkMenu.tsx",
+			"src/components/profile/Documentation/index.tsx",
+			"src/components/tools/Tool.tsx",
+			"src/containers/bookings/components/MyCalendar/myCalendar.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:notification-audio-off:base",
+		"family": "notification-audio-off",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "notification_audio_off.svg",
+		"sourcePath": "src/resources/img/icons/notification_audio_off.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:notification-audio:base",
+		"family": "notification-audio",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "notification_audio.svg",
+		"sourcePath": "src/resources/img/icons/notification_audio.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:notification-bell:base",
+		"family": "notification-bell",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "notification_bell.svg",
+		"sourcePath": "src/resources/img/icons/notification_bell.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/app/NavigationBar.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/components/session/SessionItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:notification-settings:base",
+		"family": "notification-settings",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "notification_settings.svg",
+		"sourcePath": "src/resources/img/icons/notification_settings.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:office365:base",
+		"family": "office365",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "office365.svg",
+		"sourcePath": "src/resources/img/icons/office365.svg",
+		"exportNames": ["Office365"],
+		"usageFiles": [
+			"src/containers/bookings/components/AddCalendar/addCalendar.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:open-in-new-tab:base",
+		"family": "open-in-new-tab",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "open-in-new-tab.svg",
+		"sourcePath": "src/resources/img/icons/open-in-new-tab.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:out:base",
+		"family": "out",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "out.svg",
+		"sourcePath": "src/resources/img/icons/out.svg",
+		"exportNames": ["LeaveGroupChatIcon", "LogoutIcon"],
+		"usageFiles": [
+			"src/components/profile/Profile.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/resources/img/icons.ts",
+			"src/utils/anonName/data.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:overview:filled",
+		"family": "overview",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "overview_filled.svg",
+		"sourcePath": "src/resources/img/icons/overview_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:overview:outline",
+		"family": "overview",
+		"state": "outline",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "overview_outline.svg",
+		"sourcePath": "src/resources/img/icons/overview_outline.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:paper-plane:base",
+		"family": "paper-plane",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "paper-plane.svg",
+		"sourcePath": "src/resources/img/icons/paper-plane.svg",
+		"exportNames": ["SendIcon"],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/inputField/SendButton.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pen-paper:base",
+		"family": "pen-paper",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pen-paper.svg",
+		"sourcePath": "src/resources/img/icons/pen-paper.svg",
+		"exportNames": ["FeedbackIcon"],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pen:base",
+		"family": "pen",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pen.svg",
+		"sourcePath": "src/resources/img/icons/pen.svg",
+		"exportNames": ["EditIcon", "PenIcon"],
+		"usageFiles": [
+			"src/components/editableData/EditableData.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/profile/ConsultantInformation.tsx",
+			"src/components/profile/ConsultantPrivateData.tsx",
+			"src/components/serviceExplanation/ServiceExplanation.tsx",
+			"src/components/sessionsListItem/sessionsListItemHelpers.ts",
+			"src/components/twoFactorAuth/TwoFactorAuth.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:person-circle-solid:base",
+		"family": "person-circle-solid",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "person-circle-solid.svg",
+		"sourcePath": "src/resources/img/icons/person-circle-solid.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:person-circle:base",
+		"family": "person-circle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "person-circle.svg",
+		"sourcePath": "src/resources/img/icons/person-circle.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:person:base",
+		"family": "person",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "person.svg",
+		"sourcePath": "src/resources/img/icons/person.svg",
+		"exportNames": ["PersonIcon"],
+		"usageFiles": [
+			"src/components/askerInfo/AskerInfo.tsx",
+			"src/components/login/Login.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/passwordResetRequest/RequestPasswordResetFormView.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:persons-two-google:base",
+		"family": "persons-two-google",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "persons-two-google.svg",
+		"sourcePath": "src/resources/img/icons/persons-two-google.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/tools/Tool.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:persons-two:base",
+		"family": "persons-two",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "persons-two.svg",
+		"sourcePath": "src/resources/img/icons/persons-two.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/components/sessionHeader/GroupChatHeader/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:persons:base",
+		"family": "persons",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "persons.svg",
+		"sourcePath": "src/resources/img/icons/persons.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/profile/ConsultantStatistics.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pin:base",
+		"family": "pin",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pin.svg",
+		"sourcePath": "src/resources/img/icons/pin.svg",
+		"exportNames": ["PinIcon"],
+		"usageFiles": [
+			"src/containers/registration/components/PostCodeSelection/index.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:play-circle:base",
+		"family": "play-circle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "play-circle.svg",
+		"sourcePath": "src/resources/img/icons/play-circle.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:plus-mui:base",
+		"family": "plus-mui",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "plus-mui.svg",
+		"sourcePath": "src/resources/img/icons/plus-mui.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/PanelHeader.tsx",
+			"src/components/groupChat/RuleChipsEditor.tsx",
+			"src/components/profile/EmailNotifications/NoEmailSet/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:plus:base",
+		"family": "plus",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "plus.svg",
+		"sourcePath": "src/resources/img/icons/plus.svg",
+		"exportNames": ["NewEnquiryIcon"],
+		"usageFiles": [
+			"src/components/profile/ConsultantStatistics.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsList/SessionListCreateChat.tsx",
+			"src/components/sessionsListItem/sessionsListItemHelpers.ts",
+			"src/containers/bookings/components/BookingEvents/bookingEvents.tsx",
+			"src/containers/bookings/components/NoBookings/noBookingsBooked.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:printer:base",
+		"family": "printer",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "printer.svg",
+		"sourcePath": "src/resources/img/icons/printer.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:privacy-policy:base",
+		"family": "privacy-policy",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "privacy-policy.svg",
+		"sourcePath": "src/resources/img/icons/privacy-policy.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:profil:filled",
+		"family": "profil",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "profil_filled.svg",
+		"sourcePath": "src/resources/img/icons/profil_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:profil:outline",
+		"family": "profil",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "profil_outline.svg",
+		"sourcePath": "src/resources/img/icons/profil_outline.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:qr-code:base",
+		"family": "qr-code",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "qr-code.svg",
+		"sourcePath": "src/resources/img/icons/qr-code.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/generateQrCode/GenerateQrCode.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:recovery-safe:base",
+		"family": "recovery-safe",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "recovery-safe.svg",
+		"sourcePath": "src/resources/img/icons/recovery-safe.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/E2EEncryptionSupportBanner/KeyBackupRecoveryPrompt.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:reload:base",
+		"family": "reload",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "reload.svg",
+		"sourcePath": "src/resources/img/icons/reload.svg",
+		"exportNames": ["ReloadIcon"],
+		"usageFiles": [
+			"src/components/button/Button.tsx",
+			"src/components/conversationCreate/circle/ScheduleRows.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:richtext-toggle:base",
+		"family": "richtext-toggle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "richtext-toggle.svg",
+		"sourcePath": "src/resources/img/icons/richtext-toggle.svg",
+		"exportNames": ["RichtextToggleIcon"],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/messageSubmitInterfaceSkeleton.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:screensharing:base",
+		"family": "screensharing",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "screensharing.svg",
+		"sourcePath": "src/resources/img/icons/screensharing.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:self-help-group:base",
+		"family": "self-help-group",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "self-help-group.svg",
+		"sourcePath": "src/resources/img/icons/self-help-group.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/CircleSettingsView.tsx",
+			"src/components/conversationCreate/CreateConversationView.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:send-plane:base",
+		"family": "send-plane",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "send-plane.svg",
+		"sourcePath": "src/resources/img/icons/send-plane.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:sentiment-calm:base",
+		"family": "sentiment-calm",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "sentiment-calm.svg",
+		"sourcePath": "src/resources/img/icons/sentiment-calm.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/pseudonym/WaitingQueueActionBar.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:internal-group-chat:base",
+		"family": "internal-group-chat",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "internal_group_chat.svg",
+		"sourcePath": "src/resources/img/icons/session-toolbar/internal_group_chat.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionsList/SessionToolbarFilterIcons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:supervision-chats:base",
+		"family": "supervision-chats",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "supervision_chats.svg",
+		"sourcePath": "src/resources/img/icons/session-toolbar/supervision_chats.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/sessionsList/SessionToolbarFilterIcons.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:settings:base",
+		"family": "settings",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "settings.svg",
+		"sourcePath": "src/resources/img/icons/settings.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/profile/NotificationSettings/NotificationConfigDialog.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:shield:base",
+		"family": "shield",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "shield.svg",
+		"sourcePath": "src/resources/img/icons/shield.svg",
+		"exportNames": ["ShieldIcon"],
+		"usageFiles": [
+			"src/components/message/E2EEActivatedMessage.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:smiley-positive:base",
+		"family": "smiley-positive",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "smiley-positive.svg",
+		"sourcePath": "src/resources/img/icons/smiley-positive.svg",
+		"exportNames": ["EmojiIcon"],
+		"usageFiles": [
+			"src/components/messageSubmitInterface/messageSubmitInterfaceSkeleton.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:speech-bubble-plus:base",
+		"family": "speech-bubble-plus",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "speech-bubble-plus.svg",
+		"sourcePath": "src/resources/img/icons/speech-bubble-plus.svg",
+		"exportNames": ["CreateGroupChatIcon", "SpeechBubblePlusIcon"],
+		"usageFiles": [
+			"src/components/profile/ConsultantStatistics.tsx",
+			"src/components/sessionsList/SessionListCreateChat.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:speech-bubble-team:base",
+		"family": "speech-bubble-team",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "speech-bubble-team.svg",
+		"sourcePath": "src/resources/img/icons/speech-bubble-team.svg",
+		"exportNames": ["SpeechBubbleTeamIcon"],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:speech-bubble:base",
+		"family": "speech-bubble",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "speech-bubble.svg",
+		"sourcePath": "src/resources/img/icons/speech-bubble.svg",
+		"exportNames": ["GroupChatIcon", "SpeechBubbleIcon"],
+		"usageFiles": [
+			"src/components/groupChat/GroupChatInfo.tsx",
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx",
+			"src/components/profile/ConsultantStatistics.tsx",
+			"src/components/serviceExplanation/ServiceExplanation.tsx",
+			"src/components/sessionsListItem/sessionsListItemHelpers.ts",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:stack-horizontal:base",
+		"family": "stack-horizontal",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "stack-horizontal.svg",
+		"sourcePath": "src/resources/img/icons/stack-horizontal.svg",
+		"exportNames": ["MenuHorizontalIcon"],
+		"usageFiles": [
+			"src/components/flyoutMenu/FlyoutMenu.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:stack-vertical-circle:base",
+		"family": "stack-vertical-circle",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "stack-vertical-circle.svg",
+		"sourcePath": "src/resources/img/icons/stack-vertical-circle.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:stack-vertical:base",
+		"family": "stack-vertical",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "stack-vertical.svg",
+		"sourcePath": "src/resources/img/icons/stack-vertical.svg",
+		"exportNames": ["MenuVerticalIcon"],
+		"usageFiles": [
+			"src/components/conversationCreate/circle/CircleSettingsView.tsx",
+			"src/components/conversationCreate/CreateConversationView.tsx",
+			"src/components/conversationCreate/internal/InternalChatCreateCard.tsx",
+			"src/components/conversationCreate/PanelHeader.tsx",
+			"src/components/message/MessageItemComponent.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "sidebar-icon:teams:filled",
+		"family": "teams",
+		"state": "filled",
+		"role": "selected",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "teams_filled.svg",
+		"sourcePath": "src/resources/img/icons/teams_filled.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "sidebar-icon:teams:outline",
+		"family": "teams",
+		"state": "outline",
+		"role": "default",
+		"kind": "sidebar-icon",
+		"size": null,
+		"fileName": "teams_outline.svg",
+		"sourcePath": "src/resources/img/icons/teams_outline.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:timeline-add-call:base",
+		"family": "timeline-add-call",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-add-call.svg",
+		"sourcePath": "src/resources/img/icons/timeline-add-call.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-calendar-add-on:base",
+		"family": "timeline-calendar-add-on",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-calendar-add-on.svg",
+		"sourcePath": "src/resources/img/icons/timeline-calendar-add-on.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-case-accepted:base",
+		"family": "timeline-case-accepted",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-case-accepted.svg",
+		"sourcePath": "src/resources/img/icons/timeline-case-accepted.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-case-denied:base",
+		"family": "timeline-case-denied",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-case-denied.svg",
+		"sourcePath": "src/resources/img/icons/timeline-case-denied.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-event-busy:base",
+		"family": "timeline-event-busy",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-event-busy.svg",
+		"sourcePath": "src/resources/img/icons/timeline-event-busy.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-hourglass-top:base",
+		"family": "timeline-hourglass-top",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-hourglass-top.svg",
+		"sourcePath": "src/resources/img/icons/timeline-hourglass-top.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-pin-drop:base",
+		"family": "timeline-pin-drop",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-pin-drop.svg",
+		"sourcePath": "src/resources/img/icons/timeline-pin-drop.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-request-client:base",
+		"family": "timeline-request-client",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-request-client.svg",
+		"sourcePath": "src/resources/img/icons/timeline-request-client.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx",
+			"src/components/notificationsCenter/NotificationsCenter.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-schedule:base",
+		"family": "timeline-schedule",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-schedule.svg",
+		"sourcePath": "src/resources/img/icons/timeline-schedule.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:timeline-shield-person:base",
+		"family": "timeline-shield-person",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "timeline-shield-person.svg",
+		"sourcePath": "src/resources/img/icons/timeline-shield-person.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/notificationsCenter/eventDescriptors/icons.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:tools:filled",
+		"family": "tools",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "tools_filled.svg",
+		"sourcePath": "src/resources/img/icons/tools_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:tools:outline",
+		"family": "tools",
+		"state": "outline",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "tools_outline.svg",
+		"sourcePath": "src/resources/img/icons/tools_outline.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/app/RouterConfig.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:tools:base",
+		"family": "tools",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "tools.svg",
+		"sourcePath": "src/resources/img/icons/tools.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:trash:base",
+		"family": "trash",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "trash.svg",
+		"sourcePath": "src/resources/img/icons/trash.svg",
+		"exportNames": ["TrashIcon"],
+		"usageFiles": [
+			"src/components/editableData/EditableData.tsx",
+			"src/components/message/MessageItemComponent.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/resources/img/icons.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:confirm:400",
+		"family": "confirm",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "confirm_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/confirm_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:confirm:filled",
+		"family": "confirm",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "confirm_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/confirm_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:connect:400",
+		"family": "connect",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "connect_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/connect_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:connect:filled",
+		"family": "connect",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "connect_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/connect_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:decision:400",
+		"family": "decision",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "decision_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/decision_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:decision:filled",
+		"family": "decision",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "decision_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/decision_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:email-code-graphic:base",
+		"family": "email-code-graphic",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "email_code_graphic.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/email_code_graphic.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:install:400",
+		"family": "install",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "install_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/install_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:install:filled",
+		"family": "install",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "install_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/install_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:otp-app-graphic:base",
+		"family": "otp-app-graphic",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "otp_app_graphic.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/otp_app_graphic.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:select-account:400",
+		"family": "select-account",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "select_account_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/select_account_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:select-account:filled",
+		"family": "select-account",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "select_account_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/select_account_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:verification:400",
+		"family": "verification",
+		"state": "400",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "verification_400.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/verification_400.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:verification:filled",
+		"family": "verification",
+		"state": "filled",
+		"role": "selected",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "verification_filled.svg",
+		"sourcePath": "src/resources/img/icons/two-factor/verification_filled.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/twoFactorAuth/TwoFactorSetupDialog.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:upload:base",
+		"family": "upload",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "upload.svg",
+		"sourcePath": "src/resources/img/icons/upload.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/dragAndDropArea/DragAndDropArea.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:url:base",
+		"family": "url",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "url.svg",
+		"sourcePath": "src/resources/img/icons/url.svg",
+		"exportNames": [],
+		"usageFiles": [],
+		"usage": "catalogued-only"
+	},
+	{
+		"id": "ui-icon:verified:base",
+		"family": "verified",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "verified.svg",
+		"sourcePath": "src/resources/img/icons/verified.svg",
+		"exportNames": [],
+		"usageFiles": ["src/components/login/Login.tsx"],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:video-booking:base",
+		"family": "video-booking",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "video-booking.svg",
+		"sourcePath": "src/resources/img/icons/video-booking.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/containers/bookings/components/Event/LocationType/index.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:video-call:base",
+		"family": "video-call",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "video-call.svg",
+		"sourcePath": "src/resources/img/icons/video-call.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/message/VideoChatDetails/index.tsx",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:x:base",
+		"family": "x",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "x.svg",
+		"sourcePath": "src/resources/img/icons/x.svg",
+		"exportNames": ["CrossMarkIcon", "RemoveIcon", "StopGroupChatIcon"],
+		"usageFiles": [
+			"src/components/editableData/EditableData.tsx",
+			"src/components/groupChat/JoinGroupChatView.tsx",
+			"src/components/incomingVideoCall/IncomingVideoCall.tsx",
+			"src/components/message/MessageItemComponent.tsx",
+			"src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx",
+			"src/components/notice/Notice.tsx",
+			"src/components/notifications/Notification.tsx",
+			"src/components/overlay/Overlay.tsx",
+			"src/components/productTour/ProductTourTooltip.tsx",
+			"src/components/profile/AdditionalEnquiry/AdditionalEnquiry.tsx",
+			"src/components/profile/AskerAboutMeData.tsx",
+			"src/components/session/AcceptAssign.tsx",
+			"src/components/session/DeleteSession.tsx",
+			"src/components/sessionMenu/SessionMenu.tsx",
+			"src/components/sessionMenu/sessionMenuHelpers.ts",
+			"src/components/sessionsListItem/SessionListItemComponent.tsx",
+			"src/resources/img/icons.ts",
+			"src/utils/anonName/data.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:cat-01:base",
+		"family": "cat-01",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "cat-01.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/cat-01.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:cat-02:base",
+		"family": "cat-02",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "cat-02.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/cat-02.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:cat-03:base",
+		"family": "cat-03",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "cat-03.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/cat-03.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:cat-04:base",
+		"family": "cat-04",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "cat-04.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/cat-04.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:cat-05:base",
+		"family": "cat-05",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "cat-05.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/cat-05.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:gen-avatar:base",
+		"family": "gen-avatar",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "gen-avatar.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/gen-avatar.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/AccountData.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:gen-dice:base",
+		"family": "gen-dice",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "gen-dice.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/gen-dice.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/AccountData.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:gen-key:base",
+		"family": "gen-key",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "gen-key.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/gen-key.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/AccountData.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:gen-user:base",
+		"family": "gen-user",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "gen-user.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/gen-user.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/AccountData.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pw-length:base",
+		"family": "pw-length",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pw-length.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/pw-length.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/PasswordRuleChips.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pw-lower:base",
+		"family": "pw-lower",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pw-lower.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/pw-lower.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/PasswordRuleChips.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pw-number:base",
+		"family": "pw-number",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pw-number.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/pw-number.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/PasswordRuleChips.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pw-special:base",
+		"family": "pw-special",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pw-special.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/pw-special.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/PasswordRuleChips.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "ui-icon:pw-upper:base",
+		"family": "pw-upper",
+		"state": "base",
+		"role": "default",
+		"kind": "ui-icon",
+		"size": null,
+		"fileName": "pw-upper.svg",
+		"sourcePath": "src/resources/img/registration-md3/icons/pw-upper.svg",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/accountData/PasswordRuleChips.tsx"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-eltern-und-familie:base",
+		"family": "t-01-eltern-und-familie",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-eltern-und-familie.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-eltern-und-familie.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-jungen-und-ma-nnerberatung:base",
+		"family": "t-01-jungen-und-ma-nnerberatung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-jungen-und-ma-nnerberatung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-jungen-und-ma-nnerberatung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-kinder-und-jugend-reha:base",
+		"family": "t-01-kinder-und-jugend-reha",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-kinder-und-jugend-reha.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-kinder-und-jugend-reha.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-kinder-und-jugendliche:base",
+		"family": "t-01-kinder-und-jugendliche",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-kinder-und-jugendliche.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-kinder-und-jugendliche.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-kuren-fu-r-mu-tter-und-va-ter:base",
+		"family": "t-01-kuren-fu-r-mu-tter-und-va-ter",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-kuren-fu-r-mu-tter-und-va-ter.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-kuren-fu-r-mu-tter-und-va-ter.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-schwangerschaft:base",
+		"family": "t-01-schwangerschaft",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-schwangerschaft.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-schwangerschaft.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-01-u25-suizidpra-vention:base",
+		"family": "t-01-u25-suizidpra-vention",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-01-u25-suizidpra-vention.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-01-u25-suizidpra-vention.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-02-hospiz-und-palliativberatung:base",
+		"family": "t-02-hospiz-und-palliativberatung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-02-hospiz-und-palliativberatung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-02-hospiz-und-palliativberatung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-02-leben-im-alter:base",
+		"family": "t-02-leben-im-alter",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-02-leben-im-alter.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-02-leben-im-alter.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-02-rechtliche-betreuung-und-vorsorge:base",
+		"family": "t-02-rechtliche-betreuung-und-vorsorge",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-02-rechtliche-betreuung-und-vorsorge.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-02-rechtliche-betreuung-und-vorsorge.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-02-trauerberatung:base",
+		"family": "t-02-trauerberatung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-02-trauerberatung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-02-trauerberatung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-03-aus-ru-ck-und-weiterwanderung:base",
+		"family": "t-03-aus-ru-ck-und-weiterwanderung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-03-aus-ru-ck-und-weiterwanderung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-03-aus-ru-ck-und-weiterwanderung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-03-migration:base",
+		"family": "t-03-migration",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-03-migration.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-03-migration.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-04-behinderung-und-psychische-beeintra-chtigung:base",
+		"family": "t-04-behinderung-und-psychische-beeintra-chtigung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-04-behinderung-und-psychische-beeintra-chtigung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-04-behinderung-und-psychische-beeintra-chtigung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-04-hiv-und-aids:base",
+		"family": "t-04-hiv-und-aids",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-04-hiv-und-aids.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-04-hiv-und-aids.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-04-kinder-und-jugend-reha:base",
+		"family": "t-04-kinder-und-jugend-reha",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-04-kinder-und-jugend-reha.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-04-kinder-und-jugend-reha.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-04-kuren-fu-r-mu-tter-und-va-ter:base",
+		"family": "t-04-kuren-fu-r-mu-tter-und-va-ter",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-04-kuren-fu-r-mu-tter-und-va-ter.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-04-kuren-fu-r-mu-tter-und-va-ter.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-04-sucht:base",
+		"family": "t-04-sucht",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-04-sucht.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-04-sucht.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-allgemeine-sozialberatung:base",
+		"family": "t-05-allgemeine-sozialberatung",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-allgemeine-sozialberatung.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-allgemeine-sozialberatung.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-hiv-und-aids:base",
+		"family": "t-05-hiv-und-aids",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-hiv-und-aids.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-hiv-und-aids.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-rechtliche-betreuung-und-vorsorge:base",
+		"family": "t-05-rechtliche-betreuung-und-vorsorge",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-rechtliche-betreuung-und-vorsorge.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-rechtliche-betreuung-und-vorsorge.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-schulden:base",
+		"family": "t-05-schulden",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-schulden.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-schulden.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts",
+			"src/resources/img/topics/index.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-straffa-lligkeit:base",
+		"family": "t-05-straffa-lligkeit",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-straffa-lligkeit.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-straffa-lligkeit.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	},
+	{
+		"id": "topic-icon:t-05-u25-suizidpra-vention:base",
+		"family": "t-05-u25-suizidpra-vention",
+		"state": "base",
+		"role": "default",
+		"kind": "topic-icon",
+		"size": null,
+		"fileName": "t-05-u25-suizidpra-vention.png",
+		"sourcePath": "src/resources/img/registration-md3/icons/t-05-u25-suizidpra-vention.png",
+		"exportNames": [],
+		"usageFiles": [
+			"src/components/registration/registrationDesign/registrationDesign.ts"
+		],
+		"usage": "app-used"
+	}
+]

--- a/src/components/IconCatalog/iconCatalog.styles.scss
+++ b/src/components/IconCatalog/iconCatalog.styles.scss
@@ -1,0 +1,214 @@
+.iconCatalog {
+	min-height: 100vh;
+	padding: 2rem;
+	color: var(--md-sys-color-on-surface, #1d1b20);
+	background: var(--md-sys-color-surface, #fffbfe);
+	font-family: Inter, system-ui, sans-serif;
+
+	&__header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 2rem;
+		max-width: 90rem;
+		margin: 0 auto 1.5rem;
+
+		h1 {
+			margin: 0.25rem 0 0.5rem;
+			font-size: clamp(1.75rem, 4vw, 2.75rem);
+		}
+
+		p {
+			max-width: 50rem;
+			margin: 0;
+			line-height: 1.5;
+		}
+	}
+
+	&__eyebrow {
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	&__primaryAction,
+	&__card button {
+		min-height: 2.75rem;
+		padding: 0.625rem 1rem;
+		border: 0;
+		border-radius: 999px;
+		color: var(--md-sys-color-on-primary, #fff);
+		background: var(--md-sys-color-primary, #a5000a);
+		font: inherit;
+		font-weight: 700;
+		cursor: pointer;
+	}
+
+	&__summary {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 0.75rem;
+		max-width: 90rem;
+		margin: 0 auto 1rem;
+
+		div {
+			padding: 1rem;
+			border-radius: 0.75rem;
+			background: var(--md-sys-color-surface-container, #f3edf7);
+		}
+		strong {
+			display: block;
+			font-size: 1.5rem;
+		}
+		span {
+			font-size: 0.8125rem;
+		}
+	}
+
+	&__references {
+		max-width: 90rem;
+		margin: 0 auto 1rem;
+		padding: 1rem;
+		border: 1px solid var(--md-sys-color-outline-variant, #cac4d0);
+		border-radius: 0.75rem;
+
+		summary {
+			cursor: pointer;
+			font-weight: 700;
+		}
+		ul {
+			margin-bottom: 0;
+		}
+		a {
+			color: var(--md-sys-color-primary, #a5000a);
+		}
+	}
+
+	&__filters {
+		display: grid;
+		grid-template-columns: minmax(14rem, 2fr) repeat(3, minmax(9rem, 1fr));
+		gap: 0.75rem;
+		max-width: 90rem;
+		margin: 0 auto 1.5rem;
+
+		label {
+			display: grid;
+			gap: 0.375rem;
+			font-size: 0.75rem;
+			font-weight: 700;
+		}
+		input,
+		select {
+			min-height: 2.75rem;
+			padding: 0.625rem 0.75rem;
+			border: 1px solid var(--md-sys-color-outline, #79747e);
+			border-radius: 0.5rem;
+			color: inherit;
+			background: var(--md-sys-color-surface, #fffbfe);
+			font: inherit;
+		}
+	}
+
+	&__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+		gap: 1rem;
+		max-width: 90rem;
+		margin: 0 auto;
+	}
+
+	&__card {
+		display: grid;
+		grid-template-rows: auto auto auto 1fr auto auto;
+		gap: 0.625rem;
+		min-width: 0;
+		padding: 1rem;
+		border: 1px solid var(--md-sys-color-outline-variant, #cac4d0);
+		border-radius: 1rem;
+		background: var(--md-sys-color-surface-container-lowest, #fff);
+
+		h2 {
+			margin: 0;
+			overflow-wrap: anywhere;
+			font-size: 1rem;
+		}
+		p {
+			margin: 0;
+			font-size: 0.75rem;
+			color: var(--md-sys-color-on-surface-variant, #49454f);
+		}
+		code {
+			overflow-wrap: anywhere;
+			font-size: 0.6875rem;
+		}
+		button {
+			justify-self: start;
+			min-height: 2.5rem;
+			font-size: 0.75rem;
+		}
+	}
+
+	&__preview {
+		display: grid;
+		place-items: center;
+		height: 6rem;
+		border-radius: 0.75rem;
+		background: var(--md-sys-color-surface-container, #f3edf7);
+
+		img {
+			width: 2.5rem;
+			height: 2.5rem;
+			object-fit: contain;
+		}
+		span {
+			font-size: 0.75rem;
+		}
+
+		&--topic-icon img {
+			width: 4.5rem;
+			height: 4.5rem;
+		}
+		&--client-avatar img,
+		&--legacy-client-avatar img {
+			width: 3rem;
+			height: 3rem;
+		}
+	}
+
+	&__badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+
+		span {
+			padding: 0.2rem 0.45rem;
+			border-radius: 999px;
+			background: var(--md-sys-color-secondary-container, #e8def8);
+			font-size: 0.625rem;
+		}
+	}
+
+	button:focus-visible,
+	input:focus-visible,
+	select:focus-visible,
+	a:focus-visible {
+		outline: 0.1875rem solid var(--md-sys-color-primary, #a5000a);
+		outline-offset: 0.125rem;
+	}
+}
+
+@media (width <= 48rem) {
+	.iconCatalog {
+		padding: 1rem;
+		&__header {
+			flex-direction: column;
+		}
+		&__summary {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+		&__filters {
+			grid-template-columns: 1fr;
+		}
+	}
+}

--- a/src/generated/vite-import-meta.d.ts
+++ b/src/generated/vite-import-meta.d.ts
@@ -1,0 +1,10 @@
+interface ImportMeta {
+	glob<T = unknown>(
+		pattern: string | string[],
+		options?: {
+			eager?: boolean;
+			import?: string;
+			query?: string | Record<string, string | number | boolean>;
+		}
+	): Record<string, T>;
+}


### PR DESCRIPTION
## Why

Icon usage in the frontend is scattered across four asset families (UI icons, sidebar icons, MD3 topic icons, and client/consultant avatars) with no single place to see what exists, which variant (200/400/filled) is the baseline, or whether an asset is actually referenced by app code. This makes it easy for humans and AI agents alike to substitute wrong icons or redraw existing ones. This PR rescues and finishes the icon-catalog WIP from `save/frontend-icon-catalog-wip`.

## What

- New Storybook page **Design System/Icons & Avatars**: a searchable, filterable catalog card grid (family, state, usage filters; copyable per-icon selection prompts and a global AI selection prompt; links to the five Figma reference sets).
- `scripts/generateIconCatalog.mjs`: deterministic generator that scans the asset roots and cross-references every asset against app source (tests and Storybook files excluded), emitting `src/components/IconCatalog/iconCatalog.generated.json` (committed; 310 assets, 275 app-used). Output is formatted through the repo Prettier config so the lint-staged pass keeps regeneration byte-identical. Regenerate with `npm run generate:icon-catalog`; `prestorybook` and `prebuild-storybook` hooks run it automatically.
- Rebase fix: anon-animal avatars are read from `public/static/anon-animals` following their move to `/static` in #840.
- `src/generated/vite-import-meta.d.ts`: minimal `import.meta.glob` typing for the story previews.

## Testing

- `npx tsc --noEmit` clean.
- `node scripts/generateIconCatalog.mjs` run twice: identical SHA-1 both times, byte-identical to the committed JSON, and `prettier --check` passes on it.
- `npm run build-storybook` completes successfully (runs the generator + `typecheck:storybook` via the prebuild hook); `design-system-icons-avatars--catalog` is present in the built `index.json` and the 62 anon-animal SVGs are copied into the static output.

Closes OpenResilienceInitiative/ORISO-Frontend#951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive icon catalog in Storybook.
  - Browse icon previews with search and filters for family, state, and usage.
  - View icon metadata, usage counts, and Figma reference links.
  - Copy AI-ready icon selection prompts.
  - Added responsive layouts for desktop and mobile viewing.

- **Documentation**
  - Added catalog summaries and visual references to support icon discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->