### PR TITLE
fix(empty-state): honour prefers-reduced-motion in shared animation

### DIFF
--- a/src/components/emptyState/EmptyStateAnimation.test.tsx
+++ b/src/components/emptyState/EmptyStateAnimation.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmptyStateAnimation } from './EmptyStateAnimation';
+import { EmptyState } from './EmptyState';
+import archiveAnimation from '../../resources/animations/emptyStates/archive.json';
+
+const { fakeLottieInstance } = vi.hoisted(() => ({
+	fakeLottieInstance: {
+		setSpeed: vi.fn(),
+		goToAndStop: vi.fn(),
+		getDuration: vi.fn().mockReturnValue(120)
+	}
+}));
+
+vi.mock('lottie-react', () => {
+	const MockLottie = ({
+		autoplay,
+		lottieRef,
+		onDOMLoaded
+	}: {
+		autoplay: boolean;
+		lottieRef: React.MutableRefObject<unknown>;
+		onDOMLoaded?: () => void;
+	}) => {
+		React.useEffect(() => {
+			lottieRef.current = fakeLottieInstance;
+			onDOMLoaded?.();
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, []);
+
+		return <div data-lottie="true" data-autoplay={String(autoplay)} />;
+	};
+
+	return { default: MockLottie };
+});
+
+const stubReducedMotion = (matches: boolean) =>
+	vi.stubGlobal(
+		'matchMedia',
+		vi.fn().mockReturnValue({
+			matches,
+			media: '(prefers-reduced-motion: reduce)',
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn()
+		} as unknown as MediaQueryList)
+	);
+
+describe('EmptyStateAnimation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('autoplays the animation when no motion preference is set', () => {
+		stubReducedMotion(false);
+		const { container } = render(
+			<EmptyStateAnimation
+				animationData={archiveAnimation}
+				variant="archive"
+			/>
+		);
+
+		const lottie = container.querySelector('[data-lottie="true"]');
+		expect(lottie?.getAttribute('data-autoplay')).toBe('true');
+		expect(fakeLottieInstance.setSpeed).toHaveBeenCalledWith(0.5);
+		expect(fakeLottieInstance.goToAndStop).not.toHaveBeenCalled();
+		expect(
+			container
+				.querySelector('[data-cy="empty-state-animation"]')
+				?.getAttribute('data-reduced-motion')
+		).toBe('false');
+	});
+
+	it('renders the final frame statically when the user prefers reduced motion', () => {
+		stubReducedMotion(true);
+		const { container } = render(
+			<EmptyStateAnimation
+				animationData={archiveAnimation}
+				variant="archive"
+			/>
+		);
+
+		const lottie = container.querySelector('[data-lottie="true"]');
+		expect(lottie?.getAttribute('data-autoplay')).toBe('false');
+		// 120 frames reported by the fake instance -> static jump to frame 119
+		expect(fakeLottieInstance.goToAndStop).toHaveBeenCalledWith(119, true);
+
+		const wrapper = container.querySelector(
+			'[data-cy="empty-state-animation"]'
+		);
+		expect(wrapper?.getAttribute('data-reduced-motion')).toBe('true');
+		expect(wrapper?.getAttribute('data-complete')).toBe('true');
+	});
+});
+
+describe('EmptyState', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('propagates reduced motion to its animation', () => {
+		stubReducedMotion(true);
+		const { container } = render(
+			<EmptyState headline="Nothing here yet" variant="archive" />
+		);
+
+		expect(
+			container
+				.querySelector('[data-cy="empty-state-animation"]')
+				?.getAttribute('data-reduced-motion')
+		).toBe('true');
+		expect(
+			container
+				.querySelector('[data-lottie="true"]')
+				?.getAttribute('data-autoplay')
+		).toBe('false');
+	});
+});

--- a/src/components/emptyState/EmptyStateAnimation.tsx
+++ b/src/components/emptyState/EmptyStateAnimation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import Lottie, { LottieRefCurrentProps } from 'lottie-react';
 import { readCssColor, recolorLottieAccent } from './lottieColorUtils';
 
