### PR TITLE
fix: asker timeline empty state, single-topic auto-select, about-me email race

### DIFF
--- a/src/components/app/RouterConfig.test.ts
+++ b/src/components/app/RouterConfig.test.ts
@@ -74,7 +74,10 @@ vi.mock(
 	})
 );
 
-const { RouterConfigConsultant } = await import('./RouterConfig');
+const { RouterConfigConsultant, RouterConfigUser } = await import(
+	'./RouterConfig'
+);
+const { hasUserAuthority } = await import('../../globalState');
 
 const settings = {
 	useOverviewPage: false,
@@ -110,5 +113,19 @@ describe('RouterConfigConsultant navigation', () => {
 		);
 		expect(notificationIndex).toBeGreaterThanOrEqual(0);
 		expect(profileIndex).toBeGreaterThan(notificationIndex);
+	});
+});
+
+describe('RouterConfigUser navigation', () => {
+	it('hides the Activity Timeline from askers', () => {
+		vi.mocked(hasUserAuthority).mockReturnValue(true);
+		const routerConfig = RouterConfigUser(settings);
+		const timelineItem = routerConfig.navigation.find(
+			(item) => item.to === '/notifications'
+		);
+
+		expect(
+			timelineItem.condition({ grantedAuthorities: ['ASKER_DEFAULT'] })
+		).toBe(false);
 	});
 });

--- a/src/components/app/RouterConfig.test.ts
+++ b/src/components/app/RouterConfig.test.ts
@@ -117,15 +117,40 @@ describe('RouterConfigConsultant navigation', () => {
 });
 
 describe('RouterConfigUser navigation', () => {
-	it('hides the Activity Timeline from askers', () => {
-		vi.mocked(hasUserAuthority).mockReturnValue(true);
-		const routerConfig = RouterConfigUser(settings);
+	it('keeps the Activity Timeline rail item and route but hides it from askers', () => {
+		const routerConfig = RouterConfigUser(settings, false);
 		const timelineItem = routerConfig.navigation.find(
 			(item) => item.to === '/notifications'
 		);
 
+		// The rail item must exist — this fails if the route is removed.
+		expect(timelineItem).toBeDefined();
+
+		// Askers (ASKER_DEFAULT authority) must not see the timeline …
+		const askerData = { grantedAuthorities: ['ASKER_DEFAULT'] };
+		vi.mocked(hasUserAuthority).mockReturnValue(true);
+		expect(timelineItem.condition(askerData)).toBe(false);
+		expect(hasUserAuthority).toHaveBeenCalledWith(
+			'ASKER_DEFAULT',
+			askerData
+		);
+
+		// … while non-asker users do.
+		vi.mocked(hasUserAuthority).mockReturnValue(false);
 		expect(
-			timelineItem.condition({ grantedAuthorities: ['ASKER_DEFAULT'] })
-		).toBe(false);
+			timelineItem.condition({
+				grantedAuthorities: ['CONSULTANT_DEFAULT']
+			})
+		).toBe(true);
+
+		// The NotificationsCenter page itself stays reachable via its route.
+		expect(routerConfig.profileRoutes).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					path: '/notifications',
+					exact: true
+				})
+			])
+		);
 	});
 });

--- a/src/components/notificationsCenter/ActivityTimelineEmptyState.test.tsx
+++ b/src/components/notificationsCenter/ActivityTimelineEmptyState.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActivityTimelineEmptyState } from './ActivityTimelineEmptyState';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string, fallback?: string) => fallback ?? key
+	})
+}));
+
+vi.mock('../emptyState/EmptyState', () => ({
+	EmptyState: ({ headline, variant, className }: any) => (
+		<div
+			data-testid="empty-state"
+			data-variant={variant}
+			className={className}
+		>
+			{headline}
+		</div>
+	)
+}));
+
+describe('ActivityTimelineEmptyState', () => {
+	it('uses the established illustrated all-caught-up placeholder', () => {
+		render(<ActivityTimelineEmptyState />);
+
+		const emptyState = screen.getByTestId('empty-state');
+		expect(emptyState.getAttribute('data-variant')).toBe(
+			'conversation-nothing-to-do'
+		);
+		expect(emptyState.className).toContain(
+			'notificationsCenter__fullEmptyState'
+		);
+		expect(emptyState.textContent).toBe('No notifications yet.');
+	});
+});

--- a/src/components/notificationsCenter/ActivityTimelineEmptyState.tsx
+++ b/src/components/notificationsCenter/ActivityTimelineEmptyState.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../emptyState/EmptyState';
+
+export const ActivityTimelineEmptyState = () => {
+	const { t } = useTranslation();
+
+	return (
+		<EmptyState
+			className="notificationsCenter__fullEmptyState"
+			headline={t('notifications.center.empty', 'No notifications yet.')}
+			variant="conversation-nothing-to-do"
+		/>
+	);
+};

