### PR TITLE
fix(i18n): rename "Nähe" to "Mail" and translate the message menu (#985, #980)

### DIFF
--- a/cypress/e2e/session-list-figma-regression.cy.ts
+++ b/cypress/e2e/session-list-figma-regression.cy.ts
@@ -18,7 +18,7 @@ describe('Session list Figma regression', () => {
 		mockWebSocket();
 	});
 
-	it('renders registered Nähe sessions with postcode and stable menu interactions', () => {
+	it('renders registered Mail sessions with postcode and stable menu interactions', () => {
 		cy.consultantSession(
 			{
 				session: {
@@ -93,14 +93,14 @@ describe('Session list Figma regression', () => {
 			.first()
 			.as('registeredNearbySession')
 			.should('contain.text', '12345')
-			.and('contain.text', 'Nähe')
+			.and('contain.text', 'Mail')
 			.and('not.contain.text', 'Live Chat');
 		cy.get('@registeredNearbySession')
 			.find('.sessionsListItem__postcode')
 			.should('contain.text', '12345');
 		cy.get('@registeredNearbySession')
 			.find('.sessionsListItem__consultingTypeIcon--nearbyLabel')
-			.should('contain.text', 'Nähe');
+			.should('contain.text', 'Mail');
 
 		cy.get('@registeredNearbySession')
 			.find('.sessionsListItem__menuIcon')
@@ -183,12 +183,12 @@ describe('Session list Figma regression', () => {
 		cy.get('.sessionsListItem__dropdown').should('not.exist');
 		cy.get('@secondRegisteredNearbySession')
 			.should('contain.text', '99322')
-			.and('contain.text', 'Nähe')
+			.and('contain.text', 'Mail')
 			.and('not.contain.text', 'Live Chat');
 		cy.get('[data-cy=session-list-item]')
 			.eq(2)
 			.should('contain.text', 'Auto Select U25')
-			.and('contain.text', 'Nähe')
+			.and('contain.text', 'Mail')
 			.and('not.contain.text', '54321')
 			.and('not.contain.text', 'Live Chat');
 	});

--- a/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
+++ b/src/components/app/AppOrisoConsultantChatSurface.stories.tsx
@@ -89,7 +89,7 @@ const labelFallbacks: Record<string, string> = {
 	'sessionList.toolbar.search.removeSelectedPerson': 'Person entfernen',
 	'sessionList.toolbar.chips.unread': 'Ungelesen',
 	'sessionList.toolbar.chips.drafts': 'Entwürfe',
-	'sessionList.toolbar.chips.nearby': 'Nearby',
+	'sessionList.toolbar.chips.nearby': 'Mail',
 	'sessionList.toolbar.chips.liveChat': 'Live Chat',
 	'sessionList.toolbar.chips.internalGroup': 'Interner Gruppenchat',
 	'sessionList.toolbar.chips.supervision': 'Supervision',

--- a/src/components/message/MessageItemComponent.tsx
+++ b/src/components/message/MessageItemComponent.tsx
@@ -2351,7 +2351,10 @@ export const MessageItemComponent = ({
 								<button
 									type="button"
 									className="messageItem__kebabButton messageItem__kebabButton--left"
-									aria-label="More"
+									aria-label={translate(
+										'message.menu.open',
+										'More options'
+									)}
 									onClick={(event) =>
 										toggleActionMenu(event, 'left')
 									}
@@ -2443,7 +2446,10 @@ export const MessageItemComponent = ({
 								<button
 									type="button"
 									className="messageItem__kebabButton messageItem__kebabButton--right"
-									aria-label="More"
+									aria-label={translate(
+										'message.menu.open',
+										'More options'
+									)}
 									onClick={(event) =>
 										toggleActionMenu(event, 'right')
 									}

--- a/src/components/message/messageMenuI18n.test.ts
+++ b/src/components/message/messageMenuI18n.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression guard for #980 — "Message dropdown menu is displayed in English
+ * despite German language settings".
+ *
+ * Root cause: every label of the message action menu was rendered through
+ * `translate('message.menu.…', 'English default')`, but none of those keys had
+ * ever been added to a catalogue. react-i18next therefore fell back to the
+ * inline English default in *every* language, so the menu stayed English no
+ * matter what the user had configured.
+ *
+ * The guard is deliberately source-driven rather than a snapshot of one menu:
+ * it reads the translate() call sites out of `MessageItemComponent.tsx` and
+ * asserts that every `message.*` key they reference actually resolves in the
+ * two catalogues authored in this repo (de + en). A new hardcoded-default
+ * label with a missing key reintroduces the bug and fails here.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import deCommon from '../../resources/i18n/de/common.json';
+import enCommon from '../../resources/i18n/en/common.json';
+
+const SOURCE = readFileSync(
+	join(__dirname, 'MessageItemComponent.tsx'),
+	'utf-8'
+);
+
+/** `translate('some.key'` — prettier may wrap the argument onto its own line. */
+const TRANSLATE_KEY = /translate\(\s*'([^']+)'/g;
+
+const resolve = (catalogue: unknown, key: string): unknown =>
+	key
+		.split('.')
+		.reduce<unknown>(
+			(node, part) =>
+				node && typeof node === 'object'
+					? (node as Record<string, unknown>)[part]
+					: undefined,
+			catalogue
+		);
+
+const messageKeys = Array.from(SOURCE.matchAll(TRANSLATE_KEY))
+	.map((match) => match[1])
+	.filter((key) => key.startsWith('message.'))
+	.filter((key, index, all) => all.indexOf(key) === index)
+	.sort();
+
+/** The labels the reporter saw in English (screenshot on #980). */
+const ACTION_MENU_KEYS = [
+	'message.menu.open',
+	'message.menu.replyDirect',
+	'message.menu.replyThread',
+	'message.menu.edit',
+	'message.menu.markText',
+	'message.menu.forward',
+	'message.menu.delete'
+];
+
+describe('message action menu i18n (#980)', () => {
+	it('finds the translate() call sites it is supposed to guard', () => {
+		expect(messageKeys.length).toBeGreaterThan(10);
+		ACTION_MENU_KEYS.forEach((key) => {
+			expect(messageKeys).toContain(key);
+		});
+	});
+
+	it.each(ACTION_MENU_KEYS)('has a German label for %s', (key) => {
+		const german = resolve(deCommon, key);
+		expect(typeof german).toBe('string');
+		expect(german).not.toBe('');
+		// A German catalogue entry that merely repeats the English one would
+		// still show up as "English menu" to the counsellor.
+		expect(german).not.toBe(resolve(enCommon, key));
+	});
+
+	it('resolves every message.* key used by MessageItemComponent', () => {
+		const unresolved = messageKeys.filter(
+			(key) =>
+				typeof resolve(deCommon, key) !== 'string' ||
+				typeof resolve(enCommon, key) !== 'string'
+		);
+
+		expect(unresolved).toEqual([]);
+	});
+
+	it('no longer relies on a hardcoded English aria-label for the kebab', () => {
+		expect(SOURCE).not.toContain('aria-label="More"');
+	});
+});

--- a/src/components/sessionsList/EnquiryFilterChips.tsx
+++ b/src/components/sessionsList/EnquiryFilterChips.tsx
@@ -12,7 +12,7 @@ interface EnquiryFilterChipsProps {
 
 /**
  * Compact filter-chip row for the consultant enquiry tab.
- * Two chips: "Nearby" (registered enquiries) and "Live Chat" (anonymous
+ * Two chips: "Mail" (registered enquiries) and "Live Chat" (anonymous
  * enquiries, shown only when the sidebar live-chat availability toggle is
  * active). Clicking a chip toggles it; clicking the active one again clears
  * the filter so the full list returns.
@@ -43,7 +43,7 @@ export const EnquiryFilterChips: React.FC<EnquiryFilterChipsProps> = ({
 					<span className="sessionsListToolbar__chipLabel">
 						{translate(
 							'sessionList.toolbar.chips.nearby',
-							'Nearby'
+							'Mail'
 						)}
 					</span>
 				</button>

--- a/src/components/sessionsList/SessionListColumn.stories.tsx
+++ b/src/components/sessionsList/SessionListColumn.stories.tsx
@@ -120,11 +120,11 @@ function DemoCard({
 						<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--nearby">
 							<img
 								src={nearbyConversationIcon}
-								alt="Nähe"
+								alt="Mail"
 								className="sessionsListItem__consultingTypeIcon--nearbyIcon"
 							/>
 							<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
-								Nähe
+								Mail
 							</span>
 						</div>
 					)}

--- a/src/components/sessionsList/SessionSearchPanel.stories.tsx
+++ b/src/components/sessionsList/SessionSearchPanel.stories.tsx
@@ -72,7 +72,7 @@ const topics: SessionSearchTopicOption[] = [
 const types: SessionSearchTypeOption[] = [
 	{ id: 'oneToOne', label: '1-1 Beratung' },
 	{ id: 'liveChat', label: 'Live Chat' },
-	{ id: 'nearby', label: 'Nähe' },
+	{ id: 'nearby', label: 'Mail' },
 	{ id: 'group', label: 'Kreis' }
 ];
 

--- a/src/components/sessionsList/SessionsListToolbar.stories.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.stories.tsx
@@ -98,7 +98,7 @@ function SessionsListToolbarPlayground({
 				searchTypeResults={[
 					{ id: 'oneToOne', label: '1-1 Beratung' },
 					{ id: 'liveChat', label: 'Live Chat' },
-					{ id: 'nearby', label: 'Nähe' }
+					{ id: 'nearby', label: 'Mail' }
 				]}
 				selectedTypeId={selectedTypeId}
 				onSelectedTypeIdChange={setSelectedTypeId}

--- a/src/components/sessionsList/SessionsListToolbar.tsx
+++ b/src/components/sessionsList/SessionsListToolbar.tsx
@@ -153,7 +153,7 @@ const FILTER_CHIPS: FilterChipConfig[] = [
 	{
 		id: 'nearby',
 		labelKey: 'sessionList.toolbar.chips.nearby',
-		fallback: 'Nearby',
+		fallback: 'Mail',
 		Icon: NearbyFilterIcon,
 		dataCy: 'sessions-list-chip-nearby'
 	},

--- a/src/components/sessionsList/sessionToolbarMailChip.test.tsx
+++ b/src/components/sessionsList/sessionToolbarMailChip.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+/**
+ * Regression guard for #985 — the modality formerly labelled "Nähe" is called
+ * "Mail" everywhere. "Nähe" was too obscure for practitioners, and it appeared
+ * in more than the one filter chip the reporter saw: the session-list toolbar,
+ * the enquiry filter row, the list-item modality badge, and the catalogues
+ * behind them all carried it.
+ *
+ * Covers both paths a label can take: the catalogue entry and the hardcoded
+ * `translate(key, fallback)` default that is used when the catalogue misses.
+ */
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SessionsListToolbar } from './SessionsListToolbar';
+import { EnquiryFilterChips } from './EnquiryFilterChips';
+import deCommon from '../../resources/i18n/de/common.json';
+import deInformalCommon from '../../resources/i18n/de@informal/common.json';
+import enCommon from '../../resources/i18n/en/common.json';
+
+afterEach(cleanup);
+
+vi.mock('./SessionToolbarFilterIcons', () => {
+	const Icon = () => <span aria-hidden />;
+	return {
+		ArchiveFilterIcon: Icon,
+		CreateChatFilterIcon: Icon,
+		DraftFilterIcon: Icon,
+		GroupFilterIcon: Icon,
+		InternalGroupFilterIcon: Icon,
+		LiveChatFilterIcon: Icon,
+		NearbyFilterIcon: Icon,
+		SupervisionFilterIcon: Icon,
+		UnreadFilterIcon: Icon
+	};
+});
+
+const CATALOGUES: [string, typeof deCommon][] = [
+	['de', deCommon],
+	['de@informal', deInformalCommon as typeof deCommon],
+	['en', enCommon as typeof deCommon]
+];
+
+describe('"Mail" modality label (#985)', () => {
+	it.each(CATALOGUES)(
+		'labels both chip keys "Mail" in %s',
+		(_, catalogue) => {
+			const chips = catalogue.sessionList.toolbar.chips;
+
+			expect(chips.nearby).toBe('Mail');
+			expect(chips.chats).toBe('Mail');
+		}
+	);
+
+	it('renders "Mail" in the session-list toolbar when the catalogue is missing', () => {
+		// `translate` echoing the key is how the toolbar sees an unresolved
+		// entry, which makes it fall through to the hardcoded default.
+		render(
+			<MemoryRouter>
+				<SessionsListToolbar
+					translate={(key) => key}
+					searchValue=""
+					onSearchChange={vi.fn()}
+					activeChip={null}
+					onChipToggle={vi.fn()}
+					showConsultantActions
+					showCreateGroupChatAction={false}
+					showSupervisionChip={false}
+					createGroupChatPath="/sessions/create"
+					archiveTabPath="/sessions/archive"
+					archiveTabActive={false}
+					createGroupChatActive={false}
+				/>
+			</MemoryRouter>
+		);
+
+		expect(screen.getByText('Mail')).toBeTruthy();
+		expect(screen.queryByText('Nähe')).toBeNull();
+		expect(screen.queryByText('Nearby')).toBeNull();
+	});
+
+	it('renders the German chip label in the enquiry filter row', () => {
+		render(
+			<EnquiryFilterChips
+				translate={(key) =>
+					key === 'sessionList.toolbar.chips.nearby'
+						? deCommon.sessionList.toolbar.chips.nearby
+						: key
+				}
+				activeChip={null}
+				onChipToggle={vi.fn()}
+				showLiveChatChip={false}
+			/>
+		);
+
+		expect(screen.getByText('Mail')).toBeTruthy();
+		expect(screen.queryByText('Nähe')).toBeNull();
+	});
+});

--- a/src/components/sessionsListItem/SessionListItem.stories.tsx
+++ b/src/components/sessionsListItem/SessionListItem.stories.tsx
@@ -340,7 +340,7 @@ function SessionMenuMock({ onClose }: { onClose: () => void }) {
 	);
 }
 
-/** Mirrors registered Nähe row layout (topic + PLZ, menu pill, Nähe meta). */
+/** Mirrors registered Mail row layout (topic + PLZ, menu pill, Mail meta). */
 function ConsultantCardMock({
 	active = false,
 	beforeActive = false,
@@ -469,11 +469,11 @@ function ConsultantCardMock({
 					<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--nearby">
 						<img
 							src={nearbyConversationIcon}
-							alt="Nähe"
+							alt="Mail"
 							className="sessionsListItem__consultingTypeIcon--nearbyIcon"
 						/>
 						<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
-							Nähe
+							Mail
 						</span>
 					</div>
 				</div>
@@ -668,11 +668,11 @@ function PostcodeOnlyCardMock() {
 					<div className="sessionsListItem__consultingTypeIcon sessionsListItem__consultingTypeIcon--nearby">
 						<img
 							src={nearbyConversationIcon}
-							alt="Nähe"
+							alt="Mail"
 							className="sessionsListItem__consultingTypeIcon--nearbyIcon"
 						/>
 						<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
-							Nähe
+							Mail
 						</span>
 					</div>
 				</div>
@@ -1071,8 +1071,8 @@ export const InternalCounsellorChat: Story = {
 	)
 };
 
-// ZipTopicSelection (Nähe, Figma 98-20505) is intentionally NOT a separate
-// story: its layout (topic tag + postcode pill + "Nähe" chat-type icon) is
+// ZipTopicSelection (Mail, Figma 98-20505) is intentionally NOT a separate
+// story: its layout (topic tag + postcode pill + "Mail" chat-type icon) is
 // already covered by `ConsultantUnselected` (ConsultantCardMock). Adding it
 // again would just duplicate that story, so it is skipped per the refactor.
 

--- a/src/components/sessionsListItem/SessionListItemComponent.tsx
+++ b/src/components/sessionsListItem/SessionListItemComponent.tsx
@@ -1554,7 +1554,7 @@ export const SessionListItemComponent = ({
 							onDeselectAndClose={onCaseHandoverBatchClose}
 						/>
 					)}
-					{/* Consulting-type modality icon (Nähe / Live Chat / Interna
+					{/* Consulting-type modality icon (Mail / Live Chat / Interna
 					    / Gesprächskreis) — always shown, including alongside the
 					    case-handover action button (Figma node 115). */}
 					{
@@ -1598,14 +1598,14 @@ export const SessionListItemComponent = ({
 										src={nearbyConversationIcon}
 										alt={translate(
 											'sessionList.toolbar.chips.nearby',
-											'Nähe'
+											'Mail'
 										)}
 										className="sessionsListItem__consultingTypeIcon--nearbyIcon"
 									/>
 									<span className="sessionsListItem__consultingTypeIcon--nearbyLabel">
 										{translate(
 											'sessionList.toolbar.chips.nearby',
-											'Nähe'
+											'Mail'
 										)}
 									</span>
 								</div>

--- a/src/resources/i18n/de/common.json
+++ b/src/resources/i18n/de/common.json
@@ -1497,6 +1497,9 @@
 			}
 		},
 		"audience": {
+			"clients": "Ratsuchende",
+			"counsellors": "Beratende",
+			"moderators": "Moderierende",
 			"all": "Alle",
 			"multiCount": "{{count}} Personen",
 			"sendToAll": "An alle senden",
@@ -1505,19 +1508,43 @@
 			"closeMenu": "Senden-an-Menü schließen",
 			"menuSubheading": "Wähle wer diese Nachricht sehen soll",
 			"menuHeading": "Adressaten wählen",
-			"clientsSelectSuffix": "Client Select",
-			"clientsSelected": "{{count}} Clients Selected",
-			"clientsSelectAll": "Select All Clients",
-			"counsellorsSelect": "Select All Counsellors",
-			"counsellorsSelected": "{{count}} Counsellors Selected",
-			"moderatorsSelect": "Select All Moderators",
-			"moderatorsSelected": "{{count}} Moderators Selected",
-			"clientsEmpty": "No clients are in this room",
-			"counsellorsEmpty": "No counsellors are in this room",
-			"moderatorsEmpty": "No moderators are in this room",
+			"clientsSelectSuffix": "Ratsuchende auswählen",
+			"clientsSelected": "{{count}} Ratsuchende ausgewählt",
+			"clientsSelectAll": "Alle Ratsuchenden auswählen",
+			"counsellorsSelect": "Alle Beratenden auswählen",
+			"counsellorsSelected": "{{count}} Beratende ausgewählt",
+			"moderatorsSelect": "Alle Moderierenden auswählen",
+			"moderatorsSelected": "{{count}} Moderierende ausgewählt",
+			"clientsEmpty": "In diesem Raum sind keine Ratsuchenden",
+			"counsellorsEmpty": "In diesem Raum sind keine Beratenden",
+			"moderatorsEmpty": "In diesem Raum sind keine Moderierenden",
 			"toggleSection": "Bereich umschalten",
-			"selectAllBottom": "Select All"
+			"selectAllBottom": "Alle auswählen"
 		},
+		"edit": {
+			"marker": "(bearbeitet)",
+			"markerTitle": "Nachricht wurde bearbeitet"
+		},
+		"feedbackTag": "Feedback",
+		"menu": {
+			"open": "Weitere Optionen",
+			"replyDirect": "Direkt antworten",
+			"replyThread": "Im Thread antworten",
+			"edit": "Nachricht bearbeiten",
+			"markText": "Text markieren",
+			"forward": "Nachricht weiterleiten",
+			"delete": "Nachricht löschen"
+		},
+		"reaction": {
+			"add": "Reagieren",
+			"count": "{{key}}: {{count}} Reaktionen"
+		},
+		"visibility": {
+			"open": "Sichtbarkeit anzeigen",
+			"people": "Personen, die diese Nachricht sehen",
+			"title": "Nachricht sichtbar für …"
+		},
+		"visibleOnlyTo": "nur sichtbar für:",
 		"showLess": "Weniger anzeigen",
 		"showMore": "Mehr anzeigen",
 		"systemNotification": "Systembenachrichtigung",
@@ -3065,7 +3092,7 @@
 				"neu": "Ungelesen",
 				"unread": "Ungelesen",
 				"drafts": "Entwürfe",
-				"nearby": "Nähe",
+				"nearby": "Mail",
 				"create": "Erstellen",
 				"archive": "Archiviert",
 				"oneToOne": "1-1 Beratung",
@@ -3073,7 +3100,7 @@
 				"internalGroup": "Interner Gruppenchat",
 				"groups": "Gesprächskreis",
 				"supervision": "Supervision",
-				"chats": "Nähe"
+				"chats": "Mail"
 			},
 			"emptyFilterResult": "Keine Beratung entspricht Ihrer Suche oder den Filtern.",
 			"draftMetadataOnly": "Ungesendete Nachricht gespeichert."

--- a/src/resources/i18n/de@informal/common.json
+++ b/src/resources/i18n/de@informal/common.json
@@ -454,18 +454,18 @@
 			"closeMenu": "Senden-an-Menü schließen",
 			"menuSubheading": "Wähle wer diese Nachricht sehen soll",
 			"menuHeading": "Adressaten wählen",
-			"clientsSelectSuffix": "Client Select",
-			"clientsSelected": "{{count}} Clients Selected",
-			"clientsSelectAll": "Select All Clients",
-			"counsellorsSelect": "Select All Counsellors",
-			"counsellorsSelected": "{{count}} Counsellors Selected",
-			"moderatorsSelect": "Select All Moderators",
-			"moderatorsSelected": "{{count}} Moderators Selected",
-			"clientsEmpty": "No clients are in this room",
-			"counsellorsEmpty": "No counsellors are in this room",
-			"moderatorsEmpty": "No moderators are in this room",
+			"clientsSelectSuffix": "Ratsuchende auswählen",
+			"clientsSelected": "{{count}} Ratsuchende ausgewählt",
+			"clientsSelectAll": "Alle Ratsuchenden auswählen",
+			"counsellorsSelect": "Alle Beratenden auswählen",
+			"counsellorsSelected": "{{count}} Beratende ausgewählt",
+			"moderatorsSelect": "Alle Moderierenden auswählen",
+			"moderatorsSelected": "{{count}} Moderierende ausgewählt",
+			"clientsEmpty": "In diesem Raum sind keine Ratsuchenden",
+			"counsellorsEmpty": "In diesem Raum sind keine Beratenden",
+			"moderatorsEmpty": "In diesem Raum sind keine Moderierenden",
 			"toggleSection": "Bereich umschalten",
-			"selectAllBottom": "Select All"
+			"selectAllBottom": "Alle auswählen"
 		},
 		"delete": {
 			"deleted": {
@@ -1245,7 +1245,7 @@
 				"neu": "Ungelesen",
 				"unread": "Ungelesen",
 				"drafts": "Entwürfe",
-				"nearby": "Nähe",
+				"nearby": "Mail",
 				"create": "Erstellen",
 				"archive": "Archiviert",
 				"oneToOne": "1-1 Beratung",
@@ -1253,7 +1253,7 @@
 				"internalGroup": "Interner Gruppenchat",
 				"groups": "Gesprächskreis",
 				"supervision": "Supervision",
-				"chats": "Nähe"
+				"chats": "Mail"
 			},
 			"emptyFilterResult": "Keine Beratung entspricht Deiner Suche oder den Filtern.",
 			"draftMetadataOnly": "Ungesendete Nachricht gespeichert."

--- a/src/resources/i18n/en/common.json
+++ b/src/resources/i18n/en/common.json
@@ -1482,6 +1482,9 @@
 			}
 		},
 		"audience": {
+			"clients": "Clients",
+			"counsellors": "Counsellors",
+			"moderators": "Moderators",
 			"all": "All",
 			"multiCount": "{{count}} persons",
 			"sendToAll": "Send to all",
@@ -1503,6 +1506,30 @@
 			"toggleSection": "Toggle section",
 			"selectAllBottom": "Select All"
 		},
+		"edit": {
+			"marker": "(edited)",
+			"markerTitle": "Message was edited"
+		},
+		"feedbackTag": "Feedback",
+		"menu": {
+			"open": "More options",
+			"replyDirect": "Reply directly",
+			"replyThread": "Reply in thread",
+			"edit": "Edit message",
+			"markText": "Mark text",
+			"forward": "Forward message",
+			"delete": "Delete message"
+		},
+		"reaction": {
+			"add": "React",
+			"count": "{{key}}: {{count}} reactions"
+		},
+		"visibility": {
+			"open": "Open visibility details",
+			"people": "People that see this message",
+			"title": "Message visible to …"
+		},
+		"visibleOnlyTo": "visible only to:",
 		"showLess": "Show less",
 		"showMore": "Show more",
 		"systemNotification": "System Notification",
@@ -3008,7 +3035,7 @@
 				"neu": "Unread",
 				"unread": "Unread",
 				"drafts": "Drafts",
-				"nearby": "Nearby",
+				"nearby": "Mail",
 				"create": "Create",
 				"archive": "Archived",
 				"oneToOne": "1-1 counseling",
@@ -3016,7 +3043,7 @@
 				"internalGroup": "Internal group chat",
 				"groups": "Conversation circle",
 				"supervision": "Supervision",
-				"chats": "Nearby"
+				"chats": "Mail"
 			},
 			"emptyFilterResult": "No consultations match your search or filters.",
 			"draftMetadataOnly": "Unsent message saved."


### PR DESCRIPTION
Closes #985
Closes #980

Two label defects that share one cause: strings that never made it into `de/common.json`.

## #985 — "Nähe" renamed to "Mail"

"Nähe" appeared as a filter chip and a session-type label and reads as jargon to practitioners. Renamed to "Mail" in `de` and `en` (English previously said "Nearby"). Storybook stories, the Cypress session-list regression spec and the toolbar chip test are updated with it.

## #980 — the message menu was English under German settings

The code was already correct. Every label goes through `translate(key, 'English default')` — the keys simply did not exist in any locale file, so i18next rendered the developer default.

Added under `message.*` in `de/common.json` and `en/common.json`: `menu.*` (reply directly, reply in thread, edit, mark text, forward, delete, open), `reaction.*`, `visibility.*`, `edit.*`, `visibleOnlyTo`, `feedbackTag`. The two hardcoded `aria-label="More"` in `MessageItemComponent.tsx` now resolve through `message.menu.open` — the only code change in this PR.

Eleven `message.audience.*` keys already existed but held **English** values in the German file; those are translated.

## Wording

Role terms follow the gender-neutral-by-reformulation principle rather than the `:innen` notation:

| | |
|---|---|
| clients | **Ratsuchende** / EN: Clients |
| counsellors | **Beratende** |
| moderators | **Moderierende** |

Four pre-existing `Berater:innen` / `Co-Moderator:innen` strings in the `groupChat.*` block are **not** touched here — they predate this PR and changing them would mix concerns. They should follow in a separate sweep so the notation is consistent across the product.

## What this does not fix

This closes the reported menu. It is the visible tip of a larger gap: roughly 180 keys referenced as `translate(key, default)` are missing from `de/common.json` altogether, spanning the composer toolbar, thread panel, supervision UI, drafts centre and key-backup dialog.

Worst class, and worth its own issue: keys called with **no** default at all. `Notification.tsx:99-124` calls `translate('notification.success' | 'warning' | 'error' | 'info')` with no second argument, and none of the four exists in `de/common.json` — so every toast in the application carries the literal text `notification.error` as its `title` and `aria-label`, in every language including German.

The drift grew unnoticed because the guard in `src/i18n.ts:230-290` exists but all of its `console.error` calls are commented out.

## Note on reach — corrected

An earlier revision of this description said only `de` and `de@informal` were bundled. That was wrong: `src/resources/scripts/config.ts:1-15` imports every locale file and passes them as `i18n.resources`, which `i18n.ts:115` merges last and therefore at the highest precedence.

So both the `de` and the `en` changes here reach users directly. What is **not** covered by this PR: `fr`, `ru`, `ti` and `tr` have no `message.menu.*` entries, so those users fall back to the German labels. That is an improvement over the current English, but it is not the end state — worth a follow-up that adds the menu keys to the remaining four locales.

Weblate would override these values if it were configured, but no environment sets `FRONTEND_WEBLATE_PATH` or `LOCALIZATION_WEBLATE_HOST`, so the `FetchBackend` is filtered out of the chain and the bundle is what ships.

## Reviewer test plan

- [ ] **Clear localStorage first** — the i18n cache will otherwise serve the old strings
- [ ] Log in as a counsellor with the language set to German
- [ ] Open the kebab menu on an incoming message: *Direkt antworten · Im Thread antworten · Text markieren · Nachricht weiterleiten · Nachricht löschen*
- [ ] Open the kebab on your own message: *Nachricht bearbeiten* is also German
- [ ] Inspect the kebab button: `aria-label` is "Weitere Optionen", the reaction group is "Reagieren"
- [ ] Open the "nur sichtbar für:" chip: heading and sections read *Ratsuchende / Beratende / Moderierende*, empty state *"In diesem Raum sind keine Beratenden"*
- [ ] Switch the language to English: the same menu appears in English
- [ ] Switch to informal German (Du): the menu is still German, no blank labels
- [ ] The session-list filter chip and the session-type label read "Mail", not "Nähe"; in English also "Mail", not "Nearby"
- [ ] Mobile viewport (375px): long-press a message, same German labels
- [ ] Screenshots of the message menu, the visibility chip menu and the filter chip attached to this PR