@@ -22,6 +23,9 @@ export const EmptyStateAnimation = ({
 	variant
 }: EmptyStateAnimationProps) => {
 	const lottieRef = useRef<LottieRefCurrentProps | null>(null);
+	// Same treatment as AnimatedIllustration: the illustration still reads,
+	// it just does not move — we show its resting (final) frame instead.
+	const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
 	const [playbackState, setPlaybackState] = useState('playing');
 	const accentColor = readCssColor(accentColorVar, DEFAULT_ACCENT_COLOR);
 	const secondaryColor = readCssColor(
@@ -33,14 +37,28 @@ export const EmptyStateAnimation = ({
 		[accentColor, animationData, secondaryColor]
 	);
 
-	useEffect(() => {
-		lottieRef.current?.setSpeed(speed);
-	}, [speed]);
+	const showFinalFrame = () => {
+		const totalFrames = lottieRef.current?.getDuration(true) ?? 1;
+		lottieRef.current?.goToAndStop(Math.max(totalFrames - 1, 0), true);
+	};
 
 	useEffect(() => {
+		if (reduceMotion) {
+			return;
+		}
+		lottieRef.current?.setSpeed(speed);
+	}, [reduceMotion, speed]);
+
+	useEffect(() => {
+		if (reduceMotion) {
+			setPlaybackState('complete');
+			showFinalFrame();
+			return;
+		}
 		setPlaybackState('playing');
 		lottieRef.current?.setSpeed(speed);
-	}, [animationData, speed, variant]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [animationData, reduceMotion, speed, variant]);
 
 	return (
 		<div
@@ -51,16 +69,21 @@ export const EmptyStateAnimation = ({
 			data-cy="empty-state-animation"
 			data-empty-state={variant}
 			data-loop="false"
+			data-reduced-motion={reduceMotion ? 'true' : 'false'}
 			data-secondary-color={secondaryColor.toLowerCase()}
 			data-speed={speed}
 		>
 			<Lottie
 				animationData={recoloredAnimationData}
-				autoplay
+				autoplay={!reduceMotion}
 				loop={false}
 				lottieRef={lottieRef}
 				onComplete={() => setPlaybackState('complete')}
-				onDOMLoaded={() => lottieRef.current?.setSpeed(speed)}
+				onDOMLoaded={() =>
+					reduceMotion
+						? showFinalFrame()
+						: lottieRef.current?.setSpeed(speed)
+				}
 				rendererSettings={{
 					preserveAspectRatio: 'xMidYMid meet'
 				}}


### PR DESCRIPTION
## Why

The shared `EmptyStateAnimation` (used by the session-list archive / inquiry / no-conversations empty states, the search empty state, and — once #958 lands — the new `ActivityTimelineEmptyState`) always autoplayed its Lottie animation. Users who set the OS-level reduced-motion preference still got full motion; the existing `prefers-reduced-motion` CSS blocks in `sessionsList.styles.scss` / `notificationsCenter.styles.scss` only cover chips and cards, not Lottie playback.

This serves the acceptance item "respect reduced motion and the no-animation mode" of #937 and fits epic #932 (one animated illustration system): the fix lands once, in the shared component, so every current and future consumer inherits it.

## What

- `EmptyStateAnimation` now queries `(prefers-reduced-motion: reduce)` via `useMediaQuery` — the same treatment `AnimatedIllustration` already uses.
- With reduced motion: `autoplay` is off and the component jumps straight to the animation's final resting frame (`goToAndStop`), so the illustration still reads — it just does not move. `data-complete` reports `true` immediately and a new `data-reduced-motion` attribute is exposed for styling and E2E hooks.
- Without the preference: behaviour is unchanged (autoplay, half speed, completion tracking).
- `SearchEmptyStateAnimation` and all `EmptyState` variants inherit the behaviour since they delegate to the shared component.

## Tests

- New `EmptyStateAnimation.test.tsx` (vitest, TDD red→green):
  - autoplays and sets speed when no motion preference is set;
  - renders the static final frame, disables autoplay, and reports `data-reduced-motion="true"` / `data-complete="true"` under reduced motion;
  - `EmptyState` propagates the reduced-motion behaviour to its animation.
- `npx vitest run src/components/emptyState/` → 2 files, 4 tests passed; neighboring `animatedIllustration` / `sessionsList` / `notificationsCenter` suites → 11 files, 68 tests passed. `eslint --max-warnings=0`, `tsc`, and Prettier clean on the changed files.

Refs #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)