--- a/src/components/notificationsCenter/NotificationsCenter.tsx
+++ b/src/components/notificationsCenter/NotificationsCenter.tsx
@@ -57,6 +57,7 @@ import {
 	formatClockParts,
 	formatRelativeTime
 } from './timelineTime';
+import { ActivityTimelineEmptyState } from './ActivityTimelineEmptyState';
 import '../sessionsList/sessionsList.styles';
 import './notificationsCenter.styles';
 
@@ -561,6 +562,14 @@ export const NotificationsCenter = () => {
 		);
 	};
 
+	if (notificationFeed.length === 0) {
+		return (
+			<div className="notificationsCenter notificationsCenter--empty">
+				<ActivityTimelineEmptyState />
+			</div>
+		);
+	}
+
 	return (
 		<div className="notificationsCenter">
 			<div
@@ -653,14 +662,7 @@ export const NotificationsCenter = () => {
 					)}
 				</div>
 				<div className="notificationsCenter__list" ref={listScrollRef}>
-					{notificationFeed.length === 0 ? (
-						<div className="notificationsCenter__empty">
-							{translate(
-								'notifications.center.empty',
-								'No notifications yet.'
-							)}
-						</div>
-					) : filteredFeed.length === 0 ? (
+					{filteredFeed.length === 0 ? (
 						<div className="notificationsCenter__empty">
 							{translate(
 								'notifications.center.noResults',

--- a/src/components/notificationsCenter/notificationsCenter.styles.scss
+++ b/src/components/notificationsCenter/notificationsCenter.styles.scss
@@ -15,6 +15,15 @@
 	min-height: 0;
 	background: #fcf9f9;
 
+	&--empty {
+		flex: 1;
+		min-width: 0;
+	}
+
+	&__fullEmptyState {
+		min-height: 100%;
+	}
+
 	&__listColumn {
 		position: relative;
 		display: flex;

--- a/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.test.tsx
+++ b/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AdditionalEnquiry } from './AdditionalEnquiry';
+
+const apiGetTenantAgenciesTopicsMock = vi.fn();
+const apiPostAdditionalEnquiryMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key
+	})
+}));
+
+vi.mock('react-router-dom', () => ({
+	useNavigate: () => vi.fn()
+}));
+
+vi.mock('../../../globalState', async () => {
+	const ReactModule = await import('react');
+	return {
+		UserDataContext: ReactModule.createContext({
+			reloadUserData: vi.fn()
+		})
+	};
+});
+
+vi.mock('../../../api', () => ({
+	apiGetTenantAgenciesTopics: (...args: unknown[]) =>
+		apiGetTenantAgenciesTopicsMock(...args),
+	apiPostAdditionalEnquiry: (...args: unknown[]) =>
+		apiPostAdditionalEnquiryMock(...args),
+	FETCH_ERRORS: { X_REASON: 'x-reason' },
+	X_REASON: {
+		USER_ALREADY_REGISTERED_WITH_AGENCY_AND_TOPIC: 'already-registered'
+	}
+}));
+
+vi.mock('../../form/OrisoSelect', () => ({
+	OrisoSelect: ({ label, options, value }: any) => (
+		<label>
+			{label}
+			<select aria-label={label} value={value} readOnly>
+				<option value="" />
+				{options.map((option: any) => (
+					<option key={option.value} value={option.value}>
+						{option.label}
+					</option>
+				))}
+			</select>
+		</label>
+	)
+}));
+
+vi.mock('../../button/Button', () => ({
+	BUTTON_TYPES: { LINK: 'link', PRIMARY: 'primary' },
+	Button: ({ item, disabled }: any) => (
+		<button type="button" disabled={disabled}>
+			{item.label}
+		</button>
+	)
+}));
+
+vi.mock('../../overlay/Overlay', () => ({
+	OVERLAY_FUNCTIONS: {
+		REDIRECT: 'redirect',
+		LOGOUT: 'logout',
+		CLOSE: 'close'
+	},
+	Overlay: () => null
+}));
+
+vi.mock('../../logout/logout', () => ({ logout: vi.fn() }));
+vi.mock('../../app/navigationHandler', () => ({ mobileListView: vi.fn() }));
+vi.mock('../../headline/Headline', () => ({
+	Headline: ({ text }: { text: string }) => <h2>{text}</h2>
+}));
+vi.mock('../../../resources/img/illustrations/check.svg', () => ({
+	ReactComponent: () => <svg />
+}));
+vi.mock('../../../resources/img/illustrations/x.svg', () => ({
+	ReactComponent: () => <svg />
+}));
+vi.mock('./AdditionalAgencySelection', () => ({
+	AdditionalAgencySelection: ({ selectedTopicId }: any) => (
+		<div data-testid="agency-selection">topic:{selectedTopicId}</div>
+	)
+}));
+
+describe('AdditionalEnquiry', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('selects the only available topic and continues to agency selection', async () => {
+		apiGetTenantAgenciesTopicsMock.mockResolvedValue([
+			{ id: 25, name: 'U25 Suizidprävention' }
+		]);
+
+		render(<AdditionalEnquiry />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('agency-selection').textContent).toBe(
+				'topic:25'
+			);
+		});
+		expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
+			'25'
+		);
+	});
+});

