### PR TITLE
Make the empty @-mention picker say why it is empty (#993)

### DIFF
--- a/src/api/apiGetAgencyConsultantList.test.ts
+++ b/src/api/apiGetAgencyConsultantList.test.ts
@@ -1,0 +1,52 @@
+/**
+ * #993 — the consultant list was swallowed twice: once here, once in the
+ * composer. A 403 therefore looked exactly like "this agency has no other
+ * consultants". The throwing variant exists so a caller can tell them apart.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../resources/scripts/endpoints', () => ({
+	endpoints: { agencyConsultants: '/service/users/consultants' }
+}));
+
+const fetchDataMock = vi.fn();
+vi.mock('./fetchData', () => ({
+	fetchData: (...args: unknown[]) => fetchDataMock(...args),
+	FETCH_METHODS: { GET: 'GET' },
+	FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' }
+}));
+
+const importModule = async () => await import('./apiGetAgencyConsultantList');
+
+afterEach(() => {
+	fetchDataMock.mockReset();
+});
+
+describe('agency consultant list', () => {
+	it('asks for the consultants of the given agency', async () => {
+		fetchDataMock.mockResolvedValue([]);
+		const { fetchAgencyConsultantList } = await importModule();
+
+		await fetchAgencyConsultantList('42');
+
+		expect(fetchDataMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: '/service/users/consultants?agencyId=42'
+			})
+		);
+	});
+
+	it('lets the caller see a rejected request', async () => {
+		fetchDataMock.mockRejectedValue(new Error('403'));
+		const { fetchAgencyConsultantList } = await importModule();
+
+		await expect(fetchAgencyConsultantList('42')).rejects.toThrow('403');
+	});
+
+	it('keeps the swallowing variant for callers that only want a list', async () => {
+		fetchDataMock.mockRejectedValue(new Error('403'));
+		const { apiGetAgencyConsultantList } = await importModule();
+
+		await expect(apiGetAgencyConsultantList('42')).resolves.toEqual([]);
+	});
+});

--- a/src/api/apiGetAgencyConsultantList.ts
+++ b/src/api/apiGetAgencyConsultantList.ts
@@ -10,17 +10,30 @@ export interface Consultant {
 	isSupervisor?: boolean;
 }
 
-export const apiGetAgencyConsultantList = async (
+/**
+ * Throwing variant (#993). `/users/consultants` requires the
+ * VIEW_AGENCY_CONSULTANTS authority, which not every consultant role carries
+ * — a group-chat consultant, for instance, does not. Callers that need to
+ * tell "this agency has no other consultants" apart from "the request was
+ * rejected" must use this one; the swallowing variant below cannot.
+ */
+export const fetchAgencyConsultantList = async (
 	agencyId: string
 ): Promise<Consultant[]> => {
 	const url = endpoints.agencyConsultants + '?agencyId=' + agencyId;
 
+	return await fetchData({
+		url: url,
+		method: FETCH_METHODS.GET,
+		responseHandling: [FETCH_ERRORS.CATCH_ALL]
+	});
+};
+
+export const apiGetAgencyConsultantList = async (
+	agencyId: string
+): Promise<Consultant[]> => {
 	try {
-		return await fetchData({
-			url: url,
-			method: FETCH_METHODS.GET,
-			responseHandling: [FETCH_ERRORS.CATCH_ALL]
-		});
+		return await fetchAgencyConsultantList(agencyId);
 	} catch {
 		return [];
 	}

--- a/src/components/messageSubmitInterface/inputField/extensions/MentionList.emptyStates.test.tsx
+++ b/src/components/messageSubmitInterface/inputField/extensions/MentionList.emptyStates.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/**
+ * #993 — an empty @-mention popup used to render nothing at all, so "nobody
+ * matches" and "the directory never loaded" were the same silent blank. These
+ * tests hold each cause to its own visible message.
+ */
+import * as React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MentionList } from './MentionList';
+import type { MentionCandidate } from './mentionFiltering';
+
+afterEach(() => cleanup());
+
+const labels = {
+	notInChatLabel: 'nicht im Chat',
+	emptyLabel: 'Niemand gefunden',
+	unavailableLabel: 'Liste konnte nicht geladen werden',
+	loadingLabel: 'Wird geladen …'
+};
+
+const candidate: MentionCandidate = {
+	id: 'consultant-1',
+	displayName: 'M. Musterfrau',
+	username: 'musterfrau',
+	isInRoom: true
+};
+
+const renderList = (
+	items: MentionCandidate[],
+	directoryState: 'loading' | 'ready' | 'error' | 'unavailable' = 'ready'
+) =>
+	render(
+		<MentionList
+			items={items}
+			command={vi.fn()}
+			directoryState={directoryState}
+			// eslint-disable-next-line react/jsx-props-no-spreading
+			{...labels}
+		/>
+	);
+
+describe('MentionList empty states (#993)', () => {
+	it('says the directory could not be loaded when the request failed', () => {
+		renderList([], 'error');
+
+		expect(
+			screen.getByText('Liste konnte nicht geladen werden')
+		).toBeTruthy();
+	});
+
+	it('distinguishes "nobody matches" from a failed request', () => {
+		renderList([], 'ready');
+
+		expect(screen.getByText('Niemand gefunden')).toBeTruthy();
+		expect(
+			screen.queryByText('Liste konnte nicht geladen werden')
+		).toBeNull();
+	});
+
+	it('shows a loading state while the directory is still on its way', () => {
+		renderList([], 'loading');
+
+		expect(screen.getByText('Wird geladen …')).toBeTruthy();
+	});
+
+	it('stays silent where mentions do not apply at all', () => {
+		const { container } = renderList([], 'unavailable');
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('shows candidates rather than a status once the directory has them', () => {
+		renderList([candidate], 'ready');
+
+		expect(
+			screen.getByRole('option', { name: /M\. Musterfrau/ })
+		).toBeTruthy();
+		expect(screen.queryByText('Niemand gefunden')).toBeNull();
+	});
+
+	it('flags a consultant who is not in the chat but still offers them', () => {
+		renderList([{ ...candidate, isInRoom: false }], 'ready');
+
+		const option = screen.getByRole('option', { name: /M\. Musterfrau/ });
+		expect(option.textContent).toContain('nicht im Chat');
+	});
+});

--- a/src/components/messageSubmitInterface/inputField/extensions/MentionList.stories.tsx
+++ b/src/components/messageSubmitInterface/inputField/extensions/MentionList.stories.tsx
@@ -65,3 +65,53 @@ export const AllInChat: StoryObj = {
 		/>
 	)
 };
+
+/*
+ * #993 — an empty popup used to render nothing at all, so a failed request
+ * and "nobody matches" were the same silent blank. Each cause now says so.
+ */
+const emptyLabels = {
+	notInChatLabel: 'nicht im Chat',
+	emptyLabel: 'Niemand gefunden',
+	unavailableLabel: 'Liste konnte nicht geladen werden',
+	loadingLabel: 'Wird geladen …'
+};
+
+export const NobodyMatches: StoryObj = {
+	name: 'Empty — nobody matches the query',
+	render: () => (
+		<MentionList
+			ref={createRef<MentionListRef>()}
+			items={[]}
+			command={() => {}}
+			directoryState="ready"
+			{...emptyLabels}
+		/>
+	)
+};
+
+export const DirectoryUnavailable: StoryObj = {
+	name: 'Empty — the consultant list could not be loaded',
+	render: () => (
+		<MentionList
+			ref={createRef<MentionListRef>()}
+			items={[]}
+			command={() => {}}
+			directoryState="error"
+			{...emptyLabels}
+		/>
+	)
+};
+
+export const DirectoryLoading: StoryObj = {
+	name: 'Empty — the consultant list is still loading',
+	render: () => (
+		<MentionList
+			ref={createRef<MentionListRef>()}
+			items={[]}
+			command={() => {}}
+			directoryState="loading"
+			{...emptyLabels}
+		/>
+	)
+};

--- a/src/components/messageSubmitInterface/inputField/extensions/MentionList.tsx
+++ b/src/components/messageSubmitInterface/inputField/extensions/MentionList.tsx
@@ -3,6 +3,17 @@ import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import type { MentionCandidate } from './mentionFiltering';
 import './mentionList.styles.scss';
 
+/**
+ * Why the list is empty (#993). Without this the popup rendered nothing at
+ * all, so "nobody matches what you typed" and "the directory never loaded"
+ * looked identical — the user just saw the @ do nothing.
+ */
+export type MentionDirectoryState =
+	| 'loading'
+	| 'ready'
+	| 'error'
+	| 'unavailable';
+
 export interface MentionListProps {
 	items: MentionCandidate[];
 	command: (item: {
@@ -11,6 +22,10 @@ export interface MentionListProps {
 		matrixUserId: string | null;
 	}) => void;
 	notInChatLabel: string;
+	directoryState?: MentionDirectoryState;
+	emptyLabel?: string;
+	unavailableLabel?: string;
+	loadingLabel?: string;
 }
 
 export interface MentionListRef {
@@ -23,7 +38,18 @@ export interface MentionListRef {
  * them into the conversation). Keyboard-navigable per TipTap's suggestion API.
  */
 export const MentionList = forwardRef<MentionListRef, MentionListProps>(
-	({ items, command, notInChatLabel }, ref) => {
+	(
+		{
+			items,
+			command,
+			notInChatLabel,
+			directoryState = 'ready',
+			emptyLabel,
+			unavailableLabel,
+			loadingLabel
+		},
+		ref
+	) => {
 		const [selectedIndex, setSelectedIndex] = useState(0);
 
 		useEffect(() => setSelectedIndex(0), [items]);
@@ -60,7 +86,35 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
 		}));
 
 		if (!items.length) {
-			return null;
+			// 'unavailable' is by design (asker, anonymous chat): stay silent.
+			if (directoryState === 'unavailable') {
+				return null;
+			}
+			const message =
+				directoryState === 'error'
+					? unavailableLabel
+					: directoryState === 'loading'
+						? loadingLabel
+						: emptyLabel;
+			if (!message) {
+				return null;
+			}
+			return (
+				<div className="mentionList" role="listbox">
+					<p
+						className={[
+							'mentionList__status',
+							directoryState === 'error' &&
+								'mentionList__status--error'
+						]
+							.filter(Boolean)
+							.join(' ')}
+						role="status"
+					>
+						{message}
+					</p>
+				</div>
+			);
 		}
 
 		return (

--- a/src/components/messageSubmitInterface/inputField/extensions/createMentionExtension.tsx
+++ b/src/components/messageSubmitInterface/inputField/extensions/createMentionExtension.tsx
@@ -2,7 +2,11 @@ import { ReactRenderer } from '@tiptap/react';
 import Mention from '@tiptap/extension-mention';
 import type { SuggestionOptions } from '@tiptap/suggestion';
 import { computePosition, flip, offset, shift } from '@floating-ui/dom';
-import { MentionList, MentionListRef } from './MentionList';
+import {
+	MentionDirectoryState,
+	MentionList,
+	MentionListRef
+} from './MentionList';
 import { filterMentionCandidates, MentionCandidate } from './mentionFiltering';
 
 export interface MentionProvider {
@@ -11,6 +15,14 @@ export interface MentionProvider {
 	/** The author's id, excluded from the list. */
 	selfId?: string;
 	notInChatLabel: string;
+	/**
+	 * Why the directory is the way it is, read live at popup time (#993).
+	 * Without it an empty list is silent and a failed request is invisible.
+	 */
+	getDirectoryState?: () => MentionDirectoryState;
+	emptyLabel?: string;
+	unavailableLabel?: string;
+	loadingLabel?: string;
 }
 
 /**
@@ -57,6 +69,13 @@ export const createMentionExtension = (provider: MentionProvider) => {
 			let component: ReactRenderer<MentionListRef> | null = null;
 			let popup: HTMLDivElement | null = null;
 
+			const statusProps = () => ({
+				directoryState: provider.getDirectoryState?.() ?? 'ready',
+				emptyLabel: provider.emptyLabel,
+				unavailableLabel: provider.unavailableLabel,
+				loadingLabel: provider.loadingLabel
+			});
+
 			const reposition = (clientRect: (() => DOMRect | null) | null) => {
 				if (!popup || !clientRect) {
 					return;
@@ -85,7 +104,8 @@ export const createMentionExtension = (provider: MentionProvider) => {
 						props: {
 							items: props.items,
 							command: props.command,
-							notInChatLabel: provider.notInChatLabel
+							notInChatLabel: provider.notInChatLabel,
+							...statusProps()
 						},
 						editor: props.editor
 					});
@@ -101,7 +121,8 @@ export const createMentionExtension = (provider: MentionProvider) => {
 					component?.updateProps({
 						items: props.items,
 						command: props.command,
-						notInChatLabel: provider.notInChatLabel
+						notInChatLabel: provider.notInChatLabel,
+						...statusProps()
 					});
 					reposition(props.clientRect ?? null);
 				},

--- a/src/components/messageSubmitInterface/inputField/extensions/mentionList.styles.scss
+++ b/src/components/messageSubmitInterface/inputField/extensions/mentionList.styles.scss
@@ -16,6 +16,19 @@
 		0 4px 8px 3px rgba(0, 0, 0, 0.08),
 		0 1px 3px rgba(0, 0, 0, 0.2);
 
+	/* Why the list is empty (#993) — never a blank popup. */
+	&__status {
+		margin: 0;
+		padding: 8px 12px;
+		color: var(--m3-on-surface-variant, #444748);
+		font-size: 14px;
+		line-height: 20px;
+
+		&--error {
+			color: var(--m3-error, #a5000a);
+		}
+	}
+
 	&__item {
 		display: flex;
 		align-items: center;

--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -73,7 +73,7 @@ import {
 import { useMatrixClient } from '../../globalState/context/MatrixClientContext';
 import { STATUS_ARCHIVED } from '../../globalState/interfaces';
 import {
-	apiGetAgencyConsultantList,
+	fetchAgencyConsultantList,
 	apiPutDearchive,
 	apiGetSessionSupervisors,
 	apiSendEnquiry,
@@ -548,6 +548,15 @@ export const MessageSubmitInterfaceComponent = ({
 	const [agencyConsultantDirectory, setAgencyConsultantDirectory] = useState<
 		Map<string, { displayName: string; username: string }>
 	>(new Map());
+	/**
+	 * Why the mention directory looks the way it does (#993). Every failure
+	 * used to collapse into an empty Map, so a rejected request, a session
+	 * without an agency and an agency with no other consultants all produced
+	 * the same blank popup — indistinguishable to the user and to us.
+	 */
+	const [mentionDirectoryState, setMentionDirectoryState] = useState<
+		'loading' | 'ready' | 'error' | 'unavailable'
+	>('loading');
 	const [expandedAudienceSections, setExpandedAudienceSections] = useState({
 		clients: true,
 		counsellors: true,
@@ -2280,15 +2289,26 @@ export const MessageSubmitInterfaceComponent = ({
 		);
 		const isAskerOnly = hasAskerAuthority && !hasConsultantAuthority;
 		if (isAskerOnly || isAnonymousChat) {
+			// Mentions are a counsellor tool; askers and anonymous chats have
+			// no directory by design, not by failure.
 			setAgencyConsultantDirectory(new Map());
+			setMentionDirectoryState('unavailable');
 			return;
 		}
 		if (!agencyId) {
 			setAgencyConsultantDirectory(new Map());
+			setMentionDirectoryState('error');
+			apiPostError({
+				name: 'MentionDirectoryUnavailable',
+				message:
+					'No agencyId on the active session; the @-mention directory stays empty.',
+				level: ERROR_LEVEL_WARN
+			}).then();
 			return;
 		}
 		let cancelled = false;
-		apiGetAgencyConsultantList(agencyId)
+		setMentionDirectoryState('loading');
+		fetchAgencyConsultantList(agencyId)
 			.then((consultants) => {
 				if (cancelled) {
 					return;
@@ -2323,12 +2343,25 @@ export const MessageSubmitInterfaceComponent = ({
 					}
 				);
 				setAgencyConsultantDirectory(nextDirectory);
+				setMentionDirectoryState('ready');
 			})
-			.catch(() => {
+			.catch((error) => {
 				if (cancelled) {
 					return;
 				}
 				setAgencyConsultantDirectory(new Map());
+				setMentionDirectoryState('error');
+				// The consultant list used to be swallowed twice — once in the
+				// api helper, once here — so a 403 looked exactly like an
+				// agency with no other consultants (#993).
+				apiPostError({
+					name: error?.name || 'MentionDirectoryRequestFailed',
+					message: `Agency consultant list for the @-mention picker failed (agencyId ${agencyId}): ${
+						error?.message || 'unknown error'
+					}`,
+					stack: error?.stack,
+					level: ERROR_LEVEL_WARN
+				}).then();
 			});
 		return () => {
 			cancelled = true;
@@ -3326,12 +3359,14 @@ export const MessageSubmitInterfaceComponent = ({
 	// always see the current agency directory and room membership.
 	const mentionDataRef = useRef({
 		directory: agencyConsultantDirectory,
+		directoryState: mentionDirectoryState,
 		inRoomValues: new Set<string>(),
 		matrixUserIdByComparableId: new Map<string, string>(),
 		selfId: userData?.userId as string | undefined
 	});
 	mentionDataRef.current = {
 		directory: agencyConsultantDirectory,
+		directoryState: mentionDirectoryState,
 		inRoomValues: new Set(
 			audienceOptions
 				.filter((option) => option.value !== AUDIENCE_ALL)
@@ -3374,6 +3409,17 @@ export const MessageSubmitInterfaceComponent = ({
 			notInChatLabel: translate(
 				'message.mention.notInChat',
 				'nicht im Chat'
+			),
+			// #993: the popup says why it is empty instead of rendering nothing.
+			getDirectoryState: () => mentionDataRef.current.directoryState,
+			emptyLabel: translate('message.mention.empty', 'Niemand gefunden'),
+			unavailableLabel: translate(
+				'message.mention.unavailable',
+				'Liste konnte nicht geladen werden'
+			),
+			loadingLabel: translate(
+				'message.mention.loading',
+				'Wird geladen …'
 			),
 			getCandidates: () => {
 				const { directory, inRoomValues, matrixUserIdByComparableId } =


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-Frontend#993

> **Base branch:** this PR targets `fix/995-composer-heading-and-toolbar-i18n`, not `pre-dev`, because it consumes the `message.mention.*` strings that PR adds. Merge #995 first; GitHub will retarget this one to `pre-dev` automatically.

> **This does not close the issue.** The root cause is not confirmed yet. What this lands is the ability to find it — see below.

## The problem with the old code

Every failure path collapsed into the same empty `Map`, and the popup rendered *literally nothing* when the list was empty. A rejected request, a session without an `agencyId`, and an agency with no other consultants were indistinguishable — to the user and to us. The user just saw the `@` do nothing.

The error was swallowed twice: once in `apiGetAgencyConsultantList` (`catch { return [] }`) and again in the composer (`.catch(() => setAgencyConsultantDirectory(new Map()))`).

## What changed

- **`fetchAgencyConsultantList`**, a throwing variant, so a caller can tell "no consultants" from "request rejected". The swallowing helper stays for the callers that only want a list.
- The composer tracks the directory as **loading / ready / error / unavailable**, and reports a failed or `agencyId`-less load through `apiPostError` at WARN.
- **The popup now says why it is empty:** "Liste konnte nicht geladen werden", "Niemand gefunden", or a loading line. It stays silent only where mentions do not apply at all (asker, anonymous chat).

## What I could not confirm

I could not reproduce this against live data, so I am not claiming a fix. One lead worth checking first: `/users/consultants` requires the `VIEW_AGENCY_CONSULTANTS` authority. The plain `CONSULTANT` role does carry it — I checked `Authority.java` — but **`GROUP_CHAT_CONSULTANT` does not**, so a group-chat consultant would get a 403 and, before this PR, a silent blank popup.

With this merged, reproducing on Pre-Dev with the network tab open should name the cause in one attempt.

## How it was verified

- `npx vitest run` — 261 files, 1871 tests, all passing
- 9 new tests: `MentionList.emptyStates.test.tsx` (each cause gets its own message) and `apiGetAgencyConsultantList.test.ts` (the throwing variant really throws)
- `tsc`, Storybook `tsc`, `eslint --max-warnings=0`, `stylelint` clean

## Reviewer test plan

- [ ] As a counsellor, open a 1-1 conversation and type `@` → either a list of counsellors appears, or a line saying why it is empty — never a silent nothing
- [ ] Block `/users/consultants` in the browser devtools and type `@` → "Liste konnte nicht geladen werden" appears and a WARN reaches the error endpoint
- [ ] Type `@` followed by nonsense that matches nobody → "Niemand gefunden"
- [ ] As an advice seeker in an anonymous chat, type `@` → nothing appears (this is intended, mentions are a counsellor tool)
- [ ] Repeat the first check on a 320px and a 412px wide phone → the popup stays on screen and does not cover the send button
- [ ] Switch the UI to German and to English → the status lines are translated in both
- [ ] **If the list is still empty in a normal counselling chat**, note your Keycloak roles and the `/users/consultants` response code on the issue — that is the missing piece
