### PR TITLE
fix: delete messages via Matrix redact

### DIFF
--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -309,6 +309,8 @@ interface MessageItemComponentProps extends MessageItem {
 	onReplyDirect?: () => void;
 	/** Start editing THIS message (wires the composer, own messages only). */
 	onEditDirect?: () => void;
+	/** Delete THIS message via Matrix redact (own messages only, #827). */
+	onDeleteDirect?: () => void;
 	/** Reactions (m.annotation, #435): aggregated pills for this message. */
 	reactions?: AggregatedReaction[];
 	/** Add own reaction with the given emoji key. */
@@ -365,6 +367,7 @@ export const MessageItemComponent = ({
 	replyQuote,
 	onReplyDirect,
 	onEditDirect,
+	onDeleteDirect,
 	reactions,
 	onReact,
 	onUnreact,
@@ -375,8 +378,12 @@ export const MessageItemComponent = ({
 	const { activeSession, reloadActiveSession } =
 		useContext(ActiveSessionContext);
 	const { userData } = useContext(UserDataContext);
+	const { getSetting } = useContext(ServerSettingsContext);
 	const tenant = useTenant();
 	const matrixRoomUsersContext = useMatrixRoomUsers();
+	const [deleteOverlay, setDeleteOverlay] = useState(false);
+	const [isDeleteRequestInProgress, setIsDeleteRequestInProgress] =
+		useState(false);
 	const consultantContext = useContext(ConsultantListContext);
 	const getComparableRecipientIds = useCallback(
 		(rawValue?: string | null) => {
@@ -1132,6 +1139,12 @@ export const MessageItemComponent = ({
 		alias?.messageType === ALIAS_MESSAGE_TYPES.INITIAL_APPOINTMENT_DEFINED;
 	const isFullWidthMessage =
 		isVideoCallMessage && !videoCallMessage?.eventType;
+	const canDeleteMessage =
+		Boolean(onDeleteDirect) &&
+		activeSession?.item?.status !== STATUS_ARCHIVED &&
+		Boolean(
+			getSetting<IBooleanSetting>(SETTING_MESSAGE_ALLOWDELETING)?.value
+		);
 	const actionMenuItems = useMemo(
 		() => [
 			// Relations foundation (#435): only offer direct reply where a
@@ -1177,13 +1190,21 @@ export const MessageItemComponent = ({
 				label: translate('message.menu.forward', 'Forward Message'),
 				icon: <MenuForwardIcon />
 			},
-			{
-				key: 'delete',
-				label: translate('message.menu.delete', 'Delete Message'),
-				icon: <MenuDeleteIcon />
-			}
+			// Delete (#827): Matrix redact handler + allow-deleting + not archived.
+			...(canDeleteMessage
+				? [
+						{
+							key: 'delete',
+							label: translate(
+								'message.menu.delete',
+								'Delete Message'
+							),
+							icon: <MenuDeleteIcon />
+						}
+					]
+				: [])
 		],
-		[translate, onReplyDirect, onEditDirect]
+		[translate, onReplyDirect, onEditDirect, canDeleteMessage]
 	);
 
 	const handleActionMenuItemClick = useCallback(
@@ -1199,8 +1220,55 @@ export const MessageItemComponent = ({
 			if (actionKey === 'edit' && onEditDirect) {
 				onEditDirect();
 			}
+			if (actionKey === 'delete' && onDeleteDirect) {
+				setDeleteOverlay(true);
+			}
 		},
-		[onOpenThread, onReplyDirect, onEditDirect]
+		[onOpenThread, onReplyDirect, onEditDirect, onDeleteDirect]
+	);
+
+	const confirmDeleteMessage = useCallback(() => {
+		if (!onDeleteDirect || isDeleteRequestInProgress) {
+			return;
+		}
+		setIsDeleteRequestInProgress(true);
+		try {
+			onDeleteDirect();
+			setDeleteOverlay(false);
+		} finally {
+			setIsDeleteRequestInProgress(false);
+		}
+	}, [onDeleteDirect, isDeleteRequestInProgress]);
+
+	const deleteOverlayItem: OverlayItem = useMemo(
+		() => ({
+			headline: translate('message.delete.overlay.headline'),
+			copy: translate('message.delete.overlay.copy'),
+			svg: XIllustration,
+			illustrationBackground: 'neutral',
+			buttonSet: [
+				{
+					label: translate('message.delete.overlay.cancel'),
+					function: OVERLAY_FUNCTIONS.CLOSE,
+					type: BUTTON_TYPES.SECONDARY,
+					disabled: isDeleteRequestInProgress
+				},
+				{
+					label: translate('message.delete.overlay.confirm'),
+					function: 'CONFIRM',
+					type: BUTTON_TYPES.PRIMARY,
+					disabled: isDeleteRequestInProgress
+				}
+			],
+			handleOverlay: (functionName) => {
+				if (functionName === 'CONFIRM') {
+					confirmDeleteMessage();
+					return;
+				}
+				setDeleteOverlay(false);
+			}
+		}),
+		[confirmDeleteMessage, isDeleteRequestInProgress, translate]
 	);
 
 	const openActionMenuAt = useCallback(
@@ -2655,6 +2723,14 @@ export const MessageItemComponent = ({
 						document.body
 					)
 				: null}
+			{deleteOverlay && (
+				<Overlay
+					item={deleteOverlayItem}
+					handleOverlayClose={() => {
+						setDeleteOverlay(false);
+					}}
+				/>
+			)}
 		</div>
 	);
 };

--- a/src/components/session/SessionItemComponent.tsx
+++ b/src/components/session/SessionItemComponent.tsx
@@ -3281,6 +3281,21 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 		});
 	}, []);
 
+	const handleDeleteDirect = useCallback(
+		(message: MessageItem) => {
+			if (!resolvedMatrixRoomId || !message?._id) {
+				return;
+			}
+			chatTransportService
+				.redactMessage({
+					matrixRoomId: resolvedMatrixRoomId,
+					targetEventId: message._id
+				})
+				.catch(() => undefined);
+		},
+		[resolvedMatrixRoomId]
+	);
+
 	const handleCancelEdit = useCallback(() => setEditingMessage(null), []);
 
 	// A reply or edit context never survives a conversation switch.
@@ -4938,6 +4953,14 @@ export const SessionItemComponent = (props: SessionItemProps) => {
 											isMyMessageMatrix(message.userId)
 												? () =>
 														handleEditDirect(
+															message
+														)
+												: undefined
+										}
+										onDeleteDirect={
+											isMyMessageMatrix(message.userId)
+												? () =>
+														handleDeleteDirect(
 															message
 														)
 												: undefined

--- a/src/services/chatTransportService.test.ts
+++ b/src/services/chatTransportService.test.ts
@@ -746,6 +746,32 @@ describe('chatTransportService editing + reactions (#435)', () => {
 		expect(redactEvent).toHaveBeenCalledWith(ROOM_ID, '$reaction:hs');
 		expect(result).toEqual({ success: true, event_id: '$redaction:hs' });
 	});
+
+	it('redactMessage redacts the message event via the Matrix client', async () => {
+		const redactEvent = vi.fn(async () => ({ event_id: '$redaction:hs' }));
+		const override = { getClient: () => ({}), redactEvent } as any;
+
+		const result = await chatTransportService.redactMessage({
+			matrixRoomId: ROOM_ID,
+			targetEventId: '$msg:hs',
+			matrixClientServiceOverride: override
+		});
+
+		expect(redactEvent).toHaveBeenCalledWith(ROOM_ID, '$msg:hs');
+		expect(result).toEqual({ success: true, event_id: '$redaction:hs' });
+	});
+
+	it('redactMessage rejects when the Matrix client is not initialized', async () => {
+		const override = { getClient: () => null } as any;
+
+		await expect(
+			chatTransportService.redactMessage({
+				matrixRoomId: ROOM_ID,
+				targetEventId: '$msg:hs',
+				matrixClientServiceOverride: override
+			})
+		).rejects.toThrow('Matrix client not initialized');
+	});
 });
 
 describe('chatTransportService sendTextMessage mentions (#435)', () => {

--- a/src/services/chatTransportService.ts
+++ b/src/services/chatTransportService.ts
@@ -70,6 +70,12 @@ export interface RemoveReactionOptions {
 	matrixClientServiceOverride?: MatrixClientService | null;
 }
 
+export interface RedactMessageOptions {
+	matrixRoomId: string;
+	targetEventId: string;
+	matrixClientServiceOverride?: MatrixClientService | null;
+}
+
 export interface SendFileMessageOptions extends MatrixFileMessageOptions {
 	threadRootId?: string | null;
 	supervisorMessage?: boolean;
@@ -240,6 +246,26 @@ class ChatTransportService {
 		const response = await matrixClientService.redactEvent(
 			matrixRoomId,
 			reactionEventId
+		);
+
+		return { success: true, event_id: response.event_id };
+	}
+
+	/** Delete a message by redacting the Matrix event (#827). */
+	public async redactMessage({
+		matrixRoomId,
+		targetEventId,
+		matrixClientServiceOverride
+	}: RedactMessageOptions): Promise<any> {
+		const matrixClientService =
+			matrixClientServiceOverride || getMatrixClientService();
+		if (!matrixClientService?.getClient()) {
+			return Promise.reject(new Error('Matrix client not initialized'));
+		}
+
+		const response = await matrixClientService.redactEvent(
+			matrixRoomId,
+			targetEventId
 		);
 
 		return { success: true, event_id: response.event_id };

--- a/src/services/matrixClientService.ts
+++ b/src/services/matrixClientService.ts
@@ -542,7 +542,7 @@ export class MatrixClientService {
 		}
 	}
 
-	// Redact an event (used to remove a reaction)
+	// Redact an event (reactions un-react, and message delete #827)
 	public async redactEvent(roomId: string, eventId: string): Promise<any> {
 		await this.ensureFreshToken();
 

--- a/src/utils/matrixTimelineEventFormatter.test.ts
+++ b/src/utils/matrixTimelineEventFormatter.test.ts
@@ -16,6 +16,35 @@ const makeEvent = (content: Record<string, unknown>) => ({
 	getTs: () => 1700000000000
 });
 
+describe('formatMatrixTimelineEvent redacted events (#827)', () => {
+	it('maps isRedacted() events to t: rm', () => {
+		const formatted = formatMatrixTimelineEvent(
+			{
+				...makeEvent({ msgtype: 'm.text', body: 'gone' }),
+				isRedacted: () => true
+			},
+			null,
+			'verschlüsselt'
+		);
+		expect(formatted.t).toBe('rm');
+		expect(formatted.msg).toBe('');
+		expect(formatted._id).toBe('$msg:hs');
+	});
+
+	it('leaves non-redacted messages without t: rm', () => {
+		const formatted = formatMatrixTimelineEvent(
+			{
+				...makeEvent({ msgtype: 'm.text', body: 'hallo' }),
+				isRedacted: () => false
+			},
+			null,
+			'verschlüsselt'
+		);
+		expect(formatted.t).toBeUndefined();
+		expect(formatted.msg).toBe('hallo');
+	});
+});
+
 describe('formatMatrixTimelineEvent reply relation', () => {
 	it('exposes replyToEventId and strips the legacy quote fallback', () => {
 		const formatted = formatMatrixTimelineEvent(

--- a/src/utils/matrixTimelineEventFormatter.ts
+++ b/src/utils/matrixTimelineEventFormatter.ts
@@ -30,12 +30,31 @@ export const formatMatrixTimelineEvent = (
 		return null;
 	}
 
-	const content = event?.getClearContent?.() || event?.getContent?.() || {};
 	const senderId = event?.getSender?.() || '';
 	const senderUsername = senderId?.split(':')[0]?.substring(1) || 'unknown';
 	const senderMember = matrixRoom?.getMember?.(senderId);
 	const senderDisplayName =
 		senderMember?.name || senderMember?.rawDisplayName || senderUsername;
+
+	// Matrix redact (#827): redacted events keep m.room.message type but
+	// empty content — surface as legacy deleted state for MessageItem.
+	if (event?.isRedacted?.()) {
+		return {
+			_id:
+				event?.getId?.() ||
+				`${senderId}-${event?.getTs?.() || Date.now()}`,
+			msg: '',
+			ts: new Date(event?.getTs?.() || Date.now()),
+			t: 'rm',
+			u: {
+				_id: senderId,
+				username: senderUsername,
+				name: senderDisplayName
+			}
+		};
+	}
+
+	const content = event?.getClearContent?.() || event?.getContent?.() || {};
 	const isUndecryptedEvent =
 		eventType === 'm.room.encrypted' && !content?.msgtype;
 	// Relations foundation (#435): replies are the m.in_reply_to relation.


### PR DESCRIPTION
#### Issue [#827](https://github.com/OpenResilienceInitiative/ORISO-Frontend/issues/827)

## PR Description
### Why
After Matrix migration, message delete was a no-op:
- Kebab "Delete" menu item had no handler
- Legacy REST delete path is disabled and incompatible with Matrix event IDs
- No Matrix redact path existed for messages

### What
- Wire kebab Delete to confirmation dialog → onDeleteDirect (own messages only, Message_AllowDeleting on, not archived)
- Add chatTransportService.redactMessage → matrixClientService.redactEvent
- Map event.isRedacted() to t: 'rm' in timeline formatter so deleted-message UI renders
- Add handleDeleteDirect in SessionItemComponent (mirrors handleEditDirect)

### Benefits
- Counsellors can delete their own messages via Matrix redact
- Deleted messages show as "Message deleted" in UI
- No plaintext sent to UserService — pure Matrix redact

### Actionable checkpoints
- [ ] Confirm delete button appears only for own messages
- [ ] Confirm confirmation dialog appears before delete
- [ ] Confirm message shows "Message deleted" after redact
- [ ] Confirm delete not available on archived sessions

### Definition of done
- Delete button works end-to-end on PreDev
- CI green

## Screenshots
#### On Message Sent
<img width="1896" height="906" alt="image" src="https://github.com/user-attachments/assets/2b0dbda1-ee5f-4516-be47-21ecc4647688" />
#### On Delete Overlay Is Open
<img width="1892" height="901" alt="image" src="https://github.com/user-attachments/assets/bf5e2343-757e-4da4-ac38-ab1692bece9c" />
#### After Message Redacted 
<img width="1901" height="906" alt="image" src="https://github.com/user-attachments/assets/9ba8242b-b258-4687-99c7-a9ffce3a26fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete your own messages directly from the message action menu.
  * Deletion is available only when enabled by server settings and the session is active.
  * Added a confirmation prompt to prevent accidental deletion.

* **Bug Fixes**
  * Deleted messages now display consistently as removed messages across the timeline.

* **Tests**
  * Added coverage for message deletion and redacted message display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->