--- a/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.test.tsx
+++ b/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.test.tsx
@@ -80,6 +80,9 @@ vi.mock('../../headline/Headline', () => ({
 vi.mock('../../../resources/img/illustrations/check.svg', () => ({
 	ReactComponent: () => <svg />
 }));
+vi.mock('../../animatedIllustration/AnimatedIllustration', () => ({
+	CheckAnimation: () => <svg data-testid="check-animation" />
+}));
 vi.mock('../../../resources/img/illustrations/x.svg', () => ({
 	ReactComponent: () => <svg />
 }));

--- a/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.tsx
+++ b/src/components/profile/AdditionalEnquiry/AdditionalEnquiry.tsx
@@ -86,6 +86,11 @@ export const AdditionalEnquiry: React.FC = () => {
 		apiGetTenantAgenciesTopics()
 			.then((response) => {
 				setTenantAgenciesTopics(response);
+				if (response.length === 1) {
+					const onlyTopicId = response[0].id;
+					setSelectedTopicId(onlyTopicId);
+					setCurrentSelectOption(onlyTopicId.toString());
+				}
 			})
 			.catch((error) => {
 				// console.log(error);

--- a/src/components/profile/AskerAboutMeData.test.tsx
+++ b/src/components/profile/AskerAboutMeData.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AskerAboutMeData } from './AskerAboutMeData';
+
+const apiPutEmailMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../../globalState', async () => {
+	const ReactModule = await import('react');
+	return {
+		UserDataContext: ReactModule.createContext({
+			userData: {
+				userName: 'fresh-asker',
+				email: 'old@example.test',
+				twoFactorAuth: { isActive: false, type: null }
+			},
+			reloadUserData: vi.fn()
+		})
+	};
+});
+
+vi.mock('../../api', () => ({
+	apiDeleteTwoFactorAuth: vi.fn(),
+	apiPutEmail: (...args: unknown[]) => apiPutEmailMock(...args),
+	FETCH_ERRORS: { X_REASON: 'x-reason' },
+	X_REASON: { EMAIL_NOT_AVAILABLE: 'email-not-available' }
+}));
+
+vi.mock('../../api/apiDeleteEmail', () => ({ apiDeleteEmail: vi.fn() }));
+
+vi.mock('../twoFactorAuth/twoFactorAuthConstants', () => ({
+	TWO_FACTOR_TYPES: { EMAIL: 'email' }
+}));
+
+vi.mock('../headline/Headline', () => ({
+	Headline: ({ text }: { text: string }) => <h2>{text}</h2>
+}));
+
+vi.mock('../text/Text', () => ({
+	Text: ({ text }: { text: string }) => <p>{text}</p>
+}));
+
+vi.mock('../button/Button', () => ({
+	BUTTON_TYPES: { LINK: 'link', PRIMARY: 'primary', SECONDARY: 'secondary' },
+	Button: ({ item, buttonHandle }: any) => (
+		<button type="button" disabled={item.disabled} onClick={buttonHandle}>
+			{item.label}
+		</button>
+	)
+}));
+
+vi.mock('../editableData/EditableData', () => ({
+	EditableData: ({
+		label,
+		isDisabled,
+		onSingleEditActive,
+		onValueIsValid
+	}: any) => (
+		<div>
+			<span>{label}</span>
+			{isDisabled && onSingleEditActive ? (
+				<button type="button" onClick={onSingleEditActive}>
+					edit email
+				</button>
+			) : !isDisabled && onValueIsValid ? (
+				<button
+					type="button"
+					onClick={() => onValueIsValid('new@example.test')}
+				>
+					enter valid email
+				</button>
+			) : null}
+		</div>
+	)
+}));
+
+vi.mock('../overlay/Overlay', () => ({
+	OVERLAY_FUNCTIONS: {
+		CLOSE: 'close',
+		CLOSE_SUCCESS: 'close-success',
+		CONFIRM_EDIT: 'confirm-edit',
+		DELETE_EMAIL: 'delete-email'
+	},
+	Overlay: () => null
+}));
+
+vi.mock('../../resources/img/illustrations/check.svg', () => ({
+	ReactComponent: () => <svg />
+}));
+vi.mock('../../resources/img/illustrations/x.svg', () => ({
+	ReactComponent: () => <svg />
+}));
+
+describe('AskerAboutMeData', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('allows the asker to retry saving after a generic update failure', async () => {
+		apiPutEmailMock.mockRejectedValue(new Error('temporary failure'));
+
+		render(<AskerAboutMeData />);
+
+		fireEvent.click(screen.getByRole('button', { name: 'edit email' }));
+		fireEvent.click(
+			screen.getByRole('button', { name: 'enter valid email' })
+		);
+		const saveButton = screen.getByRole('button', {
+			name: 'profile.data.edit.button.save'
+		});
+		fireEvent.click(saveButton);
+
+		await waitFor(() => expect(apiPutEmailMock).toHaveBeenCalledTimes(1));
+		fireEvent.click(saveButton);
+
+		await waitFor(() => expect(apiPutEmailMock).toHaveBeenCalledTimes(2));
+	});
+});

--- a/src/components/profile/AskerAboutMeData.tsx
+++ b/src/components/profile/AskerAboutMeData.tsx
@@ -181,7 +181,6 @@ export const AskerAboutMeData = () => {
 			apiPutEmail(email)
 				.then(reloadUserData)
 				.then(() => {
-					setIsRequestInProgress(false);
 					setIsEmailDisabled(true);
 					setEmailLabel(translate('profile.data.email'));
 				})
@@ -189,9 +188,9 @@ export const AskerAboutMeData = () => {
 					const reason = error.headers?.get(FETCH_ERRORS.X_REASON);
 					if (reason === X_REASON.EMAIL_NOT_AVAILABLE) {
 						setIsEmailNotAvailable(true);
-						setIsRequestInProgress(false);
 					}
-				});
+				})
+				.finally(() => setIsRequestInProgress(false));
 		}
 	};
 


