### PR TITLE
fix(test): stop shelling out to grep, the one timeout-immune stall in the suite

### DIFF
--- a/src/components/animatedIllustration/AnimatedIllustration.test.tsx
+++ b/src/components/animatedIllustration/AnimatedIllustration.test.tsx
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	ANIMATION_LOOPS,
@@ -69,6 +69,18 @@ function collectColors(value: unknown, found = new Set<string>()) {
 
 	return [...found];
 }
+
+// Paths stay relative to the repo root, matching what `grep -rl src/` printed
+// and the cwd-relative readFileSync further down.
+const scriptFilesUnder = (dir: string): string[] =>
+	readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const entryPath = path.join(dir, entry.name);
+		return entry.isDirectory()
+			? scriptFilesUnder(entryPath)
+			: /\.(?:js|jsx|ts|tsx)$/.test(entry.name)
+				? [entryPath]
+				: [];
+	});
 
 const stubReducedMotion = (matches: boolean) =>
 	vi.stubGlobal(
@@ -140,12 +152,17 @@ describe('animation playback policy', () => {
 	it('is the only component that talks to lottie-react', () => {
 		// Two players with two speeds is what this consolidation removed; a new
 		// direct import would let them drift apart again.
-		const hits = execSync('grep -rl "from \'lottie-react\'" src/ || true', {
-			encoding: 'utf8'
-		})
-			.split('\n')
-			.filter(Boolean)
-			.filter((file) => !file.endsWith('.test.tsx'));
+		//
+		// Searched in-process rather than by shelling out to grep: execSync
+		// blocks the worker's event loop, and vitest's testTimeout is itself a
+		// JS timer, so it cannot fire while that loop is blocked. A stalled
+		// child process here could not be timed out by the test runner and ran
+		// to GitHub's 6 h job ceiling instead.
+		const hits = scriptFilesUnder('src').filter(
+			(file) =>
+				!file.endsWith('.test.tsx') &&
+				readFileSync(file, 'utf8').includes("from 'lottie-react'")
+		);
 
 		expect(hits).toEqual([
 			'src/components/animatedIllustration/AnimatedIllustration.tsx'

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -26,6 +26,15 @@ export default defineConfig({
 	},
 	test: {
 		include: ['src/**/*.test.{ts,tsx}'],
+		// Explicit rather than inherited from the defaults, so the intent is
+		// visible: a test or hook that never settles must fail here, not sit
+		// until CI's job timeout kills the whole run. Note these only catch
+		// asynchronous stalls — a synchronous block cannot be interrupted by a
+		// JS timer, which is why no test in this suite may spawn a child
+		// process synchronously.
+		testTimeout: 10_000,
+		hookTimeout: 15_000,
+		teardownTimeout: 15_000,
 		// Polyfill the layout APIs jsdom lacks (Range.getClientRects,
 		// Element.scrollIntoView) so TipTap's focus/scroll path doesn't throw
 		// an async unhandled error that flakes the composer emoji test in CI.


### PR DESCRIPTION
## Why

Frontend CI jobs were hanging until GitHub's hard 6 h job limit killed them — 15 times on 3 Aug (5,369 min), 11 times on 2 Aug (3,887 min). A cancelled job reports **no test result at all**, so the PR check goes grey and nobody learns whether the code is sound.

[#988](https://github.com/OpenResilienceInitiative/ORISO-Frontend/pull/988) capped the damage with `timeout-minutes`. This PR removes the cause.

## Evidence

Three hung runs from 3 Aug, diffed against a green run of the same workflow:

| Run | Test files completed |
|---|---:|
| green | 258 |
| [30842236531](https://github.com/OpenResilienceInitiative/ORISO-Frontend/actions/runs/30842236531) | 226 |
| [30819790803](https://github.com/OpenResilienceInitiative/ORISO-Frontend/actions/runs/30819790803) | 226 |
| [30777738995](https://github.com/OpenResilienceInitiative/ORISO-Frontend/actions/runs/30777738995) | 220 |

**30 files never completed in all three.** Exactly one of those 30 spawns a child process — and it is the only one of all 257 test files in the repo that does:

```js
const hits = execSync('grep -rl "from \'lottie-react\'" src/ || true', {
    encoding: 'utf8'
})
```

## Why it survived every timeout

`vitest.config.mts` set no timeouts, so the defaults applied: 5 s per test, 10 s per hook. An **asynchronous** stall would therefore have failed after 5 seconds — it could never have reached 360 minutes.

`execSync` blocks the worker's event loop synchronously. Vitest's `testTimeout` is itself a JS timer, so it cannot fire while that loop is blocked. A synchronous block is the only construct in this suite that can produce a hang no test-runner timeout can interrupt, and it occurs exactly once — in the file that never completed in all three hangs.

## What changed

**1. In-process search instead of a subprocess.** A recursive walk over `src/` replaces the `grep`. Paths stay relative to the repo root, so the assertion is byte-for-byte the same; the search is narrowed to script extensions rather than every file `grep -r` would open.

**2. Explicit vitest timeouts** (`testTimeout` 10 s, `hookTimeout` 15 s, `teardownTimeout` 15 s). These do not help against a synchronous block — that is the point of the comment next to them — but they make an asynchronous stall fail in the runner instead of sitting until the job timeout.

## Verification

The guard has to keep biting, not just keep passing. Added a second file importing `lottie-react` and re-ran:

```
× animation playback policy > is the only component that talks to lottie-react
  → expected [ …(2) ] to deeply equal [ Array(1) ]
```

Removed it again → 7/7 pass. Full suite: **257 files, 1829 tests, green**. `npm run lint:scripts` (eslint `--max-warnings=0` + `tsc`) and Prettier clean.

## What this does not prove

Why the child process stalls under CI load in the first place — most likely stdio/pipe behaviour with two concurrent workers, but I did not reproduce it. The flake ran at roughly 10% of jobs and a local full-suite run passes in 45 s. This PR removes the mechanism rather than explaining it: with no subprocess, the hang cannot recur through this path whatever the underlying cause was.

If hangs reappear after this merges, that falsifies the diagnosis cleanly and the next place to look is an asynchronous stall — which the new timeouts will now surface as a normal test failure with a file name attached.

## Reviewer test plan

- [ ] `npm run test:unit` passes locally (257 files / 1829 tests)
- [ ] Confirm the guard still fails on a violation: add `import Lottie from 'lottie-react';` to any file under `src/`, re-run, see the assertion fail, remove it
- [ ] Confirm no test file spawns a subprocess any more: `grep -rln "execSync\|spawnSync\|child_process" src --include="*.test.ts*"` returns nothing
- [ ] Watch the next few days of `Frontend Branch Validation` runs — no job should approach its `timeout-minutes` cap
