### PR TITLE
fix(composer): decide the recipient list by identity, not by homeserver (#894)

### DIFF
--- a/src/components/messageSubmitInterface/audienceOptions.test.ts
+++ b/src/components/messageSubmitInterface/audienceOptions.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	AUDIENCE_ALL,
+	audienceIdentityKeys,
 	buildAudienceRoster,
 	classifyAudienceKind,
+	createAudienceCollector,
+	createIdentityLookup,
 	defaultAudienceSelection,
 	reconcileAudienceSelection,
 	restoreAudienceSelection,
@@ -31,9 +34,9 @@ describe('defaultAudienceSelection', () => {
 	});
 
 	it('falls back to the first option when there is no "all"', () => {
-		expect(defaultAudienceSelection([option('@kim'), option('@ada')])).toEqual(
-			['@kim']
-		);
+		expect(
+			defaultAudienceSelection([option('@kim'), option('@ada')])
+		).toEqual(['@kim']);
 	});
 
 	it('returns "all" for an empty option list', () => {
@@ -299,16 +302,30 @@ describe('audienceOptionsReady', () => {
 
 	it('is ready even without an "all" option', () => {
 		expect(
-			audienceOptionsReady([{ value: '@ada', label: 'Ada', kind: 'person' }])
+			audienceOptionsReady([
+				{ value: '@ada', label: 'Ada', kind: 'person' }
+			])
 		).toBe(true);
 	});
 });
 
 describe('groupAudienceOptions', () => {
 	const options: AudienceOption[] = [
-		{ value: '@enc.katze_mika:oriso.org', label: 'Katze Mika', kind: 'asker' },
-		{ value: '@consultant42:oriso.org', label: 'K. Paulstätter', kind: 'consultant' },
-		{ value: '@moderator7:oriso.org', label: 'B. Pardon', kind: 'supervisor' },
+		{
+			value: '@enc.katze_mika:oriso.org',
+			label: 'Katze Mika',
+			kind: 'asker'
+		},
+		{
+			value: '@consultant42:oriso.org',
+			label: 'K. Paulstätter',
+			kind: 'consultant'
+		},
+		{
+			value: '@moderator7:oriso.org',
+			label: 'B. Pardon',
+			kind: 'supervisor'
+		},
 		{ value: '@someone:oriso.org', label: 'Unklar', kind: 'person' },
 		{ value: AUDIENCE_ALL, label: 'Send to all', kind: 'all' }
 	];
@@ -363,10 +380,171 @@ describe('groupAudienceOptions', () => {
 	/** Matching self must be exact too — two generated names can share a word. */
 	it('does not disable someone who merely shares a word with the viewer', () => {
 		const shared: AudienceOption[] = [
-			{ value: '@alpaka_mika:oriso.org', label: 'sanftes Alpaka Mika', kind: 'asker' },
-			{ value: '@alpaka_leon:oriso.org', label: 'gutmütiges Alpaka Leon', kind: 'asker' }
+			{
+				value: '@alpaka_mika:oriso.org',
+				label: 'sanftes Alpaka Mika',
+				kind: 'asker'
+			},
+			{
+				value: '@alpaka_leon:oriso.org',
+				label: 'gutmütiges Alpaka Leon',
+				kind: 'asker'
+			}
 		];
 		const grouped = groupAudienceOptions(shared, ['alpaka_mika']);
 		expect(grouped.clients.map((o) => o.disabled)).toEqual([true, false]);
+	});
+});
+
+describe('audienceIdentityKeys', () => {
+	it('recognises one person across the spellings they arrive in', () => {
+		const keys = audienceIdentityKeys('@enc.katze_mika:oriso.org');
+		expect(keys.has('katze_mika')).toBe(true);
+		expect(keys.has('enc.katze_mika')).toBe(true);
+		expect(keys.has('@enc.katze_mika:oriso.org')).toBe(true);
+	});
+
+	/** The whole point: the homeserver must never become an identity. */
+	it('never yields the homeserver as a key', () => {
+		const keys = audienceIdentityKeys('@consultant42:oriso.org');
+		expect(keys.has('oriso')).toBe(false);
+		expect(keys.has('oriso.org')).toBe(false);
+	});
+
+	it('has nothing in common with another account on the same homeserver', () => {
+		const mine = audienceIdentityKeys('@consultant42:oriso.org');
+		const theirs = audienceIdentityKeys('@moderator7:oriso.org');
+		const shared = [...mine].filter((key) => theirs.has(key));
+		expect(shared).toEqual([]);
+	});
+});
+
+describe('createAudienceCollector', () => {
+	/**
+	 * The regression this collector exists for.
+	 *
+	 * De-duplication used to run through the composer's fuzzy
+	 * `getComparableAudienceIds`, which adds every token of four or more
+	 * characters — so `@consultant42:oriso.org` contributed `oriso`, and every
+	 * account on the homeserver looked like a duplicate of every other one. The
+	 * second recipient was silently dropped and the message went out narrowed
+	 * to the wrong audience.
+	 */
+	it('keeps two different people who share a homeserver', () => {
+		const collector = createAudienceCollector([]);
+		collector.add('@consultant42:oriso.org', 'K. Paulstätter');
+		collector.add('@moderator7:oriso.org', 'B. Pardon');
+
+		expect(collector.entries()).toEqual([
+			['@consultant42:oriso.org', 'K. Paulstätter'],
+			['@moderator7:oriso.org', 'B. Pardon']
+		]);
+	});
+
+	it('keeps a whole room of accounts on one homeserver', () => {
+		const collector = createAudienceCollector([]);
+		[
+			'@enc.katze_mika:oriso.org',
+			'@consultant42:oriso.org',
+			'@moderator7:oriso.org',
+			'@someone-else:oriso.org'
+		].forEach((id) => collector.add(id, id));
+
+		expect(collector.entries()).toHaveLength(4);
+	});
+
+	it('still collapses the same person arriving twice', () => {
+		const collector = createAudienceCollector([]);
+		collector.add('@enc.katze_mika:oriso.org', 'Katze Mika');
+		// The session payload calls the same asker by their bare username.
+		collector.add('katze_mika', 'katze_mika');
+
+		expect(collector.entries()).toEqual([
+			['@enc.katze_mika:oriso.org', 'Katze Mika']
+		]);
+	});
+
+	it('reports whether an entry was taken', () => {
+		const collector = createAudienceCollector([]);
+		expect(collector.add('@consultant42:oriso.org', 'K.')).toBe(true);
+		expect(collector.add('consultant42', 'K.')).toBe(false);
+		expect(collector.add('', 'nobody')).toBe(false);
+	});
+
+	/**
+	 * The same defect on the self test, and the more damaging half: it runs
+	 * before de-duplication, over the Matrix room member list. With the fuzzy
+	 * matcher the signed-in consultant's own `oriso` token matched every member
+	 * of the room, so the loop discarded all of them as "me" and the selector
+	 * fell back to whatever the explicit additions could supply.
+	 */
+	it('does not mistake a colleague on the same homeserver for the viewer', () => {
+		const collector = createAudienceCollector(['@consultant1:oriso.org']);
+
+		expect(collector.isSelf('@moderator7:oriso.org')).toBe(false);
+		expect(collector.isSelf('@enc.katze_mika:oriso.org')).toBe(false);
+		expect(collector.isSelf('@consultant1:oriso.org')).toBe(true);
+	});
+
+	it('drops the viewer however their own id is spelled', () => {
+		const collector = createAudienceCollector([
+			'@consultant1:oriso.org',
+			'consultant1',
+			'Kim Paulstätter'
+		]);
+		collector.add('@consultant1:oriso.org', 'me');
+		collector.add('consultant1', 'me');
+		collector.add('@moderator7:oriso.org', 'B. Pardon');
+
+		expect(collector.entries()).toEqual([
+			['@moderator7:oriso.org', 'B. Pardon']
+		]);
+	});
+
+	/** Two generated pseudonyms can share a word without being one person. */
+	it('does not merge two people who merely share a name word', () => {
+		const collector = createAudienceCollector([]);
+		collector.add('@alpaka_mika:oriso.org', 'sanftes Alpaka Mika');
+		collector.add('@alpaka_leon:oriso.org', 'gutmütiges Alpaka Leon');
+
+		expect(collector.entries()).toHaveLength(2);
+	});
+});
+
+describe('createIdentityLookup', () => {
+	it('finds the entry whichever spelling of the id is used', () => {
+		const lookup = createIdentityLookup<string>();
+		lookup.set(['@moderator7:oriso.org', 'moderator7'], 'B. Pardon');
+
+		expect(lookup.get('@moderator7:oriso.org')).toBe('B. Pardon');
+		expect(lookup.get('moderator7')).toBe('B. Pardon');
+	});
+
+	/**
+	 * Under the fuzzy matcher a single supervisor lent their label — and with
+	 * it the moderator icon — to everybody sharing the homeserver.
+	 */
+	it('does not hand a supervisor label to their homeserver neighbours', () => {
+		const lookup = createIdentityLookup<string>();
+		lookup.set(['@moderator7:oriso.org'], 'B. Pardon');
+
+		expect(lookup.get('@consultant42:oriso.org')).toBeUndefined();
+		expect(lookup.get('@enc.katze_mika:oriso.org')).toBeUndefined();
+	});
+
+	it('keeps the first label written for an identity', () => {
+		const lookup = createIdentityLookup<string>();
+		lookup.set(['moderator7'], 'B. Pardon');
+		lookup.set(['moderator7'], 'raw-id-fallback');
+
+		expect(lookup.get('moderator7')).toBe('B. Pardon');
+	});
+
+	it('ignores empty ids', () => {
+		const lookup = createIdentityLookup<string>();
+		lookup.set([null, undefined, '  '], 'nobody');
+
+		expect(lookup.size).toBe(0);
+		expect(lookup.get('')).toBeUndefined();
 	});
 });

--- a/src/components/messageSubmitInterface/audienceOptions.ts
+++ b/src/components/messageSubmitInterface/audienceOptions.ts
@@ -82,12 +82,13 @@ export const restoreAudienceSelection = (
 /**
  * The identifiers of everyone whose role we actually know, grouped by role.
  *
- * Deliberately built with a *strict* normaliser rather than the fuzzy
- * `getComparableAudienceIds` used for de-duplication elsewhere in the
- * composer. That one splits an id into tokens of four or more characters, so
- * every participant on the same homeserver shares the token `oriso` — good
- * enough to spot a duplicate of the same person, far too loose to decide
- * whether somebody is a moderator.
+ * Built with the strict normaliser below rather than the composer's fuzzy
+ * `getComparableAudienceIds`, which splits an id into tokens of four or more
+ * characters — so every participant on the same homeserver shares the token
+ * `oriso`, far too loose to decide whether somebody is a moderator.
+ *
+ * Recipient collection (`createAudienceCollector`) is strict for the same
+ * reason; the fuzzy matcher now survives only in the @-mention provider.
  */
 export interface AudienceRoster {
 	asker: Set<string>;
@@ -101,9 +102,7 @@ export interface AudienceRoster {
  * `@enc.<username>:<server>` and as a bare `<username>`, so a leading `enc.`
  * is stripped as well — otherwise the same person fails to match themselves.
  */
-export const audienceIdentityKeys = (
-	rawValue?: string | null
-): Set<string> => {
+export const audienceIdentityKeys = (rawValue?: string | null): Set<string> => {
 	const keys = new Set<string>();
 	const compact = `${rawValue || ''}`.trim().toLowerCase();
 	if (!compact) {
@@ -132,6 +131,119 @@ const collectKeys = (values: (string | null | undefined)[]): Set<string> => {
 		audienceIdentityKeys(value).forEach((key) => keys.add(key))
 	);
 	return keys;
+};
+
+/**
+ * A lookup keyed by identity rather than by one spelling of an id.
+ *
+ * The same person reaches the composer as `@enc.katze_mika:oriso.org` from the
+ * room member list, as `katze_mika` from the session payload and as a bare
+ * consultant id from the supervisor endpoint. Registering every key once means
+ * a later lookup finds them whichever spelling it happens to hold.
+ *
+ * First writer wins, so the caller's own precedence (mapped display name over
+ * username over raw id) survives.
+ */
+export const createIdentityLookup = <T>() => {
+	const byKey = new Map<string, T>();
+	return {
+		set: (rawValues: (string | null | undefined)[], value: T): void => {
+			rawValues.forEach((rawValue) =>
+				audienceIdentityKeys(rawValue).forEach((key) => {
+					if (!byKey.has(key)) {
+						byKey.set(key, value);
+					}
+				})
+			);
+		},
+		get: (rawValue?: string | null): T | undefined =>
+			Array.from(audienceIdentityKeys(rawValue))
+				.map((key) => byKey.get(key))
+				.find((entry) => entry !== undefined),
+		get size(): number {
+			return byKey.size;
+		}
+	};
+};
+
+export interface AudienceCollector {
+	/** Whether this id is the viewer themselves. */
+	isSelf: (rawValue?: string | null) => boolean;
+	/** Whether this id is somebody already collected. */
+	has: (rawValue?: string | null) => boolean;
+	/**
+	 * Record a recipient unless they are the viewer or already present.
+	 * Returns whether the entry was actually taken.
+	 */
+	add: (rawValue: string | null | undefined, label: string) => boolean;
+	/** The collected recipients as `[value, label]`, in insertion order. */
+	entries: () => [string, string][];
+}
+
+/**
+ * Gathers the conversation's recipients, keeping the two decisions that can
+ * silently drop somebody — "is this me?" and "do I already have this
+ * person?" — on strict identity.
+ *
+ * Both used to run through the composer's fuzzy `getComparableAudienceIds`,
+ * which adds every token of four or more characters to the comparison set. For
+ * a Matrix id that includes the homeserver, so *every* participant on
+ * `oriso.org` shares the token `oriso`:
+ *
+ * - as a self test, the first member of the room list matched the signed-in
+ *   user and the entire room was discarded as "me";
+ * - as a duplicate test, the second recipient matched the first and was
+ *   discarded as "already collected".
+ *
+ * Either way the recipient list came out wrong, and a message narrowed to one
+ * person could reach somebody who was never offered as a target. Strict keys
+ * (exact value, without the leading `@`, Matrix local part, `enc.` stripped)
+ * still recognise one person across their several spellings without ever
+ * conflating two people who merely share a homeserver.
+ *
+ * See OpenResilienceInitiative/ORISO-Frontend#894.
+ */
+export const createAudienceCollector = (
+	selfIdentifiers: (string | null | undefined)[] = []
+): AudienceCollector => {
+	const selfKeys = collectKeys(selfIdentifiers);
+	const labelByValue = new Map<string, string>();
+	const keysByValue = new Map<string, Set<string>>();
+
+	const isSelf = (rawValue?: string | null): boolean =>
+		Array.from(audienceIdentityKeys(rawValue)).some((key) =>
+			selfKeys.has(key)
+		);
+
+	const has = (rawValue?: string | null): boolean => {
+		const keys = Array.from(audienceIdentityKeys(rawValue));
+		if (keys.length === 0) {
+			return false;
+		}
+		return Array.from(keysByValue.values()).some((existing) =>
+			keys.some((key) => existing.has(key))
+		);
+	};
+
+	const add = (
+		rawValue: string | null | undefined,
+		label: string
+	): boolean => {
+		const compact = `${rawValue || ''}`.trim();
+		if (!compact || isSelf(compact) || has(compact)) {
+			return false;
+		}
+		labelByValue.set(compact, label);
+		keysByValue.set(compact, audienceIdentityKeys(compact));
+		return true;
+	};
+
+	return {
+		isSelf,
+		has,
+		add,
+		entries: () => Array.from(labelByValue.entries())
+	};
 };
 
 export const buildAudienceRoster = ({

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -43,6 +43,8 @@ import {
 	AUDIENCE_ALL,
 	buildAudienceRoster,
 	classifyAudienceKind,
+	createAudienceCollector,
+	createIdentityLookup,
 	defaultAudienceSelection,
 	reconcileAudienceSelection,
 	restoreAudienceSelection,
@@ -2110,6 +2112,22 @@ export const MessageSubmitInterfaceComponent = ({
 		[deriveLabelFromUserId]
 	);
 
+	/**
+	 * Fuzzy id expansion, kept only for the @-mention provider below.
+	 *
+	 * The audience selector no longer uses it: it splits an id on
+	 * non-alphanumerics and keeps every token of four or more characters, so
+	 * `@consultant42:oriso.org` yields `oriso` — a token every account on the
+	 * homeserver shares. As an identity test that is worthless, which is why
+	 * recipient collection now runs on `audienceIdentityKeys` instead (#894).
+	 *
+	 * The mention provider still matches on these tokens, and inherits the same
+	 * weakness one level down: two counsellors who merely share a surname
+	 * collide, so a pill for `hans.meier` can resolve to `@anna.meier`'s Matrix
+	 * id and mark him as in-room. That belongs to the mention feature (#435)
+	 * rather than to the Send-to selector, so it is reported separately instead
+	 * of being changed here.
+	 */
 	const getComparableAudienceIds = useCallback((rawValue?: string | null) => {
 		const compact = (rawValue || '').trim().toLowerCase();
 		if (!compact) {
@@ -2294,18 +2312,17 @@ export const MessageSubmitInterfaceComponent = ({
 			setSelectedAudienceValues([AUDIENCE_ALL]);
 			return;
 		}
-		const collected = new Map<string, string>();
-		const selfIdentifiers = new Set<string>();
-		const matrixUserIdFromSession = getCurrentMatrixUserId();
-		[
-			matrixUserIdFromSession,
+		/**
+		 * Strict identity throughout: both "is this me?" and "have I already
+		 * got this person?" used to run through `getComparableAudienceIds`,
+		 * whose 4+ character tokens include the homeserver — so every account
+		 * on `oriso.org` matched every other one. See #894.
+		 */
+		const audience = createAudienceCollector([
+			getCurrentMatrixUserId(),
 			userData?.userName,
 			userData?.displayName
-		].forEach((rawValue) => {
-			getComparableAudienceIds(rawValue).forEach((id) =>
-				selfIdentifiers.add(id)
-			);
-		});
+		]);
 		const roomId = getMatrixRoomId();
 		const matrixClient = matrixClientService?.getClient?.();
 		const room =
@@ -2313,7 +2330,10 @@ export const MessageSubmitInterfaceComponent = ({
 		const roomMembers =
 			room?.getMembers?.() || room?.getJoinedMembers?.() || [];
 		const restrictToSupervisionAudience = sessionSupervisors.length > 0;
-		const supervisorLabelByComparableId = new Map<string, string>();
+		// Also strict: under the fuzzy matcher a single supervisor in the room
+		// lent their label — and with it the moderator icon — to everybody who
+		// merely shared their homeserver.
+		const supervisorLabelByIdentity = createIdentityLookup<string>();
 		sessionSupervisors.forEach((supervisor) => {
 			const mappedConsultant = agencyConsultantDirectory.get(
 				supervisor.id
@@ -2326,13 +2346,10 @@ export const MessageSubmitInterfaceComponent = ({
 			if (!preferredLabel) {
 				return;
 			}
-			[supervisor.id, supervisor.username].forEach((rawValue) => {
-				getComparableAudienceIds(rawValue).forEach((id) => {
-					if (!supervisorLabelByComparableId.has(id)) {
-						supervisorLabelByComparableId.set(id, preferredLabel);
-					}
-				});
-			});
+			supervisorLabelByIdentity.set(
+				[supervisor.id, supervisor.username],
+				preferredLabel
+			);
 		});
 
 		roomMembers.forEach((member: any) => {
@@ -2352,26 +2369,18 @@ export const MessageSubmitInterfaceComponent = ({
 			) {
 				return;
 			}
-			const memberComparableIds = getComparableAudienceIds(memberId);
-			const isSelf = Array.from(memberComparableIds).some((id) =>
-				selfIdentifiers.has(id)
-			);
-			if (isSelf) {
+			if (audience.isSelf(memberId)) {
 				return;
 			}
+			const supervisorLabel = supervisorLabelByIdentity.get(memberId);
 			const memberName = `${member?.name || ''}`.trim();
 			if (
 				memberName.toLowerCase().startsWith('enc.') &&
-				!Array.from(memberComparableIds).some((id) =>
-					supervisorLabelByComparableId.has(id)
-				)
+				!supervisorLabel
 			) {
 				return;
 			}
-			const supervisorLabel = Array.from(memberComparableIds)
-				.map((id) => supervisorLabelByComparableId.get(id))
-				.find(Boolean);
-			collected.set(
+			audience.add(
 				memberId,
 				formatAudiencePersonLabel(
 					supervisorLabel || memberName,
@@ -2388,25 +2397,7 @@ export const MessageSubmitInterfaceComponent = ({
 			if (!compactId) {
 				return;
 			}
-			const comparableIds = getComparableAudienceIds(compactId);
-			const isSelf = Array.from(comparableIds).some((id) =>
-				selfIdentifiers.has(id)
-			);
-			if (isSelf) {
-				return;
-			}
-			if (Array.from(comparableIds).some((id) => collected.has(id))) {
-				return;
-			}
-			const existingKey = Array.from(collected.keys()).find((key) =>
-				Array.from(comparableIds).some((id) =>
-					getComparableAudienceIds(key).has(id)
-				)
-			);
-			if (existingKey) {
-				return;
-			}
-			collected.set(
+			audience.add(
 				compactId,
 				formatAudiencePersonLabel(
 					`${fallbackLabel || ''}`.trim(),
@@ -2462,13 +2453,10 @@ export const MessageSubmitInterfaceComponent = ({
 				supervisor.username
 			])
 		});
-		const mapped: AudienceOption[] = Array.from(collected.entries())
+		const mapped: AudienceOption[] = audience
+			.entries()
 			.map(([value, label]) => {
-				const supervisorLabel = Array.from(
-					getComparableAudienceIds(value)
-				)
-					.map((id) => supervisorLabelByComparableId.get(id))
-					.find(Boolean);
+				const supervisorLabel = supervisorLabelByIdentity.get(value);
 				return {
 					value,
 					label: supervisorLabel
@@ -2508,7 +2496,6 @@ export const MessageSubmitInterfaceComponent = ({
 		contact?.username,
 		deriveLabelFromUserId,
 		formatAudiencePersonLabel,
-		getComparableAudienceIds,
 		getMatrixRoomId,
 		audienceRefreshTick,
 		sessionSupervisors,


### PR DESCRIPTION
Stacked on #948 — please review that one first. Base will retarget to `pre-dev` automatically once #948 merges. **The diff to read is the single commit `fix(composer): decide the recipient list by identity, not by homeserver`.**

## The problem

The composer decided two things with `getComparableAudienceIds`, which adds every token of four or more characters to the comparison set:

- **is this me?** (`selfIdentifiers`)
- **have I already got this person?** (the `existingKey` scan in `addAudienceCandidate`)

A Matrix id carries the homeserver, so `@consultant42:oriso.org` contributes the token `oriso` — and **every account on the homeserver shares it**. Verified against the real id shape (`getCurrentMatrixUserId()` returns the full MXID from the Matrix login response):

```
selfIdentifiers contains "oriso": true
  isSelf(@moderator7:oriso.org)      -> true   <-- dropped as "me"
  isSelf(@enc.katze_mika:oriso.org)  -> true   <-- dropped as "me"
existingKey for @consultant42:oriso.org -> @moderator7:oriso.org   <-- dropped as duplicate
```

Two consequences, not one:

1. **De-duplication** — every candidate looked like a duplicate of whoever was collected first, so everybody after the first was silently dropped.
2. **Self-detection** — the same collision runs *first*, over the Matrix room member list. The signed-in consultant's own `oriso` token matched every member, so the member loop discarded the whole room as "me". This is the more damaging half: the member loop is not a reliable fallback for the explicit asker/consultant/contact/supervisor additions, it collects nobody whose homeserver matches the viewer's.

Either way the recipient list came out wrong, and a message narrowed to one person could reach somebody who was never offered as a target.

## The fix

Both decisions now use `audienceIdentityKeys` — the strict normaliser already in `audienceOptions.ts` and already unit tested (exact value, without leading `@`, Matrix local part, `enc.` stripped). No third matcher was written.

Two small helpers move the logic somewhere a test can reach it:

- `createAudienceCollector(selfIdentifiers)` — owns `isSelf` / `has` / `add`, so the two checks cannot drift apart again.
- `createIdentityLookup<T>()` — the supervisor-label lookup, which was fuzzy too and lent one supervisor's label *and moderator icon* to their homeserver neighbours. Strict now, as suggested.

`getComparableAudienceIds` is **not** dead — the @-mention provider still uses it, so it stays, with a comment recording why.

## Known issue left alone deliberately

The mention provider inherits the same weakness one level down, and I did not touch it because it belongs to the mention feature (#435), not to the Send-to selector. Reproduced:

```
hans.meier resolves to matrixUserId -> @anna.meier:oriso.org
hans.meier isInRoom -> true
```

Two counsellors sharing a surname collide, so a mention pill for one can carry the other's Matrix id. Worth its own issue — say the word and I will open it.

## Verification

- `audienceOptions.test.ts`: 51 passed (24 new assertions across `audienceIdentityKeys`, `createAudienceCollector`, `createIdentityLookup`)
- Full `messageSubmitInterface` suite: 21 files, 164 tests, all passing
- `tsc --noEmit`: clean
- Prettier: clean (all three files were clean at baseline too)
- **The new tests were checked against the old behaviour:** temporarily making `audienceIdentityKeys` emit the fuzzy 4+ character tokens again fails 13 tests, including every "same homeserver" case. They are not vacuous.

## Reviewer test plan

- [ ] Group conversation with three or more participants on the same homeserver: **every** participant appears in the Send-to list, not just the first
- [ ] Two counsellors plus one advice seeker: all three are listed, each under the right heading (client / counsellor / moderator)
- [ ] Open the composer immediately after entering a chat, before Matrix has synced members: the recipient list still fills in and is not truncated to one person
- [ ] Your own account is never offered as a recipient — check with a colleague whose account is on the same homeserver present in the room
- [ ] Supervision conversation: the supervisor shows the moderator symbol and **only** the supervisor does — nobody else on `oriso.org` picks it up
- [ ] Pick a single recipient and send: the message reaches that person and the chip keeps the restriction
- [ ] Advice seeker account: no Send-to control (unchanged)
- [ ] **Mobile (375px and 390px):** the recipient list is scrollable and every entry is tappable with more than two participants; long generated names ellipsise instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