### PR DESCRIPTION
## Why

Rescued from the `save/ratsuchenden-preview-wip` branch: three small asker-facing (Ratsuchende) fixes — a bare-text empty notifications timeline, an unnecessary manual topic selection when a tenant only offers one topic, and a race condition in the about-me email save.

## What

- **Illustrated empty state for the notifications/activity timeline**: new `ActivityTimelineEmptyState` component (reuses the shared `EmptyState` with the `conversation-nothing-to-do` Lottie variant, same as the session-list empty states) rendered by `NotificationsCenter` when the feed is empty, replacing the plain-text placeholder.
- **Single-topic auto-select in `AdditionalEnquiry`**: when `apiGetTenantAgenciesTopics` returns exactly one topic, it is pre-selected so the asker goes straight to agency selection.
- **About-me email save race fix in `AskerAboutMeData`**: `setIsRequestInProgress(false)` moved into a `.finally()` so the in-progress flag is always cleared (previously it stayed stuck on non-`EMAIL_NOT_AVAILABLE` errors and was cleared before the UI state updates on success).

Finishing work on top of the WIP: `RouterConfig.test.ts` called `RouterConfigUser` with one argument while the real signature requires `(settings, hasAssignedConsultant)` — it only passed because vitest does not type-check. The call now uses the real signature and the assertions verify the `/notifications` rail item and profile route actually exist plus the asker/non-asker visibility condition in both directions. `AdditionalEnquiry.test.tsx` additionally mocks `AnimatedIllustration` because the component's `CheckAnimation` import loads real `lottie-web`, which crashes under jsdom.

## Testing

- `npx vitest run` on the five touched suites — all pass (6 tests): `RouterConfig.test.ts` (2), `ActivityTimelineEmptyState.test.tsx` (1), `AdditionalEnquiry.test.tsx` (1), `AskerAboutMeData.test.tsx` (1), `lottieColorUtils.test.ts` (1).
- `npx tsc --noEmit` — clean (exit 0); this would have caught the previous `RouterConfigUser` arity bug.
- Reduced motion: the new empty state reuses the exact shared `EmptyState`/`EmptyStateAnimation` component used by the archive/inquiry/no-conversations session-list empty states, so behavior is identical by construction (play-once, half-speed Lottie). Note: that shared component has no `prefers-reduced-motion` handling anywhere yet — a pre-existing gap common to all empty states, not introduced or widened here.

Closes OpenResilienceInitiative/ORISO-Frontend#953
Refs OpenResilienceInitiative/ORISO-Frontend#937 (partial: delivers only the notifications-timeline empty state of the three empty states #937 asks for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)